### PR TITLE
Ensure full-width of `iframe` on pages other than homepage

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/css/openverse.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/css/openverse.css
@@ -6,3 +6,10 @@
 
     border: none;
 }
+
+.site > .site-content {
+    max-width: none;
+
+    padding: 0;
+    margin: auto;
+}


### PR DESCRIPTION
Closes: https://meta.trac.wordpress.org/ticket/5796

This PR ensures that the Openverse `iframe` added in the new WordPress.org Openverse theme (#31) renders correctly on pages without the `.home` class on the body tag.