### PR TITLE
Plugin Directory: Improve block list in plugin details

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins/client/components/plugin/style.scss
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins/client/components/plugin/style.scss
@@ -121,6 +121,51 @@
 		}
 	}
 
+	.plugin-blocks-list {
+		list-style: none;
+		margin-left: 0;
+
+		.plugin-blocks-list-item {
+			display: grid;
+			grid-template-columns: auto 1fr;
+			margin-bottom: ms(2);
+		}
+
+		.block-icon {
+			display: inline-block;
+			margin-right: ms(0);
+			padding: ms(1);
+			width: 3.5rem; // 56px
+			height: 3.5rem; // 56px
+			border: 1px solid $color__border;
+
+			&.dashicons {
+				color: inherit; // Prevent rating color being applied to star icons
+			}
+
+			svg {
+				width: 16px;
+				height: 16px;
+				fill: currentColor;
+			}
+		}
+
+		.block-title {
+			align-self: center;
+			font-weight: bold;
+		}
+
+		.has-description {
+			.block-icon {
+				grid-row: 1 / span 2;
+			}
+
+			.block-title {
+				margin-bottom: ms(-8);
+			}
+		}
+	}
+
 	.entry-meta {
 		padding: 0 ms( 4 );
 	}

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins/template-parts/section-blocks.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins/template-parts/section-blocks.php
@@ -13,16 +13,62 @@ $prefix = in_array( $section_slug, array( 'screenshots', 'faq', 'blocks' ), true
 
 $classes = [ 'plugin-' . $section_slug, 'section' ];
 $classes = implode( ' ', $classes );
+
+$allowed_svg = array(
+	'svg'   => array(
+		'class' => true,
+		'aria-hidden' => true,
+		'aria-labelledby' => true,
+		'role' => true,
+		'xmlns' => true,
+		'width' => true,
+		'height' => true,
+		'viewbox' => true,
+	),
+	'g'     => array( 'fill' => true ),
+	'title' => array( 'title' => true ),
+	'path'  => array(
+		'd' => true,
+		'fill' => true,
+		'transform' => true,
+	),
+);
 ?>
 
 <div id="<?php echo esc_attr( $prefix . $section_slug ); ?>" class="<?php echo esc_attr( $classes ); ?>">
 	<h2 id="<?php echo esc_attr( $section_slug . '-header' ); ?>"><?php echo esc_html( $section['title'] ); ?></h2>
 
 	<p><?php printf( esc_html( _n( 'This plugin provides %d block.', 'This plugin provides %d blocks.', count( $section_content ), 'wporg-plugins'  ) ), count( $section_content ) ); ?></p>
-	<dl>
-		<?php foreach ( $section_content as $block ) : ?>
-			<dt><?php if ( isset( $block->name ) ) echo esc_html( $block->name ); ?></dt>
-				<dd><?php if ( isset( $block->title ) ) echo esc_html( $block->title ); ?></dd>
+	<ul class="plugin-blocks-list">
+		<?php
+		foreach ( $section_content as $block ) :
+			$block_name = isset( $block->title ) ? $block->title : false;
+			if ( ! $block_name ) {
+				$block_name = isset( $block->name ) ? $block->name : false;
+			}
+			if ( ! $block_name ) {
+				// If we still have no name, we don't have a valid block.
+				continue;
+			}
+			$block_icon = isset( $block->icon ) ? $block->icon : '';
+			$block_classes = 'plugin-blocks-list-item';
+			$block_classes .= isset( $block->description ) ? ' has-description' : '';
+			?>
+			<li class="<?php echo esc_attr( $block_classes ); ?>">
+				<?php if ( false !== strpos( $block_icon, '<svg' ) ) : ?>
+					<span class="block-icon">
+						<?php echo wp_kses( str_replace( '<svg ', '<svg role="img" aria-hidden="true" focusable="false" ', $block_icon ), $allowed_svg ); ?>
+					</span>
+				<?php elseif ( $block_icon ) : ?>
+					<span class="block-icon dashicons dashicons-<?php echo esc_attr( $block->icon ); ?>"></span>
+				<?php else : ?>
+					<span class="block-icon dashicons dashicons-block-default"></span>
+				<?php endif; ?>
+				<span class="block-title"><?php echo esc_html( $block_name ); ?></span>
+				<?php if ( isset( $block->description ) ) : ?>
+					<span class="block-description"><?php echo esc_html( $block->description ); ?></dd>
+				<?php endif; ?>
+			</li>
 		<?php endforeach; ?>
-	</dl>
+	</ul>
 </div>


### PR DESCRIPTION
Blocks with and icon and description:

![icon-description](https://user-images.githubusercontent.com/541093/92979579-2f40c380-f461-11ea-9241-591db93325b6.png)

This block provides an SVG icon, so it's colorful:

![svg-description](https://user-images.githubusercontent.com/541093/92979577-2ea82d00-f461-11ea-9000-bc008b61b1cd.png)

List of blocks, no descriptions

![multiple-icons-nodesc](https://user-images.githubusercontent.com/541093/92979578-2f40c380-f461-11ea-944d-91124bb33bcc.png)

No block icon:

![Screen Shot 2020-09-11 at 7 03 03 PM](https://user-images.githubusercontent.com/541093/92979681-6dd67e00-f461-11ea-850d-c7bbdf310cc3.png)

https://meta.trac.wordpress.org/ticket/5411