### PR TITLE
Enhance social images for plugins on Twitter and Facebook

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins/functions.php
@@ -360,10 +360,10 @@ function social_meta_data() {
 		// Set to banner-772x250.
 		$image = $banner['banner'];
 	} elseif ( ! $icon['generated'] && ( $icon['icon_2x'] ) ) {
-		// Set to icon256x256.
+		// Set to icon-256x256.
 		$image = $icon['icon_2x'];
 	} elseif ( ! $icon['generated'] && ( $icon['icon'] ) ) {
-		// Set to icon128x128.
+		// Set to icon-128x128.
 		$image = $icon['icon'];
 	} else {
 		// Fallback to WordPress logo.

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins/functions.php
@@ -349,8 +349,26 @@ function social_meta_data() {
 	$icon   = Template::get_plugin_icon();
 	$banner = Template::get_plugin_banner();
 
-	$banner['banner']    = $banner['banner'] ?? false;
-	$banner['banner_2x'] = $banner['banner_2x'] ?? false;
+	/*
+	 * Set social image for both twitter:image and og:image in this priority:
+	 * 2x banner, 1x banner, 2x icon, 1x icon, WordPress logo.
+	 */
+	if ( $banner['banner_2x'] ) {
+		// Set to banner-1544x500.
+		$image = $banner['banner_2x'];
+	} elseif ( $banner['banner'] ) {
+		// Set to banner-772x250.
+		$image = $banner['banner'];
+	} elseif ( ! $icon['generated'] && ( $icon['icon_2x'] ) ) {
+		// Set to icon256x256.
+		$image = $icon['icon_2x'];
+	} elseif ( ! $icon['generated'] && ( $icon['icon'] ) ) {
+		// Set to icon128x128.
+		$image = $icon['icon'];
+	} else {
+		// Fallback to WordPress logo.
+		$image = dirname( __FILE__ ) . '/images/wp-logo-blue.png';
+	}
 
 	printf( '<meta property="og:title" content="%s" />' . "\n", the_title_attribute( array( 'echo' => false ) ) );
 	printf( '<meta property="og:description" content="%s" />' . "\n", esc_attr( strip_tags( get_the_excerpt() ) ) );
@@ -358,15 +376,11 @@ function social_meta_data() {
 	printf( '<meta property="og:site_name" content="%s" />' . "\n", esc_attr( $wporg_global_header_options['rosetta_title'] ?? 'WordPress.org' ) );
 	printf( '<meta property="og:type" content="website" />' . "\n" );
 	printf( '<meta property="og:url" content="%s" />' . "\n", esc_url( get_permalink() ) );
-	printf( '<meta name="twitter:card" content="summary_large_image">' . "\n" );
+	printf( '<meta name="twitter:card" content="%s">' . "\n", esc_attr( $banner['banner_2x'] || $banner['banner'] ? 'summary_large_image' : 'summary' ) );
 	printf( '<meta name="twitter:site" content="@WordPress">' . "\n" );
+	printf( '<meta name="twitter:image" content="%s" />' . "\n", esc_url( $image ) );
+	printf( '<meta property="og:image" content="%s" />' . "\n", esc_url( $image ) );
 
-	if ( $banner['banner_2x'] ) {
-		printf( '<meta name="twitter:image" content="%s" />' . "\n", esc_url( $banner['banner_2x'] ) );
-	}
-	if ( $banner['banner'] ) {
-		printf( '<meta property="og:image" content="%s" />' . "\n", esc_url( $banner['banner'] ) );
-	}
 	if ( ! $icon['generated'] && ( $icon['icon_2x'] || $icon['icon'] ) ) {
 		printf( '<meta name="thumbnail" content="%s" />' . "\n", esc_url( $icon['icon_2x'] ?: $icon['icon'] ) );
 	}


### PR DESCRIPTION
 The Twitter cart type should depend on the available images and image ratio:

- If banner (**2x** or **1x**) exist: Set Twitter card type to `"summary_large_image"`
- If banner don't exist: Fallback to Twitter card type `"summary"` to print a small square image (plugin icon or WordPress logo) 

For the image itself, probably it will be ok to include the **1x banner** for Twitter if there is no **2x banner**, and also probably it will be better to include the **2x banner** for Facebook in the first place.
So I suggest the same logic for both Twitter and Facebook:

- If banner exist: Use it for `twitter:image` and `og:image` (**2x** with fallback to **1x**)
- If only icon exist: Use it for `twitter:image` and `og:image` (**2x** with fallback to **1x**)
- If none exist: Fallback to WordPress square logo for `twitter:image` and `og:image `

https://meta.trac.wordpress.org/ticket/5826