### PR TITLE
Emit locale info from WordPress into Openverse iframe

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/header.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/header.php
@@ -22,8 +22,8 @@ get_template_part( 'header', 'wporg' );
 ?>
 
 <script>
-    // used in `message.js`
-    const currentLocale = '<?php echo get_locale() ?>';
+	// used in `message.js`
+	const currentLocale = '<?php echo get_locale() ?>';
 </script>
 
 <div id="page" class="site">

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/header.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/header.php
@@ -20,5 +20,11 @@ $wporg_global_header_options['in_wrapper'] .= '<a class="skip-link screen-reader
 
 get_template_part( 'header', 'wporg' );
 ?>
+
+<script>
+    // used in `message.js`
+    const currentLocale = '<?php echo get_locale() ?>';
+</script>
+
 <div id="page" class="site">
 	<div id="content" class="site-content">

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/index.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/index.php
@@ -19,7 +19,7 @@ get_header();
 
 	<main id="main" class="site-main" role="main">
 		<iframe id="openverse_embed">
-		    😢 Your browser does not support inline frames.
+			😢 Your browser does not support inline frames.
 		</iframe>
 	</main><!-- #main -->
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/js/message.js
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/js/message.js
@@ -6,17 +6,17 @@
  * @param {{ height: number }} value - the new dimensions of the iframe
  */
 function updateHeight(value) {
-	const height = value.height;
-	let heightProp
-	if (height) {
-		heightProp = `${height}px`;
-	} else {
-		heightProp = '100vh';
-	}
-	document
-		.documentElement
-		.style
-		.setProperty('--openverse-embed-height', heightProp);
+  const height = value.height;
+  let heightProp;
+  if (height) {
+    heightProp = `${height}px`;
+  } else {
+    heightProp = '100vh';
+  }
+  document
+    .documentElement
+    .style
+    .setProperty('--openverse-embed-height', heightProp);
 }
 
 /**
@@ -31,20 +31,20 @@ function updateHeight(value) {
  * }} value - the attributes of the new history state
  */
 function updatePath(value) {
-	const path = value.path;
-	const url = `${openverseSubpath}${path}`; // openverseSubpath defined in `index.php`
+  const path = value.path;
+  const url = `${openverseSubpath}${path}`; // openverseSubpath defined in `index.php`
 
-	console.log(`Replacing state URL: ${url}`);
-	history.replaceState(
-		value.state,
-		value.title ?? 'Openverse',
-		url,
-	);
+  console.log(`Replacing state URL: ${url}`);
+  history.replaceState(
+    value.state,
+    value.title ?? 'Openverse',
+    url,
+  );
 
-	if (value.title) {
-		console.log(`Setting document title: ${value.title}`);
-		document.title = value.title;
-	}
+  if (value.title) {
+    console.log(`Setting document title: ${value.title}`);
+    document.title = value.title;
+  }
 }
 
 /**
@@ -53,20 +53,21 @@ function updatePath(value) {
  * from the top-level HTML document.
  */
 function emitLocale() {
-	const currentLang = document.documentElement.lang
-	const currentDir = document.documentElement.dir
+  const currentLang = document.documentElement.lang;
+  const currentDir = document.documentElement.dir;
 
-	const iframe = document.getElementById('openverse_embed');
-	iframe.contentWindow.postMessage({
-		type: 'localeSet',
-		value: {
-			dir: currentDir,
-			lang: currentLang,
-			locale: currentLocale, // set in `header.php`
-		}
-	},
-	'*', // Bad practice, but we are not sending sensitive info
-	);
+  const iframe = document.getElementById('openverse_embed');
+  iframe.contentWindow.postMessage(
+    {
+      type: 'localeSet',
+      value: {
+        dir: currentDir,
+        lang: currentLang,
+        locale: currentLocale, // set in `header.php`
+      },
+    },
+    '*', // Bad practice, but we are not sending sensitive info
+  );
 }
 
 /**
@@ -74,7 +75,7 @@ function emitLocale() {
  * not have a handler configured for them.
  */
 function logUnhandled() {
-	console.error('No handler configured for event received');
+  console.error('No handler configured for event received');
 }
 
 /**
@@ -86,27 +87,27 @@ function logUnhandled() {
  *   value: any,
  * }>} message - the message object sent to this document
  */
-function handleIframeMessages ({ origin, data }) {
-	if (data.debug) {
-		console.log(`Received message from origin ${origin}:`);
-		console.log(data);
-	}
+function handleIframeMessages({ origin, data }) {
+  if (data.debug) {
+    console.log(`Received message from origin ${origin}:`);
+    console.log(data);
+  }
 
-	let handler
-	switch(data.type) {
-		case 'resize':
-			handler = updateHeight;
-			break;
-		case 'urlChange':
-			handler = updatePath;
-			break;
-		case 'localeGet':
-			handler = emitLocale;
-			break;
-		default:
-			handler = logUnhandled;
-	}
-	handler(data.value);
+  let handler;
+  switch (data.type) {
+    case 'resize':
+      handler = updateHeight;
+      break;
+    case 'urlChange':
+      handler = updatePath;
+      break;
+    case 'localeGet':
+      handler = emitLocale;
+      break;
+    default:
+      handler = logUnhandled;
+  }
+  handler(data.value);
 }
 
 window.addEventListener('message', handleIframeMessages);

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/js/message.js
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/js/message.js
@@ -48,6 +48,28 @@ function updatePath(value) {
 }
 
 /**
+ * Emit a message to the `iframe` containing information about the current
+ * locale. This function combines the locale from WordPress with attributes
+ * from the top-level HTML document.
+ */
+function emitLocale() {
+	const currentLang = document.documentElement.lang
+	const currentDir = document.documentElement.dir
+
+	const iframe = document.getElementById('openverse_embed');
+	iframe.contentWindow.postMessage({
+		type: 'localeSet',
+		locale: {
+			dir: currentDir,
+			lang: currentLang,
+			locale: currentLocale, // set in `header.php`
+		}
+	},
+	'*', // Bad practice, but we are not sending sensitive info
+	);
+}
+
+/**
  * This is the default handler for all messages received in this frame that do
  * not have a handler configured for them.
  */
@@ -77,6 +99,9 @@ function handleIframeMessages ({ origin, data }) {
 			break;
 		case 'urlChange':
 			handler = updatePath;
+			break;
+		case 'localeGet':
+			handler = emitLocale;
 			break;
 		default:
 			handler = logUnhandled;

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/js/message.js
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/js/message.js
@@ -59,7 +59,7 @@ function emitLocale() {
 	const iframe = document.getElementById('openverse_embed');
 	iframe.contentWindow.postMessage({
 		type: 'localeSet',
-		locale: {
+		value: {
 			dir: currentDir,
 			lang: currentLang,
 			locale: currentLocale, // set in `header.php`

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/js/message_test.html
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/js/message_test.html
@@ -19,7 +19,7 @@
        * @param {string} type - the type of the message being sent to the parent
        * @param {any} value - the data to send along with the message
        */
-      function sendMessage (type, value) {
+      function sendMessage (type, value = {}) {
         if (window.parent !== window) {
           const message = { debug: true, type, value };
 
@@ -64,6 +64,22 @@
           }
           sendMessage('urlChange', message);
         });
+
+        document.forms.localeGet.addEventListener('submit', (event) => {
+          event.preventDefault();
+
+          const listener = ({ origin, data }) => {
+            if (data.type !== 'localeSet') return;
+
+            console.log(`Received message from origin ${origin}:`);
+            document.getElementById('gotLocale').innerText = JSON.stringify(data, null, 2);
+
+            console.log('Removing listener')
+            window.removeEventListener('message', listener)
+          }
+          window.addEventListener('message', listener)
+          sendMessage('localeGet')
+        })
       });
     </script>
   </head>
@@ -111,6 +127,16 @@
         <button type="submit">
           Send message
         </button>
+      </div>
+    </form>
+
+    <h2>Test locale get</h2>
+    <form name="localeGet">
+      <div class="row">
+        <button type="submit">
+          Get locale
+        </button>
+        <pre><code id="gotLocale"></code></pre>
       </div>
     </form>
   </body>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/js/message_test.html
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/js/message_test.html
@@ -7,6 +7,7 @@
       .row:not(:first-of-type) {
         margin-top: 1em;
       }
+
       label {
         display: inline-block;
         width: 5em;
@@ -19,7 +20,7 @@
        * @param {string} type - the type of the message being sent to the parent
        * @param {any} value - the data to send along with the message
        */
-      function sendMessage (type, value = {}) {
+      function sendMessage(type, value = {}) {
         if (window.parent !== window) {
           const message = { debug: true, type, value };
 
@@ -69,17 +70,19 @@
           event.preventDefault();
 
           const listener = ({ origin, data }) => {
-            if (data.type !== 'localeSet') return;
+            if (data.type !== 'localeSet') {
+              return;
+            }
 
             console.log(`Received message from origin ${origin}:`);
             document.getElementById('gotLocale').innerText = JSON.stringify(data, null, 2);
 
-            console.log('Removing listener')
-            window.removeEventListener('message', listener)
-          }
-          window.addEventListener('message', listener)
-          sendMessage('localeGet')
-        })
+            console.log('Removing listener');
+            window.removeEventListener('message', listener);
+          };
+          window.addEventListener('message', listener);
+          sendMessage('localeGet');
+        });
       });
     </script>
   </head>


### PR DESCRIPTION
Fixes WordPress/openverse-frontend#189

Closes https://meta.trac.wordpress.org/ticket/5892

---

This PR adds functionality for the Openverse frontend loaded in the `iframe` to ask the parent window information about the locale.

`iframe` &mdash;(`localeGet` event)&rarr; parent window
`iframe` &larr;(`localeSet` event)&mdash; parent window

## Description

The `localeSet` message contains the following data:
```json
{
  "type": "localeSet",
  "value": {
    "dir": "",
    "lang": "en-US",
    "locale": "en_US"
  }
}
```

| Key | Interpretation |
|-|-|
| `dir` | Value of parent HTML `dir` attribute |
| `lang` | Value of parent HTML `lang` attribute |
| `locale` | Value of WordPress `get_locale()` function |