### PR TITLE
Fix PHP 7.1 compatibilty issue

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-developer/inc/rest-api.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-developer/inc/rest-api.php
@@ -24,7 +24,7 @@ class DevHub_REST_API extends DevHub_Docs_Importer {
 	 * @return string
 	 */
 	public static function change_handbook_label( $label, $post_type ) {
-		if ( $this->get_post_type() === $post_type ) {
+		if ( self::instance()->get_post_type() === $post_type ) {
 			$label = __( 'REST API Handbook', 'wporg' );
 		}
 


### PR DESCRIPTION
"$this" can no longer be used in a static function or method since PHP 7.1.