### PR TITLE
Theme Directory: Display theme upload errors as list.

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
@@ -393,7 +393,7 @@ class WPORG_Themes_Upload {
 		}
 
 		// If we had any issues with information in the style.css, exit early.
-		if( !empty( $style_errors ) ) {
+		if ( ! empty( $style_errors ) ) {
 			return $style_errors;
 		}
 

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
@@ -187,7 +187,7 @@ class WPORG_Themes_Upload {
 			);
 		}
 
-		$style_errors = [];
+		$style_errors = array();
 
 		// Do we have a readme.txt? Fetch extra data from there too.
 		$this->readme = $this->get_readme_data( $theme_files );
@@ -198,7 +198,7 @@ class WPORG_Themes_Upload {
 		// We need a screen shot. People love screen shots.
 		if ( ! $this->has_screenshot( $theme_files ) ) {
 			/* translators: 1: screenshot.png, 2: screenshot.jpg */
-			array_push( $style_errors, sprintf( __( 'The zip file must include a file named %1$s or %2$s.', 'wporg-themes' ),
+			$style_errors[] = sprintf( __( 'The zip file must include a file named %1$s or %2$s.', 'wporg-themes' ),
 				'<code>screenshot.png</code>',
 				'<code>screenshot.jpg</code>'
 			);
@@ -225,16 +225,16 @@ class WPORG_Themes_Upload {
 				__( 'https://codex.wordpress.org/Theme_Development#Theme_Stylesheet', 'wporg-themes' )
 			);
 
-			array_push( $style_errors, $error );
+			$style_errors[] = $error;
 		}
 
 		// Do not allow themes with WordPress and Theme in the theme name.
 		if ( false !== strpos( $this->theme_slug, 'wordpress' ) || preg_match( '/\btheme\b/i', $this->theme_slug ) ) {
 			/* translators: 1: 'WordPress', 2: 'theme' */
-			array_push( $style_errors, sprintf( __( 'You cannot use %1$s or %2$s in your theme name.', 'wporg-themes' ),
+			$style_errors[] = sprintf( __( 'You cannot use %1$s or %2$s in your theme name.', 'wporg-themes' ),
 				'WordPress',
 				'theme'
-			) );
+			);
 		}
 
 		// Populate author.
@@ -244,10 +244,10 @@ class WPORG_Themes_Upload {
 		// This check must be run before `get_theme_post()` to account for "twenty" themes.
 		if ( $this->has_reserved_slug() ) {
 			/* translators: 1: theme slug, 2: style.css */
-			array_push( $style_errors, sprintf( __( 'Sorry, the theme name %1$s is reserved for use by WordPress Core. Please change the name of your theme in %2$s and upload it again.', 'wporg-themes' ),
+			$style_errors[] = sprintf( __( 'Sorry, the theme name %1$s is reserved for use by WordPress Core. Please change the name of your theme in %2$s and upload it again.', 'wporg-themes' ),
 				'<code>' . $this->theme_slug . '</code>',
 				'<code>style.css</code>'
-			) );
+			);
 		}
 
 		// Populate the theme post.
@@ -264,7 +264,7 @@ class WPORG_Themes_Upload {
 				__( 'https://codex.wordpress.org/Theme_Development#Theme_Stylesheet', 'wporg-themes' )
 			);
 
-			array_push( $style_errors, $error );
+			$style_errors[] = $error;
 		}
 
 		if ( ! $this->theme->get( 'Tags' ) ) {
@@ -277,7 +277,7 @@ class WPORG_Themes_Upload {
 				__( 'https://codex.wordpress.org/Theme_Development#Theme_Stylesheet', 'wporg-themes' )
 			);
 
-			array_push( $style_errors, $error );
+			$style_errors[] = $error;
 		}
 
 		if ( ! $this->theme->get( 'Version' ) ) {
@@ -290,7 +290,7 @@ class WPORG_Themes_Upload {
 				__( 'https://codex.wordpress.org/Theme_Development#Theme_Stylesheet', 'wporg-themes' )
 			);
 
-			array_push( $style_errors, $error );
+			$style_errors[] = $error;
 
 		} else if ( preg_match( '|[^\d\.]|', $this->theme->get( 'Version' ) ) ) {
 			/* translators: %s: style.css */
@@ -305,15 +305,15 @@ class WPORG_Themes_Upload {
 		$themeuri = $this->theme->get( 'ThemeURI' );
 		$authoruri = $this->theme->get( 'AuthorURI' );
 		if ( !empty( $themeuri ) && !empty( $authoruri ) && $themeuri == $authoruri ) {
-			array_push( $style_errors, __( 'Duplicate theme and author URLs. A theme URL is a page/site that provides details about this specific theme. An author URL is a page/site that provides information about the author of the theme. You aren&rsquo;t required to provide both, so pick the one that best applies to your URL.', 'wporg-themes' ) );
+			$style_errors[] = __( 'Duplicate theme and author URLs. A theme URL is a page/site that provides details about this specific theme. An author URL is a page/site that provides information about the author of the theme. You aren&rsquo;t required to provide both, so pick the one that best applies to your URL.', 'wporg-themes' );
 		}
 
 		// Check for child theme's parent in the directory (non-buddypress only)
 		if ( $this->theme->parent() && ! in_array( 'buddypress', $this->theme->get( 'Tags' ) ) && ! $this->is_parent_available() ) {
 			/* translators: %s: parent theme */
-			array_push( $style_errors, sprintf( __( 'There is no theme called %s in the directory. For child themes, you must use a parent theme that already exists in the directory.', 'wporg-themes' ),
+			$style_errors[] = sprintf( __( 'There is no theme called %s in the directory. For child themes, you must use a parent theme that already exists in the directory.', 'wporg-themes' ),
 				'<code>' . $this->theme->parent() . '</code>'
-			) );
+			);
 		}
 
 		// Generic text to suggest "Are you in the right place?"
@@ -342,10 +342,10 @@ class WPORG_Themes_Upload {
 
 			if ( ! $is_allowed_to_upload_for_theme ) {
 				/* translators: 1: theme slug, 2: style.css */
-				array_push( $style_errors, sprintf( __( 'There is already a theme called %1$s by a different author. Please change the name of your theme in %2$s and upload it again.', 'wporg-themes' ),
+				$style_errors[] = sprintf( __( 'There is already a theme called %1$s by a different author. Please change the name of your theme in %2$s and upload it again.', 'wporg-themes' ),
 					'<code>' . $this->theme_slug . '</code>',
 					'<code>style.css</code>'
-				) . $are_you_in_the_right_place );
+				) . $are_you_in_the_right_place;
 			}
 		}
 
@@ -365,31 +365,31 @@ class WPORG_Themes_Upload {
 			$theme_owners = wp_list_pluck( $theme_uri_matches, 'post_author' );
 
 			if ( $theme_owners && ! in_array( $this->author->ID, $theme_owners ) ) {
-				array_push( $style_errors, sprintf(
+				$style_errors[] = sprintf(
 					/* translators: 1: theme name, 2: style.css */
 					__( 'There is already a theme using the Theme URL %1$s by a different author. Please check the URL of your theme in %2$s and upload it again.', 'wporg-themes' ),
 					'<code>' . esc_html( $themeuri ) . '</code>',
 					'<code>style.css</code>'
-				) . $are_you_in_the_right_place );
+				) . $are_you_in_the_right_place;
 			}
 		}
 
 		// We know it's the correct author, now we can check if it's suspended.
 		if ( ! empty( $this->theme_post ) && 'suspend' === $this->theme_post->post_status ) {
 			/* translators: %s: mailto link */
-			array_push( $style_errors, sprintf( __( 'This theme is suspended from the Theme Repository and it can&rsquo;t be updated. If you have any questions about this please contact %s.', 'wporg-themes' ),
+			$style_errors[] = sprintf( __( 'This theme is suspended from the Theme Repository and it can&rsquo;t be updated. If you have any questions about this please contact %s.', 'wporg-themes' ),
 				'<a href="mailto:themes@wordpress.org">themes@wordpress.org</a>'
-			) );
+			);
 		}
 
 		// Make sure we have version that is higher than any previously uploaded version of this theme. This check happens last to allow the non-author blocks to kick in.
 		if ( ! empty( $this->theme_post ) && ! version_compare( $this->theme->get( 'Version' ), $this->theme_post->max_version, '>' ) ) {
 			/* translators: 1: theme name, 2: theme version, 3: style.css */
-			array_push( $style_errors, sprintf( __( 'You need to upload a version of %1$s higher than %2$s. Increase the theme version number in %3$s, then upload your zip file again.', 'wporg-themes' ),
+			$style_errors[] = sprintf( __( 'You need to upload a version of %1$s higher than %2$s. Increase the theme version number in %3$s, then upload your zip file again.', 'wporg-themes' ),
 				$this->theme->display( 'Name' ),
 				'<code>' . $this->theme_post->max_version . '</code>',
 				'<code>style.css</code>'
-			) );
+			);
 		}
 
 		// If we had any issues with information in the style.css, exit early.

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
@@ -294,9 +294,9 @@ class WPORG_Themes_Upload {
 
 		} else if ( preg_match( '|[^\d\.]|', $this->theme->get( 'Version' ) ) ) {
 			/* translators: %s: style.css */
-			array_push( $style_errors, sprintf( __( 'Version strings can only contain numeric and period characters (like 1.2). Please fix your Version: line in %s and upload your theme again.', 'wporg-themes' ),
+			$style_errors[] = sprintf( __( 'Version strings can only contain numeric and period characters (like 1.2). Please fix your Version: line in %s and upload your theme again.', 'wporg-themes' ),
 				'<code>style.css</code>'
-			) );
+			);
 		}
 
 		// Version is greater than current version happens after authorship checks.

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
@@ -160,7 +160,7 @@ class WPORG_Themes_Upload {
 	 *
 	 * Runs various tests, creates Trac ticket, repopackage post, and saves the files to the SVN repo.
 	 *
-	 * @return string|array<string> Failure or success message.
+	 * @return mixed Failure or success message.
 	 */
 	public function process_upload( $file_upload ) {
 		$valid_upload = $this->validate_upload( $file_upload );

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
@@ -201,7 +201,7 @@ class WPORG_Themes_Upload {
 			array_push( $style_errors, sprintf( __( 'The zip file must include a file named %1$s or %2$s.', 'wporg-themes' ),
 				'<code>screenshot.png</code>',
 				'<code>screenshot.jpg</code>'
-			) );
+			);
 		}
 
 		// reset the theme directory to be where the stylesheet is

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
@@ -327,7 +327,7 @@ class WPORG_Themes_Upload {
 			);
 
 		// Is there already a theme with the name name by a different author?
-		if ( ! empty( $this->theme_post ) && $this->theme_post->post_author != $this->author->ID  ) {
+		if ( ! empty( $this->theme_post ) && $this->theme_post->post_author != $this->author->ID ) {
 
 			$is_allowed_to_upload_for_theme = false;
 			if (

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
@@ -160,7 +160,7 @@ class WPORG_Themes_Upload {
 	 *
 	 * Runs various tests, creates Trac ticket, repopackage post, and saves the files to the SVN repo.
 	 *
-	 * @return string Failure or success message.
+	 * @return string|array<string> Failure or success message.
 	 */
 	public function process_upload( $file_upload ) {
 		$valid_upload = $this->validate_upload( $file_upload );
@@ -187,6 +187,8 @@ class WPORG_Themes_Upload {
 			);
 		}
 
+		$style_errors = [];
+
 		// Do we have a readme.txt? Fetch extra data from there too.
 		$this->readme = $this->get_readme_data( $theme_files );
 
@@ -196,10 +198,10 @@ class WPORG_Themes_Upload {
 		// We need a screen shot. People love screen shots.
 		if ( ! $this->has_screenshot( $theme_files ) ) {
 			/* translators: 1: screenshot.png, 2: screenshot.jpg */
-			return sprintf( __( 'The zip file must include a file named %1$s or %2$s.', 'wporg-themes' ),
+			array_push( $style_errors, sprintf( __( 'The zip file must include a file named %1$s or %2$s.', 'wporg-themes' ),
 				'<code>screenshot.png</code>',
 				'<code>screenshot.jpg</code>'
-			);
+			) );
 		}
 
 		// reset the theme directory to be where the stylesheet is
@@ -223,16 +225,16 @@ class WPORG_Themes_Upload {
 				__( 'https://codex.wordpress.org/Theme_Development#Theme_Stylesheet', 'wporg-themes' )
 			);
 
-			return $error;
+			array_push( $style_errors, $error );
 		}
 
 		// Do not allow themes with WordPress and Theme in the theme name.
 		if ( false !== strpos( $this->theme_slug, 'wordpress' ) || preg_match( '/\btheme\b/i', $this->theme_slug ) ) {
 			/* translators: 1: 'WordPress', 2: 'theme' */
-			return sprintf( __( 'You cannot use %1$s or %2$s in your theme name.', 'wporg-themes' ),
+			array_push( $style_errors, sprintf( __( 'You cannot use %1$s or %2$s in your theme name.', 'wporg-themes' ),
 				'WordPress',
 				'theme'
-			);
+			) );
 		}
 
 		// Populate author.
@@ -242,10 +244,10 @@ class WPORG_Themes_Upload {
 		// This check must be run before `get_theme_post()` to account for "twenty" themes.
 		if ( $this->has_reserved_slug() ) {
 			/* translators: 1: theme slug, 2: style.css */
-			return sprintf( __( 'Sorry, the theme name %1$s is reserved for use by WordPress Core. Please change the name of your theme in %2$s and upload it again.', 'wporg-themes' ),
+			array_push( $style_errors, sprintf( __( 'Sorry, the theme name %1$s is reserved for use by WordPress Core. Please change the name of your theme in %2$s and upload it again.', 'wporg-themes' ),
 				'<code>' . $this->theme_slug . '</code>',
 				'<code>style.css</code>'
-			);
+			) );
 		}
 
 		// Populate the theme post.
@@ -262,7 +264,7 @@ class WPORG_Themes_Upload {
 				__( 'https://codex.wordpress.org/Theme_Development#Theme_Stylesheet', 'wporg-themes' )
 			);
 
-			return $error;
+			array_push( $style_errors, $error );
 		}
 
 		if ( ! $this->theme->get( 'Tags' ) ) {
@@ -275,7 +277,7 @@ class WPORG_Themes_Upload {
 				__( 'https://codex.wordpress.org/Theme_Development#Theme_Stylesheet', 'wporg-themes' )
 			);
 
-			return $error;
+			array_push( $style_errors, $error );
 		}
 
 		if ( ! $this->theme->get( 'Version' ) ) {
@@ -288,14 +290,13 @@ class WPORG_Themes_Upload {
 				__( 'https://codex.wordpress.org/Theme_Development#Theme_Stylesheet', 'wporg-themes' )
 			);
 
-			return $error;
-		}
+			array_push( $style_errors, $error );
 
-		if ( preg_match( '|[^\d\.]|', $this->theme->get( 'Version' ) ) ) {
+		} else if ( preg_match( '|[^\d\.]|', $this->theme->get( 'Version' ) ) ) {
 			/* translators: %s: style.css */
-			return sprintf( __( 'Version strings can only contain numeric and period characters (like 1.2). Please fix your Version: line in %s and upload your theme again.', 'wporg-themes' ),
+			array_push( $style_errors, sprintf( __( 'Version strings can only contain numeric and period characters (like 1.2). Please fix your Version: line in %s and upload your theme again.', 'wporg-themes' ),
 				'<code>style.css</code>'
-			);
+			) );
 		}
 
 		// Version is greater than current version happens after authorship checks.
@@ -304,15 +305,15 @@ class WPORG_Themes_Upload {
 		$themeuri = $this->theme->get( 'ThemeURI' );
 		$authoruri = $this->theme->get( 'AuthorURI' );
 		if ( !empty( $themeuri ) && !empty( $authoruri ) && $themeuri == $authoruri ) {
-			return __( 'Duplicate theme and author URLs. A theme URL is a page/site that provides details about this specific theme. An author URL is a page/site that provides information about the author of the theme. You aren&rsquo;t required to provide both, so pick the one that best applies to your URL.', 'wporg-themes' );
+			array_push( $style_errors, __( 'Duplicate theme and author URLs. A theme URL is a page/site that provides details about this specific theme. An author URL is a page/site that provides information about the author of the theme. You aren&rsquo;t required to provide both, so pick the one that best applies to your URL.', 'wporg-themes' ) );
 		}
 
 		// Check for child theme's parent in the directory (non-buddypress only)
 		if ( $this->theme->parent() && ! in_array( 'buddypress', $this->theme->get( 'Tags' ) ) && ! $this->is_parent_available() ) {
 			/* translators: %s: parent theme */
-			return sprintf( __( 'There is no theme called %s in the directory. For child themes, you must use a parent theme that already exists in the directory.', 'wporg-themes' ),
+			array_push( $style_errors, sprintf( __( 'There is no theme called %s in the directory. For child themes, you must use a parent theme that already exists in the directory.', 'wporg-themes' ),
 				'<code>' . $this->theme->parent() . '</code>'
-			);
+			) );
 		}
 
 		// Generic text to suggest "Are you in the right place?"
@@ -326,7 +327,7 @@ class WPORG_Themes_Upload {
 			);
 
 		// Is there already a theme with the name name by a different author?
-		if ( ! empty( $this->theme_post ) && $this->theme_post->post_author != $this->author->ID ) {
+		if ( ! empty( $this->theme_post ) && $this->theme_post->post_author != $this->author->ID  ) {
 
 			$is_allowed_to_upload_for_theme = false;
 			if (
@@ -341,10 +342,10 @@ class WPORG_Themes_Upload {
 
 			if ( ! $is_allowed_to_upload_for_theme ) {
 				/* translators: 1: theme slug, 2: style.css */
-				return sprintf( __( 'There is already a theme called %1$s by a different author. Please change the name of your theme in %2$s and upload it again.', 'wporg-themes' ),
+				array_push( $style_errors, sprintf( __( 'There is already a theme called %1$s by a different author. Please change the name of your theme in %2$s and upload it again.', 'wporg-themes' ),
 					'<code>' . $this->theme_slug . '</code>',
 					'<code>style.css</code>'
-				) . $are_you_in_the_right_place;
+				) . $are_you_in_the_right_place );
 			}
 		}
 
@@ -364,31 +365,36 @@ class WPORG_Themes_Upload {
 			$theme_owners = wp_list_pluck( $theme_uri_matches, 'post_author' );
 
 			if ( $theme_owners && ! in_array( $this->author->ID, $theme_owners ) ) {
-				return sprintf(
+				array_push( $style_errors, sprintf(
 					/* translators: 1: theme name, 2: style.css */
 					__( 'There is already a theme using the Theme URL %1$s by a different author. Please check the URL of your theme in %2$s and upload it again.', 'wporg-themes' ),
 					'<code>' . esc_html( $themeuri ) . '</code>',
 					'<code>style.css</code>'
-				) . $are_you_in_the_right_place;
+				) . $are_you_in_the_right_place );
 			}
 		}
 
 		// We know it's the correct author, now we can check if it's suspended.
 		if ( ! empty( $this->theme_post ) && 'suspend' === $this->theme_post->post_status ) {
 			/* translators: %s: mailto link */
-			return sprintf( __( 'This theme is suspended from the Theme Repository and it can&rsquo;t be updated. If you have any questions about this please contact %s.', 'wporg-themes' ),
+			array_push( $style_errors, sprintf( __( 'This theme is suspended from the Theme Repository and it can&rsquo;t be updated. If you have any questions about this please contact %s.', 'wporg-themes' ),
 				'<a href="mailto:themes@wordpress.org">themes@wordpress.org</a>'
-			);
+			) );
 		}
 
 		// Make sure we have version that is higher than any previously uploaded version of this theme. This check happens last to allow the non-author blocks to kick in.
 		if ( ! empty( $this->theme_post ) && ! version_compare( $this->theme->get( 'Version' ), $this->theme_post->max_version, '>' ) ) {
 			/* translators: 1: theme name, 2: theme version, 3: style.css */
-			return sprintf( __( 'You need to upload a version of %1$s higher than %2$s. Increase the theme version number in %3$s, then upload your zip file again.', 'wporg-themes' ),
+			array_push( $style_errors, sprintf( __( 'You need to upload a version of %1$s higher than %2$s. Increase the theme version number in %3$s, then upload your zip file again.', 'wporg-themes' ),
 				$this->theme->display( 'Name' ),
 				'<code>' . $this->theme_post->max_version . '</code>',
 				'<code>style.css</code>'
-			);
+			) );
+		}
+
+		// If we had any issues with information in the style.css, exit early.
+		if( !empty( $style_errors ) ) {
+			return $style_errors;
 		}
 
 		// Don't send special themes through Theme Check.

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/upload.php
@@ -62,7 +62,7 @@ function wporg_themes_render_upload_shortcode() {
 				$notice_content = "<li>{$messages}</li>";
 			}
 
-			$notice = "<h2>" . esc_attr__( 'Upload Errors', 'wporg-themes' ) . "</h2><div class='notice notice-error notice-large'><ul>{$notice_content}</ul></div>";
+			$notice = "<h2>" . esc_html__( 'Upload Errors', 'wporg-themes' ) . "</h2><div class='notice notice-error notice-large'><ul>{$notice_content}</ul></div>";
 		}
 	}
 

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/upload.php
@@ -55,7 +55,7 @@ function wporg_themes_render_upload_shortcode() {
 			$notice_content = "";
 
 			if ( is_array( $messages ) ) {
-				foreach( $messages as $message){
+				foreach ( $messages as $message){
 					$notice_content .= "<li>{$message}</li>";
 				}
 			} else {

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/upload.php
@@ -62,7 +62,7 @@ function wporg_themes_render_upload_shortcode() {
 				$notice_content = "<li>{$messages}</li>";
 			}
 
-			$notice = "<h2>Errors</h2><div class='notice notice-error notice-large'><ul>{$notice_content}</ul></div>";
+			$notice = "<h2>" . esc_attr__( 'Upload Errors', 'wporg-themes' ) . "</h2><div class='notice notice-error notice-large'><ul>{$notice_content}</ul></div>";
 		}
 	}
 

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/upload.php
@@ -49,10 +49,20 @@ function wporg_themes_render_upload_shortcode() {
 	$notice = '';
 
 	if ( ! empty( $_POST['_wpnonce'] ) && wp_verify_nonce( $_POST['_wpnonce'], 'wporg-themes-upload' ) && 'upload' === $_POST['action'] ) {
-		$message = wporg_themes_process_upload();
+		$messages = wporg_themes_process_upload();
 
-		if ( ! empty( $message ) ) {
-			$notice = "<div class='notice notice-warning'><p>{$message}</p></div>";
+		if ( ! empty( $messages ) ) {
+			$notice_content = "";
+
+			if( is_array( $messages ) ) {
+				foreach( $messages as $message){
+					$notice_content .= "<li>{$message}</li>";
+				}
+			} else {
+				$notice_content = "<li>{$messages}</li>";
+			}
+
+			$notice = "<h2>Errors</h2><div class='notice notice-error notice-large'><ul>{$notice_content}</ul></div>";
 		}
 	}
 

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/upload.php
@@ -54,7 +54,7 @@ function wporg_themes_render_upload_shortcode() {
 		if ( ! empty( $messages ) ) {
 			$notice_content = "";
 
-			if( is_array( $messages ) ) {
+			if ( is_array( $messages ) ) {
 				foreach( $messages as $message){
 					$notice_content .= "<li>{$message}</li>";
 				}


### PR DESCRIPTION
This PR makes it easier for users to identify the basic errors with their theme upload by showing them the detected errors as a list. This does not address messaging for results from the `theme-check` plugin. 

## Background
Users upload their theme on `wordpress.org/themes/upload`. Before triggering the theme check plugin, and creating a trac ticket, the back end code uses the `style.css` file in the theme and validates a number of things in order to process the upload properly. The problem is that each issue identified stops the upload. Users are forced to work through each issue one at a time because we currently only return one issue at a time.

You can read more about what happens on upload [here](https://github.com/WPTT/Theme-Requirements/issues/13).

## Solution
Let's collect all the errors related to an incorrect `style.css` file in the theme and display them all at one. This will save users revolutions in the `fix -> zip -> upload` loop.

## Screenshots

![](https://d.pr/i/7GQhjo.png)
