### PR TITLE
Update openverse.css to more agressively keep the iframe full-width

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/css/openverse.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/css/openverse.css
@@ -7,9 +7,8 @@
     border: none;
 }
 
-.site > .site-content {
-    max-width: none;
-
-    padding: 0;
-    margin: auto;
+#main {
+    width: 100% !important;
+    padding: 0 !important;
+    max-width: 100% !important;
 }


### PR DESCRIPTION
Closes https://meta.trac.wordpress.org/ticket/5907#ticket

There were a few circumstances where route changes on Openverse and a hard server refresh could cause the styles of the page to break. This simpler, more aggressive styling will fully prevent that issue.