### PR TITLE
Hide Link Quick Tag from Reviews Editor

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/support-forums/css/styles-participants.css
+++ b/wordpress.org/public_html/wp-content/plugins/support-forums/css/styles-participants.css
@@ -1,4 +1,3 @@
-.bbpress.modal-open #wp-link-wrap #wp-link #link-selector .howto,
-.bbpress.modal-open #wp-link-wrap #wp-link #search-panel {
+#qt_bbp_topic_content_link {
 	display: none;
 }


### PR DESCRIPTION
https://meta.trac.wordpress.org/ticket/5748
For the time being, since we already hide the context search from editor link modal with CSS, I think we can simply hide the link quick tag with CSS.