### PR TITLE
Revised: Update openverse.css to more agressively keep the iframe full-width

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/css/openverse.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/css/openverse.css
@@ -7,7 +7,9 @@
     border: none;
 }
 
-#main {
+#main,
+.site,
+.site-content {
     width: 100% !important;
     padding: 0 !important;
     max-width: 100% !important;


### PR DESCRIPTION
Closes https://meta.trac.wordpress.org/ticket/5915#ticket

I'm not sure if CSS on wp.org changed or what, but the previous solution to this was once again insufficient. Hopefully this is the last time we do this 😄 

