### PR TITLE
Escape the regex range character.

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-developer/inc/formatting.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-developer/inc/formatting.php
@@ -207,7 +207,7 @@ class DevHub_Formatting {
 		}
 
 		// Link to hook: {@see 'pre_get_search_form'}
-		elseif ( 1 === preg_match( '/^(?:\'|(?:&#8216;))([\$\w-&;]+)(?:\'|(?:&#8217;))$/', $link, $hook ) ) {
+		elseif ( 1 === preg_match( '/^(?:\'|(?:&#8216;))([\$\w\-&;]+)(?:\'|(?:&#8217;))$/', $link, $hook ) ) {
 			if ( ! empty( $hook[1] ) ) {
 				$url = get_post_type_archive_link( 'wp-parser-hook' ) .
 				        sanitize_title_with_dashes( html_entity_decode( $hook[1] ) ) . '/';


### PR DESCRIPTION
This fixes a PHP warning.

Fixes https://meta.trac.wordpress.org/ticket/5365