### PR TITLE
Add a better search class

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/.gitignore
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/.gitignore
@@ -1,0 +1,2 @@
+vendor
+.phpunit.result.cache

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/.wp-env.json
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/.wp-env.json
@@ -1,0 +1,3 @@
+{
+	"plugins": [".", "https://downloads.wordpress.org/plugin/jetpack.zip"]
+}

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-plugin-directory.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-plugin-directory.php
@@ -60,6 +60,9 @@ class Plugin_Directory {
 		// Cron tasks.
 		new Jobs\Manager();
 
+		// Search
+		Plugin_Search::instance();
+
 		// Add upload size limit to limit plugin ZIP file uploads to 10M
 		add_filter( 'upload_size_limit', function( $size ) {
 			return 10 * MB_IN_BYTES;
@@ -79,11 +82,6 @@ class Plugin_Directory {
 		add_filter( 'wp_insert_post_data', array( $this, 'filter_wp_insert_post_data' ), 10, 2 );
 
 		add_filter( 'jetpack_active_modules', function( $modules ) {
-			// Disable Jetpack Search
-			if ( false !== ( $i = array_search( 'search', $modules ) ) ) {
-				unset( $modules[$i] );
-			}
-
 			// Disable Jetpack Sitemaps on Rosetta sites.
 			if ( !empty( $GLOBALS['rosetta'] ) ) {
 				if ( false !== ( $i = array_search( 'sitemaps', $modules ) ) ) {
@@ -91,7 +89,7 @@ class Plugin_Directory {
 				}
 			}
 
-			return $modules;
+			return array_unique( $modules );
 		} );
 
 /*
@@ -561,22 +559,6 @@ class Plugin_Directory {
 		add_filter( 'single_post_title', array( $this, 'translate_post_title' ), 1, 2 );
 		add_filter( 'get_the_excerpt', array( $this, 'translate_post_excerpt' ), 1, 2 );
 
-		// Instantiate our copy of the Jetpack_Search class.
-		if (
-			class_exists( 'Jetpack' ) &&
-			\Jetpack::get_option( 'id' ) && // Don't load in Meta Environments
-			! class_exists( 'Jetpack_Search' ) &&
-			(
-				// Don't run the ES query if we're going to redirect to the pretty search URL
-				! isset( $_GET['s'] )
-			||
-				// But load it for the query-plugins REST API endpoint, for simpler debugging
-				( false !== strpos( $_SERVER['REQUEST_URI'], 'wp-json/plugins/v1/query-plugins' ) )
-			)
-		) {
-			require_once __DIR__ . '/libs/site-search/jetpack-search.php';
-			\Jetpack_Search::instance();
-		}
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-plugin-search.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-plugin-search.php
@@ -1,0 +1,404 @@
+<?php
+namespace WordPressdotorg\Plugin_Directory;
+
+// Hmm
+add_filter( 'option_has_jetpack_search_product', '__return_true' );
+
+
+/**
+ ** Override Jetpack Search class with special features for the Plugin Directory
+ **
+ ** @package WordPressdotorg\Plugin_Directory
+ **/
+class Plugin_Search {
+
+	// Set this to true to disable the new class and use the old jetpack-search.php code.
+	const USE_OLD_SEARCH = true;
+
+	// Internal state
+	protected $locale;
+	protected $is_block_search;
+	protected $is_english;
+	protected $en_boost;
+	protected $desc_boost;
+	protected $desc_en_boost;
+
+	/**
+	 * Fetch the instance of the Plugin_Search class.
+	 *
+	 * @static
+	 */
+	public static function instance() {
+		static $instance = null;
+
+		if ( ! $instance ) {
+			$instance = new self();
+		}
+
+		return $instance;
+	}
+
+	/**
+	 * Plugin_Search constructor.
+	 *
+	 * @access private
+	 */
+	private function __construct() {
+		if ( isset( $_GET['s'] ) )
+			return false;
+
+		add_action( 'init', array( $this, 'init' ) );
+
+		return false;
+	}
+
+	public function init() {
+
+		if ( self::USE_OLD_SEARCH ) {
+			// Instantiate our copy of the Jetpack_Search class.
+			if ( class_exists( 'Jetpack' ) && ! class_exists( 'Jetpack_Search' )
+				&& ! isset( $_GET['s'] ) ) { // Don't run the ES query if we're going to redirect to the pretty search URL
+					require_once __DIR__ . '/libs/site-search/jetpack-search.php';
+					\Jetpack_Search::instance();
+			}
+		} else {
+			add_filter( 'jetpack_get_module', array( $this, 'jetpack_get_module' ), 10, 2 );
+			add_filter( 'option_jetpack_active_modules', array( $this, 'option_jetpack_active_modules' ), 10, 1 );
+			add_filter( 'pre_option_has_jetpack_search_product', array( $this, 'option_has_jetpack_search_product' ), 10, 1 );
+
+			add_filter( 'jetpack_search_abort', array( $this, 'jetpack_search_abort' ) );
+
+			require_once( ABSPATH . 'wp-content/plugins/jetpack/modules/search/class.jetpack-search.php' );
+			require_once( ABSPATH . 'wp-content/plugins/jetpack/modules/search/class.jetpack-search-helpers.php' );
+			// $es_query_args = apply_filters( 'jetpack_search_es_query_args', $es_query_args, $query );
+			//
+			add_filter( 'jetpack_search_es_wp_query_args', array( $this, 'jetpack_search_es_wp_query_args' ), 10, 2 );
+			add_filter( 'jetpack_search_es_query_args', array( $this, 'jetpack_search_es_query_args' ), 10, 2 );
+
+			\Jetpack_Search::instance()->setup();
+		}
+
+	}
+
+	function var_export($expression, $return=FALSE) {
+		$export = var_export($expression, TRUE);
+		$patterns = [
+			"/array \(/" => '[',
+			"/^([ ]*)\)(,?)$/m" => '$1]$2',
+			"/=>[ ]?\n[ ]+\[/" => '=> [',
+			"/([ ]*)(\'[^\']+\') => ([\[\'])/" => '$1$2 => $3',
+		];
+		$export = preg_replace(array_keys($patterns), array_values($patterns), $export);
+		if ((bool)$return) return $export; else echo $export;
+	}
+
+	public function option_jetpack_active_modules( $modules ) {
+		if ( self::USE_OLD_SEARCH ) {
+			if ( $i = array_search( 'search', $modules ) )
+				unset( $modules[$i] );
+		} else {
+			$modules[] = 'search';
+		}
+
+		return array_unique( $modules );
+	}
+
+	public function option_has_jetpack_search_product( $option ) {
+		if ( !self::USE_OLD_SEARCH ) {
+			return true;
+		}
+		return $option;
+	}
+
+	/* Make sure the search module is available regardless of Jetpack plan.
+	 * This works because search indexes were manually created for w.org.
+	 */
+	public function jetpack_get_module( $module, $slug ) {
+		if ( !self::USE_OLD_SEARCH ) {
+			if ( 'search' === $slug && isset( $module[ 'plan_classes' ] ) && !in_array( 'free', $module[ 'plan_classes' ] ) ) {
+				$module[ 'plan_classes' ][] = 'free';
+			}
+		}
+
+		return $module;
+	}
+
+	public function jetpack_search_es_wp_query_args( $args, $query ) {
+
+		// Block Search.
+		$this->is_block_search = !empty( $query->query['block_search'] );
+		if ( $this->is_block_search ) {
+			$args['block_search'] = $query->query['block_search'];
+		}
+
+		// How much weighting to put on the Description field.
+		// Blocks get a much lower value here, as it's more title/excerpt (short description) based.
+		$this->desc_boost = $this->is_block_search ? 0.05 : 1;
+
+		// Because most plugins don't have any translations we need to
+		// correct for the very low scores that locale-specific fields.
+		// end up getting. This is caused by the average field length being
+		// very close to zero and thus the BM25 alg discounts fields that are
+		// significantly longer.
+		//
+		// As of 2017-01-23 it looked like we were off by about 10,000x,
+		// so rather than 0.1 we use a much smaller multiplier of en content
+		$this->en_boost             = 0.00001;
+		$this->desc_en_boost        = $this->desc_boost * $this->en_boost;
+
+		// We need to be locale aware for this
+		$this->locale = strtolower( substr( get_locale(), 0, 2 ) );
+		$this->is_english = ( !$this->locale || 'en' === $this->locale );
+
+		if ( $this->is_english ) {
+			$matching_fields      = array(
+				'all_content_en',
+			);
+		} else {
+			$matching_fields      = array(
+				'all_content_' . $this->locale,
+				'all_content_en^' . $this->en_boost,
+			);
+		}
+
+		$args['query_fields'] = $matching_fields;
+
+
+
+
+		return $args;
+	}
+
+	public function jetpack_search_es_query_args( $es_query_args, $query ) {
+		// These are the things that jetpack_search_es_wp_query_args doesn't let us change, so we need to filter the es_query_args late in the code path to add more custom stuff.
+
+		// Exclude disabled plugins.
+		$es_query_args[ 'filter' ] = [
+			'and' => [
+			  0 => [
+				'term' => [
+				  'disabled' => [
+					'value' => false,
+				  ],
+				],
+			],
+			]
+		];
+
+		if ( $this->is_block_search ) {
+			// Limit to the Block Tax.
+			$es_query_args['filter']['and'][] = [
+				'term' => [
+					'taxonomy.plugin_section.name' => [
+						'value' => 'block'
+					]
+				]
+			];
+		}
+
+		// Set boost on the match query
+
+		if ( isset( $es_query_args[ 'query' ][ 'function_score' ][ 'query' ][ 'bool' ][ 'must' ][0][ 'multi_match' ] ) ) {
+			$es_query_args[ 'query' ][ 'function_score' ][ 'query' ][ 'bool' ][ 'must' ][0][ 'multi_match' ][ 'boost' ] = 0.1;
+		}
+
+		// Old version had one less level here. Probably unimportant but this makes the unit tests pass.
+		if ( isset( $es_query_args[ 'query' ][ 'function_score' ][ 'query' ][ 'bool' ][ 'must' ][0] ) ) {
+			$es_query_args[ 'query' ][ 'function_score' ][ 'query' ][ 'bool' ][ 'must' ] = $es_query_args[ 'query' ][ 'function_score' ][ 'query' ][ 'bool' ][ 'must' ][0];
+		}
+
+		// Not sure if this matters, but again it's in the tests
+		if ( isset( $es_query_args[ 'query' ][ 'function_score' ][ 'query' ][ 'bool' ][ 'should' ][0][ 'multi_match' ][ 'operator' ] ) ) {
+			unset( $es_query_args[ 'query' ][ 'function_score' ][ 'query' ][ 'bool' ][ 'should' ][0][ 'multi_match' ][ 'operator' ] );
+		}
+
+
+		// Some extra fields here
+		if ( isset( $es_query_args[ 'query' ][ 'function_score' ][ 'query' ][ 'bool' ][ 'should' ][0][ 'multi_match' ] ) ) {
+			$es_query_args[ 'query' ][ 'function_score' ][ 'query' ][ 'bool' ][ 'should' ][0][ 'multi_match' ][ 'boost' ] = 2;
+			$es_query_args[ 'query' ][ 'function_score' ][ 'query' ][ 'bool' ][ 'should' ][0][ 'multi_match' ][ 'fields' ] = ( $this->is_english ? [
+				0 => 'title_en',
+				1 => 'excerpt_en',
+				2 => 'description_en^1',
+				3 => 'taxonomy.plugin_tags.name',
+			] : [
+				'title_' . $this->locale,
+				'excerpt_' . $this->locale,
+				'description_' . $this->locale . '^' . $this->desc_boost,
+				'title_en^' . $this->en_boost,
+				'excerpt_en^' . $this->en_boost,
+				'description_en^' . $this->desc_en_boost,
+				'taxonomy.plugin_tags.name',
+			] );
+		}
+
+		// And some more fancy bits here
+		if ( isset( $es_query_args[ 'query' ][ 'function_score' ][ 'query' ][ 'bool' ][ 'should' ] ) && 1 === count( $es_query_args[ 'query' ][ 'function_score' ][ 'query' ][ 'bool' ][ 'should' ] ) ) {
+			$search_phrase = $es_query_args[ 'query' ][ 'function_score' ][ 'query' ][ 'bool' ][ 'should' ][0][ 'multi_match' ][ 'query' ];
+
+			$es_query_args[ 'query' ][ 'function_score' ][ 'query' ][ 'bool' ][ 'should' ][] = [
+				'multi_match' => [
+				'query' => $search_phrase,
+				'fields' => ( $this->is_english ? [
+					0 => 'title_en.ngram',
+				] : [
+					'title_' . $this->locale . '.ngram',
+					'title_en.ngram^' . $this->en_boost,
+				] ),
+				'type' => 'phrase',
+				'boost' => 0.2,
+				],
+			];
+
+			$es_query_args[ 'query' ][ 'function_score' ][ 'query' ][ 'bool' ][ 'should' ][] = [
+				'multi_match' => [
+				  'query' => $search_phrase,
+				  'fields' => ( $this->is_english ? [
+					0 => 'title_en',
+					1 => 'slug_text',
+				  ] : [
+					'title_' . $this->locale,
+					'title_en^' . $this->en_boost,
+					'slug_text',
+				  ] ),
+				  'type' => 'best_fields',
+				  'boost' => 2,
+				],
+			];
+
+			$es_query_args[ 'query' ][ 'function_score' ][ 'query' ][ 'bool' ][ 'should' ][] = [
+				'multi_match' => [
+				  'query' => $search_phrase,
+				  'fields' => ( $this->is_english ? [
+					0 => 'excerpt_en',
+					1 => 'description_en^1',
+					2 => 'taxonomy.plugin_tags.name',
+				  ] : [
+					'excerpt_' . $this->locale,
+					'description_' . $this->locale . '^' . $this->desc_boost,
+					'excerpt_en^' . $this->en_boost,
+					'description_en^' . $this->desc_en_boost,
+					'taxonomy.plugin_tags.name',
+				  ] ),
+				  'type' => 'best_fields',
+				  'boost' => 2,
+				],
+			];
+
+			$es_query_args[ 'query' ][ 'function_score' ][ 'query' ][ 'bool' ][ 'should' ][] = [
+				'multi_match' => [
+				  'query' => $search_phrase,
+				  'fields' => [
+					0 => 'author',
+					1 => 'contributors',
+				  ],
+				  'type' => 'best_fields',
+				  'boost' => 2,
+				],
+			];
+		}
+
+		if ( isset( $es_query_args[ 'query' ][ 'function_score' ][ 'functions' ] ) ) {
+			$es_query_args[ 'query' ][ 'function_score' ][ 'functions' ] = [
+				0 => [
+				  'exp' => [
+					'plugin_modified' => [
+					  'origin' => date('Y-m-d'),
+					  'offset' => '180d',
+					  'scale' => '360d',
+					  'decay' => 0.5,
+					],
+				  ],
+				],
+				1 => [
+				  'exp' => [
+					'tested' => [
+					  'origin' => '5.0',
+					  'offset' => 0.1,
+					  'scale' => 0.4,
+					  'decay' => 0.6,
+					],
+				  ],
+				],
+				2 => [
+				  'field_value_factor' => [
+					'field' => 'active_installs',
+					'factor' => 0.375,
+					'modifier' => 'log2p',
+					'missing' => 1,
+				  ],
+				],
+				3 => [
+				  'filter' => [
+					'range' => [
+					  'active_installs' => [
+						'lte' => 1000000,
+					  ],
+					],
+				  ],
+				  'exp' => [
+					'active_installs' => [
+					  'origin' => 1000000,
+					  'offset' => 0,
+					  'scale' => 900000,
+					  'decay' => 0.75,
+					],
+				  ],
+				],
+				4 => [
+				  'field_value_factor' => [
+					'field' => 'support_threads_resolved',
+					'factor' => 0.25,
+					'modifier' => 'log2p',
+					'missing' => 0.5,
+				  ],
+				],
+				5 => [
+				  'field_value_factor' => [
+					'field' => 'rating',
+					'factor' => 0.25,
+					'modifier' => 'sqrt',
+					'missing' => 2.5,
+				  ],
+				],
+			];
+		}
+
+		// Old version didn't have these
+		unset( $es_query_args[ 'query' ][ 'function_score' ][ 'score_mode' ] );
+		unset( $es_query_args[ 'query' ][ 'function_score' ][ 'max_boost' ] );
+		unset( $es_query_args[ 'aggregations' ] );
+
+		// Couple of extra fields wanted in the response, mainly for debugging
+		$es_query_args[ 'fields' ] = [
+			0 => 'slug',
+			1 => 'post_id',
+			2 => 'blog_id',
+		];
+
+		// Old version had things wrapped in an extra query => filtered layer.
+		$es_query_args[ 'query' ] = [
+			'filtered' => [
+				'query' => $es_query_args[ 'query' ]
+			]
+		];
+
+		return $es_query_args;
+	}
+
+	public function log_search_es_wp_query_args( $es_wp_query_args, $query ) {
+		error_log( '--- ' . __FUNCTION__ . ' ---' );
+		error_log( $this->var_export( $es_wp_query_args, true ) );
+
+		return $es_wp_query_args;
+	}
+
+	public function log_jetpack_search_abort( $reason ) {
+		error_log( "--- jetpack_search_abort $reason ---" );
+	}
+
+	public function log_did_jetpack_search_query( $query ) {
+		error_log( '--- did_jetpack_search_query ---' );
+		error_log( $this->var_export( $query, true ) );
+	}
+}

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-plugin-search.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-plugin-search.php
@@ -13,7 +13,7 @@ add_filter( 'option_has_jetpack_search_product', '__return_true' );
 class Plugin_Search {
 
 	// Set this to true to disable the new class and use the old jetpack-search.php code.
-	const USE_OLD_SEARCH = true;
+	const USE_OLD_SEARCH = false;
 
 	// Internal state
 	protected $locale;

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/composer.json
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/composer.json
@@ -1,0 +1,9 @@
+{
+	"require-dev": {
+		"wp-phpunit/wp-phpunit": "^5.6"
+	},
+	"scripts": {
+		"test":      "wp-env run phpunit 'phpunit -c /var/www/html/wp-content/plugins/plugin-directory/phpunit.xml --verbose --exclude plugins-api'",
+		"test-slow": "wp-env run phpunit 'phpunit -c /var/www/html/wp-content/plugins/plugin-directory/phpunit.xml --verbose'"
+	}
+}

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/composer.lock
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/composer.lock
@@ -1,0 +1,67 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "b009215aa12b121d476adf3fb4af56a7",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "wp-phpunit/wp-phpunit",
+            "version": "5.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wp-phpunit/wp-phpunit.git",
+                "reference": "5ab77c1e1328e9bee65f60c246e33b13fc202375"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wp-phpunit/wp-phpunit/zipball/5ab77c1e1328e9bee65f60c246e33b13fc202375",
+                "reference": "5ab77c1e1328e9bee65f60c246e33b13fc202375",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "__loaded.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Evan Mattson",
+                    "email": "me@aaemnnost.tv"
+                },
+                {
+                    "name": "WordPress Community",
+                    "homepage": "https://wordpress.org/about/"
+                }
+            ],
+            "description": "WordPress core PHPUnit library",
+            "homepage": "https://github.com/wp-phpunit",
+            "keywords": [
+                "phpunit",
+                "test",
+                "wordpress"
+            ],
+            "support": {
+                "docs": "https://github.com/wp-phpunit/docs",
+                "issues": "https://github.com/wp-phpunit/issues",
+                "source": "https://github.com/wp-phpunit/wp-phpunit"
+            },
+            "time": "2021-03-10T17:57:07+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.0.0"
+}

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/bootstrap.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/bootstrap.php
@@ -2,15 +2,30 @@
 
 namespace WordPressdotorg\Plugin_Directory\Tests;
 
+// Require composer dependencies.
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+
 if ( 'cli' !== php_sapi_name() ) {
 	return;
 }
+
+$_tests_dir = getenv( 'WP_PHPUNIT__DIR' );
+
+// Give access to tests_add_filter() function.
+require_once $_tests_dir . '/includes/functions.php';
+
 
 /**
  * Manually load the plugin being tested.
  */
 function manually_load_plugin() {
 	require_once dirname( __FILE__ ) . '/../plugin-directory.php';
+	// Also load Jetpack, needed to test some features such as search
+	require_once dirname( __FILE__ ) . '/../../jetpack/jetpack.php';
+}
+if ( function_exists( 'tests_add_filter' ) ) {
+	tests_add_filter( 'muplugins_loaded', __NAMESPACE__ . '\manually_load_plugin' );
 }
 
-tests_add_filter( 'muplugins_loaded', __NAMESPACE__ . '\manually_load_plugin' );
+// Start up the WP testing environment.
+require $_tests_dir . '/includes/bootstrap.php';

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/phpunit/tests/api/locale-banner.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/phpunit/tests/api/locale-banner.php
@@ -2,7 +2,7 @@
 
 /**
  *
- * @group api
+ * @group plugins-api
  */
 class Tests_API_Locale_Banner extends WP_UnitTestCase {
 

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/phpunit/tests/api/svn-access.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/phpunit/tests/api/svn-access.php
@@ -2,7 +2,7 @@
 
 /**
  *
- * @group api
+ * @group plugins-api
  */
 class Tests_API_SVN_Access extends WP_UnitTestCase {
 

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/phpunit/tests/wporg-jetpack-search-class-test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/phpunit/tests/wporg-jetpack-search-class-test.php
@@ -1,0 +1,961 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use WordPressdotorg\Plugin_Directory\Plugin_Search;
+
+class TestJetpackSearchClass extends WP_UnitTestCase {
+
+	protected $plugin_search;
+
+	function setUp(): void {
+		if ( is_null( $this->plugin_search ) ) {
+			require_once( ABSPATH . 'wp-content/plugins/jetpack/jetpack.php' );
+			$this->plugin_search = Plugin_Search::instance();
+			$this->plugin_search->init();
+
+
+		}
+
+		if ( !defined( 'WP_CORE_STABLE_BRANCH' ) ) {
+			define( 'WP_CORE_STABLE_BRANCH', '5.0' );
+		}
+	}
+
+	function test_assumptions() {
+		$this->assertTrue( class_exists( 'Jetpack' ) );
+	}
+
+	function var_export($expression, $return=FALSE) {
+		$export = var_export($expression, TRUE);
+		$patterns = [
+			"/array \(/" => '[',
+			"/^([ ]*)\)(,?)$/m" => '$1]$2',
+			"/=>[ ]?\n[ ]+\[/" => '=> [',
+			"/([ ]*)(\'[^\']+\') => ([\[\'])/" => '$1$2 => $3',
+		];
+		$export = preg_replace(array_keys($patterns), array_values($patterns), $export);
+		if ((bool)$return) return $export; else echo $export;
+	}
+
+	public function data_wp_es_to_es_args() {
+		return [
+			[
+				[], // input
+				[
+					'blog_id' => 1,
+					'size' => 10,
+					'query' => [
+					  'filtered' => [
+						'query' => [
+						  'function_score' => [
+							'query' => [
+							  'match_all' => [
+							  ],
+							],
+							'functions' => [
+							  0 => [
+								'exp' => [
+								  'plugin_modified' => [
+									'origin' => 'YYYY-MM-DD',
+									'offset' => '180d',
+									'scale' => '360d',
+									'decay' => 0.5,
+								  ],
+								],
+							  ],
+							  1 => [
+								'exp' => [
+								  'tested' => [
+									'origin' => '5.0',
+									'offset' => 0.1,
+									'scale' => 0.4,
+									'decay' => 0.6,
+								  ],
+								],
+							  ],
+							  2 => [
+								'field_value_factor' => [
+								  'field' => 'active_installs',
+								  'factor' => 0.375,
+								  'modifier' => 'log2p',
+								  'missing' => 1,
+								],
+							  ],
+							  3 => [
+								'filter' => [
+								  'range' => [
+									'active_installs' => [
+									  'lte' => 1000000,
+									],
+								  ],
+								],
+								'exp' => [
+								  'active_installs' => [
+									'origin' => 1000000,
+									'offset' => 0,
+									'scale' => 900000,
+									'decay' => 0.75,
+								  ],
+								],
+							  ],
+							  4 => [
+								'field_value_factor' => [
+								  'field' => 'support_threads_resolved',
+								  'factor' => 0.25,
+								  'modifier' => 'log2p',
+								  'missing' => 0.5,
+								],
+							  ],
+							  5 => [
+								'field_value_factor' => [
+								  'field' => 'rating',
+								  'factor' => 0.25,
+								  'modifier' => 'sqrt',
+								  'missing' => 2.5,
+								],
+							  ],
+							],
+							'boost_mode' => 'multiply',
+						  ],
+						],
+					  ],
+					],
+					'sort' => [
+					  0 => [
+						'date' => [
+						  'order' => 'desc',
+						],
+					  ],
+					],
+					'filter' => [
+					  'match_all' =>
+					   [
+					  ],
+					],
+				]
+			],
+			[
+				[
+					'query'          => 'an example search',
+					'posts_per_page' => 27,
+					'paged'          => 2,
+					'orderby'        => '',
+					'order'          => '',
+					'filters'        => array(
+						array( 'term' => array( 'disabled' => array( 'value' => false ) ) ),
+					)
+				],
+				[
+					'blog_id' => 1,
+					'size' => 27,
+					'from' => 27,
+					'query' => [
+					  'filtered' => [
+						'query' => [
+						  'function_score' => [
+							'query' => [
+							  'bool' => [
+								'must' => [
+								  'multi_match' => [
+									'query' => 'an example search',
+									'fields' => [
+									  0 => 'all_content_en',
+									],
+									'boost' => 0.1,
+									'operator' => 'and',
+								  ],
+								],
+								'should' => [
+								  0 => [
+									'multi_match' => [
+									  'query' => 'an example search',
+									  'fields' => [
+										0 => 'title_en',
+										1 => 'excerpt_en',
+										2 => 'description_en^1',
+										3 => 'taxonomy.plugin_tags.name',
+									  ],
+									  'type' => 'phrase',
+									  'boost' => 2,
+									],
+								  ],
+								  1 => [
+									'multi_match' => [
+									  'query' => 'an example search',
+									  'fields' => [
+										0 => 'title_en.ngram',
+									  ],
+									  'type' => 'phrase',
+									  'boost' => 0.2,
+									],
+								  ],
+								  2 => [
+									'multi_match' => [
+									  'query' => 'an example search',
+									  'fields' => [
+										0 => 'title_en',
+										1 => 'slug_text',
+									  ],
+									  'type' => 'best_fields',
+									  'boost' => 2,
+									],
+								  ],
+								  3 => [
+									'multi_match' => [
+									  'query' => 'an example search',
+									  'fields' => [
+										0 => 'excerpt_en',
+										1 => 'description_en^1',
+										2 => 'taxonomy.plugin_tags.name',
+									  ],
+									  'type' => 'best_fields',
+									  'boost' => 2,
+									],
+								  ],
+								  4 => [
+									'multi_match' => [
+									  'query' => 'an example search',
+									  'fields' => [
+										0 => 'author',
+										1 => 'contributors',
+									  ],
+									  'type' => 'best_fields',
+									  'boost' => 2,
+									],
+								  ],
+								],
+							  ],
+							],
+							'functions' => [
+							  0 => [
+								'exp' => [
+								  'plugin_modified' => [
+									'origin' => 'YYYY-MM-DD',
+									'offset' => '180d',
+									'scale' => '360d',
+									'decay' => 0.5,
+								  ],
+								],
+							  ],
+							  1 => [
+								'exp' => [
+								  'tested' => [
+									'origin' => '5.0',
+									'offset' => 0.1,
+									'scale' => 0.4,
+									'decay' => 0.6,
+								  ],
+								],
+							  ],
+							  2 => [
+								'field_value_factor' => [
+								  'field' => 'active_installs',
+								  'factor' => 0.375,
+								  'modifier' => 'log2p',
+								  'missing' => 1,
+								],
+							  ],
+							  3 => [
+								'filter' => [
+								  'range' => [
+									'active_installs' => [
+									  'lte' => 1000000,
+									],
+								  ],
+								],
+								'exp' => [
+								  'active_installs' => [
+									'origin' => 1000000,
+									'offset' => 0,
+									'scale' => 900000,
+									'decay' => 0.75,
+								  ],
+								],
+							  ],
+							  4 => [
+								'field_value_factor' => [
+								  'field' => 'support_threads_resolved',
+								  'factor' => 0.25,
+								  'modifier' => 'log2p',
+								  'missing' => 0.5,
+								],
+							  ],
+							  5 => [
+								'field_value_factor' => [
+								  'field' => 'rating',
+								  'factor' => 0.25,
+								  'modifier' => 'sqrt',
+								  'missing' => 2.5,
+								],
+							  ],
+							],
+							'boost_mode' => 'multiply',
+						  ],
+						],
+					  ],
+					],
+					'sort' => [
+					  0 => [
+						'_score' => [
+						  'order' => 'desc',
+						],
+					  ],
+					],
+					'filter' => [
+					  'and' => [
+						0 => [
+						  'term' => [
+							'disabled' => [
+							  'value' => false,
+							],
+						  ],
+						],
+					  ],
+					],
+				]
+			],
+
+		];
+	}
+
+	public function normalize_es_arg_callback( &$item, $key ) {
+		// Change an empty object to an array, because assertSame rejects equivalent objects
+		if ( 'match_all' === $key && is_object( $item ) ) {
+			$item = [];
+		}
+		// Mask any dates
+		if ( is_string( $item ) && preg_match( '/^\d\d\d\d-\d\d-\d\d$/', $item ) ) {
+			$item = 'YYYY-MM-DD';
+		}
+
+	}
+	public function normalize_es_args( $args ) {
+		array_walk_recursive( $args, [ $this, 'normalize_es_arg_callback' ] );
+		#ksort( $args );
+		return $args;
+	}
+
+	/**
+	 * @dataProvider data_wp_es_to_es_args
+	 * Note: doesn't actually require the function. This test only makes sense with the old class, and filter__posts_request is a way to detect it.
+	 * @requires function Jetpack_Search::filter__posts_request
+	 */
+	public function test_convert_wp_es_to_es_args( $input, $expected ) {
+		$actual = Jetpack_Search::instance()->convert_wp_es_to_es_args( $input );
+
+		$this->assertSame( $this->normalize_es_args( $expected ), $this->normalize_es_args( $actual ) );
+
+	}
+
+
+	public function test_filter__posts_request() {
+		$search = $this->getMockBuilder( Jetpack_Search::class )->disableOriginalConstructor()->setMethods( ['search'] )->getMock();
+
+		// This is what should get passed to the Jetpack_Search::search() function.
+		$expects_args = [
+			'blog_id' => 1,
+			'size' => 10,
+			'from' => 0,
+			'query' => [
+			  'filtered' => [
+				'query' => [
+				  'function_score' => [
+					'query' => [
+					  'bool' => [
+						'must' => [
+						  'multi_match' => [
+							'query' => 'a test search',
+							'fields' => [
+							  0 => 'all_content_en',
+							],
+							'boost' => 0.1,
+							'operator' => 'and',
+						  ],
+						],
+						'should' => [
+						  0 => [
+							'multi_match' => [
+							  'query' => 'a test search',
+							  'fields' => [
+								0 => 'title_en',
+								1 => 'excerpt_en',
+								2 => 'description_en^1',
+								3 => 'taxonomy.plugin_tags.name',
+							  ],
+							  'type' => 'phrase',
+							  'boost' => 2,
+							],
+						  ],
+						  1 => [
+							'multi_match' => [
+							  'query' => 'a test search',
+							  'fields' => [
+								0 => 'title_en.ngram',
+							  ],
+							  'type' => 'phrase',
+							  'boost' => 0.2,
+							],
+						  ],
+						  2 => [
+							'multi_match' => [
+							  'query' => 'a test search',
+							  'fields' => [
+								0 => 'title_en',
+								1 => 'slug_text',
+							  ],
+							  'type' => 'best_fields',
+							  'boost' => 2,
+							],
+						  ],
+						  3 => [
+							'multi_match' => [
+							  'query' => 'a test search',
+							  'fields' => [
+								0 => 'excerpt_en',
+								1 => 'description_en^1',
+								2 => 'taxonomy.plugin_tags.name',
+							  ],
+							  'type' => 'best_fields',
+							  'boost' => 2,
+							],
+						  ],
+						  4 => [
+							'multi_match' => [
+							  'query' => 'a test search',
+							  'fields' => [
+								0 => 'author',
+								1 => 'contributors',
+							  ],
+							  'type' => 'best_fields',
+							  'boost' => 2,
+							],
+						  ],
+						],
+					  ],
+					],
+					'functions' => [
+					  0 => [
+						'exp' => [
+						  'plugin_modified' => [
+							'origin' => date('Y-m-d'),
+							'offset' => '180d',
+							'scale' => '360d',
+							'decay' => 0.5,
+						  ],
+						],
+					  ],
+					  1 => [
+						'exp' => [
+						  'tested' => [
+							'origin' => '5.0',
+							'offset' => 0.1,
+							'scale' => 0.4,
+							'decay' => 0.6,
+						  ],
+						],
+					  ],
+					  2 => [
+						'field_value_factor' => [
+						  'field' => 'active_installs',
+						  'factor' => 0.375,
+						  'modifier' => 'log2p',
+						  'missing' => 1,
+						],
+					  ],
+					  3 => [
+						'filter' => [
+						  'range' => [
+							'active_installs' => [
+							  'lte' => 1000000,
+							],
+						  ],
+						],
+						'exp' => [
+						  'active_installs' => [
+							'origin' => 1000000,
+							'offset' => 0,
+							'scale' => 900000,
+							'decay' => 0.75,
+						  ],
+						],
+					  ],
+					  4 => [
+						'field_value_factor' => [
+						  'field' => 'support_threads_resolved',
+						  'factor' => 0.25,
+						  'modifier' => 'log2p',
+						  'missing' => 0.5,
+						],
+					  ],
+					  5 => [
+						'field_value_factor' => [
+						  'field' => 'rating',
+						  'factor' => 0.25,
+						  'modifier' => 'sqrt',
+						  'missing' => 2.5,
+						],
+					  ],
+					],
+					'boost_mode' => 'multiply',
+				  ],
+				],
+			  ],
+			],
+			'sort' => [
+			  0 => [
+				'_score' => [
+				  'order' => 'desc',
+				],
+			  ],
+			],
+			'filter' => [
+			  'and' => [
+				0 => [
+				  'term' => [
+					'disabled' => [
+					  'value' => false,
+					],
+				  ],
+				],
+			  ],
+			],
+			'fields' => [
+			  0 => 'slug',
+			  1 => 'post_id',
+			  2 => 'blog_id',
+			],
+		];
+
+		$search->expects( $this->once() )->method( 'search' )->with( $this->equalTo( $expects_args ) );
+
+		// Construct a simple search query
+		$query = new WP_Query( [ 's' => 'a test search' ] );
+		global $wp_the_query;
+		$wp_the_query = $query; // so is_main_query() is true, otherwise the filter will short-circuit.
+
+		// Manually call the filter function, which should satisfy the expects() condition above.
+		if ( method_exists( $search, 'filter__posts_pre_query' ) ) {
+			$out = $search->filter__posts_pre_query( $query->request, $query );
+		} else {
+			$out = $search->filter__posts_request( $query->request, $query );
+		}
+
+	}
+
+	public function test_filter__posts_request_locale() {
+		$search = $this->getMockBuilder( Jetpack_Search::class )->disableOriginalConstructor()->setMethods( ['search'] )->getMock();
+
+		// This is what should get passed to the Jetpack_Search::search() function.
+		$expects_args = [
+			'blog_id' => 1,
+			'size' => 10,
+			'from' => 0,
+			'query' => [
+			  'filtered' => [
+				'query' => [
+				  'function_score' => [
+					'query' => [
+					  'bool' => [
+						'must' => [
+						  'multi_match' => [
+							'query' => 'una búsqueda de locale',
+							'fields' => [
+							  0 => 'all_content_es',
+							  1 => 'all_content_en^1.0E-5',
+							],
+							'boost' => 0.1,
+							'operator' => 'and',
+						  ],
+						],
+						'should' => [
+						  0 => [
+							'multi_match' => [
+							  'query' => 'una búsqueda de locale',
+							  'fields' => [
+								0 => 'title_es',
+								1 => 'excerpt_es',
+								2 => 'description_es^1',
+								3 => 'title_en^1.0E-5',
+								4 => 'excerpt_en^1.0E-5',
+								5 => 'description_en^1.0E-5',
+								6 => 'taxonomy.plugin_tags.name',
+							  ],
+							  'type' => 'phrase',
+							  'boost' => 2,
+							],
+						  ],
+						  1 => [
+							'multi_match' => [
+							  'query' => 'una búsqueda de locale',
+							  'fields' => [
+								0 => 'title_es.ngram',
+								1 => 'title_en.ngram^1.0E-5',
+							  ],
+							  'type' => 'phrase',
+							  'boost' => 0.2,
+							],
+						  ],
+						  2 => [
+							'multi_match' => [
+							  'query' => 'una búsqueda de locale',
+							  'fields' => [
+								0 => 'title_es',
+								1 => 'title_en^1.0E-5',
+								2 => 'slug_text',
+							  ],
+							  'type' => 'best_fields',
+							  'boost' => 2,
+							],
+						  ],
+						  3 => [
+							'multi_match' => [
+							  'query' => 'una búsqueda de locale',
+							  'fields' => [
+								0 => 'excerpt_es',
+								1 => 'description_es^1',
+								2 => 'excerpt_en^1.0E-5',
+								3 => 'description_en^1.0E-5',
+								4 => 'taxonomy.plugin_tags.name',
+							  ],
+							  'type' => 'best_fields',
+							  'boost' => 2,
+							],
+						  ],
+						  4 => [
+							'multi_match' => [
+							  'query' => 'una búsqueda de locale',
+							  'fields' => [
+								0 => 'author',
+								1 => 'contributors',
+							  ],
+							  'type' => 'best_fields',
+							  'boost' => 2,
+							],
+						  ],
+						],
+					  ],
+					],
+					'functions' => [
+					  0 => [
+						'exp' => [
+						  'plugin_modified' => [
+							'origin' => date('Y-m-d'),
+							'offset' => '180d',
+							'scale' => '360d',
+							'decay' => 0.5,
+						  ],
+						],
+					  ],
+					  1 => [
+						'exp' => [
+						  'tested' => [
+							'origin' => '5.0',
+							'offset' => 0.1,
+							'scale' => 0.4,
+							'decay' => 0.6,
+						  ],
+						],
+					  ],
+					  2 => [
+						'field_value_factor' => [
+						  'field' => 'active_installs',
+						  'factor' => 0.375,
+						  'modifier' => 'log2p',
+						  'missing' => 1,
+						],
+					  ],
+					  3 => [
+						'filter' => [
+						  'range' => [
+							'active_installs' => [
+							  'lte' => 1000000,
+							],
+						  ],
+						],
+						'exp' => [
+						  'active_installs' => [
+							'origin' => 1000000,
+							'offset' => 0,
+							'scale' => 900000,
+							'decay' => 0.75,
+						  ],
+						],
+					  ],
+					  4 => [
+						'field_value_factor' => [
+						  'field' => 'support_threads_resolved',
+						  'factor' => 0.25,
+						  'modifier' => 'log2p',
+						  'missing' => 0.5,
+						],
+					  ],
+					  5 => [
+						'field_value_factor' => [
+						  'field' => 'rating',
+						  'factor' => 0.25,
+						  'modifier' => 'sqrt',
+						  'missing' => 2.5,
+						],
+					  ],
+					],
+					'boost_mode' => 'multiply',
+				  ],
+				],
+			  ],
+			],
+			'sort' => [
+			  0 => [
+				'_score' => [
+				  'order' => 'desc',
+				],
+			  ],
+			],
+			'filter' => [
+			  'and' => [
+				0 => [
+				  'term' => [
+					'disabled' => [
+					  'value' => false,
+					],
+				  ],
+				],
+			  ],
+			],
+			'fields' => [
+			  0 => 'slug',
+			  1 => 'post_id',
+			  2 => 'blog_id',
+			],
+		];
+
+
+		$search->expects( $this->once() )->method( 'search' )->with( $this->equalTo( $expects_args ) );
+
+		// Set the locale to Spanish
+		global $locale;
+		$locale = 'es';
+
+		// Construct a simple search query
+		$query = new WP_Query( [ 's' => 'una búsqueda de locale' ] );
+		global $wp_the_query;
+		$wp_the_query = $query; // so is_main_query() is true, otherwise the filter will short-circuit.
+
+		// Manually call the filter function, which should satisfy the expects() condition above.
+		if ( method_exists( $search, 'filter__posts_pre_query' ) ) {
+			$out = $search->filter__posts_pre_query( $query->request, $query );
+		} else {
+			$out = $search->filter__posts_request( $query->request, $query );
+		}
+
+	}
+
+	public function test_filter__posts_request_block() {
+		$search = $this->getMockBuilder( Jetpack_Search::class )->disableOriginalConstructor()->setMethods( ['search'] )->getMock();
+
+		// This is what should get passed to the Jetpack_Search::search() function.
+		$expects_args = [
+			'blog_id' => 1,
+			'size' => 10,
+			'from' => 0,
+			'query' => [
+			  'filtered' => [
+				'query' => [
+				  'function_score' => [
+					'query' => [
+					  'bool' => [
+						'must' => [
+						  'multi_match' => [
+							'query' => 'my/block',
+							'fields' => [
+							  0 => 'all_content_es',
+							  1 => 'all_content_en^1.0E-5',
+							],
+							'boost' => 0.1,
+							'operator' => 'and',
+						  ],
+						],
+						'should' => [
+						  0 => [
+							'multi_match' => [
+							  'query' => 'my/block',
+							  'fields' => [
+								0 => 'title_es',
+								1 => 'excerpt_es',
+								2 => 'description_es^0.05',
+								3 => 'title_en^1.0E-5',
+								4 => 'excerpt_en^1.0E-5',
+								5 => 'description_en^5.0E-7',
+								6 => 'taxonomy.plugin_tags.name',
+							  ],
+							  'type' => 'phrase',
+							  'boost' => 2,
+							],
+						  ],
+						  1 => [
+							'multi_match' => [
+							  'query' => 'my/block',
+							  'fields' => [
+								0 => 'title_es.ngram',
+								1 => 'title_en.ngram^1.0E-5',
+							  ],
+							  'type' => 'phrase',
+							  'boost' => 0.2,
+							],
+						  ],
+						  2 => [
+							'multi_match' => [
+							  'query' => 'my/block',
+							  'fields' => [
+								0 => 'title_es',
+								1 => 'title_en^1.0E-5',
+								2 => 'slug_text',
+							  ],
+							  'type' => 'best_fields',
+							  'boost' => 2,
+							],
+						  ],
+						  3 => [
+							'multi_match' => [
+							  'query' => 'my/block',
+							  'fields' => [
+								0 => 'excerpt_es',
+								1 => 'description_es^0.05',
+								2 => 'excerpt_en^1.0E-5',
+								3 => 'description_en^5.0E-7',
+								4 => 'taxonomy.plugin_tags.name',
+							  ],
+							  'type' => 'best_fields',
+							  'boost' => 2,
+							],
+						  ],
+						  4 => [
+							'multi_match' => [
+							  'query' => 'my/block',
+							  'fields' => [
+								0 => 'author',
+								1 => 'contributors',
+							  ],
+							  'type' => 'best_fields',
+							  'boost' => 2,
+							],
+						  ],
+						],
+					  ],
+					],
+					'functions' => [
+					  0 => [
+						'exp' => [
+						  'plugin_modified' => [
+							'origin' => date('Y-m-d'),
+							'offset' => '180d',
+							'scale' => '360d',
+							'decay' => 0.5,
+						  ],
+						],
+					  ],
+					  1 => [
+						'exp' => [
+						  'tested' => [
+							'origin' => '5.0',
+							'offset' => 0.1,
+							'scale' => 0.4,
+							'decay' => 0.6,
+						  ],
+						],
+					  ],
+					  2 => [
+						'field_value_factor' => [
+						  'field' => 'active_installs',
+						  'factor' => 0.375,
+						  'modifier' => 'log2p',
+						  'missing' => 1,
+						],
+					  ],
+					  3 => [
+						'filter' => [
+						  'range' => [
+							'active_installs' => [
+							  'lte' => 1000000,
+							],
+						  ],
+						],
+						'exp' => [
+						  'active_installs' => [
+							'origin' => 1000000,
+							'offset' => 0,
+							'scale' => 900000,
+							'decay' => 0.75,
+						  ],
+						],
+					  ],
+					  4 => [
+						'field_value_factor' => [
+						  'field' => 'support_threads_resolved',
+						  'factor' => 0.25,
+						  'modifier' => 'log2p',
+						  'missing' => 0.5,
+						],
+					  ],
+					  5 => [
+						'field_value_factor' => [
+						  'field' => 'rating',
+						  'factor' => 0.25,
+						  'modifier' => 'sqrt',
+						  'missing' => 2.5,
+						],
+					  ],
+					],
+					'boost_mode' => 'multiply',
+				  ],
+				],
+			  ],
+			],
+			'sort' => [
+			  0 => [
+				'_score' => [
+				  'order' => 'desc',
+				],
+			  ],
+			],
+			'filter' => [
+			  'and' => [
+				0 => [
+				  'term' => [
+					'disabled' => [
+					  'value' => false,
+					],
+				  ],
+				],
+				1 => [
+				  'term' => [
+					'taxonomy.plugin_section.name' => [
+					  'value' => 'block',
+					],
+				  ],
+				],
+			  ],
+			],
+			'fields' => [
+			  0 => 'slug',
+			  1 => 'post_id',
+			  2 => 'blog_id',
+			],
+		];
+
+
+		$search->expects( $this->once() )->method( 'search' )->with( $this->equalTo( $expects_args ) );
+
+		// Construct a block search query
+		$query = new WP_Query( [ 's' => 'my/block', 'block_search' => true ] );
+		global $wp_the_query;
+		$wp_the_query = $query; // so is_main_query() is true, otherwise the filter will short-circuit.
+
+		// Manually call the filter function, which should satisfy the expects() condition above.
+		if ( method_exists( $search, 'filter__posts_pre_query' ) ) {
+			$out = $search->filter__posts_pre_query( $query->request, $query );
+		} else {
+			$out = $search->filter__posts_request( $query->request, $query );
+		}
+
+	}
+}

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/phpunit/tests/wporg-url-schemes.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/phpunit/tests/wporg-url-schemes.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @group plugins-api
+ */
 class TestUrlSchemes extends WP_UnitTestCase {
 
 	function http_get( $uri ) {


### PR DESCRIPTION
This replaces the old, hacked-up jetpack-search.php class with a new Plugin_Search class that uses filters to interact with the Jetpack_Search class in the currently installed version of the Jetpack plugin.

The Plugin_Search class has a constant that can be used to switch between the old and new search. Theoretically they should produce the same search results.

There are unit tests that can be run like this:

```
composer install
wp-env start
composer test
```

The tests will respect the `USE_OLD_SEARCH` constant, so they can be used to test against both the old and new search classes. This is how I confirmed that the new search works more-or-less the same.

I've also tested the basics manually on my sandbox, but not extensively. It seems to work ok. If there's a serious problem it's most likely that I've missed something in copying stuff into this PR.

Some notes for the Jetpack search folks:

It seems that the `jetpack_search_es_wp_query_args` hook is the preferred way for a plugin to interact with and customize Jetpack_Search's behaviour. I've done that where possible, but since `convert_wp_es_to_es_args()` is very limited and particular about what parameters it accepts I had to resort to filtering and altering the query at a lower level, via `jetpack_search_es_query_args`. See the `jetpack_search_es_wp_query_args()` and `jetpack_search_es_query_args()` for examples.

The plugin directory is a very specific use case that's probably right on the edge. But there are likely some ideas to be found in there that might be worth moving upstream, to make it possible to use the higher-lever filter instead.