### PR TITLE
Fix PHP 7 notices/warnings on codex.buddypress.org

### DIFF
--- a/buddypress.org/public_html/wp-content/themes/codex-buddypress-org/widgets/inbox.php
+++ b/buddypress.org/public_html/wp-content/themes/codex-buddypress-org/widgets/inbox.php
@@ -1,7 +1,11 @@
 <?php
 class BPOrg_Inbox_Widget extends WP_Widget {
-	function bporg_inbox_widget() {
-		parent::WP_Widget( false, $name = __( "Inbox", 'bporg' ) );
+	function __construct() {
+		parent::__construct( false, $name = __( "Inbox", 'bporg' ) );
+	}
+
+	function BPOrg_Inbox_Widget() {
+		self::__construct();
 	}
 
 	function widget( $args, $instance ) {
@@ -38,4 +42,4 @@ class BPOrg_Inbox_Widget extends WP_Widget {
 	<?php
 	}
 }
-add_action( 'widgets_init', create_function( '', 'return register_widget("BPOrg_Inbox_Widget");' ) );
+add_action( 'widgets_init', function () { return register_widget("BPOrg_Inbox_Widget"); } );

--- a/buddypress.org/public_html/wp-content/themes/codex-buddypress-org/widgets/login.php
+++ b/buddypress.org/public_html/wp-content/themes/codex-buddypress-org/widgets/login.php
@@ -1,7 +1,11 @@
 <?php
 class BPOrg_Login_Widget extends WP_Widget {
-	function bporg_login_widget() {
-		parent::WP_Widget( false, $name = __( "Login Form", 'bporg' ) );
+	function __construct() {
+		parent::__construct( false, $name = __( "Login Form", 'bporg' ) );
+	}
+
+	function BPOrg_Login_Widget() {
+		self::__construct();
 	}
 
 	function widget( $args, $instance ) {
@@ -72,4 +76,4 @@ class BPOrg_Login_Widget extends WP_Widget {
 	<?php
 	}
 }
-add_action( 'widgets_init', create_function( '', 'return register_widget("BPOrg_Login_Widget");' ) );
+add_action( 'widgets_init', function () { return register_widget("BPOrg_Login_Widget"); } );


### PR DESCRIPTION
This removes the PHP4 style constructor as well as a couple of create_function calls.

This is part of an effort to migrate the existing code to PHP 7.4.