### PR TITLE
Add filter to allow filtering the head tags used

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-developer/inc/head.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-developer/inc/head.php
@@ -165,6 +165,13 @@ class DevHub_Head {
 			$fields[ 'og:description'] = $desc;
 		}
 
+		/**
+		 * Allow filtering of the tag field values.
+		 *
+		 * @param array $fields List of meta tags to render to the page.
+		 */
+		$fields = apply_filters( 'devhub_head_tag_fields', $fields );
+
 		// Output fields.
 		foreach ( $fields as $property => $content ) {
 			$attribute = 0 === strpos( $property, 'og:' ) ? 'property' : 'name';


### PR DESCRIPTION
Allow customization of the head tags used by the wporg-developer theme.