### PR TITLE
Add meta.trac support to the GitHub PR process.

### DIFF
--- a/api.wordpress.org/public_html/dotorg/trac/pr/functions.php
+++ b/api.wordpress.org/public_html/dotorg/trac/pr/functions.php
@@ -176,6 +176,9 @@ function determine_trac_ticket( $pr ) {
 
 	// For now, we assume everything is destined for the Core Trac.
 	switch ( $pr->base->repo->full_name ) {
+		case 'WordPress/wordpress.org':
+			$trac = 'meta';
+			break;
 		case 'WordPress/wordpress-develop':
 		default:
 			$trac = 'core';

--- a/trac.wordpress.org/templates/site.html
+++ b/trac.wordpress.org/templates/site.html
@@ -4,7 +4,7 @@
      py:strip="">
 
 <?python
-	scripts_version = '139'
+	scripts_version = '140'
 	project_slug = req.environ['HTTP_HOST'].split(':')[0].split('.')[0]
 	wporg_endpoint = 'https://make.wordpress.org/' + project_slug + '/'
 	is_bug_gardener = 'TICKET_EDIT_DESCRIPTION' in perm(resource)

--- a/wordpress.org/public_html/style/trac/wp-trac.js
+++ b/wordpress.org/public_html/style/trac/wp-trac.js
@@ -1549,12 +1549,18 @@ var wpTrac, coreKeywordList, gardenerKeywordList, reservedTerms, coreFocusesList
 			var apiEndpoint = 'https://api.wordpress.org/dotorg/trac/pr/',
 				authenticated = !! ( wpTracCurrentUser && wpTracCurrentUser !== "anonymous" ),
 				trac = false, ticket = 0,
-				container;
+				primaryGitRepo, primaryGitRepoDesc, container;
 
 			function init() {
 				// TODO: If this is added to other Trac's, expand this..
 				if ( $body.hasClass( 'core' ) ) {
 					trac = 'core';
+					primaryGitRepo = 'WordPress/wordpress-develop';
+					primaryGitRepoDesc = 'WordPress GitHub mirror';
+				} else if ( $body.hasClass( 'meta' ) ) {
+					trac = 'meta';
+					primaryGitRepo = 'WordPress/wordpress.org';
+					primaryGitRepoDesc = 'WordPress.org Meta GitHub mirror';
 				}
 
 				// This seems to be the easiest place to find the current Ticket ID..
@@ -1595,7 +1601,7 @@ var wpTrac, coreKeywordList, gardenerKeywordList, reservedTerms, coreFocusesList
 						}
 					} else {
 						// Change the loading placeholder
-						prContainer.find( '.loading div' ).html( 'To link a Pull Request to this ticket, create a new Pull Request in the <a href="https://github.com/WordPress/wordpress-develop">WordPress GitHub mirror</a> and include this ticket’s URL in the description.' );
+						prContainer.find( '.loading div' ).html( 'To link a Pull Request to this ticket, create a new Pull Request in the <a href="https://github.com/' + primaryGitRepo + '">' + primaryGitRepoDesc + '</a> and include this ticket’s URL in the description.' );
 					}
 				});
 			}


### PR DESCRIPTION
This brings the recent addition of GitHub PR support on core.trac.wordpress.org to Meta.trac.wordpress.org

This is part of https://meta.trac.wordpress.org/ticket/4903

For more information on how this is supposed to work, check out https://make.wordpress.org/core/2020/02/21/working-on-trac-tickets-using-github-pull-requests/