### PR TITLE
Pull in Travis CI status directly rather than relying upon PR status

### DIFF
--- a/api.wordpress.org/public_html/dotorg/trac/pr/index.php
+++ b/api.wordpress.org/public_html/dotorg/trac/pr/index.php
@@ -51,6 +51,14 @@ array_walk( $prs, function( $data ) use ( $authenticated ) {
 			strtotime( $data->data->updated_at ) > time() - 30*60
 			&&
 			strtotime( $data->last_checked_at ) <= time() - 2*60
+		) ||
+		// or unit tests are running, then 2min.
+		(
+			$data->check_runs
+			&&
+			in_array( 'in_progress', $data->check_runs )
+			&&
+			strtotime( $data->last_checked_at ) <= time() - 2*60
 		)
 	) {
 		$pr_data = fetch_pr_data( $data->repo, $data->pr );

--- a/wordpress.org/public_html/style/trac/wp-trac.js
+++ b/wordpress.org/public_html/style/trac/wp-trac.js
@@ -1643,9 +1643,9 @@ var wpTrac, coreKeywordList, gardenerKeywordList, reservedTerms, coreFocusesList
 					for ( var provider in data.check_runs ) {
 						switch( data.check_runs[ provider ] ) {
 							case 'in_progress':
-								return provider + ' Running';
+								return provider + ' running';
 							case 'failed':
-								return '❌ ' + provider + ' Failed';
+								return '❌ ' + provider + ' failed';
 							case 'success':
 								continue;
 							default:
@@ -1664,7 +1664,7 @@ var wpTrac, coreKeywordList, gardenerKeywordList, reservedTerms, coreFocusesList
 					case 'dirty':
 						return '❌ Merge conflicts';
 					case 'unstable': // Not seen, Unit Tests above should catch it.
-						return '❌ Failing Tests';
+						return '❌ Failing tests';
 					case 'unknown':
 						return 'Unknown';
 				}

--- a/wordpress.org/public_html/style/trac/wp-trac.js
+++ b/wordpress.org/public_html/style/trac/wp-trac.js
@@ -1638,17 +1638,35 @@ var wpTrac, coreKeywordList, gardenerKeywordList, reservedTerms, coreFocusesList
 					return '✅ Closed';
 				}
 
+				// Unit Tests?
+				if ( data.check_runs ) {
+					for ( var provider in data.check_runs ) {
+						switch( data.check_runs[ provider ] ) {
+							case 'in_progress':
+								return provider + ' Running';
+							case 'failed':
+								return '❌ ' + provider + ' Failed';
+							case 'success':
+								continue;
+							default:
+								return '❌ ' + provider + ' ' + data.check_runs[ provider ];
+						}
+					}
+				}
+
 				// Merge State then
 				switch ( data.mergeable_state ) {
 					case 'draft':
-						return 'Work in progress';
+						return 'Draft';
+					case 'blocked': // This seems to be returned for our App with PRs but not others..
 					case 'clean':
 						return '✅ All checks pass';
 					case 'dirty':
 						return '❌ Merge conflicts';
-					case 'unstable':
-					case 'blocked':
-						return '❌ Failing tests';
+					case 'unstable': // Not seen, Unit Tests above should catch it.
+						return '❌ Failing Tests';
+					case 'unknown':
+						return 'Unknown';
 				}
 			}
 

--- a/wordpress.org/public_html/style/trac/wp-trac.js
+++ b/wordpress.org/public_html/style/trac/wp-trac.js
@@ -1647,6 +1647,7 @@ var wpTrac, coreKeywordList, gardenerKeywordList, reservedTerms, coreFocusesList
 					case 'dirty':
 						return '❌ Merge conflicts';
 					case 'unstable':
+					case 'blocked':
 						return '❌ Failing tests';
 				}
 			}

--- a/wordpress.org/public_html/style/trac/wp-trac.js
+++ b/wordpress.org/public_html/style/trac/wp-trac.js
@@ -1635,11 +1635,7 @@ var wpTrac, coreKeywordList, gardenerKeywordList, reservedTerms, coreFocusesList
 			function prStatus( data ) {
 				// Closed?
 				if ( data.closed_at ) {
-					if ( data.mergeable_state == 'clean' ) {
-						return '✅ Closed';
-					} else {
-						return '❌ Closed'
-					}
+					return '✅ Closed';
 				}
 
 				// Merge State then


### PR DESCRIPTION
This change causes the Travis CI status to be queried directly for determining the PR state, rather than relying upon the PR state variables.

Strangely the `mergeable_state` field is showing `blocked` for some PRs, where the Web and curl requests show `clean`.. After reviewing the PRs with that state, the new Travis checks will catch those otherwise they appear to be clean.

Part of https://meta.trac.wordpress.org/ticket/4903