### PR TITLE
Update handbook style for readability, spacing

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-developer/inc/cli.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-developer/inc/cli.php
@@ -447,7 +447,6 @@ class DevHub_CLI {
 
 	protected static function add_ids_and_jumpto_links( $tag, $content ) {
 		$items = self::get_tags( $tag, $content );
-		$first = true;
 		$matches = array();
 		$replacements = array();
 
@@ -456,11 +455,6 @@ class DevHub_CLI {
 			$matches[] = $item[0];
 			$id = sanitize_title_with_dashes($item[2]);
 
-			if ( ! $first ) {
-				$replacement .= '<p class="toc-jump"><a href="#top">' . __( 'Top &uarr;', 'wporg' ) . '</a></p>';
-			} else {
-				$first = false;
-			}
 			$a11y_text      = sprintf( '<span class="screen-reader-text">%s</span>', $item[2] );
 			$anchor         = sprintf( '<a href="#%1$s" class="anchor"><span aria-hidden="true">#</span>%2$s</a>', $id, $a11y_text );
 			$replacement   .= sprintf( '<%1$s class="toc-heading" id="%2$s" tabindex="-1">%3$s %4$s</%1$s>', $tag, $id, $item[2], $anchor );

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-developer/scss/main.scss
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-developer/scss/main.scss
@@ -1921,8 +1921,7 @@ aside[id^="nav_menu"] .widget-title {
 }
 
 .single-handbook {
-	font-size: 13px;
-	font-size: 1.3rem;
+	font-size: 16px;
 
 	p, ol, ul {
 		line-height: 1.6;
@@ -1930,7 +1929,6 @@ aside[id^="nav_menu"] .widget-title {
 
 	.site-main {
 		p, ol, ul {
-			font-size: 1.05em;
 			color: #555;
 		}
 	}
@@ -1946,6 +1944,22 @@ aside[id^="nav_menu"] .widget-title {
 
 	.o2-post {
 		border-top: none;
+	}
+
+	.devhub-wrap {
+		main {
+			h2 {
+				margin-top: 4rem;
+				padding-top: 4rem;
+				border-top: 1px solid #AAA;
+			}
+	
+			h3 {
+				margin-top: 4rem;
+				padding-top: 4rem;
+				border-top: 1px solid #CCC;
+			}
+		}
 	}
 
 	.handbook-name-container + #primary {

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-developer/scss/main.scss
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-developer/scss/main.scss
@@ -1931,6 +1931,10 @@ aside[id^="nav_menu"] .widget-title {
 		p, ol, ul {
 			color: #555;
 		}
+
+		li {
+			margin-bottom: 2.0rem;
+		}
 	}
 
 	.site-title {
@@ -1953,7 +1957,7 @@ aside[id^="nav_menu"] .widget-title {
 				padding-top: 4rem;
 				border-top: 1px solid #AAA;
 			}
-	
+
 			h3 {
 				margin-top: 4rem;
 				padding-top: 4rem;
@@ -2146,7 +2150,7 @@ div[class*="-table-of-contents-container"] {
 				border-right: 1px solid rgba(0,0,0,0.05);
 				border-left: none;
 			}
-	
+
 			&.menu-item-has-children > .expandable > a {
 				padding-right: 30px;
 			}

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-developer/stylesheets/main.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-developer/stylesheets/main.css
@@ -2329,6 +2329,16 @@ aside[id^="nav_menu"] .widget-title {
   border-top: none;
 }
 
+.single-handbook .devhub-wrap main h2 {
+    margin-top: 4rem;
+    border-bottom: 2px solid #333;
+}
+
+.single-handbook .devhub-wrap main h3 {
+    margin-top: 4rem;
+    border-bottom: 1px solid #333;
+}
+
 .single-handbook .handbook-name-container + #primary {
   padding-top: 5rem;
 }

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-developer/stylesheets/main.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-developer/stylesheets/main.css
@@ -2331,12 +2331,12 @@ aside[id^="nav_menu"] .widget-title {
 
 .single-handbook .devhub-wrap main h2 {
     margin-top: 4rem;
-    border-bottom: 2px solid #333;
+    border-bottom: 1px solid #AAA;
 }
 
 .single-handbook .devhub-wrap main h3 {
     margin-top: 4rem;
-    border-bottom: 1px solid #333;
+    border-bottom: 1px solid #CCC;
 }
 
 .single-handbook .handbook-name-container + #primary {

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-developer/stylesheets/main.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-developer/stylesheets/main.css
@@ -1,37 +1,86 @@
 /* =Reset
 -------------------------------------------------------------- */
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, font, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td {
-  border: 0;
-  font-family: inherit;
-  font-size: 100%;
-  font-style: inherit;
-  font-weight: inherit;
-  margin: 0;
-  outline: 0;
-  padding: 0;
-  vertical-align: baseline;
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+font,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td {
+	border: 0;
+	font-family: inherit;
+	font-size: 100%;
+	font-style: inherit;
+	font-weight: inherit;
+	margin: 0;
+	outline: 0;
+	padding: 0;
+	vertical-align: baseline;
 }
 
 html {
-  font-size: 62.5%;
-  /* Corrects text resizing oddly in IE6/7 when body font-size is set using em units http://clagnut.com/blog/348/#c790 */
-  overflow-y: scroll;
-  /* Keeps page centered in all browsers regardless of content height */
-  -webkit-text-size-adjust: 100%;
-  /* Prevents iOS text size adjust after orientation change, without disabling user zoom */
-  -ms-text-size-adjust: 100%;
-  /* www.456bereastreet.com/archive/201012/controlling_text_size_in_safari_for_ios_without_disabling_user_zoom/ */
+	font-size: 62.5%;
+	/* Corrects text resizing oddly in IE6/7 when body font-size is set using em units http://clagnut.com/blog/348/#c790 */
+	overflow-y: scroll;
+	/* Keeps page centered in all browsers regardless of content height */
+	-webkit-text-size-adjust: 100%;
+	/* Prevents iOS text size adjust after orientation change, without disabling user zoom */
+	-ms-text-size-adjust: 100%;
+	/* www.456bereastreet.com/archive/201012/controlling_text_size_in_safari_for_ios_without_disabling_user_zoom/ */
 }
 
 body {
-  background: #fff;
+	background: #fff;
 }
 
 article,
@@ -44,42 +93,50 @@ header,
 main,
 nav,
 section {
-  display: block;
+	display: block;
 }
 
-ol, ul {
-  list-style: none;
+ol,
+ul {
+	list-style: none;
 }
 
 table {
-  /* tables still need 'cellspacing="0"' in the markup */
-  border-collapse: separate;
-  border-spacing: 0;
+	/* tables still need 'cellspacing="0"' in the markup */
+	border-collapse: separate;
+	border-spacing: 0;
 }
 
-caption, th, td {
-  font-weight: normal;
-  text-align: left;
+caption,
+th,
+td {
+	font-weight: normal;
+	text-align: left;
 }
 
-blockquote, q {
-  quotes: "" "";
+blockquote,
+q {
+	quotes: '' '';
 }
 
-blockquote:before, blockquote:after, q:before, q:after {
-  content: "";
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+	content: '';
 }
 
 a:focus {
-  outline: thin dotted;
+	outline: thin dotted;
 }
 
-a:hover, a:active {
-  outline: 0;
+a:hover,
+a:active {
+	outline: 0;
 }
 
 a img {
-  border: 0;
+	border: 0;
 }
 
 /* =Global
@@ -89,142 +146,158 @@ button,
 input,
 select,
 textarea {
-  color: #404040;
-  font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
-  font-size: 16px;
-  font-size: 1.6rem;
-  line-height: 1.5;
+	color: #404040;
+	font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+	font-size: 16px;
+	font-size: 1.6rem;
+	line-height: 1.5;
 }
 
 /* Headings */
-h1, h2, h3, h4, h5, h6 {
-  clear: both;
-  font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, sans-serif;
-  font-weight: 300;
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+	clear: both;
+	font-family: 'HelveticaNeue-Light', 'Helvetica Neue Light', 'Helvetica Neue',
+		Helvetica, Arial, sans-serif;
+	font-weight: 300;
 }
 
 hr {
-  background-color: #dfdfdf;
-  border: 0;
-  height: 1px;
-  margin: 1.5em 0;
+	background-color: #dfdfdf;
+	border: 0;
+	height: 1px;
+	margin: 1.5em 0;
 }
 
 /* Text elements */
 p {
-  margin-bottom: 1.5em;
+	margin-bottom: 1.5em;
 }
 
-ul, ol {
-  margin: 0 0 1.5em 3em;
+ul,
+ol {
+	margin: 0 0 1.5em 3em;
 }
 
 ul {
-  list-style: disc;
+	list-style: disc;
 }
 
 ol {
-  list-style: decimal;
+	list-style: decimal;
 }
 
 li > ul,
 li > ol {
-  margin-bottom: 0;
-  margin-left: 1.5em;
+	margin-bottom: 0;
+	margin-left: 1.5em;
 }
 
 dt {
-  font-weight: bold;
+	font-weight: bold;
 }
 
 dd {
-  margin: 0 1.5em 1.5em;
+	margin: 0 1.5em 1.5em;
 }
 
-b, strong {
-  font-weight: bold;
+b,
+strong {
+	font-weight: bold;
 }
 
-dfn, cite, em, i {
-  font-style: italic;
+dfn,
+cite,
+em,
+i {
+	font-style: italic;
 }
 
 blockquote {
-  margin: 0 1.5em;
+	margin: 0 1.5em;
 }
 
 address {
-  margin: 0 0 1.5em;
+	margin: 0 0 1.5em;
 }
 
 pre {
-  background: #eee;
-  font-family: "Courier 10 Pitch", Courier, monospace;
-  font-size: 15px;
-  font-size: 1.5rem;
-  line-height: 1.6;
-  margin-bottom: 1.6em;
-  max-width: 100%;
-  overflow: auto;
-  padding: 1.6em;
+	background: #eee;
+	font-family: 'Courier 10 Pitch', Courier, monospace;
+	font-size: 15px;
+	font-size: 1.5rem;
+	line-height: 1.6;
+	margin-bottom: 1.6em;
+	max-width: 100%;
+	overflow: auto;
+	padding: 1.6em;
 }
 
-code, kbd, tt, var {
-  font: 15px Monaco, Consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
+code,
+kbd,
+tt,
+var {
+	font: 15px Monaco, Consolas, 'Andale Mono', 'DejaVu Sans Mono', monospace;
 }
 
-abbr, acronym {
-  cursor: help;
+abbr,
+acronym {
+	cursor: help;
 }
 
-mark, ins {
-  background: #fff9c0;
-  text-decoration: none;
+mark,
+ins {
+	background: #fff9c0;
+	text-decoration: none;
 }
 
 sup,
 sub {
-  font-size: 75%;
-  height: 0;
-  line-height: 0;
-  position: relative;
-  vertical-align: baseline;
+	font-size: 75%;
+	height: 0;
+	line-height: 0;
+	position: relative;
+	vertical-align: baseline;
 }
 
 sup {
-  bottom: 1ex;
+	bottom: 1ex;
 }
 
 sub {
-  top: .5ex;
+	top: 0.5ex;
 }
 
 small {
-  font-size: 75%;
+	font-size: 75%;
 }
 
 big {
-  font-size: 125%;
+	font-size: 125%;
 }
 
 figure {
-  margin: 0;
+	margin: 0;
 }
 
 table {
-  margin: 0 0 1.5em;
-  width: 100%;
+	margin: 0 0 1.5em;
+	width: 100%;
 }
 
 th {
-  font-weight: bold;
+	font-weight: bold;
 }
 
 img {
-  height: auto;
-  /* Make sure images are scaled correctly. */
-  max-width: 100%;
-  /* Adhere to container width. */
+	height: auto;
+	/* Make sure images are scaled correctly. */
+	max-width: 100%;
+	/* Adhere to container width. */
 }
 
 /* Form Elements */
@@ -232,85 +305,90 @@ button,
 input,
 select,
 textarea {
-  font-size: 100%;
-  /* Corrects font size not being inherited in all browsers */
-  margin: 0;
-  /* Addresses margins set differently in IE6/7, F3/4, S5, Chrome */
-  vertical-align: baseline;
-  /* Improves appearance and consistency in all browsers */
-  *vertical-align: middle;
-  /* Improves appearance and consistency in all browsers */
-  font-weight: 300;
+	font-size: 100%;
+	/* Corrects font size not being inherited in all browsers */
+	margin: 0;
+	/* Addresses margins set differently in IE6/7, F3/4, S5, Chrome */
+	vertical-align: baseline;
+	/* Improves appearance and consistency in all browsers */
+	*vertical-align: middle;
+	/* Improves appearance and consistency in all browsers */
+	font-weight: 300;
 }
 
 button,
 input {
-  line-height: normal;
-  /* Addresses FF3/4 setting line-height using !important in the UA stylesheet */
+	line-height: normal;
+	/* Addresses FF3/4 setting line-height using !important in the UA stylesheet */
 }
 
 /* Alignment */
 .alignleft {
-  display: inline;
-  float: left;
-  margin-right: 1.5em;
+	display: inline;
+	float: left;
+	margin-right: 1.5em;
 }
 
 .alignright {
-  display: inline;
-  float: right;
-  margin-left: 1.5em;
+	display: inline;
+	float: right;
+	margin-left: 1.5em;
 }
 
 .aligncenter {
-  clear: both;
-  display: block;
-  margin: 0 auto;
+	clear: both;
+	display: block;
+	margin: 0 auto;
 }
 
 .home .devhub-wrap {
-  padding-bottom: 0;
+	padding-bottom: 0;
 }
 
-.home .devhub-wrap h1, .home .devhub-wrap h2, .home .devhub-wrap h3, .home .devhub-wrap h4, .home .devhub-wrap h5, .home .devhub-wrap h6 {
-  font-family: "Open Sans", sans-serif;
+.home .devhub-wrap h1,
+.home .devhub-wrap h2,
+.home .devhub-wrap h3,
+.home .devhub-wrap h4,
+.home .devhub-wrap h5,
+.home .devhub-wrap h6 {
+	font-family: 'Open Sans', sans-serif;
 }
 
 .home .devhub-wrap #content {
-  padding: 0;
+	padding: 0;
 }
 
 .devhub-wrap {
-  padding-bottom: 1.5em;
-  /* Override inline style from wporg-markdown plugin. */
-  /* Text meant only for screen readers */
-  /* Clearing */
-  /* =Content
+	padding-bottom: 1.5em;
+	/* Override inline style from wporg-markdown plugin. */
+	/* Text meant only for screen readers */
+	/* Clearing */
+	/* =Content
 	----------------------------------------------- */
-  /* =Tabs
+	/* =Tabs
 	----------------------------------------------- */
-  /* =Media
+	/* =Media
 	----------------------------------------------- */
-  /* Make sure embeds and iframes fit their containers */
-  /* =Widgets
+	/* Make sure embeds and iframes fit their containers */
+	/* =Widgets
 	----------------------------------------------- */
-  /* Make sure select elements fit in widgets */
-  /* Search widget */
-  /* =Infinite Scroll
+	/* Make sure select elements fit in widgets */
+	/* Search widget */
+	/* =Infinite Scroll
 	----------------------------------------------- */
-  /* Globally hidden elements when Infinite Scroll is supported and in use. */
-  /* When Infinite Scroll has reached its end we need to re-display elements that were hidden (via .neverending) before */
-  /*
+	/* Globally hidden elements when Infinite Scroll is supported and in use. */
+	/* When Infinite Scroll has reached its end we need to re-display elements that were hidden (via .neverending) before */
+	/*
 	 * Header area
 	 */
-  /*
+	/*
 	 * section styles
 	 */
-  /* = Related
+	/* = Related
 	----------------------------------------------- */
-  /* Changelog */
-  /* Comments */
-  /*
+	/* Changelog */
+	/* Comments */
+	/*
 	 * Content
 	 *
 	 */
@@ -319,57 +397,63 @@ input {
 .devhub-wrap *,
 .devhub-wrap *:before,
 .devhub-wrap *:after {
-  -moz-box-sizing: border-box;
-  -webkit-box-sizing: border-box;
-  box-sizing: border-box;
+	-moz-box-sizing: border-box;
+	-webkit-box-sizing: border-box;
+	box-sizing: border-box;
 }
 
 .devhub-wrap a.github-edit {
-  padding: 0 .6em 0;
+	padding: 0 0.6em 0;
 }
 
-.devhub-wrap #content, .devhub-wrap #content-area {
-  padding: 0 10px;
+.devhub-wrap #content,
+.devhub-wrap #content-area {
+	padding: 0 10px;
 }
 
-.devhub-wrap #content .toc-heading, .devhub-wrap #content-area .toc-heading {
-  clear: left;
+.devhub-wrap #content .toc-heading,
+.devhub-wrap #content-area .toc-heading {
+	clear: left;
 }
 
-.devhub-wrap #content table, .devhub-wrap #content-area table {
-  border: 1px solid #f0f0f0;
+.devhub-wrap #content table,
+.devhub-wrap #content-area table {
+	border: 1px solid #f0f0f0;
 }
 
 @media (max-width: 991px) {
-  .devhub-wrap #content table, .devhub-wrap #content-area table {
-    overflow-x: scroll;
-    display: block;
-  }
+	.devhub-wrap #content table,
+	.devhub-wrap #content-area table {
+		overflow-x: scroll;
+		display: block;
+	}
 }
 
-.devhub-wrap #content table th, .devhub-wrap #content-area table th {
-  padding: 1em;
-  border-bottom: 1px solid #f0f0f0;
-  background: #f0f0f0;
+.devhub-wrap #content table th,
+.devhub-wrap #content-area table th {
+	padding: 1em;
+	border-bottom: 1px solid #f0f0f0;
+	background: #f0f0f0;
 }
 
-.devhub-wrap #content table td, .devhub-wrap #content-area table td {
-  padding: 0.8em 1em;
-  border: 1px solid #f0f0f0;
+.devhub-wrap #content table td,
+.devhub-wrap #content-area table td {
+	padding: 0.8em 1em;
+	border: 1px solid #f0f0f0;
 }
 
 .devhub-wrap #content-area,
 .devhub-wrap .inner-wrap {
-  margin: 2rem auto 0;
-  max-width: 60em;
+	margin: 2rem auto 0;
+	max-width: 60em;
 }
 
 .devhub-wrap .page-header {
-  margin-top: 1em;
+	margin-top: 1em;
 }
 
 .devhub-wrap a {
-  color: #21759b;
+	color: #21759b;
 }
 
 .devhub-wrap .site-main h2,
@@ -377,277 +461,293 @@ input {
 .devhub-wrap .site-main h4,
 .devhub-wrap .site-main h5,
 .devhub-wrap .site-main h6 {
-  color: #1e1e1e;
-  margin-bottom: 1.5rem;
+	color: #1e1e1e;
+	margin-bottom: 1.5rem;
 }
 
 .devhub-wrap .site-main a {
-  border: 0;
-  text-decoration: underline;
+	border: 0;
+	text-decoration: underline;
 }
 
 .devhub-wrap .site-main .table-of-contents a,
 .devhub-wrap .site-main .toc-heading a {
-  text-decoration: none;
+	text-decoration: none;
 }
 
 .devhub-wrap #headline h2 a {
-  color: #555;
-  font-weight: 300;
-  font-size: 28px;
-  line-height: 1em;
-  text-shadow: #fff 0px 1px 0px;
-  font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, sans-serif;
+	color: #555;
+	font-weight: 300;
+	font-size: 28px;
+	line-height: 1em;
+	text-shadow: #fff 0px 1px 0px;
+	font-family: 'HelveticaNeue-Light', 'Helvetica Neue Light', 'Helvetica Neue',
+		Helvetica, Arial, sans-serif;
 }
 
 .devhub-wrap h1 {
-  font-size: 28px;
-  font-size: 3rem;
-  line-height: 32px;
-  line-height: 3.2rem;
-  font-weight: 300;
-  margin-bottom: 1.5rem;
+	font-size: 28px;
+	font-size: 3rem;
+	line-height: 32px;
+	line-height: 3.2rem;
+	font-weight: 300;
+	margin-bottom: 1.5rem;
 }
 
 .devhub-wrap h2 {
-  font-size: 22px;
-  font-size: 2.2rem;
-  line-height: 26px;
-  line-height: 2.6rem;
-  font-weight: 300;
+	font-size: 22px;
+	font-size: 2.2rem;
+	line-height: 26px;
+	line-height: 2.6rem;
+	font-weight: 300;
 }
 
 .devhub-wrap h3 {
-  font-size: 20px;
-  font-size: 2rem;
-  line-height: 24px;
-  line-height: 2.4rem;
-  font-weight: 300;
+	font-size: 20px;
+	font-size: 2rem;
+	line-height: 24px;
+	line-height: 2.4rem;
+	font-weight: 300;
 }
 
 .devhub-wrap h4 {
-  font-size: 18px;
-  font-size: 1.8rem;
-  line-height: 22px;
-  line-height: 2.2rem;
-  border-bottom: none;
-  font-weight: 300;
+	font-size: 18px;
+	font-size: 1.8rem;
+	line-height: 22px;
+	line-height: 2.2rem;
+	border-bottom: none;
+	font-weight: 300;
 }
 
 .devhub-wrap h4 .dashicons {
-  font-size: 22px;
-  font-size: 2.2rem;
-  line-height: 22px;
-  line-height: 2.2rem;
-  height: 22px;
-  width: 22px;
-  height: 2.2rem;
-  width: 2.2rem;
+	font-size: 22px;
+	font-size: 2.2rem;
+	line-height: 22px;
+	line-height: 2.2rem;
+	height: 22px;
+	width: 22px;
+	height: 2.2rem;
+	width: 2.2rem;
 }
 
 .devhub-wrap a.button,
 .devhub-wrap button,
 .devhub-wrap input {
-  line-height: normal;
-  /* Addresses FF3/4 setting line-height using !important in the UA stylesheet */
+	line-height: normal;
+	/* Addresses FF3/4 setting line-height using !important in the UA stylesheet */
 }
 
 .devhub-wrap a.button,
 .devhub-wrap button,
-.devhub-wrap input[type="button"],
-.devhub-wrap input[type="reset"],
-.devhub-wrap input[type="submit"] {
-  border: 1px solid #ccc;
-  border-color: #ccc #ccc #bbb #ccc;
-  border-radius: 3px;
-  background: #fff;
-  color: rgba(0, 0, 0, 0.8);
-  cursor: pointer;
-  /* Improves usability and consistency of cursor style between image-type 'input' and others */
-  font-size: 16px;
-  font-size: 1.6rem;
-  line-height: 1.1;
-  float: none;
-  height: auto;
-  padding: .6em 1.8em;
-  text-decoration: none;
-  -webkit-appearance: button;
-  /* Corrects inability to style clickable 'input' types in iOS */
+.devhub-wrap input[type='button'],
+.devhub-wrap input[type='reset'],
+.devhub-wrap input[type='submit'] {
+	border: 1px solid #ccc;
+	border-color: #ccc #ccc #bbb #ccc;
+	border-radius: 3px;
+	background: #fff;
+	color: rgba(0, 0, 0, 0.8);
+	cursor: pointer;
+	/* Improves usability and consistency of cursor style between image-type 'input' and others */
+	font-size: 16px;
+	font-size: 1.6rem;
+	line-height: 1.1;
+	float: none;
+	height: auto;
+	padding: 0.6em 1.8em;
+	text-decoration: none;
+	-webkit-appearance: button;
+	/* Corrects inability to style clickable 'input' types in iOS */
 }
 
 .devhub-wrap a.button:hover,
 .devhub-wrap button:hover,
-.devhub-wrap input[type="button"]:hover,
-.devhub-wrap input[type="reset"]:hover,
-.devhub-wrap input[type="submit"]:hover {
-  border-color: #ccc #bbb #aaa #bbb;
-  background: #f0f0f0;
+.devhub-wrap input[type='button']:hover,
+.devhub-wrap input[type='reset']:hover,
+.devhub-wrap input[type='submit']:hover {
+	border-color: #ccc #bbb #aaa #bbb;
+	background: #f0f0f0;
 }
 
-.devhub-wrap a.button:focus, .devhub-wrap a.button:active,
+.devhub-wrap a.button:focus,
+.devhub-wrap a.button:active,
 .devhub-wrap button:focus,
 .devhub-wrap button:active,
-.devhub-wrap input[type="button"]:focus,
-.devhub-wrap input[type="button"]:active,
-.devhub-wrap input[type="reset"]:focus,
-.devhub-wrap input[type="reset"]:active,
-.devhub-wrap input[type="submit"]:focus,
-.devhub-wrap input[type="submit"]:active {
-  border-color: #aaa #bbb #bbb #bbb;
-  background: #f0f0f0;
-  -webkit-box-shadow: inset 0 1px 0 rgba(120, 200, 230, 0.6), 1px 1px 2px rgba(0, 0, 0, 0.4);
-  box-shadow: inset 0 1px 0 rgba(120, 200, 230, 0.6), 1px 1px 2px rgba(0, 0, 0, 0.4);
+.devhub-wrap input[type='button']:focus,
+.devhub-wrap input[type='button']:active,
+.devhub-wrap input[type='reset']:focus,
+.devhub-wrap input[type='reset']:active,
+.devhub-wrap input[type='submit']:focus,
+.devhub-wrap input[type='submit']:active {
+	border-color: #aaa #bbb #bbb #bbb;
+	background: #f0f0f0;
+	-webkit-box-shadow: inset 0 1px 0 rgba(120, 200, 230, 0.6),
+		1px 1px 2px rgba(0, 0, 0, 0.4);
+	box-shadow: inset 0 1px 0 rgba(120, 200, 230, 0.6),
+		1px 1px 2px rgba(0, 0, 0, 0.4);
 }
 
 .devhub-wrap a.button.shiny-blue,
 .devhub-wrap button.shiny-blue,
-.devhub-wrap input[type="button"].shiny-blue,
-.devhub-wrap input[type="reset"].shiny-blue,
-.devhub-wrap input[type="submit"].shiny-blue {
-  background-color: #21759b;
-  background-image: -webkit-gradient(linear, left top, left bottom, from(#2a95c5), to(#21759b));
-  background-image: -webkit-linear-gradient(top, #2a95c5, #21759b);
-  background-image: -moz-linear-gradient(top, #2a95c5, #21759b);
-  background-image: -ms-linear-gradient(top, #2a95c5, #21759b);
-  background-image: -o-linear-gradient(top, #2a95c5, #21759b);
-  background-image: linear-gradient(to bottom, #2a95c5, #21759b);
-  border-color: #21759b;
-  border-bottom-color: #1e6a8d;
-  -webkit-box-shadow: inset 0 1px 0 rgba(120, 200, 230, 0.5);
-  box-shadow: inset 0 1px 0 rgba(120, 200, 230, 0.5);
-  color: #fff;
-  text-decoration: none;
-  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.3);
-  padding: 3px 8px;
+.devhub-wrap input[type='button'].shiny-blue,
+.devhub-wrap input[type='reset'].shiny-blue,
+.devhub-wrap input[type='submit'].shiny-blue {
+	background-color: #21759b;
+	background-image: -webkit-gradient(
+		linear,
+		left top,
+		left bottom,
+		from(#2a95c5),
+		to(#21759b)
+	);
+	background-image: -webkit-linear-gradient(top, #2a95c5, #21759b);
+	background-image: -moz-linear-gradient(top, #2a95c5, #21759b);
+	background-image: -ms-linear-gradient(top, #2a95c5, #21759b);
+	background-image: -o-linear-gradient(top, #2a95c5, #21759b);
+	background-image: linear-gradient(to bottom, #2a95c5, #21759b);
+	border-color: #21759b;
+	border-bottom-color: #1e6a8d;
+	-webkit-box-shadow: inset 0 1px 0 rgba(120, 200, 230, 0.5);
+	box-shadow: inset 0 1px 0 rgba(120, 200, 230, 0.5);
+	color: #fff;
+	text-decoration: none;
+	text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.3);
+	padding: 3px 8px;
 }
 
 .devhub-wrap a.button.shiny-blue:hover,
 .devhub-wrap button.shiny-blue:hover,
-.devhub-wrap input[type="button"].shiny-blue:hover,
-.devhub-wrap input[type="reset"].shiny-blue:hover,
-.devhub-wrap input[type="submit"].shiny-blue:hover {
-  background-color: #278ab7;
-  background-image: -webkit-gradient(linear, left top, left bottom, from(#2e9fd2), to(#21759b));
-  background-image: -webkit-linear-gradient(top, #2e9fd2, #21759b);
-  background-image: -moz-linear-gradient(top, #2e9fd2, #21759b);
-  background-image: -ms-linear-gradient(top, #2e9fd2, #21759b);
-  background-image: -o-linear-gradient(top, #2e9fd2, #21759b);
-  background-image: linear-gradient(to bottom, #2e9fd2, #21759b);
-  border-color: #1b607f;
-  -webkit-box-shadow: inset 0 1px 0 rgba(120, 200, 230, 0.6);
-  box-shadow: inset 0 1px 0 rgba(120, 200, 230, 0.6);
-  color: #fff;
-  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.3);
+.devhub-wrap input[type='button'].shiny-blue:hover,
+.devhub-wrap input[type='reset'].shiny-blue:hover,
+.devhub-wrap input[type='submit'].shiny-blue:hover {
+	background-color: #278ab7;
+	background-image: -webkit-gradient(
+		linear,
+		left top,
+		left bottom,
+		from(#2e9fd2),
+		to(#21759b)
+	);
+	background-image: -webkit-linear-gradient(top, #2e9fd2, #21759b);
+	background-image: -moz-linear-gradient(top, #2e9fd2, #21759b);
+	background-image: -ms-linear-gradient(top, #2e9fd2, #21759b);
+	background-image: -o-linear-gradient(top, #2e9fd2, #21759b);
+	background-image: linear-gradient(to bottom, #2e9fd2, #21759b);
+	border-color: #1b607f;
+	-webkit-box-shadow: inset 0 1px 0 rgba(120, 200, 230, 0.6);
+	box-shadow: inset 0 1px 0 rgba(120, 200, 230, 0.6);
+	color: #fff;
+	text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.3);
 }
 
 .devhub-wrap a.button .dashicons,
 .devhub-wrap button .dashicons,
-.devhub-wrap input[type="button"] .dashicons,
-.devhub-wrap input[type="reset"] .dashicons,
-.devhub-wrap input[type="submit"] .dashicons {
-  vertical-align: text-bottom;
+.devhub-wrap input[type='button'] .dashicons,
+.devhub-wrap input[type='reset'] .dashicons,
+.devhub-wrap input[type='submit'] .dashicons {
+	vertical-align: text-bottom;
 }
 
 @media (min-width: 43em) and (max-width: 915px) {
-  .devhub-wrap .three-columns a.button {
-    max-width: 100%;
-    padding: .6em 1em;
-    font-size: 14px;
-    font-size: 1.4rem;
-  }
-  .devhub-wrap .three-columns .dashicons {
-    width: 16px;
-    height: 16px;
-    font-size: 16px;
-  }
+	.devhub-wrap .three-columns a.button {
+		max-width: 100%;
+		padding: 0.6em 1em;
+		font-size: 14px;
+		font-size: 1.4rem;
+	}
+	.devhub-wrap .three-columns .dashicons {
+		width: 16px;
+		height: 16px;
+		font-size: 16px;
+	}
 }
 
-.devhub-wrap input[type="checkbox"],
-.devhub-wrap input[type="radio"] {
-  box-sizing: border-box;
-  /* Addresses box sizing set to content-box in IE8/9 */
-  padding: 0;
-  /* Addresses excess padding in IE8/9 */
+.devhub-wrap input[type='checkbox'],
+.devhub-wrap input[type='radio'] {
+	box-sizing: border-box;
+	/* Addresses box sizing set to content-box in IE8/9 */
+	padding: 0;
+	/* Addresses excess padding in IE8/9 */
 }
 
-.devhub-wrap input[type="search"] {
-  -webkit-appearance: textfield;
-  /* Addresses appearance set to searchfield in S5, Chrome */
-  -webkit-box-sizing: content-box;
-  /* Addresses box sizing set to border-box in S5, Chrome (include -moz to future-proof) */
-  -moz-box-sizing: content-box;
-  box-sizing: content-box;
+.devhub-wrap input[type='search'] {
+	-webkit-appearance: textfield;
+	/* Addresses appearance set to searchfield in S5, Chrome */
+	-webkit-box-sizing: content-box;
+	/* Addresses box sizing set to border-box in S5, Chrome (include -moz to future-proof) */
+	-moz-box-sizing: content-box;
+	box-sizing: content-box;
 }
 
-.devhub-wrap input[type="search"]::-webkit-search-decoration {
-  /* Corrects inner padding displayed oddly in S5, Chrome on OSX */
-  -webkit-appearance: none;
+.devhub-wrap input[type='search']::-webkit-search-decoration {
+	/* Corrects inner padding displayed oddly in S5, Chrome on OSX */
+	-webkit-appearance: none;
 }
 
 .devhub-wrap button::-moz-focus-inner,
 .devhub-wrap input::-moz-focus-inner {
-  /* Corrects inner padding and border displayed oddly in FF3/4 www.sitepen.com/blog/2008/05/14/the-devils-in-the-details-fixing-dojos-toolbar-buttons/ */
-  border: 0;
-  padding: 0;
+	/* Corrects inner padding and border displayed oddly in FF3/4 www.sitepen.com/blog/2008/05/14/the-devils-in-the-details-fixing-dojos-toolbar-buttons/ */
+	border: 0;
+	padding: 0;
 }
 
-.devhub-wrap input[type="text"],
-.devhub-wrap input[type="email"],
-.devhub-wrap input[type="url"],
-.devhub-wrap input[type="password"],
-.devhub-wrap input[type="search"],
+.devhub-wrap input[type='text'],
+.devhub-wrap input[type='email'],
+.devhub-wrap input[type='url'],
+.devhub-wrap input[type='password'],
+.devhub-wrap input[type='search'],
 .devhub-wrap textarea {
-  padding: 3px;
-  color: #666;
-  border: 1px solid #ccc;
-  border-radius: 3px;
+	padding: 3px;
+	color: #666;
+	border: 1px solid #ccc;
+	border-radius: 3px;
 }
 
-.devhub-wrap input[type="text"]:focus,
-.devhub-wrap input[type="email"]:focus,
-.devhub-wrap input[type="url"]:focus,
-.devhub-wrap input[type="password"]:focus,
-.devhub-wrap input[type="search"]:focus,
+.devhub-wrap input[type='text']:focus,
+.devhub-wrap input[type='email']:focus,
+.devhub-wrap input[type='url']:focus,
+.devhub-wrap input[type='password']:focus,
+.devhub-wrap input[type='search']:focus,
 .devhub-wrap textarea:focus {
-  color: #111;
+	color: #111;
 }
 
 .devhub-wrap textarea {
-  overflow: auto;
-  /* Removes default vertical scrollbar in IE6/7/8/9 */
-  padding-left: 3px;
-  -moz-tab-size: 4;
-  tab-size: 4;
-  vertical-align: top;
-  /* Improves readability and alignment in all browsers */
-  width: 98%;
+	overflow: auto;
+	/* Removes default vertical scrollbar in IE6/7/8/9 */
+	padding-left: 3px;
+	-moz-tab-size: 4;
+	tab-size: 4;
+	vertical-align: top;
+	/* Improves readability and alignment in all browsers */
+	width: 98%;
 }
 
 .devhub-wrap .screen-reader-text {
-  clip: rect(1px, 1px, 1px, 1px);
-  position: absolute !important;
+	clip: rect(1px, 1px, 1px, 1px);
+	position: absolute !important;
 }
 
 .devhub-wrap .screen-reader-text:hover,
 .devhub-wrap .screen-reader-text:active,
 .devhub-wrap .screen-reader-text:focus {
-  background-color: #f1f1f1;
-  border-radius: 3px;
-  box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
-  clip: auto !important;
-  color: #21759b;
-  display: block;
-  font-size: 14px;
-  font-weight: bold;
-  height: auto;
-  left: 5px;
-  line-height: normal;
-  padding: 15px 23px 14px;
-  text-decoration: none;
-  top: 5px;
-  width: auto;
-  z-index: 100000;
-  /* Above WP toolbar */
+	background-color: #f1f1f1;
+	border-radius: 3px;
+	box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
+	clip: auto !important;
+	color: #21759b;
+	display: block;
+	font-size: 14px;
+	font-weight: bold;
+	height: auto;
+	left: 5px;
+	line-height: normal;
+	padding: 15px 23px 14px;
+	text-decoration: none;
+	top: 5px;
+	width: auto;
+	z-index: 100000;
+	/* Above WP toolbar */
 }
 
 .devhub-wrap .clear:before,
@@ -660,8 +760,8 @@ input {
 .devhub-wrap .site-content:after,
 .devhub-wrap .site-footer:before,
 .devhub-wrap .site-footer:after {
-  content: '';
-  display: table;
+	content: '';
+	display: table;
 }
 
 .devhub-wrap .clear:after,
@@ -669,1749 +769,2013 @@ input {
 .devhub-wrap .comment-content:after,
 .devhub-wrap .site-content:after,
 .devhub-wrap .site-footer:after {
-  clear: both;
+	clear: both;
 }
 
 .devhub-wrap .hentry {
-  margin: 0;
+	margin: 0;
 }
 
 .devhub-wrap .byline,
 .devhub-wrap .updated {
-  display: none;
+	display: none;
 }
 
 .devhub-wrap .single .byline,
 .devhub-wrap .group-blog .byline {
-  display: inline;
+	display: inline;
 }
 
 .devhub-wrap .page-content,
 .devhub-wrap .entry-content,
 .devhub-wrap .entry-summary {
-  margin: 1.5em 0 0;
+	margin: 1.5em 0 0;
 }
 
 .devhub-wrap .page-links {
-  clear: both;
-  margin: 0 0 1.5em;
+	clear: both;
+	margin: 0 0 1.5em;
 }
 
 .devhub-wrap .tablist {
-  margin: 0;
+	margin: 0;
 }
 
 .devhub-wrap .tablist li {
-  display: inline-block;
-  list-style: none;
+	display: inline-block;
+	list-style: none;
 }
 
 .devhub-wrap .tablist a {
-  border-color: none;
-  background-color: transparent;
-  border-color: transparent;
-  border-image: none;
-  border-style: solid solid none;
-  border-width: 1px 1px 0;
-  display: inline-block;
-  padding: .5em 1em;
-  margin-bottom: -1px;
+	border-color: none;
+	background-color: transparent;
+	border-color: transparent;
+	border-image: none;
+	border-style: solid solid none;
+	border-width: 1px 1px 0;
+	display: inline-block;
+	padding: 0.5em 1em;
+	margin-bottom: -1px;
 }
 
 .devhub-wrap .tablist a[aria-selected],
 .devhub-wrap .tablist a:focus {
-  background-color: #fff;
-  border-color: #ccc;
-  border-radius: 3px 3px 0 0;
-  color: #333;
+	background-color: #fff;
+	border-color: #ccc;
+	border-radius: 3px 3px 0 0;
+	color: #333;
 }
 
 .devhub-wrap .tab-section {
-  margin-top: 0;
-  padding: 0;
-  border: none;
+	margin-top: 0;
+	padding: 0;
+	border: none;
 }
 
-.devhub-wrap .tab-section[aria-hidden="true"] {
-  display: none;
+.devhub-wrap .tab-section[aria-hidden='true'] {
+	display: none;
 }
 
 .devhub-wrap .tab-section:focus {
-  background: #eee;
-  outline: thin dotted;
+	background: #eee;
+	outline: thin dotted;
 }
 
 .devhub-wrap .page-content img.wp-smiley,
 .devhub-wrap .entry-content img.wp-smiley,
 .devhub-wrap .comment-content img.wp-smiley {
-  border: none;
-  margin-bottom: 0;
-  margin-top: 0;
-  padding: 0;
+	border: none;
+	margin-bottom: 0;
+	margin-top: 0;
+	padding: 0;
 }
 
 .devhub-wrap .wp-caption {
-  border: 1px solid #ccc;
-  margin-bottom: 1.5em;
-  max-width: 100%;
+	border: 1px solid #ccc;
+	margin-bottom: 1.5em;
+	max-width: 100%;
 }
 
-.devhub-wrap .wp-caption img[class*="wp-image-"] {
-  display: block;
-  margin: 1.2% auto 0;
-  max-width: 98%;
+.devhub-wrap .wp-caption img[class*='wp-image-'] {
+	display: block;
+	margin: 1.2% auto 0;
+	max-width: 98%;
 }
 
 .devhub-wrap .wp-caption-text {
-  text-align: center;
+	text-align: center;
 }
 
 .devhub-wrap .wp-caption .wp-caption-text {
-  margin: 0.8075em 0;
+	margin: 0.8075em 0;
 }
 
 .devhub-wrap .site-main .gallery {
-  margin-bottom: 1.5em;
+	margin-bottom: 1.5em;
 }
 
 .devhub-wrap .site-main .gallery a img {
-  border: none;
-  height: auto;
-  max-width: 90%;
+	border: none;
+	height: auto;
+	max-width: 90%;
 }
 
 .devhub-wrap .site-main .gallery dd {
-  margin: 0;
+	margin: 0;
 }
 
 .devhub-wrap embed,
 .devhub-wrap iframe,
 .devhub-wrap object {
-  max-width: 100%;
+	max-width: 100%;
 }
 
 .devhub-wrap .widget select {
-  max-width: 100%;
+	max-width: 100%;
 }
 
 .devhub-wrap .widget_search .search-submit {
-  display: none;
+	display: none;
 }
 
 .devhub-wrap .widget-area .search-section.hide-if-js {
-  display: block;
+	display: block;
 }
 
 .devhub-wrap .infinite-scroll .paging-navigation,
 .devhub-wrap .infinite-scroll.neverending .site-footer {
-  /* Theme Footer (when set to scrolling) */
-  display: none;
+	/* Theme Footer (when set to scrolling) */
+	display: none;
 }
 
 .devhub-wrap .infinity-end.neverending .site-footer {
-  display: block;
+	display: block;
 }
 
 .devhub-wrap .breadcrumbs {
-  font-size: 13px;
-  font-size: 1.3rem;
+	font-size: 13px;
+	font-size: 1.3rem;
 }
 
 .devhub-wrap .breadcrumbs .active {
-  font-weight: 600;
+	font-weight: 600;
 }
 
 .devhub-wrap .breadcrumb-trail {
-  margin-bottom: 2rem;
+	margin-bottom: 2rem;
 }
 
 .devhub-wrap .breadcrumb-trail a {
-  text-decoration: none;
+	text-decoration: none;
 }
 
 .devhub-wrap h1.entry-title,
 .devhub-wrap h1.page-title {
-  font-weight: 300;
-  font-size: 37px;
-  font-size: 3.7rem;
-  color: #606060;
-  text-align: center;
+	font-weight: 300;
+	font-size: 37px;
+	font-size: 3.7rem;
+	color: #606060;
+	text-align: center;
 }
 
 .devhub-wrap h1.entry-title a,
 .devhub-wrap h1.page-title a {
-  text-decoration: none;
-  color: #606060;
+	text-decoration: none;
+	color: #606060;
 }
 
 .devhub-wrap h1.single-entry-title,
 .devhub-wrap h2.entry-title {
-  text-align: left;
-  font-size: 30px;
-  font-size: 3rem;
-  padding: 0 0 24px;
-  padding: 0 0 2.4rem;
+	text-align: left;
+	font-size: 30px;
+	font-size: 3rem;
+	padding: 0 0 24px;
+	padding: 0 0 2.4rem;
 }
 
 .devhub-wrap h1.single-entry-title a,
 .devhub-wrap h2.entry-title a {
-  text-decoration: none;
-  color: #606060;
+	text-decoration: none;
+	color: #606060;
 }
 
 .devhub-wrap section {
-  overflow: auto;
+	overflow: auto;
 }
 
 .devhub-wrap section.error-404 {
-  overflow: visible;
+	overflow: visible;
 }
 
 .devhub-wrap .home-landing .section {
-  padding: 50px 0 10px;
-  padding: 5rem 0 1rem;
-  margin-top: 60px;
-  margin-top: 6rem;
-  overflow: auto;
+	padding: 50px 0 10px;
+	padding: 5rem 0 1rem;
+	margin-top: 60px;
+	margin-top: 6rem;
+	overflow: auto;
 }
 
 .devhub-wrap .home-landing .section .no-bullets li {
-  line-height: 20px;
-  line-height: 2rem;
-  margin-bottom: 12.5px;
-  margin-bottom: 1.25rem;
+	line-height: 20px;
+	line-height: 2rem;
+	margin-bottom: 12.5px;
+	margin-bottom: 1.25rem;
 }
 
 .devhub-wrap .home-landing .section .no-bullets li a {
-  color: #4ca6cf;
-  font-size: 125%;
+	color: #4ca6cf;
+	font-size: 125%;
 }
 
 .devhub-wrap .home-landing .section .widget-title {
-  line-height: 60px;
-  line-height: 6rem;
+	line-height: 60px;
+	line-height: 6rem;
 }
 
 .devhub-wrap .home-landing .section.search-guide {
-  border-top: 2px solid #efefef;
+	border-top: 2px solid #efefef;
 }
 
 @media (max-width: 974px) {
-  .devhub-wrap .home-landing .section {
-    width: 640px;
-    margin: 0 auto;
-  }
+	.devhub-wrap .home-landing .section {
+		width: 640px;
+		margin: 0 auto;
+	}
 }
 
 .devhub-wrap .color.section {
-  color: #fff;
+	color: #fff;
 }
 
 .devhub-wrap .section {
-  /*background: #0073aa;*/
-  padding: 30px 0;
-  padding: 3rem 0;
+	/*background: #0073aa;*/
+	padding: 30px 0;
+	padding: 3rem 0;
 }
 
 .devhub-wrap .section .box {
-  text-align: center;
-  padding: 0 30px 90px;
-  padding: 0 3rem 9rem;
-  width: 320px;
+	text-align: center;
+	padding: 0 30px 90px;
+	padding: 0 3rem 9rem;
+	width: 320px;
 }
 
 .devhub-wrap .section .box .widget-description {
-  padding: 1em 0 0;
-  margin-bottom: 5px;
-  margin-bottom: 1rem;
+	padding: 1em 0 0;
+	margin-bottom: 5px;
+	margin-bottom: 1rem;
 }
 
 .devhub-wrap .section.search-guide {
-  padding-top: 60px;
-  padding-top: 6rem;
-  margin-top: 0;
+	padding-top: 60px;
+	padding-top: 6rem;
+	margin-top: 0;
 }
 
 .devhub-wrap .section.search-guide .box {
-  text-align: left;
+	text-align: left;
 }
 
 .devhub-wrap .section .widget-title {
-  font-size: 25px;
-  font-size: 2.5rem;
-  line-height: 20px;
-  line-height: 2rem;
+	font-size: 25px;
+	font-size: 2.5rem;
+	line-height: 20px;
+	line-height: 2rem;
 }
 
 .devhub-wrap .section .widget-title .dashicons {
-  color: #222;
-  font-size: 108px;
-  font-size: 10.8rem;
-  line-height: 84px;
-  line-height: 8.4rem;
-  height: 84px;
-  width: 84px;
-  height: 8.4rem;
-  width: 8.4rem;
-  display: block;
-  margin: 0 auto;
-  opacity: 0.4;
+	color: #222;
+	font-size: 108px;
+	font-size: 10.8rem;
+	line-height: 84px;
+	line-height: 8.4rem;
+	height: 84px;
+	width: 84px;
+	height: 8.4rem;
+	width: 8.4rem;
+	display: block;
+	margin: 0 auto;
+	opacity: 0.4;
 }
 
 .devhub-wrap .section .widget-title .dashicons.dashicons-rest-api {
-  font-size: 90px;
-  font-size: 9rem;
+	font-size: 90px;
+	font-size: 9rem;
 }
 
 @media (min-width: 43em) and (max-width: 915px) {
-  .devhub-wrap .section .three-columns .widget-title {
-    font-size: 35px;
-    font-size: 3.5rem;
-  }
+	.devhub-wrap .section .three-columns .widget-title {
+		font-size: 35px;
+		font-size: 3.5rem;
+	}
 }
 
 .devhub-wrap .section.gray {
-  background: #797878;
-  color: #fff;
+	background: #797878;
+	color: #fff;
 }
 
 .devhub-wrap .section.gray h2,
 .devhub-wrap .section.gray h3,
 .devhub-wrap .section.gray h4 {
-  color: #fff;
+	color: #fff;
 }
 
 .devhub-wrap .section.gray .inner-wrap {
-  max-width: 760px;
-  max-width: 76rem;
-  margin: 1.2em auto 0;
+	max-width: 760px;
+	max-width: 76rem;
+	margin: 1.2em auto 0;
 }
 
 .devhub-wrap .section.gray .inner-wrap .code-ref-left {
-  float: left;
-  width: 60%;
-  clear: none;
-  text-align: center;
+	float: left;
+	width: 60%;
+	clear: none;
+	text-align: center;
 }
 
 .devhub-wrap .section.gray .inner-wrap .code-ref-right {
-  float: left;
-  width: 40%;
-  clear: none;
-  margin-top: 1.1em;
-  text-align: center;
+	float: left;
+	width: 40%;
+	clear: none;
+	margin-top: 1.1em;
+	text-align: center;
 }
 
 @media (max-width: 43em) {
-  .devhub-wrap .section.gray .inner-wrap .code-ref-left,
-  .devhub-wrap .section.gray .inner-wrap .code-ref-right {
-    float: none;
-    width: 100%;
-    padding: 0 4px;
-    clear: both;
-    text-align: center;
-  }
-  .devhub-wrap .section.gray .inner-wrap .code-ref-left .widget-description {
-    margin-left: 0;
-  }
-  .devhub-wrap .section.gray .inner-wrap .go {
-    float: none;
-  }
+	.devhub-wrap .section.gray .inner-wrap .code-ref-left,
+	.devhub-wrap .section.gray .inner-wrap .code-ref-right {
+		float: none;
+		width: 100%;
+		padding: 0 4px;
+		clear: both;
+		text-align: center;
+	}
+	.devhub-wrap .section.gray .inner-wrap .code-ref-left .widget-description {
+		margin-left: 0;
+	}
+	.devhub-wrap .section.gray .inner-wrap .go {
+		float: none;
+	}
 }
 
 .devhub-wrap .section.gray .widget-title {
-  font-weight: 300;
-  font-size: 50px;
-  font-size: 5rem;
-  line-height: 68px;
-  line-height: 6.8rem;
+	font-weight: 300;
+	font-size: 50px;
+	font-size: 5rem;
+	line-height: 68px;
+	line-height: 6.8rem;
 }
 
 .devhub-wrap .section.gray .widget-title .dashicons {
-  font-size: 68px;
-  font-size: 6.8rem;
-  line-height: 68px;
-  line-height: 6.8rem;
-  height: 6.8px;
-  width: 6.8px;
-  height: 6.8rem;
-  width: 6.8rem;
+	font-size: 68px;
+	font-size: 6.8rem;
+	line-height: 68px;
+	line-height: 6.8rem;
+	height: 6.8px;
+	width: 6.8px;
+	height: 6.8rem;
+	width: 6.8rem;
 }
 
 @media (min-width: 43em) and (max-width: 915px) {
-  .devhub-wrap .section.gray .widget-title {
-    font-size: 35px;
-    font-size: 3.5rem;
-  }
+	.devhub-wrap .section.gray .widget-title {
+		font-size: 35px;
+		font-size: 3.5rem;
+	}
 }
 
 .devhub-wrap .section.gray .widget-description {
-  margin-left: 85px;
-  margin-left: 8.5rem;
+	margin-left: 85px;
+	margin-left: 8.5rem;
 }
 
 .devhub-wrap .section.light-gray {
-  background: #f2f2f2;
-  color: #606060;
+	background: #f2f2f2;
+	color: #606060;
 }
 
 .devhub-wrap .section.light-gray .widget-title {
-  color: #606060;
-  font-weight: 600;
+	color: #606060;
+	font-weight: 600;
 }
 
 .devhub-wrap .section.light-gray .widget-title a {
-  color: #2D96C2;
+	color: #2d96c2;
 }
 
 .devhub-wrap .section.light-gray a {
-  color: #606060;
-  text-decoration: none;
+	color: #606060;
+	text-decoration: none;
 }
 
 .devhub-wrap .section.light-gray a.make-wp-link:after {
-  content: "\f345";
-  font-family: 'dashicons';
-  margin-left: 4px;
-  vertical-align: middle;
+	content: '\f345';
+	font-family: 'dashicons';
+	margin-left: 4px;
+	vertical-align: middle;
 }
 
 .devhub-wrap .section .home-primary-content {
-  max-width: 600px;
-  max-width: 60rem;
-  margin: 0 auto;
+	max-width: 600px;
+	max-width: 60rem;
+	margin: 0 auto;
 }
 
 .devhub-wrap .box {
-  padding: 30px;
-  padding: 3rem;
-  float: left;
-  clear: none;
+	padding: 30px;
+	padding: 3rem;
+	float: left;
+	clear: none;
 }
 
 @media (min-width: 43em) and (max-width: 915px) {
-  .devhub-wrap .three-columns .box {
-    padding: 30px 20px;
-    padding: 3rem 2rem;
-  }
+	.devhub-wrap .three-columns .box {
+		padding: 30px 20px;
+		padding: 3rem 2rem;
+	}
 }
 
 .devhub-wrap .reference-landing .section.search-section {
-  padding-top: 0;
+	padding-top: 0;
 }
 
 .devhub-wrap div#inner-search {
-  background-color: #666;
-  margin-bottom: 1em;
-  padding-top: 2px;
+	background-color: #666;
+	margin-bottom: 1em;
+	padding-top: 2px;
 }
 
 .devhub-wrap div#inner-search .section.search-section {
-  color: #ffffff;
+	color: #ffffff;
 }
 
 .devhub-wrap div#inner-search div#inner-search-icon-container {
-  margin: 0 auto;
-  max-width: 60em;
-  cursor: pointer;
+	margin: 0 auto;
+	max-width: 60em;
+	cursor: pointer;
 }
 
-.devhub-wrap div#inner-search div#inner-search-icon-container div#inner-search-icon {
-  background-color: #666;
-  color: #ffffff;
-  text-align: center;
-  margin-right: 26px;
-  margin-left: 4px;
-  float: right;
-  padding: 5px;
-  -webkit-border-bottom-right-radius: 5px;
-  -webkit-border-bottom-left-radius: 5px;
-  -moz-border-radius-bottomright: 5px;
-  -moz-border-radius-bottomleft: 5px;
-  border-bottom-right-radius: 5px;
-  border-bottom-left-radius: 5px;
+.devhub-wrap
+	div#inner-search
+	div#inner-search-icon-container
+	div#inner-search-icon {
+	background-color: #666;
+	color: #ffffff;
+	text-align: center;
+	margin-right: 26px;
+	margin-left: 4px;
+	float: right;
+	padding: 5px;
+	-webkit-border-bottom-right-radius: 5px;
+	-webkit-border-bottom-left-radius: 5px;
+	-moz-border-radius-bottomright: 5px;
+	-moz-border-radius-bottomleft: 5px;
+	border-bottom-right-radius: 5px;
+	border-bottom-left-radius: 5px;
 }
 
-.devhub-wrap div#inner-search div#inner-search-icon-container div#inner-search-icon .dashicons-search {
-  height: auto;
-  width: auto;
+.devhub-wrap
+	div#inner-search
+	div#inner-search-icon-container
+	div#inner-search-icon
+	.dashicons-search {
+	height: auto;
+	width: auto;
 }
 
-.devhub-wrap div#inner-search div#inner-search-icon-container div#inner-search-icon .dashicons-search:before {
-  font-size: 36px;
-  line-height: 36px;
+.devhub-wrap
+	div#inner-search
+	div#inner-search-icon-container
+	div#inner-search-icon
+	.dashicons-search:before {
+	font-size: 36px;
+	line-height: 36px;
 }
 
 .devhub-wrap .archive-filter-form {
-  margin: 5rem 0;
-  font-size: 1.5rem;
+	margin: 5rem 0;
+	font-size: 1.5rem;
 }
 
-.devhub-wrap .archive-filter-form input[type="submit"] {
-  margin-left: .5em;
-  padding: 0.2em 0.5em;
-  line-height: 1;
-  font-size: 1.5rem;
+.devhub-wrap .archive-filter-form input[type='submit'] {
+	margin-left: 0.5em;
+	padding: 0.2em 0.5em;
+	line-height: 1;
+	font-size: 1.5rem;
 }
 
 .devhub-wrap .searchform {
-  overflow: hidden;
-  height: auto;
-  position: relative;
+	overflow: hidden;
+	height: auto;
+	position: relative;
 }
 
-.devhub-wrap .searchform input[type="text"] {
-  border-radius: 0;
-  margin: 0 auto;
-  padding: 0.5em;
-  width: 100%;
+.devhub-wrap .searchform input[type='text'] {
+	border-radius: 0;
+	margin: 0 auto;
+	padding: 0.5em;
+	width: 100%;
 }
 
 .devhub-wrap .searchform .button-search {
-  background: transparent;
-  border: none;
-  border-radius: 0;
-  box-shadow: none;
-  color: #32373c;
-  display: block;
-  height: 40px;
-  padding: 0.5rem 1rem;
-  position: absolute;
-  right: 0;
-  top: 0;
-  text-shadow: none;
+	background: transparent;
+	border: none;
+	border-radius: 0;
+	box-shadow: none;
+	color: #32373c;
+	display: block;
+	height: 40px;
+	padding: 0.5rem 1rem;
+	position: absolute;
+	right: 0;
+	top: 0;
+	text-shadow: none;
 }
 
 .devhub-wrap .searchform label {
-  width: 560px;
-  width: 56rem;
-  max-width: 100%;
-  margin-right: 15px;
-  display: inline-block;
-  float: left;
+	width: 560px;
+	width: 56rem;
+	max-width: 100%;
+	margin-right: 15px;
+	display: inline-block;
+	float: left;
 }
 
-.devhub-wrap .searchform label .search-field input[type="text"] {
-  width: 100%;
+.devhub-wrap .searchform label .search-field input[type='text'] {
+	width: 100%;
 }
 
 .devhub-wrap .searchform div {
-  overflow: auto;
+	overflow: auto;
 }
 
 .devhub-wrap .searchform .search-post-type {
-  margin-top: 1em;
+	margin-top: 1em;
 }
 
 .devhub-wrap .searchform .search-post-type label {
-  border-right: 1px solid #ccc;
-  float: none;
-  width: inherit;
-  margin-left: 1em;
-  margin-right: 0;
-  padding-left: 0;
-  padding-right: 1.3em;
+	border-right: 1px solid #ccc;
+	float: none;
+	width: inherit;
+	margin-left: 1em;
+	margin-right: 0;
+	padding-left: 0;
+	padding-right: 1.3em;
 }
 
 .devhub-wrap .searchform .search-post-type label input {
-  margin-bottom: 6px;
-  padding-left: 0.5em;
-  vertical-align: middle;
+	margin-bottom: 6px;
+	padding-left: 0.5em;
+	vertical-align: middle;
 }
 
 .devhub-wrap .searchform .search-post-type label:last-child {
-  border-right-width: 0;
+	border-right-width: 0;
 }
 
 @media (max-width: 688px) {
-  .devhub-wrap .searchform .search-post-type span {
-    display: block;
-  }
-  .devhub-wrap .searchform .search-post-type label {
-    margin-left: 0;
-    margin-right: 1em;
-    width: 130px;
-  }
-  .devhub-wrap .searchform .search-post-type label:last-child {
-    margin-right: 0;
-    padding-right: 0;
-    width: initial;
-  }
+	.devhub-wrap .searchform .search-post-type span {
+		display: block;
+	}
+	.devhub-wrap .searchform .search-post-type label {
+		margin-left: 0;
+		margin-right: 1em;
+		width: 130px;
+	}
+	.devhub-wrap .searchform .search-post-type label:last-child {
+		margin-right: 0;
+		padding-right: 0;
+		width: initial;
+	}
 }
 
 .devhub-wrap .search-results-summary {
-  font-style: italic;
-  margin-bottom: 1em;
+	font-style: italic;
+	margin-bottom: 1em;
 }
 
-.devhub-wrap .reference-landing .section, .devhub-wrap .search-section {
-  max-width: 970px;
-  max-width: 97rem;
-  margin: 0 auto;
-  padding: 1.5em 1em;
+.devhub-wrap .reference-landing .section,
+.devhub-wrap .search-section {
+	max-width: 970px;
+	max-width: 97rem;
+	margin: 0 auto;
+	padding: 1.5em 1em;
 }
 
 .devhub-wrap .reference-landing .section h2,
 .devhub-wrap .reference-landing .section h3,
 .devhub-wrap .reference-landing .section h4 {
-  margin-bottom: 1em;
-  color: #404040;
+	margin-bottom: 1em;
+	color: #404040;
 }
 
 .devhub-wrap .reference-landing .section h2.widget-title,
 .devhub-wrap .reference-landing .section h3.widget-title,
 .devhub-wrap .reference-landing .section h4.widget-title {
-  margin-bottom: 0;
+	margin-bottom: 0;
 }
 
 .devhub-wrap .reference-landing .section.search-guide {
-  padding-bottom: 0;
+	padding-bottom: 0;
 }
 
-.devhub-wrap .reference-landing .section.section.topic-guide, .devhub-wrap .reference-landing .section.section.new-in-guide {
-  padding-top: 0;
+.devhub-wrap .reference-landing .section.section.topic-guide,
+.devhub-wrap .reference-landing .section.section.new-in-guide {
+	padding-top: 0;
 }
 
 .devhub-wrap .reference-landing .box,
 .devhub-wrap .sidebar .box {
-  padding: 0;
-  border: 2px solid #cccccc;
-  background-color: #eeeeee;
+	padding: 0;
+	border: 2px solid #cccccc;
+	background-color: #eeeeee;
 }
 
 .devhub-wrap .reference-landing .box ul,
 .devhub-wrap .sidebar .box ul {
-  padding: 2em;
+	padding: 2em;
 }
 
 .devhub-wrap .reference-landing .box .widget-title,
 .devhub-wrap .sidebar .box .widget-title {
-  padding: 10px 30px;
-  padding: 1rem 30px;
-  font-size: 16px;
-  font-size: 1.6rem;
+	padding: 10px 30px;
+	padding: 1rem 30px;
+	font-size: 16px;
+	font-size: 1.6rem;
 }
 
 .devhub-wrap .reference-landing .box .widget-content,
 .devhub-wrap .sidebar .box .widget-content {
-  padding: 16px 30px;
-  padding: 1.6rem 3rem;
+	padding: 16px 30px;
+	padding: 1.6rem 3rem;
 }
 
 .devhub-wrap .reference-landing .box ul {
-  padding: 0;
-  overflow: hidden;
+	padding: 0;
+	overflow: hidden;
 }
 
 .devhub-wrap .three-columns .box {
-  width: 31%;
-  margin: 1.15%;
+	width: 31%;
+	margin: 1.15%;
 }
 
 @media (min-width: 43em) and (max-width: 915px) {
-  .devhub-wrap .three-columns .box {
-    margin: 1% 0;
-  }
+	.devhub-wrap .three-columns .box {
+		margin: 1% 0;
+	}
 }
 
 .devhub-wrap .two-columns .box {
-  width: 48%;
-  margin: 1% 1% 1% 0;
+	width: 48%;
+	margin: 1% 1% 1% 0;
 }
 
 .devhub-wrap .new-in-guide.two-columns .box {
-  width: 43%;
+	width: 43%;
 }
 
 @media (max-width: 688px) {
-  .devhub-wrap .new-in-guide.two-columns .box {
-    width: 100%;
-  }
+	.devhub-wrap .new-in-guide.two-columns .box {
+		width: 100%;
+	}
 }
 
 .devhub-wrap .new-in-guide.two-columns .box:first-child {
-  width: 53%;
+	width: 53%;
 }
 
 @media (max-width: 688px) {
-  .devhub-wrap .new-in-guide.two-columns .box:first-child {
-    width: 100%;
-  }
+	.devhub-wrap .new-in-guide.two-columns .box:first-child {
+		width: 100%;
+	}
 }
 
 .devhub-wrap #sidebar,
 .devhub-wrap .no-bullets,
 .devhub-wrap .sidebar .widget ul {
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
+	list-style-type: none;
+	margin: 0;
+	padding: 0;
 }
 
 .devhub-wrap .horizontal-list {
-  display: block;
-  width: 100%;
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
-  text-align: center;
+	display: block;
+	width: 100%;
+	list-style-type: none;
+	margin: 0;
+	padding: 0;
+	text-align: center;
 }
 
 .devhub-wrap .horizontal-list li {
-  display: inline;
+	display: inline;
 }
 
 .devhub-wrap .horizontal-list li a {
-  padding: 0px 40px;
-  padding: 0 4rem;
-  border-left: 1px solid #ccc;
+	padding: 0px 40px;
+	padding: 0 4rem;
+	border-left: 1px solid #ccc;
 }
 
 .devhub-wrap .horizontal-list li:first-child a {
-  padding-left: 0;
-  border-left: none;
+	padding-left: 0;
+	border-left: none;
 }
 
 .devhub-wrap .view-all-new-in {
-  font-style: italic;
+	font-style: italic;
 }
 
 .devhub-wrap .box.transparent {
-  background: none;
-  color: #333;
+	background: none;
+	color: #333;
 }
 
 .devhub-wrap .box.transparent h2,
 .devhub-wrap .box.transparent h3,
 .devhub-wrap .box.transparent h4 {
-  color: #32373c;
+	color: #32373c;
 }
 
 .devhub-wrap .box.gray {
-  background: #fff;
-  border: 1px solid #d8d8d8;
+	background: #fff;
+	border: 1px solid #d8d8d8;
 }
 
 .devhub-wrap .box.gray .widget-title {
-  color: #666666;
-  background: #d8d8d8;
-  text-transform: uppercase;
+	color: #666666;
+	background: #d8d8d8;
+	text-transform: uppercase;
 }
 
 .devhub-wrap .box .unordered-list {
-  list-style-type: none;
-  padding: 0;
-  margin: 0;
-  font-size: 13px;
-  font-size: 1.3rem;
-  line-height: 30px;
-  line-height: 3rem;
+	list-style-type: none;
+	padding: 0;
+	margin: 0;
+	font-size: 13px;
+	font-size: 1.3rem;
+	line-height: 30px;
+	line-height: 3rem;
 }
 
 .devhub-wrap .widget-description {
-  font-weight: 400;
+	font-weight: 400;
 }
 
 .devhub-wrap .go {
-  color: #4ca6cf;
+	color: #4ca6cf;
 }
 
 .devhub-wrap .handbook h1 {
-  margin: 24px 0;
-  font-size: 20px;
-  font-weight: normal;
+	margin: 24px 0;
+	font-size: 20px;
+	font-weight: normal;
 }
 
-.devhub-wrap .wp-parser-class, .devhub-wrap .wp-parser-function, .devhub-wrap .wp-parser-hook, .devhub-wrap .wp-parser-method {
-  border-bottom: 1px solid #dfdfdf;
+.devhub-wrap .wp-parser-class,
+.devhub-wrap .wp-parser-function,
+.devhub-wrap .wp-parser-hook,
+.devhub-wrap .wp-parser-method {
+	border-bottom: 1px solid #dfdfdf;
 }
 
-.devhub-wrap .wp-parser-class h1, .devhub-wrap .wp-parser-function h1, .devhub-wrap .wp-parser-hook h1, .devhub-wrap .wp-parser-method h1 {
-  margin: 24px 0;
-  padding-left: 100px;
-  text-indent: -100px;
-  color: #24831d;
-  font-family: monospace;
-  font-size: 20px;
+.devhub-wrap .wp-parser-class h1,
+.devhub-wrap .wp-parser-function h1,
+.devhub-wrap .wp-parser-hook h1,
+.devhub-wrap .wp-parser-method h1 {
+	margin: 24px 0;
+	padding-left: 100px;
+	text-indent: -100px;
+	color: #24831d;
+	font-family: monospace;
+	font-size: 20px;
 }
 
-.devhub-wrap .wp-parser-class h1 .hook-func, .devhub-wrap .wp-parser-function h1 .hook-func, .devhub-wrap .wp-parser-hook h1 .hook-func, .devhub-wrap .wp-parser-method h1 .hook-func {
-  color: #888888;
+.devhub-wrap .wp-parser-class h1 .hook-func,
+.devhub-wrap .wp-parser-function h1 .hook-func,
+.devhub-wrap .wp-parser-hook h1 .hook-func,
+.devhub-wrap .wp-parser-method h1 .hook-func {
+	color: #888888;
 }
 
-.devhub-wrap .wp-parser-class h1 .arg-type, .devhub-wrap .wp-parser-function h1 .arg-type, .devhub-wrap .wp-parser-hook h1 .arg-type, .devhub-wrap .wp-parser-method h1 .arg-type {
-  color: #cd2f23;
-  font-style: italic;
+.devhub-wrap .wp-parser-class h1 .arg-type,
+.devhub-wrap .wp-parser-function h1 .arg-type,
+.devhub-wrap .wp-parser-hook h1 .arg-type,
+.devhub-wrap .wp-parser-method h1 .arg-type {
+	color: #cd2f23;
+	font-style: italic;
 }
 
-.devhub-wrap .wp-parser-class h1 .arg-name, .devhub-wrap .wp-parser-function h1 .arg-name, .devhub-wrap .wp-parser-hook h1 .arg-name, .devhub-wrap .wp-parser-method h1 .arg-name {
-  color: #0f55c8;
+.devhub-wrap .wp-parser-class h1 .arg-name,
+.devhub-wrap .wp-parser-function h1 .arg-name,
+.devhub-wrap .wp-parser-hook h1 .arg-name,
+.devhub-wrap .wp-parser-method h1 .arg-name {
+	color: #0f55c8;
 }
 
-.devhub-wrap .wp-parser-class h1 .arg-default, .devhub-wrap .wp-parser-function h1 .arg-default, .devhub-wrap .wp-parser-hook h1 .arg-default, .devhub-wrap .wp-parser-method h1 .arg-default {
-  color: #000000;
+.devhub-wrap .wp-parser-class h1 .arg-default,
+.devhub-wrap .wp-parser-function h1 .arg-default,
+.devhub-wrap .wp-parser-hook h1 .arg-default,
+.devhub-wrap .wp-parser-method h1 .arg-default {
+	color: #000000;
 }
 
-.devhub-wrap .wp-parser-class h1 a:hover, .devhub-wrap .wp-parser-function h1 a:hover, .devhub-wrap .wp-parser-hook h1 a:hover, .devhub-wrap .wp-parser-method h1 a:hover {
-  border-bottom: 1px dotted #21759b;
+.devhub-wrap .wp-parser-class h1 a:hover,
+.devhub-wrap .wp-parser-function h1 a:hover,
+.devhub-wrap .wp-parser-hook h1 a:hover,
+.devhub-wrap .wp-parser-method h1 a:hover {
+	border-bottom: 1px dotted #21759b;
 }
 
-.devhub-wrap .wp-parser-class h2, .devhub-wrap .wp-parser-function h2, .devhub-wrap .wp-parser-hook h2, .devhub-wrap .wp-parser-method h2 {
-  font-family: Georgia, Times, serif;
-  margin-bottom: .5em;
+.devhub-wrap .wp-parser-class h2,
+.devhub-wrap .wp-parser-function h2,
+.devhub-wrap .wp-parser-hook h2,
+.devhub-wrap .wp-parser-method h2 {
+	font-family: Georgia, Times, serif;
+	margin-bottom: 0.5em;
 }
 
-.devhub-wrap .wp-parser-class .return-type, .devhub-wrap .wp-parser-function .return-type, .devhub-wrap .wp-parser-hook .return-type, .devhub-wrap .wp-parser-method .return-type {
-  font-style: italic;
+.devhub-wrap .wp-parser-class .return-type,
+.devhub-wrap .wp-parser-function .return-type,
+.devhub-wrap .wp-parser-hook .return-type,
+.devhub-wrap .wp-parser-method .return-type {
+	font-style: italic;
 }
 
-.devhub-wrap .wp-parser-class .parameters p, .devhub-wrap .wp-parser-function .parameters p, .devhub-wrap .wp-parser-hook .parameters p, .devhub-wrap .wp-parser-method .parameters p {
-  margin-bottom: 0;
+.devhub-wrap .wp-parser-class .parameters p,
+.devhub-wrap .wp-parser-function .parameters p,
+.devhub-wrap .wp-parser-hook .parameters p,
+.devhub-wrap .wp-parser-method .parameters p {
+	margin-bottom: 0;
 }
 
-.devhub-wrap .wp-parser-class .parameters dd .desc .type, .devhub-wrap .wp-parser-class .parameters dd .desc .required, .devhub-wrap .wp-parser-function .parameters dd .desc .type, .devhub-wrap .wp-parser-function .parameters dd .desc .required, .devhub-wrap .wp-parser-hook .parameters dd .desc .type, .devhub-wrap .wp-parser-hook .parameters dd .desc .required, .devhub-wrap .wp-parser-method .parameters dd .desc .type, .devhub-wrap .wp-parser-method .parameters dd .desc .required {
-  font-style: italic;
+.devhub-wrap .wp-parser-class .parameters dd .desc .type,
+.devhub-wrap .wp-parser-class .parameters dd .desc .required,
+.devhub-wrap .wp-parser-function .parameters dd .desc .type,
+.devhub-wrap .wp-parser-function .parameters dd .desc .required,
+.devhub-wrap .wp-parser-hook .parameters dd .desc .type,
+.devhub-wrap .wp-parser-hook .parameters dd .desc .required,
+.devhub-wrap .wp-parser-method .parameters dd .desc .type,
+.devhub-wrap .wp-parser-method .parameters dd .desc .required {
+	font-style: italic;
 }
 
-.devhub-wrap .wp-parser-class .parameters dd .default, .devhub-wrap .wp-parser-function .parameters dd .default, .devhub-wrap .wp-parser-hook .parameters dd .default, .devhub-wrap .wp-parser-method .parameters dd .default {
-  font-style: italic;
+.devhub-wrap .wp-parser-class .parameters dd .default,
+.devhub-wrap .wp-parser-function .parameters dd .default,
+.devhub-wrap .wp-parser-hook .parameters dd .default,
+.devhub-wrap .wp-parser-method .parameters dd .default {
+	font-style: italic;
 }
 
-.devhub-wrap .wp-parser-class .parameters dd ul, .devhub-wrap .wp-parser-function .parameters dd ul, .devhub-wrap .wp-parser-hook .parameters dd ul, .devhub-wrap .wp-parser-method .parameters dd ul {
-  margin-left: 25px;
-  margin-left: 2.5rem;
+.devhub-wrap .wp-parser-class .parameters dd ul,
+.devhub-wrap .wp-parser-function .parameters dd ul,
+.devhub-wrap .wp-parser-hook .parameters dd ul,
+.devhub-wrap .wp-parser-method .parameters dd ul {
+	margin-left: 25px;
+	margin-left: 2.5rem;
 }
 
-.devhub-wrap .wp-parser-class .parameters .param-hash, .devhub-wrap .wp-parser-function .parameters .param-hash, .devhub-wrap .wp-parser-hook .parameters .param-hash, .devhub-wrap .wp-parser-method .parameters .param-hash {
-  margin-left: 1.2em;
-  margin-bottom: 0.5em;
+.devhub-wrap .wp-parser-class .parameters .param-hash,
+.devhub-wrap .wp-parser-function .parameters .param-hash,
+.devhub-wrap .wp-parser-hook .parameters .param-hash,
+.devhub-wrap .wp-parser-method .parameters .param-hash {
+	margin-left: 1.2em;
+	margin-bottom: 0.5em;
 }
 
-.devhub-wrap .wp-parser-class .parameters .param-hash > li, .devhub-wrap .wp-parser-function .parameters .param-hash > li, .devhub-wrap .wp-parser-hook .parameters .param-hash > li, .devhub-wrap .wp-parser-method .parameters .param-hash > li {
-  margin-top: 1em;
+.devhub-wrap .wp-parser-class .parameters .param-hash > li,
+.devhub-wrap .wp-parser-function .parameters .param-hash > li,
+.devhub-wrap .wp-parser-hook .parameters .param-hash > li,
+.devhub-wrap .wp-parser-method .parameters .param-hash > li {
+	margin-top: 1em;
 }
 
-.devhub-wrap .wp-parser-class .parameters .param-hash li li, .devhub-wrap .wp-parser-function .parameters .param-hash li li, .devhub-wrap .wp-parser-hook .parameters .param-hash li li, .devhub-wrap .wp-parser-method .parameters .param-hash li li {
-  list-style-type: circle;
+.devhub-wrap .wp-parser-class .parameters .param-hash li li,
+.devhub-wrap .wp-parser-function .parameters .param-hash li li,
+.devhub-wrap .wp-parser-hook .parameters .param-hash li li,
+.devhub-wrap .wp-parser-method .parameters .param-hash li li {
+	list-style-type: circle;
 }
 
-.devhub-wrap .wp-parser-class .parameters .param-hash .param-hash > li, .devhub-wrap .wp-parser-function .parameters .param-hash .param-hash > li, .devhub-wrap .wp-parser-hook .parameters .param-hash .param-hash > li, .devhub-wrap .wp-parser-method .parameters .param-hash .param-hash > li {
-  list-style-type: disc;
+.devhub-wrap .wp-parser-class .parameters .param-hash .param-hash > li,
+.devhub-wrap .wp-parser-function .parameters .param-hash .param-hash > li,
+.devhub-wrap .wp-parser-hook .parameters .param-hash .param-hash > li,
+.devhub-wrap .wp-parser-method .parameters .param-hash .param-hash > li {
+	list-style-type: disc;
 }
 
-.devhub-wrap .wp-parser-class .learn-more, .devhub-wrap .wp-parser-function .learn-more, .devhub-wrap .wp-parser-hook .learn-more, .devhub-wrap .wp-parser-method .learn-more {
-  background-color: #f1f1f1;
-  border: 1px solid #dfdfdf;
-  border-radius: 5px;
-  padding: 20px;
+.devhub-wrap .wp-parser-class .learn-more,
+.devhub-wrap .wp-parser-function .learn-more,
+.devhub-wrap .wp-parser-hook .learn-more,
+.devhub-wrap .wp-parser-method .learn-more {
+	background-color: #f1f1f1;
+	border: 1px solid #dfdfdf;
+	border-radius: 5px;
+	padding: 20px;
 }
 
 .devhub-wrap .wp-parser-class .deprecated,
-.devhub-wrap .wp-parser-class .private-access, .devhub-wrap .wp-parser-function .deprecated,
-.devhub-wrap .wp-parser-function .private-access, .devhub-wrap .wp-parser-hook .deprecated,
-.devhub-wrap .wp-parser-hook .private-access, .devhub-wrap .wp-parser-method .deprecated,
+.devhub-wrap .wp-parser-class .private-access,
+.devhub-wrap .wp-parser-function .deprecated,
+.devhub-wrap .wp-parser-function .private-access,
+.devhub-wrap .wp-parser-hook .deprecated,
+.devhub-wrap .wp-parser-hook .private-access,
+.devhub-wrap .wp-parser-method .deprecated,
 .devhub-wrap .wp-parser-method .private-access {
-  margin-top: 30px;
-  padding: 20px;
+	margin-top: 30px;
+	padding: 20px;
 }
 
 .devhub-wrap .wp-parser-class .deprecated p,
-.devhub-wrap .wp-parser-class .private-access p, .devhub-wrap .wp-parser-function .deprecated p,
-.devhub-wrap .wp-parser-function .private-access p, .devhub-wrap .wp-parser-hook .deprecated p,
-.devhub-wrap .wp-parser-hook .private-access p, .devhub-wrap .wp-parser-method .deprecated p,
+.devhub-wrap .wp-parser-class .private-access p,
+.devhub-wrap .wp-parser-function .deprecated p,
+.devhub-wrap .wp-parser-function .private-access p,
+.devhub-wrap .wp-parser-hook .deprecated p,
+.devhub-wrap .wp-parser-hook .private-access p,
+.devhub-wrap .wp-parser-method .deprecated p,
 .devhub-wrap .wp-parser-method .private-access p {
-  margin-bottom: 0px;
+	margin-bottom: 0px;
 }
 
-.devhub-wrap .wp-parser-class .deprecated, .devhub-wrap .wp-parser-function .deprecated, .devhub-wrap .wp-parser-hook .deprecated, .devhub-wrap .wp-parser-method .deprecated {
-  background-color: #fbeaea;
-  border: 1px solid #dc3232;
+.devhub-wrap .wp-parser-class .deprecated,
+.devhub-wrap .wp-parser-function .deprecated,
+.devhub-wrap .wp-parser-hook .deprecated,
+.devhub-wrap .wp-parser-method .deprecated {
+	background-color: #fbeaea;
+	border: 1px solid #dc3232;
 }
 
-.devhub-wrap .wp-parser-class .deprecated-method, .devhub-wrap .wp-parser-function .deprecated-method, .devhub-wrap .wp-parser-hook .deprecated-method, .devhub-wrap .wp-parser-method .deprecated-method {
-  color: #be2423;
-  font-style: italic;
+.devhub-wrap .wp-parser-class .deprecated-method,
+.devhub-wrap .wp-parser-function .deprecated-method,
+.devhub-wrap .wp-parser-hook .deprecated-method,
+.devhub-wrap .wp-parser-method .deprecated-method {
+	color: #be2423;
+	font-style: italic;
 }
 
-.devhub-wrap .wp-parser-class .private-access, .devhub-wrap .wp-parser-function .private-access, .devhub-wrap .wp-parser-hook .private-access, .devhub-wrap .wp-parser-method .private-access {
-  border: 1px solid #ffb900;
-  background-color: #fff8e5;
+.devhub-wrap .wp-parser-class .private-access,
+.devhub-wrap .wp-parser-function .private-access,
+.devhub-wrap .wp-parser-hook .private-access,
+.devhub-wrap .wp-parser-method .private-access {
+	border: 1px solid #ffb900;
+	background-color: #fff8e5;
 }
 
-.devhub-wrap .wp-parser-class .callout, .devhub-wrap .wp-parser-function .callout, .devhub-wrap .wp-parser-hook .callout, .devhub-wrap .wp-parser-method .callout {
-  margin-top: 30px;
+.devhub-wrap .wp-parser-class .callout,
+.devhub-wrap .wp-parser-function .callout,
+.devhub-wrap .wp-parser-hook .callout,
+.devhub-wrap .wp-parser-method .callout {
+	margin-top: 30px;
 }
 
-.devhub-wrap .wp-parser-class .toc-jump, .devhub-wrap .wp-parser-function .toc-jump, .devhub-wrap .wp-parser-hook .toc-jump, .devhub-wrap .wp-parser-method .toc-jump {
-  display: inline-block;
-  float: right;
+.devhub-wrap .wp-parser-class .toc-jump,
+.devhub-wrap .wp-parser-function .toc-jump,
+.devhub-wrap .wp-parser-hook .toc-jump,
+.devhub-wrap .wp-parser-method .toc-jump {
+	display: inline-block;
+	float: right;
 }
 
 .devhub-wrap .callout:before {
-  top: 0.4em;
+	top: 0.4em;
 }
 
-.devhub-wrap.archive .wp-parser-class h1, .devhub-wrap.archive .wp-parser-function h1, .devhub-wrap.archive .wp-parser-hook h1, .devhub-wrap.archive .wp-parser-method h1, .devhub-wrap.search .wp-parser-class h1, .devhub-wrap.search .wp-parser-function h1, .devhub-wrap.search .wp-parser-hook h1, .devhub-wrap.search .wp-parser-method h1 {
-  font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
-  color: #21759b;
-  font-weight: normal;
+.devhub-wrap.archive .wp-parser-class h1,
+.devhub-wrap.archive .wp-parser-function h1,
+.devhub-wrap.archive .wp-parser-hook h1,
+.devhub-wrap.archive .wp-parser-method h1,
+.devhub-wrap.search .wp-parser-class h1,
+.devhub-wrap.search .wp-parser-function h1,
+.devhub-wrap.search .wp-parser-hook h1,
+.devhub-wrap.search .wp-parser-method h1 {
+	font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+	color: #21759b;
+	font-weight: normal;
 }
 
-.devhub-wrap.archive .wp-parser-class div.sourcefile, .devhub-wrap.archive .wp-parser-function div.sourcefile, .devhub-wrap.archive .wp-parser-hook div.sourcefile, .devhub-wrap.archive .wp-parser-method div.sourcefile, .devhub-wrap.search .wp-parser-class div.sourcefile, .devhub-wrap.search .wp-parser-function div.sourcefile, .devhub-wrap.search .wp-parser-hook div.sourcefile, .devhub-wrap.search .wp-parser-method div.sourcefile {
-  color: #999999;
-  font-style: italic;
+.devhub-wrap.archive .wp-parser-class div.sourcefile,
+.devhub-wrap.archive .wp-parser-function div.sourcefile,
+.devhub-wrap.archive .wp-parser-hook div.sourcefile,
+.devhub-wrap.archive .wp-parser-method div.sourcefile,
+.devhub-wrap.search .wp-parser-class div.sourcefile,
+.devhub-wrap.search .wp-parser-function div.sourcefile,
+.devhub-wrap.search .wp-parser-hook div.sourcefile,
+.devhub-wrap.search .wp-parser-method div.sourcefile {
+	color: #999999;
+	font-style: italic;
 }
 
-.devhub-wrap .single .wp-parser-class, .devhub-wrap .single .wp-parser-function, .devhub-wrap .single .wp-parser-hook, .devhub-wrap .single .wp-parser-method {
-  border-bottom-style: none;
+.devhub-wrap .single .wp-parser-class,
+.devhub-wrap .single .wp-parser-function,
+.devhub-wrap .single .wp-parser-hook,
+.devhub-wrap .single .wp-parser-method {
+	border-bottom-style: none;
 }
 
 .devhub-wrap .related {
-  /* Hide the title and toc links (same as .screen-reader-text)
+	/* Hide the title and toc links (same as .screen-reader-text)
 		   this allows for linking from the toc. */
 }
 
-.devhub-wrap .related .show-more, .devhub-wrap .related .hide-more {
-  display: none;
+.devhub-wrap .related .show-more,
+.devhub-wrap .related .hide-more {
+	display: none;
 }
 
-.devhub-wrap .related h3, .devhub-wrap .related .uses .toc-jump, .devhub-wrap .related .used-by .toc-jump {
-  height: 0;
-  margin-bottom: 0;
-  clip: rect(1px, 1px, 1px, 1px);
-  position: absolute !important;
+.devhub-wrap .related h3,
+.devhub-wrap .related .uses .toc-jump,
+.devhub-wrap .related .used-by .toc-jump {
+	height: 0;
+	margin-bottom: 0;
+	clip: rect(1px, 1px, 1px, 1px);
+	position: absolute !important;
 }
 
-.devhub-wrap .related .used-by, .devhub-wrap .related .uses {
-  overflow-x: auto;
-  clear: right;
+.devhub-wrap .related .used-by,
+.devhub-wrap .related .uses {
+	overflow-x: auto;
+	clear: right;
 }
 
 .devhub-wrap .related td p {
-  margin-bottom: 0;
+	margin-bottom: 0;
 }
 
-.devhub-wrap .related th, .devhub-wrap .related td {
-  width: 50%;
+.devhub-wrap .related th,
+.devhub-wrap .related td {
+	width: 50%;
 }
 
 @media (max-width: 43em) {
-  .devhub-wrap .related .related-desc, .devhub-wrap .related span {
-    display: none;
-  }
+	.devhub-wrap .related .related-desc,
+	.devhub-wrap .related span {
+		display: none;
+	}
 }
 
 .devhub-wrap .source-content {
-  overflow: auto;
+	overflow: auto;
 }
 
 .devhub-wrap .source-code-links {
-  margin-left: 2em;
-  margin-top: 1em;
+	margin-left: 2em;
+	margin-top: 1em;
 }
 
 .devhub-wrap .source-code-links span {
-  border-left: 1px solid #999;
-  margin-left: 1em;
-  padding-left: 1em;
+	border-left: 1px solid #999;
+	margin-left: 1em;
+	padding-left: 1em;
 }
 
 .devhub-wrap .source-code-links span:first-child {
-  display: none;
-  border-left: 0;
-  margin-left: 1em;
-  padding-left: 0;
+	display: none;
+	border-left: 0;
+	margin-left: 1em;
+	padding-left: 0;
 }
 
 .devhub-wrap .source-code-container {
-  overflow-x: auto;
-  overflow-y: hidden;
+	overflow-x: auto;
+	overflow-y: hidden;
 }
 
-.devhub-wrap .show-complete-source, .devhub-wrap .less-complete-source {
-  display: none;
+.devhub-wrap .show-complete-source,
+.devhub-wrap .less-complete-source {
+	display: none;
 }
 
 .devhub-wrap .changelog table .changelog-version {
-  width: 10%;
+	width: 10%;
 }
 
 .devhub-wrap .changelog table .changelog-desc {
-  width: 90%;
+	width: 90%;
 }
 
 .devhub-wrap .loop-pagination {
-  text-align: center;
-  font-size: 18px;
-  margin-bottom: 20px;
+	text-align: center;
+	font-size: 18px;
+	margin-bottom: 20px;
 }
 
 .devhub-wrap .comment-content a {
-  word-wrap: break-word;
+	word-wrap: break-word;
 }
 
-.devhub-wrap .single-wp-parser-function .bad-note .comment-content, .devhub-wrap .single-wp-parser-method .bad-note .comment-content, .devhub-wrap .single-wp-parser-hook .bad-note .comment-content, .devhub-wrap .single-wp-parser-class .bad-note .comment-content {
-  opacity: .6;
+.devhub-wrap .single-wp-parser-function .bad-note .comment-content,
+.devhub-wrap .single-wp-parser-method .bad-note .comment-content,
+.devhub-wrap .single-wp-parser-hook .bad-note .comment-content,
+.devhub-wrap .single-wp-parser-class .bad-note .comment-content {
+	opacity: 0.6;
 }
 
-.devhub-wrap .single-wp-parser-function .bad-note .comment-content:hover, .devhub-wrap .single-wp-parser-method .bad-note .comment-content:hover, .devhub-wrap .single-wp-parser-hook .bad-note .comment-content:hover, .devhub-wrap .single-wp-parser-class .bad-note .comment-content:hover {
-  opacity: 1;
+.devhub-wrap .single-wp-parser-function .bad-note .comment-content:hover,
+.devhub-wrap .single-wp-parser-method .bad-note .comment-content:hover,
+.devhub-wrap .single-wp-parser-hook .bad-note .comment-content:hover,
+.devhub-wrap .single-wp-parser-class .bad-note .comment-content:hover {
+	opacity: 1;
 }
 
 .devhub-wrap .single-wp-parser-function .comment-awaiting-moderation,
-.devhub-wrap .single-wp-parser-function .comment-edited, .devhub-wrap .single-wp-parser-method .comment-awaiting-moderation,
-.devhub-wrap .single-wp-parser-method .comment-edited, .devhub-wrap .single-wp-parser-hook .comment-awaiting-moderation,
-.devhub-wrap .single-wp-parser-hook .comment-edited, .devhub-wrap .single-wp-parser-class .comment-awaiting-moderation,
+.devhub-wrap .single-wp-parser-function .comment-edited,
+.devhub-wrap .single-wp-parser-method .comment-awaiting-moderation,
+.devhub-wrap .single-wp-parser-method .comment-edited,
+.devhub-wrap .single-wp-parser-hook .comment-awaiting-moderation,
+.devhub-wrap .single-wp-parser-hook .comment-edited,
+.devhub-wrap .single-wp-parser-class .comment-awaiting-moderation,
 .devhub-wrap .single-wp-parser-class .comment-edited {
-  background-color: #fff8e5;
-  padding: .2em .5em;
-  margin-right: .5em;
-  border-radius: 3px;
-  border: 1px solid #ffb900;
+	background-color: #fff8e5;
+	padding: 0.2em 0.5em;
+	margin-right: 0.5em;
+	border-radius: 3px;
+	border: 1px solid #ffb900;
 }
 
 .devhub-wrap .single-wp-parser-function .depth-2 .comment-awaiting-moderation,
-.devhub-wrap .single-wp-parser-function .depth-2 .comment-edited, .devhub-wrap .single-wp-parser-method .depth-2 .comment-awaiting-moderation,
-.devhub-wrap .single-wp-parser-method .depth-2 .comment-edited, .devhub-wrap .single-wp-parser-hook .depth-2 .comment-awaiting-moderation,
-.devhub-wrap .single-wp-parser-hook .depth-2 .comment-edited, .devhub-wrap .single-wp-parser-class .depth-2 .comment-awaiting-moderation,
+.devhub-wrap .single-wp-parser-function .depth-2 .comment-edited,
+.devhub-wrap .single-wp-parser-method .depth-2 .comment-awaiting-moderation,
+.devhub-wrap .single-wp-parser-method .depth-2 .comment-edited,
+.devhub-wrap .single-wp-parser-hook .depth-2 .comment-awaiting-moderation,
+.devhub-wrap .single-wp-parser-hook .depth-2 .comment-edited,
+.devhub-wrap .single-wp-parser-class .depth-2 .comment-awaiting-moderation,
 .devhub-wrap .single-wp-parser-class .depth-2 .comment-edited {
-  display: inline-block;
-  margin: 2px 0;
+	display: inline-block;
+	margin: 2px 0;
 }
 
 .devhub-wrap .single-wp-parser-function .comment-list,
-.devhub-wrap .single-wp-parser-function .comment-list ol, .devhub-wrap .single-wp-parser-method .comment-list,
-.devhub-wrap .single-wp-parser-method .comment-list ol, .devhub-wrap .single-wp-parser-hook .comment-list,
-.devhub-wrap .single-wp-parser-hook .comment-list ol, .devhub-wrap .single-wp-parser-class .comment-list,
+.devhub-wrap .single-wp-parser-function .comment-list ol,
+.devhub-wrap .single-wp-parser-method .comment-list,
+.devhub-wrap .single-wp-parser-method .comment-list ol,
+.devhub-wrap .single-wp-parser-hook .comment-list,
+.devhub-wrap .single-wp-parser-hook .comment-list ol,
+.devhub-wrap .single-wp-parser-class .comment-list,
 .devhub-wrap .single-wp-parser-class .comment-list ol {
-  list-style: none;
-  margin: 0 0 1.5em 0;
-  padding: 0;
+	list-style: none;
+	margin: 0 0 1.5em 0;
+	padding: 0;
 }
 
 .devhub-wrap .single-wp-parser-function .comment-list li,
-.devhub-wrap .single-wp-parser-function #comment-preview, .devhub-wrap .single-wp-parser-method .comment-list li,
-.devhub-wrap .single-wp-parser-method #comment-preview, .devhub-wrap .single-wp-parser-hook .comment-list li,
-.devhub-wrap .single-wp-parser-hook #comment-preview, .devhub-wrap .single-wp-parser-class .comment-list li,
+.devhub-wrap .single-wp-parser-function #comment-preview,
+.devhub-wrap .single-wp-parser-method .comment-list li,
+.devhub-wrap .single-wp-parser-method #comment-preview,
+.devhub-wrap .single-wp-parser-hook .comment-list li,
+.devhub-wrap .single-wp-parser-hook #comment-preview,
+.devhub-wrap .single-wp-parser-class .comment-list li,
 .devhub-wrap .single-wp-parser-class #comment-preview {
-  margin-top: 3rem;
-  background: #fff;
-  overflow: auto;
+	margin-top: 3rem;
+	background: #fff;
+	overflow: auto;
 }
 
 .devhub-wrap .single-wp-parser-function .comment-list li article,
-.devhub-wrap .single-wp-parser-function #comment-preview article, .devhub-wrap .single-wp-parser-method .comment-list li article,
-.devhub-wrap .single-wp-parser-method #comment-preview article, .devhub-wrap .single-wp-parser-hook .comment-list li article,
-.devhub-wrap .single-wp-parser-hook #comment-preview article, .devhub-wrap .single-wp-parser-class .comment-list li article,
+.devhub-wrap .single-wp-parser-function #comment-preview article,
+.devhub-wrap .single-wp-parser-method .comment-list li article,
+.devhub-wrap .single-wp-parser-method #comment-preview article,
+.devhub-wrap .single-wp-parser-hook .comment-list li article,
+.devhub-wrap .single-wp-parser-hook #comment-preview article,
+.devhub-wrap .single-wp-parser-class .comment-list li article,
 .devhub-wrap .single-wp-parser-class #comment-preview article {
-  overflow: auto;
+	overflow: auto;
 }
 
 .devhub-wrap .single-wp-parser-function .comment-list li.depth-1,
-.devhub-wrap .single-wp-parser-function #comment-preview, .devhub-wrap .single-wp-parser-method .comment-list li.depth-1,
-.devhub-wrap .single-wp-parser-method #comment-preview, .devhub-wrap .single-wp-parser-hook .comment-list li.depth-1,
-.devhub-wrap .single-wp-parser-hook #comment-preview, .devhub-wrap .single-wp-parser-class .comment-list li.depth-1,
+.devhub-wrap .single-wp-parser-function #comment-preview,
+.devhub-wrap .single-wp-parser-method .comment-list li.depth-1,
+.devhub-wrap .single-wp-parser-method #comment-preview,
+.devhub-wrap .single-wp-parser-hook .comment-list li.depth-1,
+.devhub-wrap .single-wp-parser-hook #comment-preview,
+.devhub-wrap .single-wp-parser-class .comment-list li.depth-1,
 .devhub-wrap .single-wp-parser-class #comment-preview {
-  border: 1px solid #dfdfdf;
-  border-radius: 2px;
-  width: 100%;
+	border: 1px solid #dfdfdf;
+	border-radius: 2px;
+	width: 100%;
 }
 
-.devhub-wrap .single-wp-parser-function .comment-list li.depth-2, .devhub-wrap .single-wp-parser-method .comment-list li.depth-2, .devhub-wrap .single-wp-parser-hook .comment-list li.depth-2, .devhub-wrap .single-wp-parser-class .comment-list li.depth-2 {
-  border-top: 1px solid #dfdfdf;
-  padding: 0;
-  margin: 0;
+.devhub-wrap .single-wp-parser-function .comment-list li.depth-2,
+.devhub-wrap .single-wp-parser-method .comment-list li.depth-2,
+.devhub-wrap .single-wp-parser-hook .comment-list li.depth-2,
+.devhub-wrap .single-wp-parser-class .comment-list li.depth-2 {
+	border-top: 1px solid #dfdfdf;
+	padding: 0;
+	margin: 0;
 }
 
-.devhub-wrap .single-wp-parser-function .comment-list li.depth-2 .comment-content, .devhub-wrap .single-wp-parser-method .comment-list li.depth-2 .comment-content, .devhub-wrap .single-wp-parser-hook .comment-list li.depth-2 .comment-content, .devhub-wrap .single-wp-parser-class .comment-list li.depth-2 .comment-content {
-  padding: .9em 0;
+.devhub-wrap
+	.single-wp-parser-function
+	.comment-list
+	li.depth-2
+	.comment-content,
+.devhub-wrap .single-wp-parser-method .comment-list li.depth-2 .comment-content,
+.devhub-wrap .single-wp-parser-hook .comment-list li.depth-2 .comment-content,
+.devhub-wrap .single-wp-parser-class .comment-list li.depth-2 .comment-content {
+	padding: 0.9em 0;
 }
 
-.devhub-wrap .single-wp-parser-function .comment-list li.depth-2 .comment-content p, .devhub-wrap .single-wp-parser-method .comment-list li.depth-2 .comment-content p, .devhub-wrap .single-wp-parser-hook .comment-list li.depth-2 .comment-content p, .devhub-wrap .single-wp-parser-class .comment-list li.depth-2 .comment-content p {
-  margin-bottom: 0;
-  font-size: .9em;
+.devhub-wrap
+	.single-wp-parser-function
+	.comment-list
+	li.depth-2
+	.comment-content
+	p,
+.devhub-wrap
+	.single-wp-parser-method
+	.comment-list
+	li.depth-2
+	.comment-content
+	p,
+.devhub-wrap .single-wp-parser-hook .comment-list li.depth-2 .comment-content p,
+.devhub-wrap
+	.single-wp-parser-class
+	.comment-list
+	li.depth-2
+	.comment-content
+	p {
+	margin-bottom: 0;
+	font-size: 0.9em;
 }
 
-.devhub-wrap .single-wp-parser-function .comment ul.children, .devhub-wrap .single-wp-parser-method .comment ul.children, .devhub-wrap .single-wp-parser-hook .comment ul.children, .devhub-wrap .single-wp-parser-class .comment ul.children {
-  margin: 0 0 1.5em 0;
-  border-bottom: 1px solid #dfdfdf;
+.devhub-wrap .single-wp-parser-function .comment ul.children,
+.devhub-wrap .single-wp-parser-method .comment ul.children,
+.devhub-wrap .single-wp-parser-hook .comment ul.children,
+.devhub-wrap .single-wp-parser-class .comment ul.children {
+	margin: 0 0 1.5em 0;
+	border-bottom: 1px solid #dfdfdf;
 }
 
-.devhub-wrap .single-wp-parser-function .feedback, .devhub-wrap .single-wp-parser-method .feedback, .devhub-wrap .single-wp-parser-hook .feedback, .devhub-wrap .single-wp-parser-class .feedback {
-  width: 90%;
-  float: right;
-  margin-right: 1.5rem;
+.devhub-wrap .single-wp-parser-function .feedback,
+.devhub-wrap .single-wp-parser-method .feedback,
+.devhub-wrap .single-wp-parser-hook .feedback,
+.devhub-wrap .single-wp-parser-class .feedback {
+	width: 90%;
+	float: right;
+	margin-right: 1.5rem;
 }
 
-.devhub-wrap .single-wp-parser-function .feedback-links, .devhub-wrap .single-wp-parser-method .feedback-links, .devhub-wrap .single-wp-parser-hook .feedback-links, .devhub-wrap .single-wp-parser-class .feedback-links {
-  margin: 0 1.5rem 1em 1.5rem;
-  font-size: 0.9em;
-  clear: both;
+.devhub-wrap .single-wp-parser-function .feedback-links,
+.devhub-wrap .single-wp-parser-method .feedback-links,
+.devhub-wrap .single-wp-parser-hook .feedback-links,
+.devhub-wrap .single-wp-parser-class .feedback-links {
+	margin: 0 1.5rem 1em 1.5rem;
+	font-size: 0.9em;
+	clear: both;
 }
 
 .devhub-wrap .single-wp-parser-function .feedback-editor-title,
-.devhub-wrap .single-wp-parser-function .feedback-title, .devhub-wrap .single-wp-parser-method .feedback-editor-title,
-.devhub-wrap .single-wp-parser-method .feedback-title, .devhub-wrap .single-wp-parser-hook .feedback-editor-title,
-.devhub-wrap .single-wp-parser-hook .feedback-title, .devhub-wrap .single-wp-parser-class .feedback-editor-title,
+.devhub-wrap .single-wp-parser-function .feedback-title,
+.devhub-wrap .single-wp-parser-method .feedback-editor-title,
+.devhub-wrap .single-wp-parser-method .feedback-title,
+.devhub-wrap .single-wp-parser-hook .feedback-editor-title,
+.devhub-wrap .single-wp-parser-hook .feedback-title,
+.devhub-wrap .single-wp-parser-class .feedback-editor-title,
 .devhub-wrap .single-wp-parser-class .feedback-title {
-  font-size: 1.8rem;
-  font-weight: 300;
-  line-height: 2.2rem;
-  margin-bottom: 1em;
+	font-size: 1.8rem;
+	font-weight: 300;
+	line-height: 2.2rem;
+	margin-bottom: 1em;
 }
 
-.devhub-wrap .single-wp-parser-function .feedback-toggle, .devhub-wrap .single-wp-parser-method .feedback-toggle, .devhub-wrap .single-wp-parser-hook .feedback-toggle, .devhub-wrap .single-wp-parser-class .feedback-toggle {
-  margin: 0 0 0 1.5rem;
-  display: inline-block;
+.devhub-wrap .single-wp-parser-function .feedback-toggle,
+.devhub-wrap .single-wp-parser-method .feedback-toggle,
+.devhub-wrap .single-wp-parser-hook .feedback-toggle,
+.devhub-wrap .single-wp-parser-class .feedback-toggle {
+	margin: 0 0 0 1.5rem;
+	display: inline-block;
 }
 
-.devhub-wrap .single-wp-parser-function #wp-feedback-wrap, .devhub-wrap .single-wp-parser-method #wp-feedback-wrap, .devhub-wrap .single-wp-parser-hook #wp-feedback-wrap, .devhub-wrap .single-wp-parser-class #wp-feedback-wrap {
-  padding-bottom: 1em;
+.devhub-wrap .single-wp-parser-function #wp-feedback-wrap,
+.devhub-wrap .single-wp-parser-method #wp-feedback-wrap,
+.devhub-wrap .single-wp-parser-hook #wp-feedback-wrap,
+.devhub-wrap .single-wp-parser-class #wp-feedback-wrap {
+	padding-bottom: 1em;
 }
 
 .devhub-wrap .single-wp-parser-function #comment-preview,
-.js .devhub-wrap .single-wp-parser-function .comment-form-comment, .devhub-wrap .single-wp-parser-method #comment-preview,
-.js .devhub-wrap .single-wp-parser-method .comment-form-comment, .devhub-wrap .single-wp-parser-hook #comment-preview,
-.js .devhub-wrap .single-wp-parser-hook .comment-form-comment, .devhub-wrap .single-wp-parser-class #comment-preview,
+.js .devhub-wrap .single-wp-parser-function .comment-form-comment,
+.devhub-wrap .single-wp-parser-method #comment-preview,
+.js .devhub-wrap .single-wp-parser-method .comment-form-comment,
+.devhub-wrap .single-wp-parser-hook #comment-preview,
+.js .devhub-wrap .single-wp-parser-hook .comment-form-comment,
+.devhub-wrap .single-wp-parser-class #comment-preview,
 .js .devhub-wrap .single-wp-parser-class .comment-form-comment {
-  margin-top: 0;
-  border: 1px solid #ccc;
-  border-radius: 0 3px 3px 3px;
-  clear: both;
+	margin-top: 0;
+	border: 1px solid #ccc;
+	border-radius: 0 3px 3px 3px;
+	clear: both;
 }
 
-.devhub-wrap .single-wp-parser-function #comment-preview.tab-section-selected, .devhub-wrap .single-wp-parser-method #comment-preview.tab-section-selected, .devhub-wrap .single-wp-parser-hook #comment-preview.tab-section-selected, .devhub-wrap .single-wp-parser-class #comment-preview.tab-section-selected {
-  border-radius: 3px;
+.devhub-wrap .single-wp-parser-function #comment-preview.tab-section-selected,
+.devhub-wrap .single-wp-parser-method #comment-preview.tab-section-selected,
+.devhub-wrap .single-wp-parser-hook #comment-preview.tab-section-selected,
+.devhub-wrap .single-wp-parser-class #comment-preview.tab-section-selected {
+	border-radius: 3px;
 }
 
-.devhub-wrap .single-wp-parser-function #comment-preview .comment-content, .devhub-wrap .single-wp-parser-method #comment-preview .comment-content, .devhub-wrap .single-wp-parser-hook #comment-preview .comment-content, .devhub-wrap .single-wp-parser-class #comment-preview .comment-content {
-  min-height: 6em;
+.devhub-wrap .single-wp-parser-function #comment-preview .comment-content,
+.devhub-wrap .single-wp-parser-method #comment-preview .comment-content,
+.devhub-wrap .single-wp-parser-hook #comment-preview .comment-content,
+.devhub-wrap .single-wp-parser-class #comment-preview .comment-content {
+	min-height: 6em;
 }
 
-.devhub-wrap .single-wp-parser-function label[for=comment],
+.devhub-wrap .single-wp-parser-function label[for='comment'],
 .devhub-wrap .single-wp-parser-function .comment-form-comment,
-.devhub-wrap .single-wp-parser-function .comment-preview, .devhub-wrap .single-wp-parser-method label[for=comment],
+.devhub-wrap .single-wp-parser-function .comment-preview,
+.devhub-wrap .single-wp-parser-method label[for='comment'],
 .devhub-wrap .single-wp-parser-method .comment-form-comment,
-.devhub-wrap .single-wp-parser-method .comment-preview, .devhub-wrap .single-wp-parser-hook label[for=comment],
+.devhub-wrap .single-wp-parser-method .comment-preview,
+.devhub-wrap .single-wp-parser-hook label[for='comment'],
 .devhub-wrap .single-wp-parser-hook .comment-form-comment,
-.devhub-wrap .single-wp-parser-hook .comment-preview, .devhub-wrap .single-wp-parser-class label[for=comment],
+.devhub-wrap .single-wp-parser-hook .comment-preview,
+.devhub-wrap .single-wp-parser-class label[for='comment'],
 .devhub-wrap .single-wp-parser-class .comment-form-comment,
 .devhub-wrap .single-wp-parser-class .comment-preview {
-  margin-bottom: 1em;
+	margin-bottom: 1em;
 }
 
-.js .devhub-wrap .single-wp-parser-function .comment-form-comment, .js .devhub-wrap .single-wp-parser-method .comment-form-comment, .js .devhub-wrap .single-wp-parser-hook .comment-form-comment, .js .devhub-wrap .single-wp-parser-class .comment-form-comment {
-  padding: 0 .7em .7em;
+.js .devhub-wrap .single-wp-parser-function .comment-form-comment,
+.js .devhub-wrap .single-wp-parser-method .comment-form-comment,
+.js .devhub-wrap .single-wp-parser-hook .comment-form-comment,
+.js .devhub-wrap .single-wp-parser-class .comment-form-comment {
+	padding: 0 0.7em 0.7em;
 }
 
-.devhub-wrap .single-wp-parser-function .tablist .spinner, .devhub-wrap .single-wp-parser-method .tablist .spinner, .devhub-wrap .single-wp-parser-hook .tablist .spinner, .devhub-wrap .single-wp-parser-class .tablist .spinner {
-  background: url("/wp-includes/images/spinner-2x.gif") no-repeat scroll 0 50%;
-  -webkit-background-size: 20px 20px;
-  background-size: 20px 20px;
-  margin: 0 0.5em;
-  padding-left: 20px;
+.devhub-wrap .single-wp-parser-function .tablist .spinner,
+.devhub-wrap .single-wp-parser-method .tablist .spinner,
+.devhub-wrap .single-wp-parser-hook .tablist .spinner,
+.devhub-wrap .single-wp-parser-class .tablist .spinner {
+	background: url('/wp-includes/images/spinner-2x.gif') no-repeat scroll 0 50%;
+	-webkit-background-size: 20px 20px;
+	background-size: 20px 20px;
+	margin: 0 0.5em;
+	padding-left: 20px;
 }
 
-.devhub-wrap .single-wp-parser-function .comment-list .avatar, .devhub-wrap .single-wp-parser-method .comment-list .avatar, .devhub-wrap .single-wp-parser-hook .comment-list .avatar, .devhub-wrap .single-wp-parser-class .comment-list .avatar {
-  float: left;
-  margin: -2px 1em 0 0;
-  padding: 0.125em;
-  border: 1px solid #eee;
+.devhub-wrap .single-wp-parser-function .comment-list .avatar,
+.devhub-wrap .single-wp-parser-method .comment-list .avatar,
+.devhub-wrap .single-wp-parser-hook .comment-list .avatar,
+.devhub-wrap .single-wp-parser-class .comment-list .avatar {
+	float: left;
+	margin: -2px 1em 0 0;
+	padding: 0.125em;
+	border: 1px solid #eee;
 }
 
-.devhub-wrap .single-wp-parser-function .comment-meta, .devhub-wrap .single-wp-parser-method .comment-meta, .devhub-wrap .single-wp-parser-hook .comment-meta, .devhub-wrap .single-wp-parser-class .comment-meta {
-  padding: .5em 1em;
-  background-color: #f7f7f7;
-  overflow: auto;
+.devhub-wrap .single-wp-parser-function .comment-meta,
+.devhub-wrap .single-wp-parser-method .comment-meta,
+.devhub-wrap .single-wp-parser-hook .comment-meta,
+.devhub-wrap .single-wp-parser-class .comment-meta {
+	padding: 0.5em 1em;
+	background-color: #f7f7f7;
+	overflow: auto;
 }
 
-.devhub-wrap .single-wp-parser-function .comment-content, .devhub-wrap .single-wp-parser-method .comment-content, .devhub-wrap .single-wp-parser-hook .comment-content, .devhub-wrap .single-wp-parser-class .comment-content {
-  margin-left: 60px;
-  margin-left: 3.75rem;
-  margin-left: 0;
-  clear: both;
-  padding: 2rem 1.5rem .5rem;
+.devhub-wrap .single-wp-parser-function .comment-content,
+.devhub-wrap .single-wp-parser-method .comment-content,
+.devhub-wrap .single-wp-parser-hook .comment-content,
+.devhub-wrap .single-wp-parser-class .comment-content {
+	margin-left: 60px;
+	margin-left: 3.75rem;
+	margin-left: 0;
+	clear: both;
+	padding: 2rem 1.5rem 0.5rem;
 }
 
-.devhub-wrap .single-wp-parser-function .comment-content ol, .devhub-wrap .single-wp-parser-method .comment-content ol, .devhub-wrap .single-wp-parser-hook .comment-content ol, .devhub-wrap .single-wp-parser-class .comment-content ol {
-  list-style: decimal inside;
-  margin: 0 0 1.5em 0;
-  border-top: none;
-  margin: 0 0 1.5em 1.5em;
-  padding: 0;
+.devhub-wrap .single-wp-parser-function .comment-content ol,
+.devhub-wrap .single-wp-parser-method .comment-content ol,
+.devhub-wrap .single-wp-parser-hook .comment-content ol,
+.devhub-wrap .single-wp-parser-class .comment-content ol {
+	list-style: decimal inside;
+	margin: 0 0 1.5em 0;
+	border-top: none;
+	margin: 0 0 1.5em 1.5em;
+	padding: 0;
 }
 
-.devhub-wrap .single-wp-parser-function .comment-content ul, .devhub-wrap .single-wp-parser-method .comment-content ul, .devhub-wrap .single-wp-parser-hook .comment-content ul, .devhub-wrap .single-wp-parser-class .comment-content ul {
-  list-style: square inside;
-  margin: 0 0 1.5em 0;
-  border-top: none;
-  margin: 0 0 1.5em 1.5em;
-  padding: 0;
+.devhub-wrap .single-wp-parser-function .comment-content ul,
+.devhub-wrap .single-wp-parser-method .comment-content ul,
+.devhub-wrap .single-wp-parser-hook .comment-content ul,
+.devhub-wrap .single-wp-parser-class .comment-content ul {
+	list-style: square inside;
+	margin: 0 0 1.5em 0;
+	border-top: none;
+	margin: 0 0 1.5em 1.5em;
+	padding: 0;
 }
 
-.devhub-wrap .single-wp-parser-function .comment-content li, .devhub-wrap .single-wp-parser-method .comment-content li, .devhub-wrap .single-wp-parser-hook .comment-content li, .devhub-wrap .single-wp-parser-class .comment-content li {
-  border: none;
-  padding: 0;
+.devhub-wrap .single-wp-parser-function .comment-content li,
+.devhub-wrap .single-wp-parser-method .comment-content li,
+.devhub-wrap .single-wp-parser-hook .comment-content li,
+.devhub-wrap .single-wp-parser-class .comment-content li {
+	border: none;
+	padding: 0;
 }
 
-.devhub-wrap .single-wp-parser-function #respond, .devhub-wrap .single-wp-parser-method #respond, .devhub-wrap .single-wp-parser-hook #respond, .devhub-wrap .single-wp-parser-class #respond {
-  overflow: hidden;
+.devhub-wrap .single-wp-parser-function #respond,
+.devhub-wrap .single-wp-parser-method #respond,
+.devhub-wrap .single-wp-parser-hook #respond,
+.devhub-wrap .single-wp-parser-class #respond {
+	overflow: hidden;
 }
 
-.devhub-wrap .single-wp-parser-function #respond .log-in-out a, .devhub-wrap .single-wp-parser-method #respond .log-in-out a, .devhub-wrap .single-wp-parser-hook #respond .log-in-out a, .devhub-wrap .single-wp-parser-class #respond .log-in-out a {
-  font-style: italic;
+.devhub-wrap .single-wp-parser-function #respond .log-in-out a,
+.devhub-wrap .single-wp-parser-method #respond .log-in-out a,
+.devhub-wrap .single-wp-parser-hook #respond .log-in-out a,
+.devhub-wrap .single-wp-parser-class #respond .log-in-out a {
+	font-style: italic;
 }
 
-.devhub-wrap .single-wp-parser-function #reply-title small a, .devhub-wrap .single-wp-parser-method #reply-title small a, .devhub-wrap .single-wp-parser-hook #reply-title small a, .devhub-wrap .single-wp-parser-class #reply-title small a {
-  font-style: italic;
+.devhub-wrap .single-wp-parser-function #reply-title small a,
+.devhub-wrap .single-wp-parser-method #reply-title small a,
+.devhub-wrap .single-wp-parser-hook #reply-title small a,
+.devhub-wrap .single-wp-parser-class #reply-title small a {
+	font-style: italic;
 }
 
-.devhub-wrap .single-wp-parser-function #respond #submit, .devhub-wrap .single-wp-parser-method #respond #submit, .devhub-wrap .single-wp-parser-hook #respond #submit, .devhub-wrap .single-wp-parser-class #respond #submit {
-  float: left;
-  margin: 0 0 1.5em;
+.devhub-wrap .single-wp-parser-function #respond #submit,
+.devhub-wrap .single-wp-parser-method #respond #submit,
+.devhub-wrap .single-wp-parser-hook #respond #submit,
+.devhub-wrap .single-wp-parser-class #respond #submit {
+	float: left;
+	margin: 0 0 1.5em;
 }
 
-.devhub-wrap .single-wp-parser-function .comment-author, .devhub-wrap .single-wp-parser-method .comment-author, .devhub-wrap .single-wp-parser-hook .comment-author, .devhub-wrap .single-wp-parser-class .comment-author {
-  float: left;
-  line-height: 1.8;
+.devhub-wrap .single-wp-parser-function .comment-author,
+.devhub-wrap .single-wp-parser-method .comment-author,
+.devhub-wrap .single-wp-parser-hook .comment-author,
+.devhub-wrap .single-wp-parser-class .comment-author {
+	float: left;
+	line-height: 1.8;
 }
 
-.devhub-wrap .single-wp-parser-function #add-user-note, .devhub-wrap .single-wp-parser-method #add-user-note, .devhub-wrap .single-wp-parser-hook #add-user-note, .devhub-wrap .single-wp-parser-class #add-user-note {
-  font-size: 1.6rem;
+.devhub-wrap .single-wp-parser-function #add-user-note,
+.devhub-wrap .single-wp-parser-method #add-user-note,
+.devhub-wrap .single-wp-parser-hook #add-user-note,
+.devhub-wrap .single-wp-parser-class #add-user-note {
+	font-size: 1.6rem;
 }
 
-.devhub-wrap .single-wp-parser-function .text-button, .devhub-wrap .single-wp-parser-method .text-button, .devhub-wrap .single-wp-parser-hook .text-button, .devhub-wrap .single-wp-parser-class .text-button {
-  background: #fff none repeat scroll 0 0;
-  border-color: #ccc #ccc #bbb;
-  border-radius: 3px;
-  border-style: solid;
-  border-width: 1px;
-  padding: 0 5px;
+.devhub-wrap .single-wp-parser-function .text-button,
+.devhub-wrap .single-wp-parser-method .text-button,
+.devhub-wrap .single-wp-parser-hook .text-button,
+.devhub-wrap .single-wp-parser-class .text-button {
+	background: #fff none repeat scroll 0 0;
+	border-color: #ccc #ccc #bbb;
+	border-radius: 3px;
+	border-style: solid;
+	border-width: 1px;
+	padding: 0 5px;
 }
 
-.devhub-wrap .single-wp-parser-function .comment-form ul, .devhub-wrap .single-wp-parser-function .feedback-form ul, .devhub-wrap .single-wp-parser-method .comment-form ul, .devhub-wrap .single-wp-parser-method .feedback-form ul, .devhub-wrap .single-wp-parser-hook .comment-form ul, .devhub-wrap .single-wp-parser-hook .feedback-form ul, .devhub-wrap .single-wp-parser-class .comment-form ul, .devhub-wrap .single-wp-parser-class .feedback-form ul {
-  margin-left: 1.5em;
+.devhub-wrap .single-wp-parser-function .comment-form ul,
+.devhub-wrap .single-wp-parser-function .feedback-form ul,
+.devhub-wrap .single-wp-parser-method .comment-form ul,
+.devhub-wrap .single-wp-parser-method .feedback-form ul,
+.devhub-wrap .single-wp-parser-hook .comment-form ul,
+.devhub-wrap .single-wp-parser-hook .feedback-form ul,
+.devhub-wrap .single-wp-parser-class .comment-form ul,
+.devhub-wrap .single-wp-parser-class .feedback-form ul {
+	margin-left: 1.5em;
 }
 
-.devhub-wrap .single-wp-parser-function .feedback-form ul li, .devhub-wrap .single-wp-parser-method .feedback-form ul li, .devhub-wrap .single-wp-parser-hook .feedback-form ul li, .devhub-wrap .single-wp-parser-class .feedback-form ul li {
-  margin: 0;
-  overflow: visible;
+.devhub-wrap .single-wp-parser-function .feedback-form ul li,
+.devhub-wrap .single-wp-parser-method .feedback-form ul li,
+.devhub-wrap .single-wp-parser-hook .feedback-form ul li,
+.devhub-wrap .single-wp-parser-class .feedback-form ul li {
+	margin: 0;
+	overflow: visible;
 }
 
 .devhub-wrap.single-post .comment-list,
 .devhub-wrap.single-post .comment-list ol {
-  list-style: none;
-  margin: 1.5em 0;
-  padding: 0;
+	list-style: none;
+	margin: 1.5em 0;
+	padding: 0;
 }
 
 .devhub-wrap.single-post .comment-list li {
-  margin: 1.5em 0;
-  padding: 1em 0 0 0;
-  border-top: 1px solid #ddd;
+	margin: 1.5em 0;
+	padding: 1em 0 0 0;
+	border-top: 1px solid #ddd;
 }
 
 .devhub-wrap.single-post .comment-list p {
-  margin: 0 0 0 42px;
+	margin: 0 0 0 42px;
 }
 
 .devhub-wrap.single-post .comment-list .alt {
-  background: inherit;
+	background: inherit;
 }
 
 .devhub-wrap.single-post .comment-meta {
-  font-size: 0.65em;
-  color: #888;
-  float: right;
-  margin-top: -15px;
+	font-size: 0.65em;
+	color: #888;
+	float: right;
+	margin-top: -15px;
 }
 
 .devhub-wrap.single-post .comment-author img {
-  float: left;
-  margin: 0 10px 0 0;
+	float: left;
+	margin: 0 10px 0 0;
 }
 
 .devhub-wrap.single-post .comments-area {
-  margin: 1.5em 0 0 0;
+	margin: 1.5em 0 0 0;
 }
 
 .devhub-wrap #content-area.has-sidebar {
-  float: none;
-  margin: 0 auto;
-  width: 60em;
+	float: none;
+	margin: 0 auto;
+	width: 60em;
 }
 
 .devhub-wrap .has-sidebar main {
-  float: right;
-  width: 67%;
-  margin: 0;
-  clear: none;
-  padding: 0 12px;
-  padding: 0 1.2rem;
+	float: right;
+	width: 67%;
+	margin: 0;
+	clear: none;
+	padding: 0 12px;
+	padding: 0 1.2rem;
 }
 
 .devhub-wrap .has-sidebar .widget-area {
-  float: left;
-  overflow: hidden;
-  width: 27%;
-  margin-left: -55px;
-  margin: 0;
-  clear: none;
+	float: left;
+	overflow: hidden;
+	width: 27%;
+	margin-left: -55px;
+	margin: 0;
+	clear: none;
 }
 
 .devhub-wrap .has-sidebar .widget-area .widget {
-  width: 100%;
+	width: 100%;
 }
 
 .devhub-wrap nav.handbook-navigation {
-  margin-bottom: 3em;
+	margin-bottom: 3em;
 }
 
 .devhub-wrap nav.handbook-navigation .nav-links a {
-  width: 49%;
-  display: inline-block;
+	width: 49%;
+	display: inline-block;
 }
 
-.devhub-wrap nav.handbook-navigation .nav-links a[rel="prev"] {
-  text-align: left;
+.devhub-wrap nav.handbook-navigation .nav-links a[rel='prev'] {
+	text-align: left;
 }
 
-.devhub-wrap nav.handbook-navigation .nav-links a[rel="next"] {
-  text-align: right;
-  float: right;
+.devhub-wrap nav.handbook-navigation .nav-links a[rel='next'] {
+	text-align: right;
+	float: right;
 }
 
 .devhub-wrap .user-note-voting {
-  font-size: 1.2em;
-  clear: left;
-  float: left;
-  margin-right: 10px;
+	font-size: 1.2em;
+	clear: left;
+	float: left;
+	margin-right: 10px;
 }
 
-.devhub-wrap .user-note-voting-up .dashicons, .devhub-wrap .user-note-voting-down .dashicons {
-  font-size: 30px;
-  height: 30px;
-  width: 30px;
-  color: #000;
+.devhub-wrap .user-note-voting-up .dashicons,
+.devhub-wrap .user-note-voting-down .dashicons {
+	font-size: 30px;
+	height: 30px;
+	width: 30px;
+	color: #000;
 }
 
-.devhub-wrap .site-main .user-note-voting-down, .devhub-wrap .site-main .user-note-voting-up {
-  text-decoration: none;
+.devhub-wrap .site-main .user-note-voting-down,
+.devhub-wrap .site-main .user-note-voting-up {
+	text-decoration: none;
 }
 
 .devhub-wrap .user-note-voting-up {
-  margin-left: -9px;
+	margin-left: -9px;
 }
 
 .devhub-wrap span.user-note-voting-up,
 .devhub-wrap span.user-note-voting-down {
-  cursor: default;
+	cursor: default;
 }
 
 .devhub-wrap .user-note-voting-count {
-  margin-right: -2px;
+	margin-right: -2px;
 }
 
 .devhub-wrap .user-voted.user-note-voting-up .dashicons {
-  color: green;
+	color: green;
 }
 
 .devhub-wrap .user-voted.user-note-voting-down .dashicons {
-  color: red;
+	color: red;
 }
 
 .devhub-wrap .user-submitted-note .dashicons {
-  color: grey;
+	color: grey;
 }
 
 .devhub-wrap .syntaxhighlighter {
-  /* These are !important due to use of !important in SyntaxHighlighter Evolved plugin. */
-  max-width: 100% !important;
-  width: inherit !important;
-  padding-bottom: 0.5rem !important;
+	/* These are !important due to use of !important in SyntaxHighlighter Evolved plugin. */
+	max-width: 100% !important;
+	width: inherit !important;
+	padding-bottom: 0.5rem !important;
 }
 
-.devhub-wrap.archive .hentry, .devhub-wrap.blog .hentry {
-  padding: 0 0 1.5em 0;
-  border-bottom: 1px solid #ddd;
+.devhub-wrap.archive .hentry,
+.devhub-wrap.blog .hentry {
+	padding: 0 0 1.5em 0;
+	border-bottom: 1px solid #ddd;
 }
 
 /** Site Header **/
 .site-header {
-  background: #0073aa;
-  float: none;
-  margin: 0 0 4em;
-  padding: 18px 0;
-  width: auto;
-  margin: 0;
+	background: #0073aa;
+	float: none;
+	margin: 0 0 4em;
+	padding: 18px 0;
+	width: auto;
+	margin: 0;
 }
 
 .site-branding {
-  height: 32px;
-  box-sizing: border-box;
-  margin: 0 auto;
-  max-width: 960px;
-  padding: 0 10px;
-  position: relative;
+	height: 32px;
+	box-sizing: border-box;
+	margin: 0 auto;
+	max-width: 960px;
+	padding: 0 10px;
+	position: relative;
 }
 
 .site-title {
-  line-height: 1;
-  margin: 0;
-  padding: 0;
-  font-family: 'Open Sans', sans-serif;
-  display: inline-block;
-  text-align: left;
-  color: black;
+	line-height: 1;
+	margin: 0;
+	padding: 0;
+	font-family: 'Open Sans', sans-serif;
+	display: inline-block;
+	text-align: left;
+	color: black;
 }
 
 .site-title a {
-  color: #fff;
-  font-size: 28px;
-  font-weight: 300;
-  line-height: 1;
-  border-bottom: 0;
+	color: #fff;
+	font-size: 28px;
+	font-weight: 300;
+	line-height: 1;
+	border-bottom: 0;
 }
 
 @media screen and (max-width: 500px) {
-  .site-title a {
-    font-size: 17px;
-    font-size: 4.5vw;
-    vertical-align: middle;
-    vertical-align: -moz-middle-with-baseline;
-    vertical-align: -webkit-baseline-middle;
-  }
+	.site-title a {
+		font-size: 17px;
+		font-size: 4.5vw;
+		vertical-align: middle;
+		vertical-align: -moz-middle-with-baseline;
+		vertical-align: -webkit-baseline-middle;
+	}
 }
 
 @media screen and (max-width: 769px) {
-  .site-title {
-    margin-left: 10px;
-  }
+	.site-title {
+		margin-left: 10px;
+	}
 }
 
 .site-header.home {
-  padding: 28px 20px;
-  padding: 2.8rem 2.0rem;
-  text-align: center;
+	padding: 28px 20px;
+	padding: 2.8rem 2rem;
+	text-align: center;
 }
 
 .site-header.home .site-branding {
-  height: initial;
+	height: initial;
 }
 
 .site-header.home .site-title {
-  max-width: none;
-  font-weight: 300;
-  margin: 36px 0 11.25px;
-  margin: 3.6rem 0 1.125rem;
-  text-align: center;
-  display: inherit;
-  clear: both;
+	max-width: none;
+	font-weight: 300;
+	margin: 36px 0 11.25px;
+	margin: 3.6rem 0 1.125rem;
+	text-align: center;
+	display: inherit;
+	clear: both;
 }
 
 .site-header.home .site-title a {
-  font-size: 68.6646px;
-  font-size: 6.86646rem;
+	font-size: 68.6646px;
+	font-size: 6.86646rem;
 }
 
 @media (max-width: 500px) {
-  .site-header.home .site-title a {
-    font-size: 50px;
-    font-size: 5rem;
-  }
+	.site-header.home .site-title a {
+		font-size: 50px;
+		font-size: 5rem;
+	}
 }
 
 .site-header.home .site-description {
-  color: rgba(255, 255, 255, 0.8);
-  font-size: 2.25rem;
-  font-weight: 300;
-  text-align: center;
+	color: rgba(255, 255, 255, 0.8);
+	font-size: 2.25rem;
+	font-weight: 300;
+	text-align: center;
 }
 
 .menu-container {
-  background: #0073aa;
-  clear: both;
-  float: right;
-  width: 100%;
+	background: #0073aa;
+	clear: both;
+	float: right;
+	width: 100%;
 }
 
 .menu-container ul {
-  display: none;
-  list-style: none;
-  margin: 0;
-  padding-left: 0;
+	display: none;
+	list-style: none;
+	margin: 0;
+	padding-left: 0;
 }
 
 .menu-container ul li {
-  border-top: 1px solid rgba(255, 255, 255, 0.2);
-  padding: 16px;
+	border-top: 1px solid rgba(255, 255, 255, 0.2);
+	padding: 16px;
 }
 
 .menu-container a {
-  color: rgba(255, 255, 255, 0.8);
-  display: block;
-  text-decoration: none;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
-  font-size: 12.8px;
+	color: rgba(255, 255, 255, 0.8);
+	display: block;
+	text-decoration: none;
+	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',
+		'Oxygen-Sans', 'Ubuntu', 'Cantarell', 'Helvetica Neue', sans-serif;
+	font-size: 12.8px;
 }
 
-.menu-container a:hover, .menu-container a:active {
-  color: #fff;
-  border-bottom: 1px solid #fff;
+.menu-container a:hover,
+.menu-container a:active {
+	color: #fff;
+	border-bottom: 1px solid #fff;
 }
 
 @media screen and (max-width: 48em) {
-  .menu-container a:hover, .menu-container a:active {
-    border-bottom: 0;
-  }
+	.menu-container a:hover,
+	.menu-container a:active {
+		border-bottom: 0;
+	}
 }
 
 @media screen and (min-width: 48em) {
-  .menu-container {
-    float: right;
-    position: relative;
-    width: auto;
-    top: auto;
-    margin-right: 4px;
-  }
-  .menu-container ul {
-    display: inline-block;
-    font-size: 0;
-    margin-top: 5px;
-  }
-  .menu-container ul li {
-    border: 0;
-    display: inline-block;
-    font-size: 1.4rem;
-    margin-right: 2.1rem;
-    padding: 0;
-  }
-  .menu-container ul li:last-of-type {
-    margin: 0;
-  }
+	.menu-container {
+		float: right;
+		position: relative;
+		width: auto;
+		top: auto;
+		margin-right: 4px;
+	}
+	.menu-container ul {
+		display: inline-block;
+		font-size: 0;
+		margin-top: 5px;
+	}
+	.menu-container ul li {
+		border: 0;
+		display: inline-block;
+		font-size: 1.4rem;
+		margin-right: 2.1rem;
+		padding: 0;
+	}
+	.menu-container ul li:last-of-type {
+		margin: 0;
+	}
 }
 
 .main-navigation {
-  clear: both;
-  position: absolute;
-  left: 0;
-  width: 100%;
-  top: 50px;
-  z-index: 10;
+	clear: both;
+	position: absolute;
+	left: 0;
+	width: 100%;
+	top: 50px;
+	z-index: 10;
 }
 
 .main-navigation.toggled ul {
-  display: block;
+	display: block;
 }
 
 .menu-toggle.dashicons {
-  background: transparent;
-  border: none;
-  color: #fff;
-  font-size: 25px;
-  height: 5.5rem;
-  outline-style: none;
-  overflow: hidden;
-  position: absolute;
-  right: 0.5rem;
-  top: -60px;
-  width: 5.5rem;
-  -webkit-appearance: none;
+	background: transparent;
+	border: none;
+	color: #fff;
+	font-size: 25px;
+	height: 5.5rem;
+	outline-style: none;
+	overflow: hidden;
+	position: absolute;
+	right: 0.5rem;
+	top: -60px;
+	width: 5.5rem;
+	-webkit-appearance: none;
 }
 
 .toggled .menu-toggle.dashicons:before {
-  content: "\f343";
+	content: '\f343';
 }
 
 @media screen and (min-width: 48em) {
-  .menu-toggle.dashicons {
-    display: none;
-  }
-  .main-navigation {
-    float: right;
-    position: relative;
-    width: auto;
-    top: auto;
-  }
-  .main-navigation.toggled {
-    padding: 1px 0;
-  }
-  .main-navigation ul {
-    display: inline-block;
-    font-size: 0;
-  }
-  .main-navigation ul li {
-    border: 0;
-    display: inline-block;
-    font-size: 1rem;
-    margin-right: 1rem;
-    padding: 0;
-  }
-  .main-navigation ul li:last-of-type {
-    margin-right: 0;
-  }
-  .main-navigation button.button-search {
-    display: inline-block;
-  }
+	.menu-toggle.dashicons {
+		display: none;
+	}
+	.main-navigation {
+		float: right;
+		position: relative;
+		width: auto;
+		top: auto;
+	}
+	.main-navigation.toggled {
+		padding: 1px 0;
+	}
+	.main-navigation ul {
+		display: inline-block;
+		font-size: 0;
+	}
+	.main-navigation ul li {
+		border: 0;
+		display: inline-block;
+		font-size: 1rem;
+		margin-right: 1rem;
+		padding: 0;
+	}
+	.main-navigation ul li:last-of-type {
+		margin-right: 0;
+	}
+	.main-navigation button.button-search {
+		display: inline-block;
+	}
 }
 
 /** WP editor link button modal **/
 #wp-link-wrap {
-  height: 210px !important;
-  margin-top: -125px !important;
+	height: 210px !important;
+	margin-top: -125px !important;
 }
 
 @media screen and (max-height: 520px) {
-  #wp-link-wrap {
-    margin-top: inherit !important;
-  }
+	#wp-link-wrap {
+		margin-top: inherit !important;
+	}
 }
 
 #link-selector #search-panel,
 #link-selector #wplink-link-existing-content,
 #link-selector #link-options .link-target {
-  display: none;
+	display: none;
 }
 
 /** Handbook **/
-aside[id^="handbook"] .widget-title,
-aside[id^="nav_menu"] .widget-title {
-  font-size: 16px;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  background-color: transparent;
-  padding: 1rem 12px;
-  margin-bottom: 0;
-  color: inherit;
+aside[id^='handbook'] .widget-title,
+aside[id^='nav_menu'] .widget-title {
+	font-size: 16px;
+	text-transform: uppercase;
+	letter-spacing: 1px;
+	background-color: transparent;
+	padding: 1rem 12px;
+	margin-bottom: 0;
+	color: inherit;
 }
 
 .widget-area .widget .searchform .button-search {
-  height: 100%;
+	height: 100%;
 }
 
 .post-type-archive-handbook .site-main .widget-area,
 .single-handbook .site-main .widget-area {
-  float: left;
-  margin-right: 4%;
+	float: left;
+	margin-right: 4%;
 }
 
 .handbook-header {
-  line-height: 2em;
+	line-height: 2em;
 }
 
 .handbook-header h1 {
-  margin-top: 0;
+	margin-top: 0;
 }
 
 .single-handbook {
-  font-size: 13px;
-  font-size: 1.3rem;
+	font-size: 16px;
 }
 
-.single-handbook p, .single-handbook ol, .single-handbook ul {
-  line-height: 1.6;
+.single-handbook p,
+.single-handbook ol,
+.single-handbook ul {
+	line-height: 1.6;
 }
 
-.single-handbook .site-main p, .single-handbook .site-main ol, .single-handbook .site-main ul {
-  font-size: 1.05em;
-  color: #555;
+.single-handbook .site-main p,
+.single-handbook .site-main ol,
+.single-handbook .site-main ul {
+	color: #555;
 }
 
 .single-handbook .site-title {
-  margin-left: 0;
+	margin-left: 0;
 }
 
 .single-handbook .content-area h1 {
-  margin-top: 0;
-  padding-top: 0;
+	margin-top: 0;
+	padding-top: 0;
 }
 
 .single-handbook .o2-post {
-  border-top: none;
+	border-top: none;
 }
 
 .single-handbook .devhub-wrap main h2 {
-    margin-top: 4rem;
-    border-bottom: 1px solid #AAA;
+	margin-top: 4rem;
+	padding-top: 4rem;
+	border-top: 1px solid #aaa;
 }
 
 .single-handbook .devhub-wrap main h3 {
-    margin-top: 4rem;
-    border-bottom: 1px solid #CCC;
+	margin-top: 4rem;
+	padding-top: 4rem;
+	border-top: 1px solid #ccc;
 }
 
 .single-handbook .handbook-name-container + #primary {
-  padding-top: 5rem;
+	padding-top: 5rem;
 }
 
 .post-type-archive-handbook .handbook-name a:not(:hover),
 .single-handbook .handbook-name a:not(:hover) {
-  color: inherit;
+	color: inherit;
 }
 
 .handbook-name-container {
-  position: absolute;
-  right: 0;
-  width: 75%;
-  margin-left: 25%;
-  background-color: #fff;
+	position: absolute;
+	right: 0;
+	width: 75%;
+	margin-left: 25%;
+	background-color: #fff;
 }
 
 /** Table of Contents */
 .site-main .table-of-contents {
-  float: right;
-  width: 250px;
-  border: 1px solid #eee;
-  margin: 0 0 15px 15px;
-  z-index: 1;
-  position: relative;
-  color: #555d66;
-  background-color: #fff;
-  box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
-  border-radius: 3px;
+	float: right;
+	width: 250px;
+	border: 1px solid #eee;
+	margin: 0 0 15px 15px;
+	z-index: 1;
+	position: relative;
+	color: #555d66;
+	background-color: #fff;
+	box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
+	border-radius: 3px;
 }
 
 @media (min-width: 971px) {
-  .site-main .table-of-contents {
-    margin: 0 -30px 15px 15px;
-  }
+	.site-main .table-of-contents {
+		margin: 0 -30px 15px 15px;
+	}
 }
 
 .site-main .table-of-contents h2 {
-  margin: 0;
-  padding: 0.7rem 1.2rem;
-  font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, sans-serif;
-  font-size: 1.3em;
-  color: #32373c;
-  text-transform: uppercase;
-  border-bottom: 1px solid #eee;
-  margin-bottom: 0;
+	margin: 0;
+	padding: 0.7rem 1.2rem;
+	font-family: 'HelveticaNeue-Light', 'Helvetica Neue Light', 'Helvetica Neue',
+		Helvetica, Arial, sans-serif;
+	font-size: 1.3em;
+	color: #32373c;
+	text-transform: uppercase;
+	border-bottom: 1px solid #eee;
+	margin-bottom: 0;
 }
 
 .post-type-archive-handbook ul.items,
 .single-handbook ul.items,
 .table-of-contents ul.items {
-  margin: 0;
-  list-style-type: none;
-  padding: 1.2rem;
+	margin: 0;
+	list-style-type: none;
+	padding: 1.2rem;
 }
 
 .post-type-archive-handbook ul.items li,
 .single-handbook ul.items li,
 .table-of-contents ul.items li {
-  padding: 4px;
+	padding: 4px;
 }
 
 .post-type-archive-handbook ul.items li a,
 .single-handbook ul.items li a,
 .table-of-contents ul.items li a {
-  text-decoration: none;
+	text-decoration: none;
 }
 
 .post-type-archive-handbook ul.items li a:hover,
 .single-handbook ul.items li a:hover,
 .table-of-contents ul.items li a:hover {
-  color: #0073aa;
-  text-decoration: underline;
+	color: #0073aa;
+	text-decoration: underline;
 }
 
 .post-type-archive-handbook ul.items li ul li,
@@ -2420,841 +2784,937 @@ aside[id^="nav_menu"] .widget-title {
 .single-handbook ul.items li ul li ul li,
 .table-of-contents ul.items li ul li,
 .table-of-contents ul.items li ul li ul li {
-  list-style-type: circle;
-  padding-bottom: 0;
+	list-style-type: circle;
+	padding-bottom: 0;
 }
 
 /* Highlight current heading and adjust scroll position for fixed toolbar */
 .toc-heading:target {
-  position: initial;
-  padding-top: 50px;
-  margin-top: -50px;
+	position: initial;
+	padding-top: 50px;
+	margin-top: -50px;
 }
 
 /* Remove negative margin because there is no jump link before these headlines */
 .entry-content h2.toc-heading:first-of-type:target,
 .entry-content h3.toc-heading:first-of-type:target,
 h2.toc-heading + h3.toc-heading:target {
-  margin-top: 0;
+	margin-top: 0;
 }
 
 .toc-heading:target:before {
-  content: '';
-  position: absolute;
-  left: -10px;
-  top: 50px;
-  border-left: 5px solid #0073aa;
-  height: 50%;
-  height: calc(100% - 50px);
+	content: '';
+	position: absolute;
+	left: -10px;
+	top: 50px;
+	border-left: 5px solid #0073aa;
+	height: 50%;
+	height: calc(100% - 50px);
 }
 
 .toc-jump {
-  position: relative;
-  height: 50px;
+	position: relative;
+	height: 50px;
 }
 
 .toc-jump:after {
-  content: '';
-  display: table;
-  clear: both;
+	content: '';
+	display: table;
+	clear: both;
 }
 
 .toc-jump a {
-  z-index: 1;
+	z-index: 1;
 }
 
 @media (max-width: 480px) {
-  .table-of-contents {
-    display: none;
-  }
+	.table-of-contents {
+		display: none;
+	}
 }
 
 /** Menu */
 #secondary aside.widget_wporg_handbook_pages,
 #secondary aside.widget_nav_menu {
-  font-size: 16px;
-  height: 100%;
-  overflow-y: auto;
+	font-size: 16px;
+	height: 100%;
+	overflow-y: auto;
 }
 
 .widget_wporg_handbook_pages h1,
 .widget_nav_menu h1 {
-  font-size: 1.6em;
-  font-weight: bold;
-  margin-bottom: 0.6em;
+	font-size: 1.6em;
+	font-weight: bold;
+	margin-bottom: 0.6em;
 }
 
-div[class*="-table-of-contents-container"] {
-  font-size: 0.8em;
+div[class*='-table-of-contents-container'] {
+	font-size: 0.8em;
 }
 
-div[class*="-table-of-contents-container"] *:focus {
-  outline: 0;
+div[class*='-table-of-contents-container'] *:focus {
+	outline: 0;
 }
 
-div[class*="-table-of-contents-container"] ul {
-  margin-left: 0;
-  padding-left: 0;
-  list-style: none;
+div[class*='-table-of-contents-container'] ul {
+	margin-left: 0;
+	padding-left: 0;
+	list-style: none;
 }
 
-div[class*="-table-of-contents-container"] ul li .expandable {
-  display: flex;
-  flex-direction: row-reverse;
-  align-items: stretch;
-  position: relative;
+div[class*='-table-of-contents-container'] ul li .expandable {
+	display: flex;
+	flex-direction: row-reverse;
+	align-items: stretch;
+	position: relative;
 }
 
-div[class*="-table-of-contents-container"] ul li .dashicons {
-  position: absolute;
-  right: 0;
-  cursor: pointer;
-  padding: 8px 4px;
-  display: inline-block;
-  font-size: 20px;
-  width: auto;
-  height: 100%;
-  color: #0073aa;
-  background-color: #fafafa;
-  border: 0;
-  border-left: 1px solid rgba(0, 0, 0, 0.05);
-  border-radius: 0;
-  box-shadow: none;
-  -webkit-appearance: none;
+div[class*='-table-of-contents-container'] ul li .dashicons {
+	position: absolute;
+	right: 0;
+	cursor: pointer;
+	padding: 8px 4px;
+	display: inline-block;
+	font-size: 20px;
+	width: auto;
+	height: 100%;
+	color: #0073aa;
+	background-color: #fafafa;
+	border: 0;
+	border-left: 1px solid rgba(0, 0, 0, 0.05);
+	border-radius: 0;
+	box-shadow: none;
+	-webkit-appearance: none;
 }
 
-div[class*="-table-of-contents-container"] ul li .dashicons:hover,
-div[class*="-table-of-contents-container"] ul li .dashicons:focus {
-  color: #fff;
-  background-color: #0073aa;
+div[class*='-table-of-contents-container'] ul li .dashicons:hover,
+div[class*='-table-of-contents-container'] ul li .dashicons:focus {
+	color: #fff;
+	background-color: #0073aa;
 }
 
-div[class*="-table-of-contents-container"] ul li.open > div > .dashicons {
-  transform: rotate(180deg);
-  border-right: 1px solid rgba(0, 0, 0, 0.05);
-  border-left: none;
+div[class*='-table-of-contents-container'] ul li.open > div > .dashicons {
+	transform: rotate(180deg);
+	border-right: 1px solid rgba(0, 0, 0, 0.05);
+	border-left: none;
 }
 
-div[class*="-table-of-contents-container"] ul li.menu-item-has-children > .expandable > a {
-  padding-right: 30px;
+div[class*='-table-of-contents-container']
+	ul
+	li.menu-item-has-children
+	> .expandable
+	> a {
+	padding-right: 30px;
 }
 
-div[class*="-table-of-contents-container"] ul a {
-  display: block;
-  width: 100%;
-  font-size: 1.05em;
-  padding: 8px 8px 8px 13px;
-  text-decoration: none;
+div[class*='-table-of-contents-container'] ul a {
+	display: block;
+	width: 100%;
+	font-size: 1.05em;
+	padding: 8px 8px 8px 13px;
+	text-decoration: none;
 }
 
-div[class*="-table-of-contents-container"] ul a:hover, div[class*="-table-of-contents-container"] ul a:focus {
-  color: #fff;
-  background-color: #0073aa;
+div[class*='-table-of-contents-container'] ul a:hover,
+div[class*='-table-of-contents-container'] ul a:focus {
+	color: #fff;
+	background-color: #0073aa;
 }
 
-div[class*="-table-of-contents-container"] ul a.active {
-  color: #555;
-  background-color: #fff;
-  font-weight: bold;
+div[class*='-table-of-contents-container'] ul a.active {
+	color: #555;
+	background-color: #fff;
+	font-weight: bold;
 }
 
-div[class*="-table-of-contents-container"] ul.default-open {
-  display: block !important;
+div[class*='-table-of-contents-container'] ul.default-open {
+	display: block !important;
 }
 
-div[class*="-table-of-contents-container"] > ul > li.open > div > a:not(:focus) {
-  color: #0073aa;
+div[class*='-table-of-contents-container']
+	> ul
+	> li.open
+	> div
+	> a:not(:focus) {
+	color: #0073aa;
 }
 
-div[class*="-table-of-contents-container"] > ul > li.open > div > a:hover {
-  color: #fff;
-  background-color: #0073aa;
+div[class*='-table-of-contents-container'] > ul > li.open > div > a:hover {
+	color: #fff;
+	background-color: #0073aa;
 }
 
-div[class*="-table-of-contents-container"] .current-menu-item ul,
-div[class*="-table-of-contents-container"] .current-menu-ancestor ul {
-  display: block;
+div[class*='-table-of-contents-container'] .current-menu-item ul,
+div[class*='-table-of-contents-container'] .current-menu-ancestor ul {
+	display: block;
 }
 
-div[class*="-table-of-contents-container"] .current-menu-ancestor:not(.open) .expandable .dashicons:not(:focus),
-div[class*="-table-of-contents-container"] .current-menu-item > .expandable .dashicons:not(:focus) {
-  background: #fff;
-  color: #0073aa;
+div[class*='-table-of-contents-container']
+	.current-menu-ancestor:not(.open)
+	.expandable
+	.dashicons:not(:focus),
+div[class*='-table-of-contents-container']
+	.current-menu-item
+	> .expandable
+	.dashicons:not(:focus) {
+	background: #fff;
+	color: #0073aa;
 }
 
-div[class*="-table-of-contents-container"] .current-menu-ancestor .expandable .dashicons:hover,
-div[class*="-table-of-contents-container"] .current-menu-item .expandable .dashicons:hover {
-  background-color: #0073aa !important;
-  color: #fff !important;
+div[class*='-table-of-contents-container']
+	.current-menu-ancestor
+	.expandable
+	.dashicons:hover,
+div[class*='-table-of-contents-container']
+	.current-menu-item
+	.expandable
+	.dashicons:hover {
+	background-color: #0073aa !important;
+	color: #fff !important;
 }
 
-div[class*="-table-of-contents-container"] .children,
-div[class*="-table-of-contents-container"] .sub-menu {
-  overflow: hidden;
-  display: none;
+div[class*='-table-of-contents-container'] .children,
+div[class*='-table-of-contents-container'] .sub-menu {
+	overflow: hidden;
+	display: none;
 }
 
-#secondary div[class*="-table-of-contents-container"] ul li {
-  padding: 1px 0;
-  position: relative;
+#secondary div[class*='-table-of-contents-container'] ul li {
+	padding: 1px 0;
+	position: relative;
 }
 
-#secondary div[class*="-table-of-contents-container"] ul ul {
-  margin-left: 12px;
-  border-left: 2px solid #21759b;
+#secondary div[class*='-table-of-contents-container'] ul ul {
+	margin-left: 12px;
+	border-left: 2px solid #21759b;
 }
 
 /* New handbook design */
 .single-handbook #page {
-  background: linear-gradient(to right, #fafafa 35%, #fff 35%);
-  max-width: 100%;
-  padding: 0;
-  overflow: auto;
+	background: linear-gradient(to right, #fafafa 35%, #fff 35%);
+	max-width: 100%;
+	padding: 0;
+	overflow: auto;
 }
 
 .single-handbook #content {
-  max-width: 960px;
-  margin: 0 auto;
-  display: flex;
-  padding-top: 0;
+	max-width: 960px;
+	margin: 0 auto;
+	display: flex;
+	padding-top: 0;
 }
 
 .single-handbook header {
-  margin: 0;
+	margin: 0;
 }
 
 .single-handbook #secondary {
-  clear: left;
-  margin: 0;
-  background: #fafafa;
-  overflow: hidden;
-  width: 25%;
-  padding-top: 2rem;
+	clear: left;
+	margin: 0;
+	background: #fafafa;
+	overflow: hidden;
+	width: 25%;
+	padding-top: 2rem;
 }
 
 .single-handbook #primary {
-  padding: 4rem 0 4rem 4rem;
-  background: #fff;
-  box-sizing: border-box;
-  width: 72%;
+	padding: 4rem 0 4rem 4rem;
+	background: #fff;
+	box-sizing: border-box;
+	width: 72%;
 }
 
 @media (max-width: 876px) {
-  .single-handbook #primary {
-    padding: 4rem 20px;
-    width: 100%;
-  }
+	.single-handbook #primary {
+		padding: 4rem 20px;
+		width: 100%;
+	}
 }
 
-.single-handbook .widget_wporg_handbook_pages
-.widget_nav_menu {
-  background-color: transparent;
+.single-handbook .widget_wporg_handbook_pages .widget_nav_menu {
+	background-color: transparent;
 }
 
 .single-handbook nav.o2-post-actions button {
-  top: 10px;
+	top: 10px;
 }
 
 .single-handbook .make-welcome {
-  margin: 0 !important;
+	margin: 0 !important;
 }
 
 /** /Handbook **/
 .rest-api-handbook-reference .table-of-contents {
-  float: none;
-  overflow: hidden;
-  width: 100%;
-  margin: 0 auto 1em;
-  clear: both;
+	float: none;
+	overflow: hidden;
+	width: 100%;
+	margin: 0 auto 1em;
+	clear: both;
 }
 
 .rest-api-handbook-reference .table-of-contents ul.items li ul li {
-  display: inline;
+	display: inline;
 }
 
 .rest-api-handbook-reference .table-of-contents ul.items li ul li::after {
-  content: '; ';
+	content: '; ';
 }
 
-.rest-api-handbook-reference .table-of-contents ul.items li ul li:last-child::after {
-  content: '';
+.rest-api-handbook-reference
+	.table-of-contents
+	ul.items
+	li
+	ul
+	li:last-child::after {
+	content: '';
 }
 
 /* Menu toggle */
 #secondary-toggle {
-  display: none;
+	display: none;
 }
 
 body.responsive-show {
-  position: fixed;
-  top: 32px;
+	position: fixed;
+	top: 32px;
 }
 
 body.responsive-show #secondary {
-  left: 0;
-  overflow-y: scroll;
+	left: 0;
+	overflow-y: scroll;
 }
 
 body.responsive-show #secondary .search-section {
-  margin-top: 32px;
-  width: 100%;
+	margin-top: 32px;
+	width: 100%;
 }
 
 body.responsive-show #secondary-toggle {
-  height: 32px;
-  margin-left: 8px;
-  width: 100%;
+	height: 32px;
+	margin-left: 8px;
+	width: 100%;
 }
 
 body.responsive-show #primary-modal {
-  display: block;
+	display: block;
 }
 
 body.responsive-show #o2-expand-editor {
-  display: none;
+	display: none;
 }
 
 @media only screen and (max-width: 782px) {
-  #secondary {
-    top: 46px;
-  }
-  body.responsive-show {
-    position: fixed;
-    top: 46px;
-    left: 0;
-    right: 0;
-    bottom: 0;
-  }
-  body.responsive-show #secondary {
-    left: 0;
-  }
+	#secondary {
+		top: 46px;
+	}
+	body.responsive-show {
+		position: fixed;
+		top: 46px;
+		left: 0;
+		right: 0;
+		bottom: 0;
+	}
+	body.responsive-show #secondary {
+		left: 0;
+	}
 }
 
 @media only screen and (max-width: 480px) {
-  body.responsive-show #secondary {
-    top: 46px;
-  }
-  body.responsive-show #wpadminbar {
-    top: -46px;
-  }
+	body.responsive-show #secondary {
+		top: 46px;
+	}
+	body.responsive-show #wpadminbar {
+		top: -46px;
+	}
 }
 
 @media (max-width: 876px) {
-  #secondary {
-    position: fixed;
-    z-index: 10;
-    bottom: 0px;
-    overflow-y: auto;
-    transition: all .25s ease;
-    top: 32px;
-    left: -100%;
-    width: 60%;
-    min-width: 300px;
-    box-shadow: 0 0 20px rgba(0, 0, 0, 0.2);
-  }
-  #secondary-toggle {
-    display: block;
-    float: left;
-    margin-left: 17px;
-    margin-right: 0;
-    width: 48px;
-    height: 48px;
-    white-space: nowrap;
-    position: relative;
-    z-index: 1;
-  }
-  #secondary-toggle:before {
-    content: '\f333';
-    -webkit-font-smoothing: antialiased;
-    font: normal 32px/1 'dashicons';
-    position: relative;
-    top: 0;
-    color: #fff;
-  }
-  #secondary-toggle strong {
-    display: none;
-  }
-  #page {
-    overflow-x: hidden;
-  }
-  body.responsive-show {
-    overflow-y: visible;
-    position: static;
-  }
-  body.responsive-show #page {
-    overflow-x: visible;
-  }
-  body.responsive-show #secondary-toggle:before {
-    color: #0073aa;
-  }
-  .content-area {
-    width: 100%;
-  }
-  #primary,
-  #secondary {
-    -webkit-backface-visibility: hidden;
-  }
+	#secondary {
+		position: fixed;
+		z-index: 10;
+		bottom: 0px;
+		overflow-y: auto;
+		transition: all 0.25s ease;
+		top: 32px;
+		left: -100%;
+		width: 60%;
+		min-width: 300px;
+		box-shadow: 0 0 20px rgba(0, 0, 0, 0.2);
+	}
+	#secondary-toggle {
+		display: block;
+		float: left;
+		margin-left: 17px;
+		margin-right: 0;
+		width: 48px;
+		height: 48px;
+		white-space: nowrap;
+		position: relative;
+		z-index: 1;
+	}
+	#secondary-toggle:before {
+		content: '\f333';
+		-webkit-font-smoothing: antialiased;
+		font: normal 32px/1 'dashicons';
+		position: relative;
+		top: 0;
+		color: #fff;
+	}
+	#secondary-toggle strong {
+		display: none;
+	}
+	#page {
+		overflow-x: hidden;
+	}
+	body.responsive-show {
+		overflow-y: visible;
+		position: static;
+	}
+	body.responsive-show #page {
+		overflow-x: visible;
+	}
+	body.responsive-show #secondary-toggle:before {
+		color: #0073aa;
+	}
+	.content-area {
+		width: 100%;
+	}
+	#primary,
+	#secondary {
+		-webkit-backface-visibility: hidden;
+	}
 }
 
 @media (max-width: 59.999999em) {
-  .devhub-wrap {
-    max-width: 100%;
-    width: 100%;
-  }
-  .devhub-wrap #content,
-  .devhub-wrap #content-area,
-  .devhub-wrap .inner-wrap {
-    max-width: 100%;
-    padding: 0 13px;
-  }
-  .devhub-wrap #content-area .has-sidebar,
-  .devhub-wrap .inner-wrap .has-sidebar {
-    width: 100%;
-  }
-  .devhub-wrap #content-area {
-    padding-left: 2%;
-  }
-  .devhub-wrap.archive .meta, .devhub-wrap.search .meta {
-    font-size: 100%;
-    margin-bottom: 1.5em;
-  }
-  .devhub-wrap.archive .meta a, .devhub-wrap.search .meta a {
-    color: #21759b;
-  }
+	.devhub-wrap {
+		max-width: 100%;
+		width: 100%;
+	}
+	.devhub-wrap #content,
+	.devhub-wrap #content-area,
+	.devhub-wrap .inner-wrap {
+		max-width: 100%;
+		padding: 0 13px;
+	}
+	.devhub-wrap #content-area .has-sidebar,
+	.devhub-wrap .inner-wrap .has-sidebar {
+		width: 100%;
+	}
+	.devhub-wrap #content-area {
+		padding-left: 2%;
+	}
+	.devhub-wrap.archive .meta,
+	.devhub-wrap.search .meta {
+		font-size: 100%;
+		margin-bottom: 1.5em;
+	}
+	.devhub-wrap.archive .meta a,
+	.devhub-wrap.search .meta a {
+		color: #21759b;
+	}
 }
 
 @media (min-width: 43em) {
-  .devhub-wrap.archive .meta, .devhub-wrap.search .meta {
-    float: right;
-  }
-  .devhub-wrap.archive .sourcefile, .devhub-wrap.search .sourcefile {
-    float: left;
-  }
+	.devhub-wrap.archive .meta,
+	.devhub-wrap.search .meta {
+		float: right;
+	}
+	.devhub-wrap.archive .sourcefile,
+	.devhub-wrap.search .sourcefile {
+		float: left;
+	}
 }
 
 @media (min-width: 43em) and (max-width: 43em) {
-  .devhub-wrap #content-area {
-    padding-left: 2%;
-  }
+	.devhub-wrap #content-area {
+		padding-left: 2%;
+	}
 }
 
 @media (max-width: 43em) {
-  #content-area.has-sidebar main {
-    float: right;
-    width: 96%;
-    margin: 0 auto;
-    clear: both;
-    padding: 0 12px;
-    padding: 0 1.2rem;
-  }
-  #content-area.has-sidebar .widget-area {
-    float: none;
-    overflow: hidden;
-    width: 80%;
-    margin: 0 auto;
-    clear: both;
-  }
-  #content-area.has-sidebar .widget-area .widget {
-    width: 100%;
-  }
-  .devhub-wrap .three-columns .box,
-  .devhub-wrap .section .box,
-  .devhub-wrap .home-primary-content,
-  .devhub-wrap .reference-landing .section {
-    float: none;
-    width: 100%;
-    padding: 1.5em 2%;
-    clear: both;
-    text-align: center;
-    display: block;
-  }
-  .devhub-wrap .reference-landing .section .box,
-  .devhub-wrap .sidebar .box {
-    padding: 0;
-    margin-bottom: 1.5em;
-  }
-  .devhub-wrap .home-primary-content .entry-content,
-  .devhub-wrap .reference-landing .section {
-    text-align: left;
-  }
-  .devhub-wrap .horizontal-list li {
-    display: block;
-  }
-  .devhub-wrap .horizontal-list li a {
-    border-left: none;
-  }
-  .devhub-wrap .horizontal-list li:first-child a {
-    padding: 0 40px;
-    padding: 0 4rem;
-  }
-  .devhub-wrap .reference-landing .searchform {
-    text-alignment: center;
-  }
-  .devhub-wrap .reference-landing .searchform input[type="text"],
-  .devhub-wrap .reference-landing .searchform input[type="submit"] {
-    width: 100%;
-    margin-right: 0;
-    margin-bottom: 1em;
-    float: none;
-    clear: both;
-  }
-  .devhub-wrap .wp-parser-class h1, .devhub-wrap .wp-parser-function h1, .devhub-wrap .wp-parser-hook h1, .devhub-wrap .wp-parser-method h1 {
-    padding-left: 45px;
-    text-indent: -45px;
-  }
-  .devhub-wrap .two-columns .box {
-    width: 99%;
-  }
+	#content-area.has-sidebar main {
+		float: right;
+		width: 96%;
+		margin: 0 auto;
+		clear: both;
+		padding: 0 12px;
+		padding: 0 1.2rem;
+	}
+	#content-area.has-sidebar .widget-area {
+		float: none;
+		overflow: hidden;
+		width: 80%;
+		margin: 0 auto;
+		clear: both;
+	}
+	#content-area.has-sidebar .widget-area .widget {
+		width: 100%;
+	}
+	.devhub-wrap .three-columns .box,
+	.devhub-wrap .section .box,
+	.devhub-wrap .home-primary-content,
+	.devhub-wrap .reference-landing .section {
+		float: none;
+		width: 100%;
+		padding: 1.5em 2%;
+		clear: both;
+		text-align: center;
+		display: block;
+	}
+	.devhub-wrap .reference-landing .section .box,
+	.devhub-wrap .sidebar .box {
+		padding: 0;
+		margin-bottom: 1.5em;
+	}
+	.devhub-wrap .home-primary-content .entry-content,
+	.devhub-wrap .reference-landing .section {
+		text-align: left;
+	}
+	.devhub-wrap .horizontal-list li {
+		display: block;
+	}
+	.devhub-wrap .horizontal-list li a {
+		border-left: none;
+	}
+	.devhub-wrap .horizontal-list li:first-child a {
+		padding: 0 40px;
+		padding: 0 4rem;
+	}
+	.devhub-wrap .reference-landing .searchform {
+		text-alignment: center;
+	}
+	.devhub-wrap .reference-landing .searchform input[type='text'],
+	.devhub-wrap .reference-landing .searchform input[type='submit'] {
+		width: 100%;
+		margin-right: 0;
+		margin-bottom: 1em;
+		float: none;
+		clear: both;
+	}
+	.devhub-wrap .wp-parser-class h1,
+	.devhub-wrap .wp-parser-function h1,
+	.devhub-wrap .wp-parser-hook h1,
+	.devhub-wrap .wp-parser-method h1 {
+		padding-left: 45px;
+		text-indent: -45px;
+	}
+	.devhub-wrap .two-columns .box {
+		width: 99%;
+	}
 }
 
 @media (max-width: 32em) {
-  .devhub-wrap .table-of-contents {
-    float: none;
-    margin-left: 0;
-    width: 100%;
-  }
-  .devhub-wrap section {
-    overflow: inherit;
-  }
-  .devhub-wrap hr {
-    clear: both;
-  }
+	.devhub-wrap .table-of-contents {
+		float: none;
+		margin-left: 0;
+		width: 100%;
+	}
+	.devhub-wrap section {
+		overflow: inherit;
+	}
+	.devhub-wrap hr {
+		clear: both;
+	}
 }
 
 @media (max-width: 22em) {
-  ul, ol {
-    margin-left: 1.2em;
-  }
-  .devhub-wrap .wp-parser-class h1, .devhub-wrap .wp-parser-function h1, .devhub-wrap .wp-parser-hook h1, .devhub-wrap .wp-parser-method h1 {
-    padding-left: 20px;
-    line-height: 2rem;
-    text-indent: -20px;
-    font-size: 16px;
-  }
-  .devhub-wrap.single-wp-parser-function .comment-list li, .devhub-wrap.single-wp-parser-method .comment-list li, .devhub-wrap.single-wp-parser-hook .comment-list li {
-    padding-left: 0;
-    padding-right: 0;
-  }
-  .devhub-wrap.single-wp-parser-function .comment-list .avatar, .devhub-wrap.single-wp-parser-method .comment-list .avatar, .devhub-wrap.single-wp-parser-hook .comment-list .avatar {
-    margin: 0 1em 0 0;
-  }
-  .devhub-wrap .source-code-links {
-    margin-left: 0;
-  }
-  .devhub-wrap .source-code-links span:first-child {
-    margin-left: 0;
-  }
+	ul,
+	ol {
+		margin-left: 1.2em;
+	}
+	.devhub-wrap .wp-parser-class h1,
+	.devhub-wrap .wp-parser-function h1,
+	.devhub-wrap .wp-parser-hook h1,
+	.devhub-wrap .wp-parser-method h1 {
+		padding-left: 20px;
+		line-height: 2rem;
+		text-indent: -20px;
+		font-size: 16px;
+	}
+	.devhub-wrap.single-wp-parser-function .comment-list li,
+	.devhub-wrap.single-wp-parser-method .comment-list li,
+	.devhub-wrap.single-wp-parser-hook .comment-list li {
+		padding-left: 0;
+		padding-right: 0;
+	}
+	.devhub-wrap.single-wp-parser-function .comment-list .avatar,
+	.devhub-wrap.single-wp-parser-method .comment-list .avatar,
+	.devhub-wrap.single-wp-parser-hook .comment-list .avatar {
+		margin: 0 1em 0 0;
+	}
+	.devhub-wrap .source-code-links {
+		margin-left: 0;
+	}
+	.devhub-wrap .source-code-links span:first-child {
+		margin-left: 0;
+	}
 }
 
-.single-command #content h2, .single-command #content h3 {
-  margin-top: 4rem;
-  margin-bottom: 2.5rem;
-  font-size: 2.5rem;
+.single-command #content h2,
+.single-command #content h3 {
+	margin-top: 4rem;
+	margin-bottom: 2.5rem;
+	font-size: 2.5rem;
 }
 
 .single-command #content h2.entry-title {
-  padding: 0;
-  font-size: 3.5rem;
-  line-height: 4.5rem;
-  margin-top: 3rem;
-  margin-bottom: 1rem;
-  font-family: Monaco, Consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
+	padding: 0;
+	font-size: 3.5rem;
+	line-height: 4.5rem;
+	margin-top: 3rem;
+	margin-bottom: 1rem;
+	font-family: Monaco, Consolas, 'Andale Mono', 'DejaVu Sans Mono', monospace;
 }
 
 .single-command #content h2.entry-title a {
-  color: #000;
+	color: #000;
 }
 
 .single-command #content h2.entry-title a span {
-  color: #949494;
+	color: #949494;
 }
 
 .single-command #content .entry-content {
-  margin-top: 2rem;
+	margin-top: 2rem;
 }
 
 .single-command #content .excerpt {
-  margin-bottom: 1.3rem;
+	margin-bottom: 1.3rem;
 }
 
 .single-command #content .quick-links {
-  margin-left: 0.5rem;
-  color: #ABABAB;
+	margin-left: 0.5rem;
+	color: #ababab;
 }
 
 .single-command #content .quick-links a {
-  text-decoration: underline;
-  color: #ABABAB;
+	text-decoration: underline;
+	color: #ababab;
 }
 
 .single-command #content .quick-links a:hover {
-  color: #757575;
+	color: #757575;
 }
 
 .single-command #content .toc-jump {
-  float: right;
-  font-size: 75%;
-  margin-top: 11px;
+	float: right;
+	font-size: 75%;
+	margin-top: 11px;
 }
 
 .single-command #content table {
-  border-collapse: collapse;
-  border: 1px solid #eee;
-  padding: 0;
-  margin: 0 0 ms(0);
-  font-size: ms(-2);
-  width: 100%;
+	border-collapse: collapse;
+	border: 1px solid #eee;
+	padding: 0;
+	margin: 0 0 ms(0);
+	font-size: ms(-2);
+	width: 100%;
 }
 
 .single-command #content table thead {
-  background: #eee;
+	background: #eee;
 }
 
 .single-command #content table thead th {
-  font-weight: bold;
-  padding: 1em;
+	font-weight: bold;
+	padding: 1em;
 }
 
-.single-command #content table th, .single-command #content table td {
-  padding: 0.8em 1em;
-  margin: 0;
-  font-weight: normal;
-  text-align: left;
-  vertical-align: top;
-  border: 1px solid #eee;
+.single-command #content table th,
+.single-command #content table td {
+	padding: 0.8em 1em;
+	margin: 0;
+	font-weight: normal;
+	text-align: left;
+	vertical-align: top;
+	border: 1px solid #eee;
 }
 
 .single-command #content table tbody tr:nth-child(even) {
-  background: rgba(0, 0, 0, 0.025);
+	background: rgba(0, 0, 0, 0.025);
 }
 
-.single-command .devhub-wrap *, .single-command .devhub-wrap *::before, .single-command .devhub-wrap *::after {
-  -moz-box-sizing: border-box;
-  -webkit-box-sizing: border-box;
-  box-sizing: border-box;
+.single-command .devhub-wrap *,
+.single-command .devhub-wrap *::before,
+.single-command .devhub-wrap *::after {
+	-moz-box-sizing: border-box;
+	-webkit-box-sizing: border-box;
+	box-sizing: border-box;
 }
 
-.single-command .devhub-wrap a.button, .single-command .devhub-wrap button, .single-command .devhub-wrap input[type="button"], .single-command .devhub-wrap input[type="reset"], .single-command .devhub-wrap input[type="submit"] {
-  border: 1px solid;
-  border-color: #ccc;
-  border-radius: 3px;
-  background: #f7f7f7;
-  color: rgba(0, 0, 0, 0.8);
-  cursor: pointer;
-  font-size: 1.2rem;
-  line-height: 1;
-  float: none;
-  height: auto;
-  padding: .8rem 1.2rem;
-  margin: .4rem 0;
-  text-decoration: none;
-  -webkit-appearance: none;
+.single-command .devhub-wrap a.button,
+.single-command .devhub-wrap button,
+.single-command .devhub-wrap input[type='button'],
+.single-command .devhub-wrap input[type='reset'],
+.single-command .devhub-wrap input[type='submit'] {
+	border: 1px solid;
+	border-color: #ccc;
+	border-radius: 3px;
+	background: #f7f7f7;
+	color: rgba(0, 0, 0, 0.8);
+	cursor: pointer;
+	font-size: 1.2rem;
+	line-height: 1;
+	float: none;
+	height: auto;
+	padding: 0.8rem 1.2rem;
+	margin: 0.4rem 0;
+	text-decoration: none;
+	-webkit-appearance: none;
 }
 
-.single-command .devhub-wrap a.button:hover, .single-command .devhub-wrap button:hover, .single-command .devhub-wrap input[type="button"]:hover, .single-command .devhub-wrap input[type="reset"]:hover, .single-command .devhub-wrap input[type="submit"]:hover {
-  border-color: #ccc #bbb #aaa #bbb;
-  background: #eee;
+.single-command .devhub-wrap a.button:hover,
+.single-command .devhub-wrap button:hover,
+.single-command .devhub-wrap input[type='button']:hover,
+.single-command .devhub-wrap input[type='reset']:hover,
+.single-command .devhub-wrap input[type='submit']:hover {
+	border-color: #ccc #bbb #aaa #bbb;
+	background: #eee;
 }
 
-.single-command .devhub-wrap a.button:focus, .single-command .devhub-wrap a.button:active, .single-command .devhub-wrap button:focus, .single-command .devhub-wrap button:active, .single-command .devhub-wrap input[type="button"]:focus, .single-command .devhub-wrap input[type="button"]:active, .single-command .devhub-wrap input[type="reset"]:focus, .single-command .devhub-wrap input[type="reset"]:active, .single-command .devhub-wrap input[type="submit"]:focus, .single-command .devhub-wrap input[type="submit"]:active {
-  border-color: #bbb;
-  background: #eee;
-  -webkit-box-shadow: 0 0 4px rgba(0, 0, 0, 0.2);
-  box-shadow: 0 0 4px rgba(0, 0, 0, 0.2);
+.single-command .devhub-wrap a.button:focus,
+.single-command .devhub-wrap a.button:active,
+.single-command .devhub-wrap button:focus,
+.single-command .devhub-wrap button:active,
+.single-command .devhub-wrap input[type='button']:focus,
+.single-command .devhub-wrap input[type='button']:active,
+.single-command .devhub-wrap input[type='reset']:focus,
+.single-command .devhub-wrap input[type='reset']:active,
+.single-command .devhub-wrap input[type='submit']:focus,
+.single-command .devhub-wrap input[type='submit']:active {
+	border-color: #bbb;
+	background: #eee;
+	-webkit-box-shadow: 0 0 4px rgba(0, 0, 0, 0.2);
+	box-shadow: 0 0 4px rgba(0, 0, 0, 0.2);
 }
 
-.single-command .devhub-wrap a.button > span, .single-command .devhub-wrap button > span, .single-command .devhub-wrap input[type="button"] > span, .single-command .devhub-wrap input[type="reset"] > span, .single-command .devhub-wrap input[type="submit"] > span {
-  color: #757575;
+.single-command .devhub-wrap a.button > span,
+.single-command .devhub-wrap button > span,
+.single-command .devhub-wrap input[type='button'] > span,
+.single-command .devhub-wrap input[type='reset'] > span,
+.single-command .devhub-wrap input[type='submit'] > span {
+	color: #757575;
 }
 
-.single-command .devhub-wrap a.button > span.red, .single-command .devhub-wrap button > span.red, .single-command .devhub-wrap input[type="button"] > span.red, .single-command .devhub-wrap input[type="reset"] > span.red, .single-command .devhub-wrap input[type="submit"] > span.red {
-  color: #dc3232;
+.single-command .devhub-wrap a.button > span.red,
+.single-command .devhub-wrap button > span.red,
+.single-command .devhub-wrap input[type='button'] > span.red,
+.single-command .devhub-wrap input[type='reset'] > span.red,
+.single-command .devhub-wrap input[type='submit'] > span.red {
+	color: #dc3232;
 }
 
-.single-command .devhub-wrap a.button > span.green, .single-command .devhub-wrap button > span.green, .single-command .devhub-wrap input[type="button"] > span.green, .single-command .devhub-wrap input[type="reset"] > span.green, .single-command .devhub-wrap input[type="submit"] > span.green {
-  color: #46B450;
+.single-command .devhub-wrap a.button > span.green,
+.single-command .devhub-wrap button > span.green,
+.single-command .devhub-wrap input[type='button'] > span.green,
+.single-command .devhub-wrap input[type='reset'] > span.green,
+.single-command .devhub-wrap input[type='submit'] > span.green {
+	color: #46b450;
 }
 
 .single-command .btn-group {
-  display: inline;
+	display: inline;
 }
 
 .single-command .btn-group > a {
-  position: relative;
+	position: relative;
 }
 
 @media (min-width: 571px) {
-  .single-command .btn-group > a:first-child {
-    right: -6px;
-    border-radius: 3px 0 0 3px;
-  }
-  .single-command .btn-group > a:last-child {
-    border-radius: 0 3px 3px 0;
-  }
+	.single-command .btn-group > a:first-child {
+		right: -6px;
+		border-radius: 3px 0 0 3px;
+	}
+	.single-command .btn-group > a:last-child {
+		border-radius: 0 3px 3px 0;
+	}
 }
 
 .single-command .github-tracker {
-  margin-bottom: 2.5rem;
+	margin-bottom: 2.5rem;
 }
 
 .single-command .github-tracker img.icon-github {
-  width: 23px;
-  position: relative;
-  top: 6px;
-  margin-right: 5px;
-  cursor: pointer;
+	width: 23px;
+	position: relative;
+	top: 6px;
+	margin-right: 5px;
+	cursor: pointer;
 }
 
-code[class*="language-"], pre[class*="language-"] {
-  direction: ltr;
-  text-align: left;
-  white-space: pre;
-  word-spacing: normal;
-  word-break: normal;
-  -moz-tab-size: 4;
-  -o-tab-size: 4;
-  tab-size: 4;
-  -webkit-hyphens: none;
-  -moz-hyphens: none;
-  -ms-hyphens: none;
-  hyphens: none;
-  background: #2b303b;
-  color: #c0c5ce;
+code[class*='language-'],
+pre[class*='language-'] {
+	direction: ltr;
+	text-align: left;
+	white-space: pre;
+	word-spacing: normal;
+	word-break: normal;
+	-moz-tab-size: 4;
+	-o-tab-size: 4;
+	tab-size: 4;
+	-webkit-hyphens: none;
+	-moz-hyphens: none;
+	-ms-hyphens: none;
+	hyphens: none;
+	background: #2b303b;
+	color: #c0c5ce;
 }
 
-pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection, code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
-  text-shadow: none;
-  background: #a7adba;
+pre[class*='language-']::-moz-selection,
+pre[class*='language-'] ::-moz-selection,
+code[class*='language-']::-moz-selection,
+code[class*='language-'] ::-moz-selection {
+	text-shadow: none;
+	background: #a7adba;
 }
 
-pre[class*="language-"]::selection, pre[class*="language-"] ::selection, code[class*="language-"]::selection, code[class*="language-"] ::selection {
-  text-shadow: none;
-  background: #a7adba;
+pre[class*='language-']::selection,
+pre[class*='language-'] ::selection,
+code[class*='language-']::selection,
+code[class*='language-'] ::selection {
+	text-shadow: none;
+	background: #a7adba;
 }
 
-pre[class*="language-"] {
-  overflow: auto;
+pre[class*='language-'] {
+	overflow: auto;
 }
 
-:not(pre) > code[class*="language-"] {
-  border-radius: .3em;
+:not(pre) > code[class*='language-'] {
+	border-radius: 0.3em;
 }
 
-.token.comment, .token.prolog, .token.doctype, .token.cdata {
-  color: #65737e;
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+	color: #65737e;
 }
 
 .token.punctuation {
-  color: #c0c5ce;
+	color: #c0c5ce;
 }
 
 .token.namespace {
-  opacity: .7;
+	opacity: 0.7;
 }
 
-.token.operator, .token.boolean, .token.number {
-  color: #d08770;
+.token.operator,
+.token.boolean,
+.token.number {
+	color: #d08770;
 }
 
 .token.property {
-  color: #ebcb8b;
+	color: #ebcb8b;
 }
 
 .token.tag {
-  color: #8fa1b3;
+	color: #8fa1b3;
 }
 
 .token.string {
-  color: #96b5b4;
+	color: #96b5b4;
 }
 
 .token.selector {
-  color: #b48ead;
+	color: #b48ead;
 }
 
 .token.attr-name {
-  color: #d08770;
+	color: #d08770;
 }
 
-.token.entity, .token.url, .language-css .token.string, .style .token.string {
-  color: #96b5b4;
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string {
+	color: #96b5b4;
 }
 
-.token.attr-value, .token.keyword, .token.control, .token.directive, .token.unit {
-  color: #a3be8c;
+.token.attr-value,
+.token.keyword,
+.token.control,
+.token.directive,
+.token.unit {
+	color: #a3be8c;
 }
 
-.token.statement, .token.regex, .token.atrule {
-  color: #96b5b4;
+.token.statement,
+.token.regex,
+.token.atrule {
+	color: #96b5b4;
 }
 
-.token.placeholder, .token.variable {
-  color: #8fa1b3;
+.token.placeholder,
+.token.variable {
+	color: #8fa1b3;
 }
 
 .token.deleted {
-  text-decoration: line-through;
+	text-decoration: line-through;
 }
 
 .token.inserted {
-  border-bottom: 1px dotted #eff1f5;
-  text-decoration: none;
+	border-bottom: 1px dotted #eff1f5;
+	text-decoration: none;
 }
 
 .token.italic {
-  font-style: italic;
+	font-style: italic;
 }
 
-.token.important, .token.bold {
-  font-weight: bold;
+.token.important,
+.token.bold {
+	font-weight: bold;
 }
 
 .token.important {
-  color: #bf616a;
+	color: #bf616a;
 }
 
 .token.entity {
-  cursor: help;
+	cursor: help;
 }
 
 pre > code.highlight {
-  outline: 0.4em solid #bf616a;
-  outline-offset: .4em;
+	outline: 0.4em solid #bf616a;
+	outline-offset: 0.4em;
 }
 
 button.code-tab,
 button.code-tab:hover {
-  background: #fff;
-  border: none;
-  box-shadow: none;
-  text-shadow: none;
-  border: 1px solid #D0DFDA;
-  border-radius: 30px 0 0 30px;
-  padding: 8px 20px;
+	background: #fff;
+	border: none;
+	box-shadow: none;
+	text-shadow: none;
+	border: 1px solid #d0dfda;
+	border-radius: 30px 0 0 30px;
+	padding: 8px 20px;
 }
 
 button.code-tab + button.code-tab {
-  border-radius: 0 30px 30px 0;
+	border-radius: 0 30px 30px 0;
 }
 
 button.code-tab:focus,
 button.code-tab.is-active:focus {
-  outline: none;
-  border: 1px solid #222;
-  box-shadow: none;
+	outline: none;
+	border: 1px solid #222;
+	box-shadow: none;
 }
 
 button.code-tab.is-active {
-  background: #00B975;
-  border: 1px solid #00B975;
-  box-shadow: none;
-  color: #fff;
+	background: #00b975;
+	border: 1px solid #00b975;
+	box-shadow: none;
+	color: #fff;
 }
 
 .code-tab-block {
-  display: none;
+	display: none;
 }
 
 .code-tab-block.is-active {
-  display: block;
+	display: block;
 }

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-developer/stylesheets/main.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-developer/stylesheets/main.css
@@ -2314,6 +2314,10 @@ aside[id^="nav_menu"] .widget-title {
   color: #555;
 }
 
+.single-handbook .site-main li {
+  margin-bottom: 2.0rem;
+}
+
 .single-handbook .site-title {
   margin-left: 0;
 }

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-developer/stylesheets/main.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-developer/stylesheets/main.css
@@ -1,86 +1,37 @@
 /* =Reset
 -------------------------------------------------------------- */
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-font,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td {
-	border: 0;
-	font-family: inherit;
-	font-size: 100%;
-	font-style: inherit;
-	font-weight: inherit;
-	margin: 0;
-	outline: 0;
-	padding: 0;
-	vertical-align: baseline;
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, font, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td {
+  border: 0;
+  font-family: inherit;
+  font-size: 100%;
+  font-style: inherit;
+  font-weight: inherit;
+  margin: 0;
+  outline: 0;
+  padding: 0;
+  vertical-align: baseline;
 }
 
 html {
-	font-size: 62.5%;
-	/* Corrects text resizing oddly in IE6/7 when body font-size is set using em units http://clagnut.com/blog/348/#c790 */
-	overflow-y: scroll;
-	/* Keeps page centered in all browsers regardless of content height */
-	-webkit-text-size-adjust: 100%;
-	/* Prevents iOS text size adjust after orientation change, without disabling user zoom */
-	-ms-text-size-adjust: 100%;
-	/* www.456bereastreet.com/archive/201012/controlling_text_size_in_safari_for_ios_without_disabling_user_zoom/ */
+  font-size: 62.5%;
+  /* Corrects text resizing oddly in IE6/7 when body font-size is set using em units http://clagnut.com/blog/348/#c790 */
+  overflow-y: scroll;
+  /* Keeps page centered in all browsers regardless of content height */
+  -webkit-text-size-adjust: 100%;
+  /* Prevents iOS text size adjust after orientation change, without disabling user zoom */
+  -ms-text-size-adjust: 100%;
+  /* www.456bereastreet.com/archive/201012/controlling_text_size_in_safari_for_ios_without_disabling_user_zoom/ */
 }
 
 body {
-	background: #fff;
+  background: #fff;
 }
 
 article,
@@ -93,50 +44,42 @@ header,
 main,
 nav,
 section {
-	display: block;
+  display: block;
 }
 
-ol,
-ul {
-	list-style: none;
+ol, ul {
+  list-style: none;
 }
 
 table {
-	/* tables still need 'cellspacing="0"' in the markup */
-	border-collapse: separate;
-	border-spacing: 0;
+  /* tables still need 'cellspacing="0"' in the markup */
+  border-collapse: separate;
+  border-spacing: 0;
 }
 
-caption,
-th,
-td {
-	font-weight: normal;
-	text-align: left;
+caption, th, td {
+  font-weight: normal;
+  text-align: left;
 }
 
-blockquote,
-q {
-	quotes: '' '';
+blockquote, q {
+  quotes: "" "";
 }
 
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-	content: '';
+blockquote:before, blockquote:after, q:before, q:after {
+  content: "";
 }
 
 a:focus {
-	outline: thin dotted;
+  outline: thin dotted;
 }
 
-a:hover,
-a:active {
-	outline: 0;
+a:hover, a:active {
+  outline: 0;
 }
 
 a img {
-	border: 0;
+  border: 0;
 }
 
 /* =Global
@@ -146,158 +89,142 @@ button,
 input,
 select,
 textarea {
-	color: #404040;
-	font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-	font-size: 16px;
-	font-size: 1.6rem;
-	line-height: 1.5;
+  color: #404040;
+  font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 16px;
+  font-size: 1.6rem;
+  line-height: 1.5;
 }
 
 /* Headings */
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-	clear: both;
-	font-family: 'HelveticaNeue-Light', 'Helvetica Neue Light', 'Helvetica Neue',
-		Helvetica, Arial, sans-serif;
-	font-weight: 300;
+h1, h2, h3, h4, h5, h6 {
+  clear: both;
+  font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-weight: 300;
 }
 
 hr {
-	background-color: #dfdfdf;
-	border: 0;
-	height: 1px;
-	margin: 1.5em 0;
+  background-color: #dfdfdf;
+  border: 0;
+  height: 1px;
+  margin: 1.5em 0;
 }
 
 /* Text elements */
 p {
-	margin-bottom: 1.5em;
+  margin-bottom: 1.5em;
 }
 
-ul,
-ol {
-	margin: 0 0 1.5em 3em;
+ul, ol {
+  margin: 0 0 1.5em 3em;
 }
 
 ul {
-	list-style: disc;
+  list-style: disc;
 }
 
 ol {
-	list-style: decimal;
+  list-style: decimal;
 }
 
 li > ul,
 li > ol {
-	margin-bottom: 0;
-	margin-left: 1.5em;
+  margin-bottom: 0;
+  margin-left: 1.5em;
 }
 
 dt {
-	font-weight: bold;
+  font-weight: bold;
 }
 
 dd {
-	margin: 0 1.5em 1.5em;
+  margin: 0 1.5em 1.5em;
 }
 
-b,
-strong {
-	font-weight: bold;
+b, strong {
+  font-weight: bold;
 }
 
-dfn,
-cite,
-em,
-i {
-	font-style: italic;
+dfn, cite, em, i {
+  font-style: italic;
 }
 
 blockquote {
-	margin: 0 1.5em;
+  margin: 0 1.5em;
 }
 
 address {
-	margin: 0 0 1.5em;
+  margin: 0 0 1.5em;
 }
 
 pre {
-	background: #eee;
-	font-family: 'Courier 10 Pitch', Courier, monospace;
-	font-size: 15px;
-	font-size: 1.5rem;
-	line-height: 1.6;
-	margin-bottom: 1.6em;
-	max-width: 100%;
-	overflow: auto;
-	padding: 1.6em;
+  background: #eee;
+  font-family: "Courier 10 Pitch", Courier, monospace;
+  font-size: 15px;
+  font-size: 1.5rem;
+  line-height: 1.6;
+  margin-bottom: 1.6em;
+  max-width: 100%;
+  overflow: auto;
+  padding: 1.6em;
 }
 
-code,
-kbd,
-tt,
-var {
-	font: 15px Monaco, Consolas, 'Andale Mono', 'DejaVu Sans Mono', monospace;
+code, kbd, tt, var {
+  font: 15px Monaco, Consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
 }
 
-abbr,
-acronym {
-	cursor: help;
+abbr, acronym {
+  cursor: help;
 }
 
-mark,
-ins {
-	background: #fff9c0;
-	text-decoration: none;
+mark, ins {
+  background: #fff9c0;
+  text-decoration: none;
 }
 
 sup,
 sub {
-	font-size: 75%;
-	height: 0;
-	line-height: 0;
-	position: relative;
-	vertical-align: baseline;
+  font-size: 75%;
+  height: 0;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
 }
 
 sup {
-	bottom: 1ex;
+  bottom: 1ex;
 }
 
 sub {
-	top: 0.5ex;
+  top: .5ex;
 }
 
 small {
-	font-size: 75%;
+  font-size: 75%;
 }
 
 big {
-	font-size: 125%;
+  font-size: 125%;
 }
 
 figure {
-	margin: 0;
+  margin: 0;
 }
 
 table {
-	margin: 0 0 1.5em;
-	width: 100%;
+  margin: 0 0 1.5em;
+  width: 100%;
 }
 
 th {
-	font-weight: bold;
+  font-weight: bold;
 }
 
 img {
-	height: auto;
-	/* Make sure images are scaled correctly. */
-	max-width: 100%;
-	/* Adhere to container width. */
+  height: auto;
+  /* Make sure images are scaled correctly. */
+  max-width: 100%;
+  /* Adhere to container width. */
 }
 
 /* Form Elements */
@@ -305,90 +232,85 @@ button,
 input,
 select,
 textarea {
-	font-size: 100%;
-	/* Corrects font size not being inherited in all browsers */
-	margin: 0;
-	/* Addresses margins set differently in IE6/7, F3/4, S5, Chrome */
-	vertical-align: baseline;
-	/* Improves appearance and consistency in all browsers */
-	*vertical-align: middle;
-	/* Improves appearance and consistency in all browsers */
-	font-weight: 300;
+  font-size: 100%;
+  /* Corrects font size not being inherited in all browsers */
+  margin: 0;
+  /* Addresses margins set differently in IE6/7, F3/4, S5, Chrome */
+  vertical-align: baseline;
+  /* Improves appearance and consistency in all browsers */
+  *vertical-align: middle;
+  /* Improves appearance and consistency in all browsers */
+  font-weight: 300;
 }
 
 button,
 input {
-	line-height: normal;
-	/* Addresses FF3/4 setting line-height using !important in the UA stylesheet */
+  line-height: normal;
+  /* Addresses FF3/4 setting line-height using !important in the UA stylesheet */
 }
 
 /* Alignment */
 .alignleft {
-	display: inline;
-	float: left;
-	margin-right: 1.5em;
+  display: inline;
+  float: left;
+  margin-right: 1.5em;
 }
 
 .alignright {
-	display: inline;
-	float: right;
-	margin-left: 1.5em;
+  display: inline;
+  float: right;
+  margin-left: 1.5em;
 }
 
 .aligncenter {
-	clear: both;
-	display: block;
-	margin: 0 auto;
+  clear: both;
+  display: block;
+  margin: 0 auto;
 }
 
 .home .devhub-wrap {
-	padding-bottom: 0;
+  padding-bottom: 0;
 }
 
-.home .devhub-wrap h1,
-.home .devhub-wrap h2,
-.home .devhub-wrap h3,
-.home .devhub-wrap h4,
-.home .devhub-wrap h5,
-.home .devhub-wrap h6 {
-	font-family: 'Open Sans', sans-serif;
+.home .devhub-wrap h1, .home .devhub-wrap h2, .home .devhub-wrap h3, .home .devhub-wrap h4, .home .devhub-wrap h5, .home .devhub-wrap h6 {
+  font-family: "Open Sans", sans-serif;
 }
 
 .home .devhub-wrap #content {
-	padding: 0;
+  padding: 0;
 }
 
 .devhub-wrap {
-	padding-bottom: 1.5em;
-	/* Override inline style from wporg-markdown plugin. */
-	/* Text meant only for screen readers */
-	/* Clearing */
-	/* =Content
+  padding-bottom: 1.5em;
+  /* Override inline style from wporg-markdown plugin. */
+  /* Text meant only for screen readers */
+  /* Clearing */
+  /* =Content
 	----------------------------------------------- */
-	/* =Tabs
+  /* =Tabs
 	----------------------------------------------- */
-	/* =Media
+  /* =Media
 	----------------------------------------------- */
-	/* Make sure embeds and iframes fit their containers */
-	/* =Widgets
+  /* Make sure embeds and iframes fit their containers */
+  /* =Widgets
 	----------------------------------------------- */
-	/* Make sure select elements fit in widgets */
-	/* Search widget */
-	/* =Infinite Scroll
+  /* Make sure select elements fit in widgets */
+  /* Search widget */
+  /* =Infinite Scroll
 	----------------------------------------------- */
-	/* Globally hidden elements when Infinite Scroll is supported and in use. */
-	/* When Infinite Scroll has reached its end we need to re-display elements that were hidden (via .neverending) before */
-	/*
+  /* Globally hidden elements when Infinite Scroll is supported and in use. */
+  /* When Infinite Scroll has reached its end we need to re-display elements that were hidden (via .neverending) before */
+  /*
 	 * Header area
 	 */
-	/*
+  /*
 	 * section styles
 	 */
-	/* = Related
+  /* = Related
 	----------------------------------------------- */
-	/* Changelog */
-	/* Comments */
-	/*
+  /* Changelog */
+  /* Comments */
+  /*
 	 * Content
 	 *
 	 */
@@ -397,63 +319,57 @@ input {
 .devhub-wrap *,
 .devhub-wrap *:before,
 .devhub-wrap *:after {
-	-moz-box-sizing: border-box;
-	-webkit-box-sizing: border-box;
-	box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
 }
 
 .devhub-wrap a.github-edit {
-	padding: 0 0.6em 0;
+  padding: 0 .6em 0;
 }
 
-.devhub-wrap #content,
-.devhub-wrap #content-area {
-	padding: 0 10px;
+.devhub-wrap #content, .devhub-wrap #content-area {
+  padding: 0 10px;
 }
 
-.devhub-wrap #content .toc-heading,
-.devhub-wrap #content-area .toc-heading {
-	clear: left;
+.devhub-wrap #content .toc-heading, .devhub-wrap #content-area .toc-heading {
+  clear: left;
 }
 
-.devhub-wrap #content table,
-.devhub-wrap #content-area table {
-	border: 1px solid #f0f0f0;
+.devhub-wrap #content table, .devhub-wrap #content-area table {
+  border: 1px solid #f0f0f0;
 }
 
 @media (max-width: 991px) {
-	.devhub-wrap #content table,
-	.devhub-wrap #content-area table {
-		overflow-x: scroll;
-		display: block;
-	}
+  .devhub-wrap #content table, .devhub-wrap #content-area table {
+    overflow-x: scroll;
+    display: block;
+  }
 }
 
-.devhub-wrap #content table th,
-.devhub-wrap #content-area table th {
-	padding: 1em;
-	border-bottom: 1px solid #f0f0f0;
-	background: #f0f0f0;
+.devhub-wrap #content table th, .devhub-wrap #content-area table th {
+  padding: 1em;
+  border-bottom: 1px solid #f0f0f0;
+  background: #f0f0f0;
 }
 
-.devhub-wrap #content table td,
-.devhub-wrap #content-area table td {
-	padding: 0.8em 1em;
-	border: 1px solid #f0f0f0;
+.devhub-wrap #content table td, .devhub-wrap #content-area table td {
+  padding: 0.8em 1em;
+  border: 1px solid #f0f0f0;
 }
 
 .devhub-wrap #content-area,
 .devhub-wrap .inner-wrap {
-	margin: 2rem auto 0;
-	max-width: 60em;
+  margin: 2rem auto 0;
+  max-width: 60em;
 }
 
 .devhub-wrap .page-header {
-	margin-top: 1em;
+  margin-top: 1em;
 }
 
 .devhub-wrap a {
-	color: #21759b;
+  color: #21759b;
 }
 
 .devhub-wrap .site-main h2,
@@ -461,293 +377,277 @@ input {
 .devhub-wrap .site-main h4,
 .devhub-wrap .site-main h5,
 .devhub-wrap .site-main h6 {
-	color: #1e1e1e;
-	margin-bottom: 1.5rem;
+  color: #1e1e1e;
+  margin-bottom: 1.5rem;
 }
 
 .devhub-wrap .site-main a {
-	border: 0;
-	text-decoration: underline;
+  border: 0;
+  text-decoration: underline;
 }
 
 .devhub-wrap .site-main .table-of-contents a,
 .devhub-wrap .site-main .toc-heading a {
-	text-decoration: none;
+  text-decoration: none;
 }
 
 .devhub-wrap #headline h2 a {
-	color: #555;
-	font-weight: 300;
-	font-size: 28px;
-	line-height: 1em;
-	text-shadow: #fff 0px 1px 0px;
-	font-family: 'HelveticaNeue-Light', 'Helvetica Neue Light', 'Helvetica Neue',
-		Helvetica, Arial, sans-serif;
+  color: #555;
+  font-weight: 300;
+  font-size: 28px;
+  line-height: 1em;
+  text-shadow: #fff 0px 1px 0px;
+  font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
 .devhub-wrap h1 {
-	font-size: 28px;
-	font-size: 3rem;
-	line-height: 32px;
-	line-height: 3.2rem;
-	font-weight: 300;
-	margin-bottom: 1.5rem;
+  font-size: 28px;
+  font-size: 3rem;
+  line-height: 32px;
+  line-height: 3.2rem;
+  font-weight: 300;
+  margin-bottom: 1.5rem;
 }
 
 .devhub-wrap h2 {
-	font-size: 22px;
-	font-size: 2.2rem;
-	line-height: 26px;
-	line-height: 2.6rem;
-	font-weight: 300;
+  font-size: 22px;
+  font-size: 2.2rem;
+  line-height: 26px;
+  line-height: 2.6rem;
+  font-weight: 300;
 }
 
 .devhub-wrap h3 {
-	font-size: 20px;
-	font-size: 2rem;
-	line-height: 24px;
-	line-height: 2.4rem;
-	font-weight: 300;
+  font-size: 20px;
+  font-size: 2rem;
+  line-height: 24px;
+  line-height: 2.4rem;
+  font-weight: 300;
 }
 
 .devhub-wrap h4 {
-	font-size: 18px;
-	font-size: 1.8rem;
-	line-height: 22px;
-	line-height: 2.2rem;
-	border-bottom: none;
-	font-weight: 300;
+  font-size: 18px;
+  font-size: 1.8rem;
+  line-height: 22px;
+  line-height: 2.2rem;
+  border-bottom: none;
+  font-weight: 300;
 }
 
 .devhub-wrap h4 .dashicons {
-	font-size: 22px;
-	font-size: 2.2rem;
-	line-height: 22px;
-	line-height: 2.2rem;
-	height: 22px;
-	width: 22px;
-	height: 2.2rem;
-	width: 2.2rem;
+  font-size: 22px;
+  font-size: 2.2rem;
+  line-height: 22px;
+  line-height: 2.2rem;
+  height: 22px;
+  width: 22px;
+  height: 2.2rem;
+  width: 2.2rem;
 }
 
 .devhub-wrap a.button,
 .devhub-wrap button,
 .devhub-wrap input {
-	line-height: normal;
-	/* Addresses FF3/4 setting line-height using !important in the UA stylesheet */
+  line-height: normal;
+  /* Addresses FF3/4 setting line-height using !important in the UA stylesheet */
 }
 
 .devhub-wrap a.button,
 .devhub-wrap button,
-.devhub-wrap input[type='button'],
-.devhub-wrap input[type='reset'],
-.devhub-wrap input[type='submit'] {
-	border: 1px solid #ccc;
-	border-color: #ccc #ccc #bbb #ccc;
-	border-radius: 3px;
-	background: #fff;
-	color: rgba(0, 0, 0, 0.8);
-	cursor: pointer;
-	/* Improves usability and consistency of cursor style between image-type 'input' and others */
-	font-size: 16px;
-	font-size: 1.6rem;
-	line-height: 1.1;
-	float: none;
-	height: auto;
-	padding: 0.6em 1.8em;
-	text-decoration: none;
-	-webkit-appearance: button;
-	/* Corrects inability to style clickable 'input' types in iOS */
+.devhub-wrap input[type="button"],
+.devhub-wrap input[type="reset"],
+.devhub-wrap input[type="submit"] {
+  border: 1px solid #ccc;
+  border-color: #ccc #ccc #bbb #ccc;
+  border-radius: 3px;
+  background: #fff;
+  color: rgba(0, 0, 0, 0.8);
+  cursor: pointer;
+  /* Improves usability and consistency of cursor style between image-type 'input' and others */
+  font-size: 16px;
+  font-size: 1.6rem;
+  line-height: 1.1;
+  float: none;
+  height: auto;
+  padding: .6em 1.8em;
+  text-decoration: none;
+  -webkit-appearance: button;
+  /* Corrects inability to style clickable 'input' types in iOS */
 }
 
 .devhub-wrap a.button:hover,
 .devhub-wrap button:hover,
-.devhub-wrap input[type='button']:hover,
-.devhub-wrap input[type='reset']:hover,
-.devhub-wrap input[type='submit']:hover {
-	border-color: #ccc #bbb #aaa #bbb;
-	background: #f0f0f0;
+.devhub-wrap input[type="button"]:hover,
+.devhub-wrap input[type="reset"]:hover,
+.devhub-wrap input[type="submit"]:hover {
+  border-color: #ccc #bbb #aaa #bbb;
+  background: #f0f0f0;
 }
 
-.devhub-wrap a.button:focus,
-.devhub-wrap a.button:active,
+.devhub-wrap a.button:focus, .devhub-wrap a.button:active,
 .devhub-wrap button:focus,
 .devhub-wrap button:active,
-.devhub-wrap input[type='button']:focus,
-.devhub-wrap input[type='button']:active,
-.devhub-wrap input[type='reset']:focus,
-.devhub-wrap input[type='reset']:active,
-.devhub-wrap input[type='submit']:focus,
-.devhub-wrap input[type='submit']:active {
-	border-color: #aaa #bbb #bbb #bbb;
-	background: #f0f0f0;
-	-webkit-box-shadow: inset 0 1px 0 rgba(120, 200, 230, 0.6),
-		1px 1px 2px rgba(0, 0, 0, 0.4);
-	box-shadow: inset 0 1px 0 rgba(120, 200, 230, 0.6),
-		1px 1px 2px rgba(0, 0, 0, 0.4);
+.devhub-wrap input[type="button"]:focus,
+.devhub-wrap input[type="button"]:active,
+.devhub-wrap input[type="reset"]:focus,
+.devhub-wrap input[type="reset"]:active,
+.devhub-wrap input[type="submit"]:focus,
+.devhub-wrap input[type="submit"]:active {
+  border-color: #aaa #bbb #bbb #bbb;
+  background: #f0f0f0;
+  -webkit-box-shadow: inset 0 1px 0 rgba(120, 200, 230, 0.6), 1px 1px 2px rgba(0, 0, 0, 0.4);
+  box-shadow: inset 0 1px 0 rgba(120, 200, 230, 0.6), 1px 1px 2px rgba(0, 0, 0, 0.4);
 }
 
 .devhub-wrap a.button.shiny-blue,
 .devhub-wrap button.shiny-blue,
-.devhub-wrap input[type='button'].shiny-blue,
-.devhub-wrap input[type='reset'].shiny-blue,
-.devhub-wrap input[type='submit'].shiny-blue {
-	background-color: #21759b;
-	background-image: -webkit-gradient(
-		linear,
-		left top,
-		left bottom,
-		from(#2a95c5),
-		to(#21759b)
-	);
-	background-image: -webkit-linear-gradient(top, #2a95c5, #21759b);
-	background-image: -moz-linear-gradient(top, #2a95c5, #21759b);
-	background-image: -ms-linear-gradient(top, #2a95c5, #21759b);
-	background-image: -o-linear-gradient(top, #2a95c5, #21759b);
-	background-image: linear-gradient(to bottom, #2a95c5, #21759b);
-	border-color: #21759b;
-	border-bottom-color: #1e6a8d;
-	-webkit-box-shadow: inset 0 1px 0 rgba(120, 200, 230, 0.5);
-	box-shadow: inset 0 1px 0 rgba(120, 200, 230, 0.5);
-	color: #fff;
-	text-decoration: none;
-	text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.3);
-	padding: 3px 8px;
+.devhub-wrap input[type="button"].shiny-blue,
+.devhub-wrap input[type="reset"].shiny-blue,
+.devhub-wrap input[type="submit"].shiny-blue {
+  background-color: #21759b;
+  background-image: -webkit-gradient(linear, left top, left bottom, from(#2a95c5), to(#21759b));
+  background-image: -webkit-linear-gradient(top, #2a95c5, #21759b);
+  background-image: -moz-linear-gradient(top, #2a95c5, #21759b);
+  background-image: -ms-linear-gradient(top, #2a95c5, #21759b);
+  background-image: -o-linear-gradient(top, #2a95c5, #21759b);
+  background-image: linear-gradient(to bottom, #2a95c5, #21759b);
+  border-color: #21759b;
+  border-bottom-color: #1e6a8d;
+  -webkit-box-shadow: inset 0 1px 0 rgba(120, 200, 230, 0.5);
+  box-shadow: inset 0 1px 0 rgba(120, 200, 230, 0.5);
+  color: #fff;
+  text-decoration: none;
+  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.3);
+  padding: 3px 8px;
 }
 
 .devhub-wrap a.button.shiny-blue:hover,
 .devhub-wrap button.shiny-blue:hover,
-.devhub-wrap input[type='button'].shiny-blue:hover,
-.devhub-wrap input[type='reset'].shiny-blue:hover,
-.devhub-wrap input[type='submit'].shiny-blue:hover {
-	background-color: #278ab7;
-	background-image: -webkit-gradient(
-		linear,
-		left top,
-		left bottom,
-		from(#2e9fd2),
-		to(#21759b)
-	);
-	background-image: -webkit-linear-gradient(top, #2e9fd2, #21759b);
-	background-image: -moz-linear-gradient(top, #2e9fd2, #21759b);
-	background-image: -ms-linear-gradient(top, #2e9fd2, #21759b);
-	background-image: -o-linear-gradient(top, #2e9fd2, #21759b);
-	background-image: linear-gradient(to bottom, #2e9fd2, #21759b);
-	border-color: #1b607f;
-	-webkit-box-shadow: inset 0 1px 0 rgba(120, 200, 230, 0.6);
-	box-shadow: inset 0 1px 0 rgba(120, 200, 230, 0.6);
-	color: #fff;
-	text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.3);
+.devhub-wrap input[type="button"].shiny-blue:hover,
+.devhub-wrap input[type="reset"].shiny-blue:hover,
+.devhub-wrap input[type="submit"].shiny-blue:hover {
+  background-color: #278ab7;
+  background-image: -webkit-gradient(linear, left top, left bottom, from(#2e9fd2), to(#21759b));
+  background-image: -webkit-linear-gradient(top, #2e9fd2, #21759b);
+  background-image: -moz-linear-gradient(top, #2e9fd2, #21759b);
+  background-image: -ms-linear-gradient(top, #2e9fd2, #21759b);
+  background-image: -o-linear-gradient(top, #2e9fd2, #21759b);
+  background-image: linear-gradient(to bottom, #2e9fd2, #21759b);
+  border-color: #1b607f;
+  -webkit-box-shadow: inset 0 1px 0 rgba(120, 200, 230, 0.6);
+  box-shadow: inset 0 1px 0 rgba(120, 200, 230, 0.6);
+  color: #fff;
+  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.3);
 }
 
 .devhub-wrap a.button .dashicons,
 .devhub-wrap button .dashicons,
-.devhub-wrap input[type='button'] .dashicons,
-.devhub-wrap input[type='reset'] .dashicons,
-.devhub-wrap input[type='submit'] .dashicons {
-	vertical-align: text-bottom;
+.devhub-wrap input[type="button"] .dashicons,
+.devhub-wrap input[type="reset"] .dashicons,
+.devhub-wrap input[type="submit"] .dashicons {
+  vertical-align: text-bottom;
 }
 
 @media (min-width: 43em) and (max-width: 915px) {
-	.devhub-wrap .three-columns a.button {
-		max-width: 100%;
-		padding: 0.6em 1em;
-		font-size: 14px;
-		font-size: 1.4rem;
-	}
-	.devhub-wrap .three-columns .dashicons {
-		width: 16px;
-		height: 16px;
-		font-size: 16px;
-	}
+  .devhub-wrap .three-columns a.button {
+    max-width: 100%;
+    padding: .6em 1em;
+    font-size: 14px;
+    font-size: 1.4rem;
+  }
+  .devhub-wrap .three-columns .dashicons {
+    width: 16px;
+    height: 16px;
+    font-size: 16px;
+  }
 }
 
-.devhub-wrap input[type='checkbox'],
-.devhub-wrap input[type='radio'] {
-	box-sizing: border-box;
-	/* Addresses box sizing set to content-box in IE8/9 */
-	padding: 0;
-	/* Addresses excess padding in IE8/9 */
+.devhub-wrap input[type="checkbox"],
+.devhub-wrap input[type="radio"] {
+  box-sizing: border-box;
+  /* Addresses box sizing set to content-box in IE8/9 */
+  padding: 0;
+  /* Addresses excess padding in IE8/9 */
 }
 
-.devhub-wrap input[type='search'] {
-	-webkit-appearance: textfield;
-	/* Addresses appearance set to searchfield in S5, Chrome */
-	-webkit-box-sizing: content-box;
-	/* Addresses box sizing set to border-box in S5, Chrome (include -moz to future-proof) */
-	-moz-box-sizing: content-box;
-	box-sizing: content-box;
+.devhub-wrap input[type="search"] {
+  -webkit-appearance: textfield;
+  /* Addresses appearance set to searchfield in S5, Chrome */
+  -webkit-box-sizing: content-box;
+  /* Addresses box sizing set to border-box in S5, Chrome (include -moz to future-proof) */
+  -moz-box-sizing: content-box;
+  box-sizing: content-box;
 }
 
-.devhub-wrap input[type='search']::-webkit-search-decoration {
-	/* Corrects inner padding displayed oddly in S5, Chrome on OSX */
-	-webkit-appearance: none;
+.devhub-wrap input[type="search"]::-webkit-search-decoration {
+  /* Corrects inner padding displayed oddly in S5, Chrome on OSX */
+  -webkit-appearance: none;
 }
 
 .devhub-wrap button::-moz-focus-inner,
 .devhub-wrap input::-moz-focus-inner {
-	/* Corrects inner padding and border displayed oddly in FF3/4 www.sitepen.com/blog/2008/05/14/the-devils-in-the-details-fixing-dojos-toolbar-buttons/ */
-	border: 0;
-	padding: 0;
+  /* Corrects inner padding and border displayed oddly in FF3/4 www.sitepen.com/blog/2008/05/14/the-devils-in-the-details-fixing-dojos-toolbar-buttons/ */
+  border: 0;
+  padding: 0;
 }
 
-.devhub-wrap input[type='text'],
-.devhub-wrap input[type='email'],
-.devhub-wrap input[type='url'],
-.devhub-wrap input[type='password'],
-.devhub-wrap input[type='search'],
+.devhub-wrap input[type="text"],
+.devhub-wrap input[type="email"],
+.devhub-wrap input[type="url"],
+.devhub-wrap input[type="password"],
+.devhub-wrap input[type="search"],
 .devhub-wrap textarea {
-	padding: 3px;
-	color: #666;
-	border: 1px solid #ccc;
-	border-radius: 3px;
+  padding: 3px;
+  color: #666;
+  border: 1px solid #ccc;
+  border-radius: 3px;
 }
 
-.devhub-wrap input[type='text']:focus,
-.devhub-wrap input[type='email']:focus,
-.devhub-wrap input[type='url']:focus,
-.devhub-wrap input[type='password']:focus,
-.devhub-wrap input[type='search']:focus,
+.devhub-wrap input[type="text"]:focus,
+.devhub-wrap input[type="email"]:focus,
+.devhub-wrap input[type="url"]:focus,
+.devhub-wrap input[type="password"]:focus,
+.devhub-wrap input[type="search"]:focus,
 .devhub-wrap textarea:focus {
-	color: #111;
+  color: #111;
 }
 
 .devhub-wrap textarea {
-	overflow: auto;
-	/* Removes default vertical scrollbar in IE6/7/8/9 */
-	padding-left: 3px;
-	-moz-tab-size: 4;
-	tab-size: 4;
-	vertical-align: top;
-	/* Improves readability and alignment in all browsers */
-	width: 98%;
+  overflow: auto;
+  /* Removes default vertical scrollbar in IE6/7/8/9 */
+  padding-left: 3px;
+  -moz-tab-size: 4;
+  tab-size: 4;
+  vertical-align: top;
+  /* Improves readability and alignment in all browsers */
+  width: 98%;
 }
 
 .devhub-wrap .screen-reader-text {
-	clip: rect(1px, 1px, 1px, 1px);
-	position: absolute !important;
+  clip: rect(1px, 1px, 1px, 1px);
+  position: absolute !important;
 }
 
 .devhub-wrap .screen-reader-text:hover,
 .devhub-wrap .screen-reader-text:active,
 .devhub-wrap .screen-reader-text:focus {
-	background-color: #f1f1f1;
-	border-radius: 3px;
-	box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
-	clip: auto !important;
-	color: #21759b;
-	display: block;
-	font-size: 14px;
-	font-weight: bold;
-	height: auto;
-	left: 5px;
-	line-height: normal;
-	padding: 15px 23px 14px;
-	text-decoration: none;
-	top: 5px;
-	width: auto;
-	z-index: 100000;
-	/* Above WP toolbar */
+  background-color: #f1f1f1;
+  border-radius: 3px;
+  box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
+  clip: auto !important;
+  color: #21759b;
+  display: block;
+  font-size: 14px;
+  font-weight: bold;
+  height: auto;
+  left: 5px;
+  line-height: normal;
+  padding: 15px 23px 14px;
+  text-decoration: none;
+  top: 5px;
+  width: auto;
+  z-index: 100000;
+  /* Above WP toolbar */
 }
 
 .devhub-wrap .clear:before,
@@ -760,8 +660,8 @@ input {
 .devhub-wrap .site-content:after,
 .devhub-wrap .site-footer:before,
 .devhub-wrap .site-footer:after {
-	content: '';
-	display: table;
+  content: '';
+  display: table;
 }
 
 .devhub-wrap .clear:after,
@@ -769,2013 +669,1749 @@ input {
 .devhub-wrap .comment-content:after,
 .devhub-wrap .site-content:after,
 .devhub-wrap .site-footer:after {
-	clear: both;
+  clear: both;
 }
 
 .devhub-wrap .hentry {
-	margin: 0;
+  margin: 0;
 }
 
 .devhub-wrap .byline,
 .devhub-wrap .updated {
-	display: none;
+  display: none;
 }
 
 .devhub-wrap .single .byline,
 .devhub-wrap .group-blog .byline {
-	display: inline;
+  display: inline;
 }
 
 .devhub-wrap .page-content,
 .devhub-wrap .entry-content,
 .devhub-wrap .entry-summary {
-	margin: 1.5em 0 0;
+  margin: 1.5em 0 0;
 }
 
 .devhub-wrap .page-links {
-	clear: both;
-	margin: 0 0 1.5em;
+  clear: both;
+  margin: 0 0 1.5em;
 }
 
 .devhub-wrap .tablist {
-	margin: 0;
+  margin: 0;
 }
 
 .devhub-wrap .tablist li {
-	display: inline-block;
-	list-style: none;
+  display: inline-block;
+  list-style: none;
 }
 
 .devhub-wrap .tablist a {
-	border-color: none;
-	background-color: transparent;
-	border-color: transparent;
-	border-image: none;
-	border-style: solid solid none;
-	border-width: 1px 1px 0;
-	display: inline-block;
-	padding: 0.5em 1em;
-	margin-bottom: -1px;
+  border-color: none;
+  background-color: transparent;
+  border-color: transparent;
+  border-image: none;
+  border-style: solid solid none;
+  border-width: 1px 1px 0;
+  display: inline-block;
+  padding: .5em 1em;
+  margin-bottom: -1px;
 }
 
 .devhub-wrap .tablist a[aria-selected],
 .devhub-wrap .tablist a:focus {
-	background-color: #fff;
-	border-color: #ccc;
-	border-radius: 3px 3px 0 0;
-	color: #333;
+  background-color: #fff;
+  border-color: #ccc;
+  border-radius: 3px 3px 0 0;
+  color: #333;
 }
 
 .devhub-wrap .tab-section {
-	margin-top: 0;
-	padding: 0;
-	border: none;
+  margin-top: 0;
+  padding: 0;
+  border: none;
 }
 
-.devhub-wrap .tab-section[aria-hidden='true'] {
-	display: none;
+.devhub-wrap .tab-section[aria-hidden="true"] {
+  display: none;
 }
 
 .devhub-wrap .tab-section:focus {
-	background: #eee;
-	outline: thin dotted;
+  background: #eee;
+  outline: thin dotted;
 }
 
 .devhub-wrap .page-content img.wp-smiley,
 .devhub-wrap .entry-content img.wp-smiley,
 .devhub-wrap .comment-content img.wp-smiley {
-	border: none;
-	margin-bottom: 0;
-	margin-top: 0;
-	padding: 0;
+  border: none;
+  margin-bottom: 0;
+  margin-top: 0;
+  padding: 0;
 }
 
 .devhub-wrap .wp-caption {
-	border: 1px solid #ccc;
-	margin-bottom: 1.5em;
-	max-width: 100%;
+  border: 1px solid #ccc;
+  margin-bottom: 1.5em;
+  max-width: 100%;
 }
 
-.devhub-wrap .wp-caption img[class*='wp-image-'] {
-	display: block;
-	margin: 1.2% auto 0;
-	max-width: 98%;
+.devhub-wrap .wp-caption img[class*="wp-image-"] {
+  display: block;
+  margin: 1.2% auto 0;
+  max-width: 98%;
 }
 
 .devhub-wrap .wp-caption-text {
-	text-align: center;
+  text-align: center;
 }
 
 .devhub-wrap .wp-caption .wp-caption-text {
-	margin: 0.8075em 0;
+  margin: 0.8075em 0;
 }
 
 .devhub-wrap .site-main .gallery {
-	margin-bottom: 1.5em;
+  margin-bottom: 1.5em;
 }
 
 .devhub-wrap .site-main .gallery a img {
-	border: none;
-	height: auto;
-	max-width: 90%;
+  border: none;
+  height: auto;
+  max-width: 90%;
 }
 
 .devhub-wrap .site-main .gallery dd {
-	margin: 0;
+  margin: 0;
 }
 
 .devhub-wrap embed,
 .devhub-wrap iframe,
 .devhub-wrap object {
-	max-width: 100%;
+  max-width: 100%;
 }
 
 .devhub-wrap .widget select {
-	max-width: 100%;
+  max-width: 100%;
 }
 
 .devhub-wrap .widget_search .search-submit {
-	display: none;
+  display: none;
 }
 
 .devhub-wrap .widget-area .search-section.hide-if-js {
-	display: block;
+  display: block;
 }
 
 .devhub-wrap .infinite-scroll .paging-navigation,
 .devhub-wrap .infinite-scroll.neverending .site-footer {
-	/* Theme Footer (when set to scrolling) */
-	display: none;
+  /* Theme Footer (when set to scrolling) */
+  display: none;
 }
 
 .devhub-wrap .infinity-end.neverending .site-footer {
-	display: block;
+  display: block;
 }
 
 .devhub-wrap .breadcrumbs {
-	font-size: 13px;
-	font-size: 1.3rem;
+  font-size: 13px;
+  font-size: 1.3rem;
 }
 
 .devhub-wrap .breadcrumbs .active {
-	font-weight: 600;
+  font-weight: 600;
 }
 
 .devhub-wrap .breadcrumb-trail {
-	margin-bottom: 2rem;
+  margin-bottom: 2rem;
 }
 
 .devhub-wrap .breadcrumb-trail a {
-	text-decoration: none;
+  text-decoration: none;
 }
 
 .devhub-wrap h1.entry-title,
 .devhub-wrap h1.page-title {
-	font-weight: 300;
-	font-size: 37px;
-	font-size: 3.7rem;
-	color: #606060;
-	text-align: center;
+  font-weight: 300;
+  font-size: 37px;
+  font-size: 3.7rem;
+  color: #606060;
+  text-align: center;
 }
 
 .devhub-wrap h1.entry-title a,
 .devhub-wrap h1.page-title a {
-	text-decoration: none;
-	color: #606060;
+  text-decoration: none;
+  color: #606060;
 }
 
 .devhub-wrap h1.single-entry-title,
 .devhub-wrap h2.entry-title {
-	text-align: left;
-	font-size: 30px;
-	font-size: 3rem;
-	padding: 0 0 24px;
-	padding: 0 0 2.4rem;
+  text-align: left;
+  font-size: 30px;
+  font-size: 3rem;
+  padding: 0 0 24px;
+  padding: 0 0 2.4rem;
 }
 
 .devhub-wrap h1.single-entry-title a,
 .devhub-wrap h2.entry-title a {
-	text-decoration: none;
-	color: #606060;
+  text-decoration: none;
+  color: #606060;
 }
 
 .devhub-wrap section {
-	overflow: auto;
+  overflow: auto;
 }
 
 .devhub-wrap section.error-404 {
-	overflow: visible;
+  overflow: visible;
 }
 
 .devhub-wrap .home-landing .section {
-	padding: 50px 0 10px;
-	padding: 5rem 0 1rem;
-	margin-top: 60px;
-	margin-top: 6rem;
-	overflow: auto;
+  padding: 50px 0 10px;
+  padding: 5rem 0 1rem;
+  margin-top: 60px;
+  margin-top: 6rem;
+  overflow: auto;
 }
 
 .devhub-wrap .home-landing .section .no-bullets li {
-	line-height: 20px;
-	line-height: 2rem;
-	margin-bottom: 12.5px;
-	margin-bottom: 1.25rem;
+  line-height: 20px;
+  line-height: 2rem;
+  margin-bottom: 12.5px;
+  margin-bottom: 1.25rem;
 }
 
 .devhub-wrap .home-landing .section .no-bullets li a {
-	color: #4ca6cf;
-	font-size: 125%;
+  color: #4ca6cf;
+  font-size: 125%;
 }
 
 .devhub-wrap .home-landing .section .widget-title {
-	line-height: 60px;
-	line-height: 6rem;
+  line-height: 60px;
+  line-height: 6rem;
 }
 
 .devhub-wrap .home-landing .section.search-guide {
-	border-top: 2px solid #efefef;
+  border-top: 2px solid #efefef;
 }
 
 @media (max-width: 974px) {
-	.devhub-wrap .home-landing .section {
-		width: 640px;
-		margin: 0 auto;
-	}
+  .devhub-wrap .home-landing .section {
+    width: 640px;
+    margin: 0 auto;
+  }
 }
 
 .devhub-wrap .color.section {
-	color: #fff;
+  color: #fff;
 }
 
 .devhub-wrap .section {
-	/*background: #0073aa;*/
-	padding: 30px 0;
-	padding: 3rem 0;
+  /*background: #0073aa;*/
+  padding: 30px 0;
+  padding: 3rem 0;
 }
 
 .devhub-wrap .section .box {
-	text-align: center;
-	padding: 0 30px 90px;
-	padding: 0 3rem 9rem;
-	width: 320px;
+  text-align: center;
+  padding: 0 30px 90px;
+  padding: 0 3rem 9rem;
+  width: 320px;
 }
 
 .devhub-wrap .section .box .widget-description {
-	padding: 1em 0 0;
-	margin-bottom: 5px;
-	margin-bottom: 1rem;
+  padding: 1em 0 0;
+  margin-bottom: 5px;
+  margin-bottom: 1rem;
 }
 
 .devhub-wrap .section.search-guide {
-	padding-top: 60px;
-	padding-top: 6rem;
-	margin-top: 0;
+  padding-top: 60px;
+  padding-top: 6rem;
+  margin-top: 0;
 }
 
 .devhub-wrap .section.search-guide .box {
-	text-align: left;
+  text-align: left;
 }
 
 .devhub-wrap .section .widget-title {
-	font-size: 25px;
-	font-size: 2.5rem;
-	line-height: 20px;
-	line-height: 2rem;
+  font-size: 25px;
+  font-size: 2.5rem;
+  line-height: 20px;
+  line-height: 2rem;
 }
 
 .devhub-wrap .section .widget-title .dashicons {
-	color: #222;
-	font-size: 108px;
-	font-size: 10.8rem;
-	line-height: 84px;
-	line-height: 8.4rem;
-	height: 84px;
-	width: 84px;
-	height: 8.4rem;
-	width: 8.4rem;
-	display: block;
-	margin: 0 auto;
-	opacity: 0.4;
+  color: #222;
+  font-size: 108px;
+  font-size: 10.8rem;
+  line-height: 84px;
+  line-height: 8.4rem;
+  height: 84px;
+  width: 84px;
+  height: 8.4rem;
+  width: 8.4rem;
+  display: block;
+  margin: 0 auto;
+  opacity: 0.4;
 }
 
 .devhub-wrap .section .widget-title .dashicons.dashicons-rest-api {
-	font-size: 90px;
-	font-size: 9rem;
+  font-size: 90px;
+  font-size: 9rem;
 }
 
 @media (min-width: 43em) and (max-width: 915px) {
-	.devhub-wrap .section .three-columns .widget-title {
-		font-size: 35px;
-		font-size: 3.5rem;
-	}
+  .devhub-wrap .section .three-columns .widget-title {
+    font-size: 35px;
+    font-size: 3.5rem;
+  }
 }
 
 .devhub-wrap .section.gray {
-	background: #797878;
-	color: #fff;
+  background: #797878;
+  color: #fff;
 }
 
 .devhub-wrap .section.gray h2,
 .devhub-wrap .section.gray h3,
 .devhub-wrap .section.gray h4 {
-	color: #fff;
+  color: #fff;
 }
 
 .devhub-wrap .section.gray .inner-wrap {
-	max-width: 760px;
-	max-width: 76rem;
-	margin: 1.2em auto 0;
+  max-width: 760px;
+  max-width: 76rem;
+  margin: 1.2em auto 0;
 }
 
 .devhub-wrap .section.gray .inner-wrap .code-ref-left {
-	float: left;
-	width: 60%;
-	clear: none;
-	text-align: center;
+  float: left;
+  width: 60%;
+  clear: none;
+  text-align: center;
 }
 
 .devhub-wrap .section.gray .inner-wrap .code-ref-right {
-	float: left;
-	width: 40%;
-	clear: none;
-	margin-top: 1.1em;
-	text-align: center;
+  float: left;
+  width: 40%;
+  clear: none;
+  margin-top: 1.1em;
+  text-align: center;
 }
 
 @media (max-width: 43em) {
-	.devhub-wrap .section.gray .inner-wrap .code-ref-left,
-	.devhub-wrap .section.gray .inner-wrap .code-ref-right {
-		float: none;
-		width: 100%;
-		padding: 0 4px;
-		clear: both;
-		text-align: center;
-	}
-	.devhub-wrap .section.gray .inner-wrap .code-ref-left .widget-description {
-		margin-left: 0;
-	}
-	.devhub-wrap .section.gray .inner-wrap .go {
-		float: none;
-	}
+  .devhub-wrap .section.gray .inner-wrap .code-ref-left,
+  .devhub-wrap .section.gray .inner-wrap .code-ref-right {
+    float: none;
+    width: 100%;
+    padding: 0 4px;
+    clear: both;
+    text-align: center;
+  }
+  .devhub-wrap .section.gray .inner-wrap .code-ref-left .widget-description {
+    margin-left: 0;
+  }
+  .devhub-wrap .section.gray .inner-wrap .go {
+    float: none;
+  }
 }
 
 .devhub-wrap .section.gray .widget-title {
-	font-weight: 300;
-	font-size: 50px;
-	font-size: 5rem;
-	line-height: 68px;
-	line-height: 6.8rem;
+  font-weight: 300;
+  font-size: 50px;
+  font-size: 5rem;
+  line-height: 68px;
+  line-height: 6.8rem;
 }
 
 .devhub-wrap .section.gray .widget-title .dashicons {
-	font-size: 68px;
-	font-size: 6.8rem;
-	line-height: 68px;
-	line-height: 6.8rem;
-	height: 6.8px;
-	width: 6.8px;
-	height: 6.8rem;
-	width: 6.8rem;
+  font-size: 68px;
+  font-size: 6.8rem;
+  line-height: 68px;
+  line-height: 6.8rem;
+  height: 6.8px;
+  width: 6.8px;
+  height: 6.8rem;
+  width: 6.8rem;
 }
 
 @media (min-width: 43em) and (max-width: 915px) {
-	.devhub-wrap .section.gray .widget-title {
-		font-size: 35px;
-		font-size: 3.5rem;
-	}
+  .devhub-wrap .section.gray .widget-title {
+    font-size: 35px;
+    font-size: 3.5rem;
+  }
 }
 
 .devhub-wrap .section.gray .widget-description {
-	margin-left: 85px;
-	margin-left: 8.5rem;
+  margin-left: 85px;
+  margin-left: 8.5rem;
 }
 
 .devhub-wrap .section.light-gray {
-	background: #f2f2f2;
-	color: #606060;
+  background: #f2f2f2;
+  color: #606060;
 }
 
 .devhub-wrap .section.light-gray .widget-title {
-	color: #606060;
-	font-weight: 600;
+  color: #606060;
+  font-weight: 600;
 }
 
 .devhub-wrap .section.light-gray .widget-title a {
-	color: #2d96c2;
+  color: #2D96C2;
 }
 
 .devhub-wrap .section.light-gray a {
-	color: #606060;
-	text-decoration: none;
+  color: #606060;
+  text-decoration: none;
 }
 
 .devhub-wrap .section.light-gray a.make-wp-link:after {
-	content: '\f345';
-	font-family: 'dashicons';
-	margin-left: 4px;
-	vertical-align: middle;
+  content: "\f345";
+  font-family: 'dashicons';
+  margin-left: 4px;
+  vertical-align: middle;
 }
 
 .devhub-wrap .section .home-primary-content {
-	max-width: 600px;
-	max-width: 60rem;
-	margin: 0 auto;
+  max-width: 600px;
+  max-width: 60rem;
+  margin: 0 auto;
 }
 
 .devhub-wrap .box {
-	padding: 30px;
-	padding: 3rem;
-	float: left;
-	clear: none;
+  padding: 30px;
+  padding: 3rem;
+  float: left;
+  clear: none;
 }
 
 @media (min-width: 43em) and (max-width: 915px) {
-	.devhub-wrap .three-columns .box {
-		padding: 30px 20px;
-		padding: 3rem 2rem;
-	}
+  .devhub-wrap .three-columns .box {
+    padding: 30px 20px;
+    padding: 3rem 2rem;
+  }
 }
 
 .devhub-wrap .reference-landing .section.search-section {
-	padding-top: 0;
+  padding-top: 0;
 }
 
 .devhub-wrap div#inner-search {
-	background-color: #666;
-	margin-bottom: 1em;
-	padding-top: 2px;
+  background-color: #666;
+  margin-bottom: 1em;
+  padding-top: 2px;
 }
 
 .devhub-wrap div#inner-search .section.search-section {
-	color: #ffffff;
+  color: #ffffff;
 }
 
 .devhub-wrap div#inner-search div#inner-search-icon-container {
-	margin: 0 auto;
-	max-width: 60em;
-	cursor: pointer;
+  margin: 0 auto;
+  max-width: 60em;
+  cursor: pointer;
 }
 
-.devhub-wrap
-	div#inner-search
-	div#inner-search-icon-container
-	div#inner-search-icon {
-	background-color: #666;
-	color: #ffffff;
-	text-align: center;
-	margin-right: 26px;
-	margin-left: 4px;
-	float: right;
-	padding: 5px;
-	-webkit-border-bottom-right-radius: 5px;
-	-webkit-border-bottom-left-radius: 5px;
-	-moz-border-radius-bottomright: 5px;
-	-moz-border-radius-bottomleft: 5px;
-	border-bottom-right-radius: 5px;
-	border-bottom-left-radius: 5px;
+.devhub-wrap div#inner-search div#inner-search-icon-container div#inner-search-icon {
+  background-color: #666;
+  color: #ffffff;
+  text-align: center;
+  margin-right: 26px;
+  margin-left: 4px;
+  float: right;
+  padding: 5px;
+  -webkit-border-bottom-right-radius: 5px;
+  -webkit-border-bottom-left-radius: 5px;
+  -moz-border-radius-bottomright: 5px;
+  -moz-border-radius-bottomleft: 5px;
+  border-bottom-right-radius: 5px;
+  border-bottom-left-radius: 5px;
 }
 
-.devhub-wrap
-	div#inner-search
-	div#inner-search-icon-container
-	div#inner-search-icon
-	.dashicons-search {
-	height: auto;
-	width: auto;
+.devhub-wrap div#inner-search div#inner-search-icon-container div#inner-search-icon .dashicons-search {
+  height: auto;
+  width: auto;
 }
 
-.devhub-wrap
-	div#inner-search
-	div#inner-search-icon-container
-	div#inner-search-icon
-	.dashicons-search:before {
-	font-size: 36px;
-	line-height: 36px;
+.devhub-wrap div#inner-search div#inner-search-icon-container div#inner-search-icon .dashicons-search:before {
+  font-size: 36px;
+  line-height: 36px;
 }
 
 .devhub-wrap .archive-filter-form {
-	margin: 5rem 0;
-	font-size: 1.5rem;
+  margin: 5rem 0;
+  font-size: 1.5rem;
 }
 
-.devhub-wrap .archive-filter-form input[type='submit'] {
-	margin-left: 0.5em;
-	padding: 0.2em 0.5em;
-	line-height: 1;
-	font-size: 1.5rem;
+.devhub-wrap .archive-filter-form input[type="submit"] {
+  margin-left: .5em;
+  padding: 0.2em 0.5em;
+  line-height: 1;
+  font-size: 1.5rem;
 }
 
 .devhub-wrap .searchform {
-	overflow: hidden;
-	height: auto;
-	position: relative;
+  overflow: hidden;
+  height: auto;
+  position: relative;
 }
 
-.devhub-wrap .searchform input[type='text'] {
-	border-radius: 0;
-	margin: 0 auto;
-	padding: 0.5em;
-	width: 100%;
+.devhub-wrap .searchform input[type="text"] {
+  border-radius: 0;
+  margin: 0 auto;
+  padding: 0.5em;
+  width: 100%;
 }
 
 .devhub-wrap .searchform .button-search {
-	background: transparent;
-	border: none;
-	border-radius: 0;
-	box-shadow: none;
-	color: #32373c;
-	display: block;
-	height: 40px;
-	padding: 0.5rem 1rem;
-	position: absolute;
-	right: 0;
-	top: 0;
-	text-shadow: none;
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+  color: #32373c;
+  display: block;
+  height: 40px;
+  padding: 0.5rem 1rem;
+  position: absolute;
+  right: 0;
+  top: 0;
+  text-shadow: none;
 }
 
 .devhub-wrap .searchform label {
-	width: 560px;
-	width: 56rem;
-	max-width: 100%;
-	margin-right: 15px;
-	display: inline-block;
-	float: left;
+  width: 560px;
+  width: 56rem;
+  max-width: 100%;
+  margin-right: 15px;
+  display: inline-block;
+  float: left;
 }
 
-.devhub-wrap .searchform label .search-field input[type='text'] {
-	width: 100%;
+.devhub-wrap .searchform label .search-field input[type="text"] {
+  width: 100%;
 }
 
 .devhub-wrap .searchform div {
-	overflow: auto;
+  overflow: auto;
 }
 
 .devhub-wrap .searchform .search-post-type {
-	margin-top: 1em;
+  margin-top: 1em;
 }
 
 .devhub-wrap .searchform .search-post-type label {
-	border-right: 1px solid #ccc;
-	float: none;
-	width: inherit;
-	margin-left: 1em;
-	margin-right: 0;
-	padding-left: 0;
-	padding-right: 1.3em;
+  border-right: 1px solid #ccc;
+  float: none;
+  width: inherit;
+  margin-left: 1em;
+  margin-right: 0;
+  padding-left: 0;
+  padding-right: 1.3em;
 }
 
 .devhub-wrap .searchform .search-post-type label input {
-	margin-bottom: 6px;
-	padding-left: 0.5em;
-	vertical-align: middle;
+  margin-bottom: 6px;
+  padding-left: 0.5em;
+  vertical-align: middle;
 }
 
 .devhub-wrap .searchform .search-post-type label:last-child {
-	border-right-width: 0;
+  border-right-width: 0;
 }
 
 @media (max-width: 688px) {
-	.devhub-wrap .searchform .search-post-type span {
-		display: block;
-	}
-	.devhub-wrap .searchform .search-post-type label {
-		margin-left: 0;
-		margin-right: 1em;
-		width: 130px;
-	}
-	.devhub-wrap .searchform .search-post-type label:last-child {
-		margin-right: 0;
-		padding-right: 0;
-		width: initial;
-	}
+  .devhub-wrap .searchform .search-post-type span {
+    display: block;
+  }
+  .devhub-wrap .searchform .search-post-type label {
+    margin-left: 0;
+    margin-right: 1em;
+    width: 130px;
+  }
+  .devhub-wrap .searchform .search-post-type label:last-child {
+    margin-right: 0;
+    padding-right: 0;
+    width: initial;
+  }
 }
 
 .devhub-wrap .search-results-summary {
-	font-style: italic;
-	margin-bottom: 1em;
+  font-style: italic;
+  margin-bottom: 1em;
 }
 
-.devhub-wrap .reference-landing .section,
-.devhub-wrap .search-section {
-	max-width: 970px;
-	max-width: 97rem;
-	margin: 0 auto;
-	padding: 1.5em 1em;
+.devhub-wrap .reference-landing .section, .devhub-wrap .search-section {
+  max-width: 970px;
+  max-width: 97rem;
+  margin: 0 auto;
+  padding: 1.5em 1em;
 }
 
 .devhub-wrap .reference-landing .section h2,
 .devhub-wrap .reference-landing .section h3,
 .devhub-wrap .reference-landing .section h4 {
-	margin-bottom: 1em;
-	color: #404040;
+  margin-bottom: 1em;
+  color: #404040;
 }
 
 .devhub-wrap .reference-landing .section h2.widget-title,
 .devhub-wrap .reference-landing .section h3.widget-title,
 .devhub-wrap .reference-landing .section h4.widget-title {
-	margin-bottom: 0;
+  margin-bottom: 0;
 }
 
 .devhub-wrap .reference-landing .section.search-guide {
-	padding-bottom: 0;
+  padding-bottom: 0;
 }
 
-.devhub-wrap .reference-landing .section.section.topic-guide,
-.devhub-wrap .reference-landing .section.section.new-in-guide {
-	padding-top: 0;
+.devhub-wrap .reference-landing .section.section.topic-guide, .devhub-wrap .reference-landing .section.section.new-in-guide {
+  padding-top: 0;
 }
 
 .devhub-wrap .reference-landing .box,
 .devhub-wrap .sidebar .box {
-	padding: 0;
-	border: 2px solid #cccccc;
-	background-color: #eeeeee;
+  padding: 0;
+  border: 2px solid #cccccc;
+  background-color: #eeeeee;
 }
 
 .devhub-wrap .reference-landing .box ul,
 .devhub-wrap .sidebar .box ul {
-	padding: 2em;
+  padding: 2em;
 }
 
 .devhub-wrap .reference-landing .box .widget-title,
 .devhub-wrap .sidebar .box .widget-title {
-	padding: 10px 30px;
-	padding: 1rem 30px;
-	font-size: 16px;
-	font-size: 1.6rem;
+  padding: 10px 30px;
+  padding: 1rem 30px;
+  font-size: 16px;
+  font-size: 1.6rem;
 }
 
 .devhub-wrap .reference-landing .box .widget-content,
 .devhub-wrap .sidebar .box .widget-content {
-	padding: 16px 30px;
-	padding: 1.6rem 3rem;
+  padding: 16px 30px;
+  padding: 1.6rem 3rem;
 }
 
 .devhub-wrap .reference-landing .box ul {
-	padding: 0;
-	overflow: hidden;
+  padding: 0;
+  overflow: hidden;
 }
 
 .devhub-wrap .three-columns .box {
-	width: 31%;
-	margin: 1.15%;
+  width: 31%;
+  margin: 1.15%;
 }
 
 @media (min-width: 43em) and (max-width: 915px) {
-	.devhub-wrap .three-columns .box {
-		margin: 1% 0;
-	}
+  .devhub-wrap .three-columns .box {
+    margin: 1% 0;
+  }
 }
 
 .devhub-wrap .two-columns .box {
-	width: 48%;
-	margin: 1% 1% 1% 0;
+  width: 48%;
+  margin: 1% 1% 1% 0;
 }
 
 .devhub-wrap .new-in-guide.two-columns .box {
-	width: 43%;
+  width: 43%;
 }
 
 @media (max-width: 688px) {
-	.devhub-wrap .new-in-guide.two-columns .box {
-		width: 100%;
-	}
+  .devhub-wrap .new-in-guide.two-columns .box {
+    width: 100%;
+  }
 }
 
 .devhub-wrap .new-in-guide.two-columns .box:first-child {
-	width: 53%;
+  width: 53%;
 }
 
 @media (max-width: 688px) {
-	.devhub-wrap .new-in-guide.two-columns .box:first-child {
-		width: 100%;
-	}
+  .devhub-wrap .new-in-guide.two-columns .box:first-child {
+    width: 100%;
+  }
 }
 
 .devhub-wrap #sidebar,
 .devhub-wrap .no-bullets,
 .devhub-wrap .sidebar .widget ul {
-	list-style-type: none;
-	margin: 0;
-	padding: 0;
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
 }
 
 .devhub-wrap .horizontal-list {
-	display: block;
-	width: 100%;
-	list-style-type: none;
-	margin: 0;
-	padding: 0;
-	text-align: center;
+  display: block;
+  width: 100%;
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+  text-align: center;
 }
 
 .devhub-wrap .horizontal-list li {
-	display: inline;
+  display: inline;
 }
 
 .devhub-wrap .horizontal-list li a {
-	padding: 0px 40px;
-	padding: 0 4rem;
-	border-left: 1px solid #ccc;
+  padding: 0px 40px;
+  padding: 0 4rem;
+  border-left: 1px solid #ccc;
 }
 
 .devhub-wrap .horizontal-list li:first-child a {
-	padding-left: 0;
-	border-left: none;
+  padding-left: 0;
+  border-left: none;
 }
 
 .devhub-wrap .view-all-new-in {
-	font-style: italic;
+  font-style: italic;
 }
 
 .devhub-wrap .box.transparent {
-	background: none;
-	color: #333;
+  background: none;
+  color: #333;
 }
 
 .devhub-wrap .box.transparent h2,
 .devhub-wrap .box.transparent h3,
 .devhub-wrap .box.transparent h4 {
-	color: #32373c;
+  color: #32373c;
 }
 
 .devhub-wrap .box.gray {
-	background: #fff;
-	border: 1px solid #d8d8d8;
+  background: #fff;
+  border: 1px solid #d8d8d8;
 }
 
 .devhub-wrap .box.gray .widget-title {
-	color: #666666;
-	background: #d8d8d8;
-	text-transform: uppercase;
+  color: #666666;
+  background: #d8d8d8;
+  text-transform: uppercase;
 }
 
 .devhub-wrap .box .unordered-list {
-	list-style-type: none;
-	padding: 0;
-	margin: 0;
-	font-size: 13px;
-	font-size: 1.3rem;
-	line-height: 30px;
-	line-height: 3rem;
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+  font-size: 13px;
+  font-size: 1.3rem;
+  line-height: 30px;
+  line-height: 3rem;
 }
 
 .devhub-wrap .widget-description {
-	font-weight: 400;
+  font-weight: 400;
 }
 
 .devhub-wrap .go {
-	color: #4ca6cf;
+  color: #4ca6cf;
 }
 
 .devhub-wrap .handbook h1 {
-	margin: 24px 0;
-	font-size: 20px;
-	font-weight: normal;
+  margin: 24px 0;
+  font-size: 20px;
+  font-weight: normal;
 }
 
-.devhub-wrap .wp-parser-class,
-.devhub-wrap .wp-parser-function,
-.devhub-wrap .wp-parser-hook,
-.devhub-wrap .wp-parser-method {
-	border-bottom: 1px solid #dfdfdf;
+.devhub-wrap .wp-parser-class, .devhub-wrap .wp-parser-function, .devhub-wrap .wp-parser-hook, .devhub-wrap .wp-parser-method {
+  border-bottom: 1px solid #dfdfdf;
 }
 
-.devhub-wrap .wp-parser-class h1,
-.devhub-wrap .wp-parser-function h1,
-.devhub-wrap .wp-parser-hook h1,
-.devhub-wrap .wp-parser-method h1 {
-	margin: 24px 0;
-	padding-left: 100px;
-	text-indent: -100px;
-	color: #24831d;
-	font-family: monospace;
-	font-size: 20px;
+.devhub-wrap .wp-parser-class h1, .devhub-wrap .wp-parser-function h1, .devhub-wrap .wp-parser-hook h1, .devhub-wrap .wp-parser-method h1 {
+  margin: 24px 0;
+  padding-left: 100px;
+  text-indent: -100px;
+  color: #24831d;
+  font-family: monospace;
+  font-size: 20px;
 }
 
-.devhub-wrap .wp-parser-class h1 .hook-func,
-.devhub-wrap .wp-parser-function h1 .hook-func,
-.devhub-wrap .wp-parser-hook h1 .hook-func,
-.devhub-wrap .wp-parser-method h1 .hook-func {
-	color: #888888;
+.devhub-wrap .wp-parser-class h1 .hook-func, .devhub-wrap .wp-parser-function h1 .hook-func, .devhub-wrap .wp-parser-hook h1 .hook-func, .devhub-wrap .wp-parser-method h1 .hook-func {
+  color: #888888;
 }
 
-.devhub-wrap .wp-parser-class h1 .arg-type,
-.devhub-wrap .wp-parser-function h1 .arg-type,
-.devhub-wrap .wp-parser-hook h1 .arg-type,
-.devhub-wrap .wp-parser-method h1 .arg-type {
-	color: #cd2f23;
-	font-style: italic;
+.devhub-wrap .wp-parser-class h1 .arg-type, .devhub-wrap .wp-parser-function h1 .arg-type, .devhub-wrap .wp-parser-hook h1 .arg-type, .devhub-wrap .wp-parser-method h1 .arg-type {
+  color: #cd2f23;
+  font-style: italic;
 }
 
-.devhub-wrap .wp-parser-class h1 .arg-name,
-.devhub-wrap .wp-parser-function h1 .arg-name,
-.devhub-wrap .wp-parser-hook h1 .arg-name,
-.devhub-wrap .wp-parser-method h1 .arg-name {
-	color: #0f55c8;
+.devhub-wrap .wp-parser-class h1 .arg-name, .devhub-wrap .wp-parser-function h1 .arg-name, .devhub-wrap .wp-parser-hook h1 .arg-name, .devhub-wrap .wp-parser-method h1 .arg-name {
+  color: #0f55c8;
 }
 
-.devhub-wrap .wp-parser-class h1 .arg-default,
-.devhub-wrap .wp-parser-function h1 .arg-default,
-.devhub-wrap .wp-parser-hook h1 .arg-default,
-.devhub-wrap .wp-parser-method h1 .arg-default {
-	color: #000000;
+.devhub-wrap .wp-parser-class h1 .arg-default, .devhub-wrap .wp-parser-function h1 .arg-default, .devhub-wrap .wp-parser-hook h1 .arg-default, .devhub-wrap .wp-parser-method h1 .arg-default {
+  color: #000000;
 }
 
-.devhub-wrap .wp-parser-class h1 a:hover,
-.devhub-wrap .wp-parser-function h1 a:hover,
-.devhub-wrap .wp-parser-hook h1 a:hover,
-.devhub-wrap .wp-parser-method h1 a:hover {
-	border-bottom: 1px dotted #21759b;
+.devhub-wrap .wp-parser-class h1 a:hover, .devhub-wrap .wp-parser-function h1 a:hover, .devhub-wrap .wp-parser-hook h1 a:hover, .devhub-wrap .wp-parser-method h1 a:hover {
+  border-bottom: 1px dotted #21759b;
 }
 
-.devhub-wrap .wp-parser-class h2,
-.devhub-wrap .wp-parser-function h2,
-.devhub-wrap .wp-parser-hook h2,
-.devhub-wrap .wp-parser-method h2 {
-	font-family: Georgia, Times, serif;
-	margin-bottom: 0.5em;
+.devhub-wrap .wp-parser-class h2, .devhub-wrap .wp-parser-function h2, .devhub-wrap .wp-parser-hook h2, .devhub-wrap .wp-parser-method h2 {
+  font-family: Georgia, Times, serif;
+  margin-bottom: .5em;
 }
 
-.devhub-wrap .wp-parser-class .return-type,
-.devhub-wrap .wp-parser-function .return-type,
-.devhub-wrap .wp-parser-hook .return-type,
-.devhub-wrap .wp-parser-method .return-type {
-	font-style: italic;
+.devhub-wrap .wp-parser-class .return-type, .devhub-wrap .wp-parser-function .return-type, .devhub-wrap .wp-parser-hook .return-type, .devhub-wrap .wp-parser-method .return-type {
+  font-style: italic;
 }
 
-.devhub-wrap .wp-parser-class .parameters p,
-.devhub-wrap .wp-parser-function .parameters p,
-.devhub-wrap .wp-parser-hook .parameters p,
-.devhub-wrap .wp-parser-method .parameters p {
-	margin-bottom: 0;
+.devhub-wrap .wp-parser-class .parameters p, .devhub-wrap .wp-parser-function .parameters p, .devhub-wrap .wp-parser-hook .parameters p, .devhub-wrap .wp-parser-method .parameters p {
+  margin-bottom: 0;
 }
 
-.devhub-wrap .wp-parser-class .parameters dd .desc .type,
-.devhub-wrap .wp-parser-class .parameters dd .desc .required,
-.devhub-wrap .wp-parser-function .parameters dd .desc .type,
-.devhub-wrap .wp-parser-function .parameters dd .desc .required,
-.devhub-wrap .wp-parser-hook .parameters dd .desc .type,
-.devhub-wrap .wp-parser-hook .parameters dd .desc .required,
-.devhub-wrap .wp-parser-method .parameters dd .desc .type,
-.devhub-wrap .wp-parser-method .parameters dd .desc .required {
-	font-style: italic;
+.devhub-wrap .wp-parser-class .parameters dd .desc .type, .devhub-wrap .wp-parser-class .parameters dd .desc .required, .devhub-wrap .wp-parser-function .parameters dd .desc .type, .devhub-wrap .wp-parser-function .parameters dd .desc .required, .devhub-wrap .wp-parser-hook .parameters dd .desc .type, .devhub-wrap .wp-parser-hook .parameters dd .desc .required, .devhub-wrap .wp-parser-method .parameters dd .desc .type, .devhub-wrap .wp-parser-method .parameters dd .desc .required {
+  font-style: italic;
 }
 
-.devhub-wrap .wp-parser-class .parameters dd .default,
-.devhub-wrap .wp-parser-function .parameters dd .default,
-.devhub-wrap .wp-parser-hook .parameters dd .default,
-.devhub-wrap .wp-parser-method .parameters dd .default {
-	font-style: italic;
+.devhub-wrap .wp-parser-class .parameters dd .default, .devhub-wrap .wp-parser-function .parameters dd .default, .devhub-wrap .wp-parser-hook .parameters dd .default, .devhub-wrap .wp-parser-method .parameters dd .default {
+  font-style: italic;
 }
 
-.devhub-wrap .wp-parser-class .parameters dd ul,
-.devhub-wrap .wp-parser-function .parameters dd ul,
-.devhub-wrap .wp-parser-hook .parameters dd ul,
-.devhub-wrap .wp-parser-method .parameters dd ul {
-	margin-left: 25px;
-	margin-left: 2.5rem;
+.devhub-wrap .wp-parser-class .parameters dd ul, .devhub-wrap .wp-parser-function .parameters dd ul, .devhub-wrap .wp-parser-hook .parameters dd ul, .devhub-wrap .wp-parser-method .parameters dd ul {
+  margin-left: 25px;
+  margin-left: 2.5rem;
 }
 
-.devhub-wrap .wp-parser-class .parameters .param-hash,
-.devhub-wrap .wp-parser-function .parameters .param-hash,
-.devhub-wrap .wp-parser-hook .parameters .param-hash,
-.devhub-wrap .wp-parser-method .parameters .param-hash {
-	margin-left: 1.2em;
-	margin-bottom: 0.5em;
+.devhub-wrap .wp-parser-class .parameters .param-hash, .devhub-wrap .wp-parser-function .parameters .param-hash, .devhub-wrap .wp-parser-hook .parameters .param-hash, .devhub-wrap .wp-parser-method .parameters .param-hash {
+  margin-left: 1.2em;
+  margin-bottom: 0.5em;
 }
 
-.devhub-wrap .wp-parser-class .parameters .param-hash > li,
-.devhub-wrap .wp-parser-function .parameters .param-hash > li,
-.devhub-wrap .wp-parser-hook .parameters .param-hash > li,
-.devhub-wrap .wp-parser-method .parameters .param-hash > li {
-	margin-top: 1em;
+.devhub-wrap .wp-parser-class .parameters .param-hash > li, .devhub-wrap .wp-parser-function .parameters .param-hash > li, .devhub-wrap .wp-parser-hook .parameters .param-hash > li, .devhub-wrap .wp-parser-method .parameters .param-hash > li {
+  margin-top: 1em;
 }
 
-.devhub-wrap .wp-parser-class .parameters .param-hash li li,
-.devhub-wrap .wp-parser-function .parameters .param-hash li li,
-.devhub-wrap .wp-parser-hook .parameters .param-hash li li,
-.devhub-wrap .wp-parser-method .parameters .param-hash li li {
-	list-style-type: circle;
+.devhub-wrap .wp-parser-class .parameters .param-hash li li, .devhub-wrap .wp-parser-function .parameters .param-hash li li, .devhub-wrap .wp-parser-hook .parameters .param-hash li li, .devhub-wrap .wp-parser-method .parameters .param-hash li li {
+  list-style-type: circle;
 }
 
-.devhub-wrap .wp-parser-class .parameters .param-hash .param-hash > li,
-.devhub-wrap .wp-parser-function .parameters .param-hash .param-hash > li,
-.devhub-wrap .wp-parser-hook .parameters .param-hash .param-hash > li,
-.devhub-wrap .wp-parser-method .parameters .param-hash .param-hash > li {
-	list-style-type: disc;
+.devhub-wrap .wp-parser-class .parameters .param-hash .param-hash > li, .devhub-wrap .wp-parser-function .parameters .param-hash .param-hash > li, .devhub-wrap .wp-parser-hook .parameters .param-hash .param-hash > li, .devhub-wrap .wp-parser-method .parameters .param-hash .param-hash > li {
+  list-style-type: disc;
 }
 
-.devhub-wrap .wp-parser-class .learn-more,
-.devhub-wrap .wp-parser-function .learn-more,
-.devhub-wrap .wp-parser-hook .learn-more,
-.devhub-wrap .wp-parser-method .learn-more {
-	background-color: #f1f1f1;
-	border: 1px solid #dfdfdf;
-	border-radius: 5px;
-	padding: 20px;
+.devhub-wrap .wp-parser-class .learn-more, .devhub-wrap .wp-parser-function .learn-more, .devhub-wrap .wp-parser-hook .learn-more, .devhub-wrap .wp-parser-method .learn-more {
+  background-color: #f1f1f1;
+  border: 1px solid #dfdfdf;
+  border-radius: 5px;
+  padding: 20px;
 }
 
 .devhub-wrap .wp-parser-class .deprecated,
-.devhub-wrap .wp-parser-class .private-access,
-.devhub-wrap .wp-parser-function .deprecated,
-.devhub-wrap .wp-parser-function .private-access,
-.devhub-wrap .wp-parser-hook .deprecated,
-.devhub-wrap .wp-parser-hook .private-access,
-.devhub-wrap .wp-parser-method .deprecated,
+.devhub-wrap .wp-parser-class .private-access, .devhub-wrap .wp-parser-function .deprecated,
+.devhub-wrap .wp-parser-function .private-access, .devhub-wrap .wp-parser-hook .deprecated,
+.devhub-wrap .wp-parser-hook .private-access, .devhub-wrap .wp-parser-method .deprecated,
 .devhub-wrap .wp-parser-method .private-access {
-	margin-top: 30px;
-	padding: 20px;
+  margin-top: 30px;
+  padding: 20px;
 }
 
 .devhub-wrap .wp-parser-class .deprecated p,
-.devhub-wrap .wp-parser-class .private-access p,
-.devhub-wrap .wp-parser-function .deprecated p,
-.devhub-wrap .wp-parser-function .private-access p,
-.devhub-wrap .wp-parser-hook .deprecated p,
-.devhub-wrap .wp-parser-hook .private-access p,
-.devhub-wrap .wp-parser-method .deprecated p,
+.devhub-wrap .wp-parser-class .private-access p, .devhub-wrap .wp-parser-function .deprecated p,
+.devhub-wrap .wp-parser-function .private-access p, .devhub-wrap .wp-parser-hook .deprecated p,
+.devhub-wrap .wp-parser-hook .private-access p, .devhub-wrap .wp-parser-method .deprecated p,
 .devhub-wrap .wp-parser-method .private-access p {
-	margin-bottom: 0px;
+  margin-bottom: 0px;
 }
 
-.devhub-wrap .wp-parser-class .deprecated,
-.devhub-wrap .wp-parser-function .deprecated,
-.devhub-wrap .wp-parser-hook .deprecated,
-.devhub-wrap .wp-parser-method .deprecated {
-	background-color: #fbeaea;
-	border: 1px solid #dc3232;
+.devhub-wrap .wp-parser-class .deprecated, .devhub-wrap .wp-parser-function .deprecated, .devhub-wrap .wp-parser-hook .deprecated, .devhub-wrap .wp-parser-method .deprecated {
+  background-color: #fbeaea;
+  border: 1px solid #dc3232;
 }
 
-.devhub-wrap .wp-parser-class .deprecated-method,
-.devhub-wrap .wp-parser-function .deprecated-method,
-.devhub-wrap .wp-parser-hook .deprecated-method,
-.devhub-wrap .wp-parser-method .deprecated-method {
-	color: #be2423;
-	font-style: italic;
+.devhub-wrap .wp-parser-class .deprecated-method, .devhub-wrap .wp-parser-function .deprecated-method, .devhub-wrap .wp-parser-hook .deprecated-method, .devhub-wrap .wp-parser-method .deprecated-method {
+  color: #be2423;
+  font-style: italic;
 }
 
-.devhub-wrap .wp-parser-class .private-access,
-.devhub-wrap .wp-parser-function .private-access,
-.devhub-wrap .wp-parser-hook .private-access,
-.devhub-wrap .wp-parser-method .private-access {
-	border: 1px solid #ffb900;
-	background-color: #fff8e5;
+.devhub-wrap .wp-parser-class .private-access, .devhub-wrap .wp-parser-function .private-access, .devhub-wrap .wp-parser-hook .private-access, .devhub-wrap .wp-parser-method .private-access {
+  border: 1px solid #ffb900;
+  background-color: #fff8e5;
 }
 
-.devhub-wrap .wp-parser-class .callout,
-.devhub-wrap .wp-parser-function .callout,
-.devhub-wrap .wp-parser-hook .callout,
-.devhub-wrap .wp-parser-method .callout {
-	margin-top: 30px;
+.devhub-wrap .wp-parser-class .callout, .devhub-wrap .wp-parser-function .callout, .devhub-wrap .wp-parser-hook .callout, .devhub-wrap .wp-parser-method .callout {
+  margin-top: 30px;
 }
 
-.devhub-wrap .wp-parser-class .toc-jump,
-.devhub-wrap .wp-parser-function .toc-jump,
-.devhub-wrap .wp-parser-hook .toc-jump,
-.devhub-wrap .wp-parser-method .toc-jump {
-	display: inline-block;
-	float: right;
+.devhub-wrap .wp-parser-class .toc-jump, .devhub-wrap .wp-parser-function .toc-jump, .devhub-wrap .wp-parser-hook .toc-jump, .devhub-wrap .wp-parser-method .toc-jump {
+  display: inline-block;
+  float: right;
 }
 
 .devhub-wrap .callout:before {
-	top: 0.4em;
+  top: 0.4em;
 }
 
-.devhub-wrap.archive .wp-parser-class h1,
-.devhub-wrap.archive .wp-parser-function h1,
-.devhub-wrap.archive .wp-parser-hook h1,
-.devhub-wrap.archive .wp-parser-method h1,
-.devhub-wrap.search .wp-parser-class h1,
-.devhub-wrap.search .wp-parser-function h1,
-.devhub-wrap.search .wp-parser-hook h1,
-.devhub-wrap.search .wp-parser-method h1 {
-	font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-	color: #21759b;
-	font-weight: normal;
+.devhub-wrap.archive .wp-parser-class h1, .devhub-wrap.archive .wp-parser-function h1, .devhub-wrap.archive .wp-parser-hook h1, .devhub-wrap.archive .wp-parser-method h1, .devhub-wrap.search .wp-parser-class h1, .devhub-wrap.search .wp-parser-function h1, .devhub-wrap.search .wp-parser-hook h1, .devhub-wrap.search .wp-parser-method h1 {
+  font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  color: #21759b;
+  font-weight: normal;
 }
 
-.devhub-wrap.archive .wp-parser-class div.sourcefile,
-.devhub-wrap.archive .wp-parser-function div.sourcefile,
-.devhub-wrap.archive .wp-parser-hook div.sourcefile,
-.devhub-wrap.archive .wp-parser-method div.sourcefile,
-.devhub-wrap.search .wp-parser-class div.sourcefile,
-.devhub-wrap.search .wp-parser-function div.sourcefile,
-.devhub-wrap.search .wp-parser-hook div.sourcefile,
-.devhub-wrap.search .wp-parser-method div.sourcefile {
-	color: #999999;
-	font-style: italic;
+.devhub-wrap.archive .wp-parser-class div.sourcefile, .devhub-wrap.archive .wp-parser-function div.sourcefile, .devhub-wrap.archive .wp-parser-hook div.sourcefile, .devhub-wrap.archive .wp-parser-method div.sourcefile, .devhub-wrap.search .wp-parser-class div.sourcefile, .devhub-wrap.search .wp-parser-function div.sourcefile, .devhub-wrap.search .wp-parser-hook div.sourcefile, .devhub-wrap.search .wp-parser-method div.sourcefile {
+  color: #999999;
+  font-style: italic;
 }
 
-.devhub-wrap .single .wp-parser-class,
-.devhub-wrap .single .wp-parser-function,
-.devhub-wrap .single .wp-parser-hook,
-.devhub-wrap .single .wp-parser-method {
-	border-bottom-style: none;
+.devhub-wrap .single .wp-parser-class, .devhub-wrap .single .wp-parser-function, .devhub-wrap .single .wp-parser-hook, .devhub-wrap .single .wp-parser-method {
+  border-bottom-style: none;
 }
 
 .devhub-wrap .related {
-	/* Hide the title and toc links (same as .screen-reader-text)
+  /* Hide the title and toc links (same as .screen-reader-text)
 		   this allows for linking from the toc. */
 }
 
-.devhub-wrap .related .show-more,
-.devhub-wrap .related .hide-more {
-	display: none;
+.devhub-wrap .related .show-more, .devhub-wrap .related .hide-more {
+  display: none;
 }
 
-.devhub-wrap .related h3,
-.devhub-wrap .related .uses .toc-jump,
-.devhub-wrap .related .used-by .toc-jump {
-	height: 0;
-	margin-bottom: 0;
-	clip: rect(1px, 1px, 1px, 1px);
-	position: absolute !important;
+.devhub-wrap .related h3, .devhub-wrap .related .uses .toc-jump, .devhub-wrap .related .used-by .toc-jump {
+  height: 0;
+  margin-bottom: 0;
+  clip: rect(1px, 1px, 1px, 1px);
+  position: absolute !important;
 }
 
-.devhub-wrap .related .used-by,
-.devhub-wrap .related .uses {
-	overflow-x: auto;
-	clear: right;
+.devhub-wrap .related .used-by, .devhub-wrap .related .uses {
+  overflow-x: auto;
+  clear: right;
 }
 
 .devhub-wrap .related td p {
-	margin-bottom: 0;
+  margin-bottom: 0;
 }
 
-.devhub-wrap .related th,
-.devhub-wrap .related td {
-	width: 50%;
+.devhub-wrap .related th, .devhub-wrap .related td {
+  width: 50%;
 }
 
 @media (max-width: 43em) {
-	.devhub-wrap .related .related-desc,
-	.devhub-wrap .related span {
-		display: none;
-	}
+  .devhub-wrap .related .related-desc, .devhub-wrap .related span {
+    display: none;
+  }
 }
 
 .devhub-wrap .source-content {
-	overflow: auto;
+  overflow: auto;
 }
 
 .devhub-wrap .source-code-links {
-	margin-left: 2em;
-	margin-top: 1em;
+  margin-left: 2em;
+  margin-top: 1em;
 }
 
 .devhub-wrap .source-code-links span {
-	border-left: 1px solid #999;
-	margin-left: 1em;
-	padding-left: 1em;
+  border-left: 1px solid #999;
+  margin-left: 1em;
+  padding-left: 1em;
 }
 
 .devhub-wrap .source-code-links span:first-child {
-	display: none;
-	border-left: 0;
-	margin-left: 1em;
-	padding-left: 0;
+  display: none;
+  border-left: 0;
+  margin-left: 1em;
+  padding-left: 0;
 }
 
 .devhub-wrap .source-code-container {
-	overflow-x: auto;
-	overflow-y: hidden;
+  overflow-x: auto;
+  overflow-y: hidden;
 }
 
-.devhub-wrap .show-complete-source,
-.devhub-wrap .less-complete-source {
-	display: none;
+.devhub-wrap .show-complete-source, .devhub-wrap .less-complete-source {
+  display: none;
 }
 
 .devhub-wrap .changelog table .changelog-version {
-	width: 10%;
+  width: 10%;
 }
 
 .devhub-wrap .changelog table .changelog-desc {
-	width: 90%;
+  width: 90%;
 }
 
 .devhub-wrap .loop-pagination {
-	text-align: center;
-	font-size: 18px;
-	margin-bottom: 20px;
+  text-align: center;
+  font-size: 18px;
+  margin-bottom: 20px;
 }
 
 .devhub-wrap .comment-content a {
-	word-wrap: break-word;
+  word-wrap: break-word;
 }
 
-.devhub-wrap .single-wp-parser-function .bad-note .comment-content,
-.devhub-wrap .single-wp-parser-method .bad-note .comment-content,
-.devhub-wrap .single-wp-parser-hook .bad-note .comment-content,
-.devhub-wrap .single-wp-parser-class .bad-note .comment-content {
-	opacity: 0.6;
+.devhub-wrap .single-wp-parser-function .bad-note .comment-content, .devhub-wrap .single-wp-parser-method .bad-note .comment-content, .devhub-wrap .single-wp-parser-hook .bad-note .comment-content, .devhub-wrap .single-wp-parser-class .bad-note .comment-content {
+  opacity: .6;
 }
 
-.devhub-wrap .single-wp-parser-function .bad-note .comment-content:hover,
-.devhub-wrap .single-wp-parser-method .bad-note .comment-content:hover,
-.devhub-wrap .single-wp-parser-hook .bad-note .comment-content:hover,
-.devhub-wrap .single-wp-parser-class .bad-note .comment-content:hover {
-	opacity: 1;
+.devhub-wrap .single-wp-parser-function .bad-note .comment-content:hover, .devhub-wrap .single-wp-parser-method .bad-note .comment-content:hover, .devhub-wrap .single-wp-parser-hook .bad-note .comment-content:hover, .devhub-wrap .single-wp-parser-class .bad-note .comment-content:hover {
+  opacity: 1;
 }
 
 .devhub-wrap .single-wp-parser-function .comment-awaiting-moderation,
-.devhub-wrap .single-wp-parser-function .comment-edited,
-.devhub-wrap .single-wp-parser-method .comment-awaiting-moderation,
-.devhub-wrap .single-wp-parser-method .comment-edited,
-.devhub-wrap .single-wp-parser-hook .comment-awaiting-moderation,
-.devhub-wrap .single-wp-parser-hook .comment-edited,
-.devhub-wrap .single-wp-parser-class .comment-awaiting-moderation,
+.devhub-wrap .single-wp-parser-function .comment-edited, .devhub-wrap .single-wp-parser-method .comment-awaiting-moderation,
+.devhub-wrap .single-wp-parser-method .comment-edited, .devhub-wrap .single-wp-parser-hook .comment-awaiting-moderation,
+.devhub-wrap .single-wp-parser-hook .comment-edited, .devhub-wrap .single-wp-parser-class .comment-awaiting-moderation,
 .devhub-wrap .single-wp-parser-class .comment-edited {
-	background-color: #fff8e5;
-	padding: 0.2em 0.5em;
-	margin-right: 0.5em;
-	border-radius: 3px;
-	border: 1px solid #ffb900;
+  background-color: #fff8e5;
+  padding: .2em .5em;
+  margin-right: .5em;
+  border-radius: 3px;
+  border: 1px solid #ffb900;
 }
 
 .devhub-wrap .single-wp-parser-function .depth-2 .comment-awaiting-moderation,
-.devhub-wrap .single-wp-parser-function .depth-2 .comment-edited,
-.devhub-wrap .single-wp-parser-method .depth-2 .comment-awaiting-moderation,
-.devhub-wrap .single-wp-parser-method .depth-2 .comment-edited,
-.devhub-wrap .single-wp-parser-hook .depth-2 .comment-awaiting-moderation,
-.devhub-wrap .single-wp-parser-hook .depth-2 .comment-edited,
-.devhub-wrap .single-wp-parser-class .depth-2 .comment-awaiting-moderation,
+.devhub-wrap .single-wp-parser-function .depth-2 .comment-edited, .devhub-wrap .single-wp-parser-method .depth-2 .comment-awaiting-moderation,
+.devhub-wrap .single-wp-parser-method .depth-2 .comment-edited, .devhub-wrap .single-wp-parser-hook .depth-2 .comment-awaiting-moderation,
+.devhub-wrap .single-wp-parser-hook .depth-2 .comment-edited, .devhub-wrap .single-wp-parser-class .depth-2 .comment-awaiting-moderation,
 .devhub-wrap .single-wp-parser-class .depth-2 .comment-edited {
-	display: inline-block;
-	margin: 2px 0;
+  display: inline-block;
+  margin: 2px 0;
 }
 
 .devhub-wrap .single-wp-parser-function .comment-list,
-.devhub-wrap .single-wp-parser-function .comment-list ol,
-.devhub-wrap .single-wp-parser-method .comment-list,
-.devhub-wrap .single-wp-parser-method .comment-list ol,
-.devhub-wrap .single-wp-parser-hook .comment-list,
-.devhub-wrap .single-wp-parser-hook .comment-list ol,
-.devhub-wrap .single-wp-parser-class .comment-list,
+.devhub-wrap .single-wp-parser-function .comment-list ol, .devhub-wrap .single-wp-parser-method .comment-list,
+.devhub-wrap .single-wp-parser-method .comment-list ol, .devhub-wrap .single-wp-parser-hook .comment-list,
+.devhub-wrap .single-wp-parser-hook .comment-list ol, .devhub-wrap .single-wp-parser-class .comment-list,
 .devhub-wrap .single-wp-parser-class .comment-list ol {
-	list-style: none;
-	margin: 0 0 1.5em 0;
-	padding: 0;
+  list-style: none;
+  margin: 0 0 1.5em 0;
+  padding: 0;
 }
 
 .devhub-wrap .single-wp-parser-function .comment-list li,
-.devhub-wrap .single-wp-parser-function #comment-preview,
-.devhub-wrap .single-wp-parser-method .comment-list li,
-.devhub-wrap .single-wp-parser-method #comment-preview,
-.devhub-wrap .single-wp-parser-hook .comment-list li,
-.devhub-wrap .single-wp-parser-hook #comment-preview,
-.devhub-wrap .single-wp-parser-class .comment-list li,
+.devhub-wrap .single-wp-parser-function #comment-preview, .devhub-wrap .single-wp-parser-method .comment-list li,
+.devhub-wrap .single-wp-parser-method #comment-preview, .devhub-wrap .single-wp-parser-hook .comment-list li,
+.devhub-wrap .single-wp-parser-hook #comment-preview, .devhub-wrap .single-wp-parser-class .comment-list li,
 .devhub-wrap .single-wp-parser-class #comment-preview {
-	margin-top: 3rem;
-	background: #fff;
-	overflow: auto;
+  margin-top: 3rem;
+  background: #fff;
+  overflow: auto;
 }
 
 .devhub-wrap .single-wp-parser-function .comment-list li article,
-.devhub-wrap .single-wp-parser-function #comment-preview article,
-.devhub-wrap .single-wp-parser-method .comment-list li article,
-.devhub-wrap .single-wp-parser-method #comment-preview article,
-.devhub-wrap .single-wp-parser-hook .comment-list li article,
-.devhub-wrap .single-wp-parser-hook #comment-preview article,
-.devhub-wrap .single-wp-parser-class .comment-list li article,
+.devhub-wrap .single-wp-parser-function #comment-preview article, .devhub-wrap .single-wp-parser-method .comment-list li article,
+.devhub-wrap .single-wp-parser-method #comment-preview article, .devhub-wrap .single-wp-parser-hook .comment-list li article,
+.devhub-wrap .single-wp-parser-hook #comment-preview article, .devhub-wrap .single-wp-parser-class .comment-list li article,
 .devhub-wrap .single-wp-parser-class #comment-preview article {
-	overflow: auto;
+  overflow: auto;
 }
 
 .devhub-wrap .single-wp-parser-function .comment-list li.depth-1,
-.devhub-wrap .single-wp-parser-function #comment-preview,
-.devhub-wrap .single-wp-parser-method .comment-list li.depth-1,
-.devhub-wrap .single-wp-parser-method #comment-preview,
-.devhub-wrap .single-wp-parser-hook .comment-list li.depth-1,
-.devhub-wrap .single-wp-parser-hook #comment-preview,
-.devhub-wrap .single-wp-parser-class .comment-list li.depth-1,
+.devhub-wrap .single-wp-parser-function #comment-preview, .devhub-wrap .single-wp-parser-method .comment-list li.depth-1,
+.devhub-wrap .single-wp-parser-method #comment-preview, .devhub-wrap .single-wp-parser-hook .comment-list li.depth-1,
+.devhub-wrap .single-wp-parser-hook #comment-preview, .devhub-wrap .single-wp-parser-class .comment-list li.depth-1,
 .devhub-wrap .single-wp-parser-class #comment-preview {
-	border: 1px solid #dfdfdf;
-	border-radius: 2px;
-	width: 100%;
+  border: 1px solid #dfdfdf;
+  border-radius: 2px;
+  width: 100%;
 }
 
-.devhub-wrap .single-wp-parser-function .comment-list li.depth-2,
-.devhub-wrap .single-wp-parser-method .comment-list li.depth-2,
-.devhub-wrap .single-wp-parser-hook .comment-list li.depth-2,
-.devhub-wrap .single-wp-parser-class .comment-list li.depth-2 {
-	border-top: 1px solid #dfdfdf;
-	padding: 0;
-	margin: 0;
+.devhub-wrap .single-wp-parser-function .comment-list li.depth-2, .devhub-wrap .single-wp-parser-method .comment-list li.depth-2, .devhub-wrap .single-wp-parser-hook .comment-list li.depth-2, .devhub-wrap .single-wp-parser-class .comment-list li.depth-2 {
+  border-top: 1px solid #dfdfdf;
+  padding: 0;
+  margin: 0;
 }
 
-.devhub-wrap
-	.single-wp-parser-function
-	.comment-list
-	li.depth-2
-	.comment-content,
-.devhub-wrap .single-wp-parser-method .comment-list li.depth-2 .comment-content,
-.devhub-wrap .single-wp-parser-hook .comment-list li.depth-2 .comment-content,
-.devhub-wrap .single-wp-parser-class .comment-list li.depth-2 .comment-content {
-	padding: 0.9em 0;
+.devhub-wrap .single-wp-parser-function .comment-list li.depth-2 .comment-content, .devhub-wrap .single-wp-parser-method .comment-list li.depth-2 .comment-content, .devhub-wrap .single-wp-parser-hook .comment-list li.depth-2 .comment-content, .devhub-wrap .single-wp-parser-class .comment-list li.depth-2 .comment-content {
+  padding: .9em 0;
 }
 
-.devhub-wrap
-	.single-wp-parser-function
-	.comment-list
-	li.depth-2
-	.comment-content
-	p,
-.devhub-wrap
-	.single-wp-parser-method
-	.comment-list
-	li.depth-2
-	.comment-content
-	p,
-.devhub-wrap .single-wp-parser-hook .comment-list li.depth-2 .comment-content p,
-.devhub-wrap
-	.single-wp-parser-class
-	.comment-list
-	li.depth-2
-	.comment-content
-	p {
-	margin-bottom: 0;
-	font-size: 0.9em;
+.devhub-wrap .single-wp-parser-function .comment-list li.depth-2 .comment-content p, .devhub-wrap .single-wp-parser-method .comment-list li.depth-2 .comment-content p, .devhub-wrap .single-wp-parser-hook .comment-list li.depth-2 .comment-content p, .devhub-wrap .single-wp-parser-class .comment-list li.depth-2 .comment-content p {
+  margin-bottom: 0;
+  font-size: .9em;
 }
 
-.devhub-wrap .single-wp-parser-function .comment ul.children,
-.devhub-wrap .single-wp-parser-method .comment ul.children,
-.devhub-wrap .single-wp-parser-hook .comment ul.children,
-.devhub-wrap .single-wp-parser-class .comment ul.children {
-	margin: 0 0 1.5em 0;
-	border-bottom: 1px solid #dfdfdf;
+.devhub-wrap .single-wp-parser-function .comment ul.children, .devhub-wrap .single-wp-parser-method .comment ul.children, .devhub-wrap .single-wp-parser-hook .comment ul.children, .devhub-wrap .single-wp-parser-class .comment ul.children {
+  margin: 0 0 1.5em 0;
+  border-bottom: 1px solid #dfdfdf;
 }
 
-.devhub-wrap .single-wp-parser-function .feedback,
-.devhub-wrap .single-wp-parser-method .feedback,
-.devhub-wrap .single-wp-parser-hook .feedback,
-.devhub-wrap .single-wp-parser-class .feedback {
-	width: 90%;
-	float: right;
-	margin-right: 1.5rem;
+.devhub-wrap .single-wp-parser-function .feedback, .devhub-wrap .single-wp-parser-method .feedback, .devhub-wrap .single-wp-parser-hook .feedback, .devhub-wrap .single-wp-parser-class .feedback {
+  width: 90%;
+  float: right;
+  margin-right: 1.5rem;
 }
 
-.devhub-wrap .single-wp-parser-function .feedback-links,
-.devhub-wrap .single-wp-parser-method .feedback-links,
-.devhub-wrap .single-wp-parser-hook .feedback-links,
-.devhub-wrap .single-wp-parser-class .feedback-links {
-	margin: 0 1.5rem 1em 1.5rem;
-	font-size: 0.9em;
-	clear: both;
+.devhub-wrap .single-wp-parser-function .feedback-links, .devhub-wrap .single-wp-parser-method .feedback-links, .devhub-wrap .single-wp-parser-hook .feedback-links, .devhub-wrap .single-wp-parser-class .feedback-links {
+  margin: 0 1.5rem 1em 1.5rem;
+  font-size: 0.9em;
+  clear: both;
 }
 
 .devhub-wrap .single-wp-parser-function .feedback-editor-title,
-.devhub-wrap .single-wp-parser-function .feedback-title,
-.devhub-wrap .single-wp-parser-method .feedback-editor-title,
-.devhub-wrap .single-wp-parser-method .feedback-title,
-.devhub-wrap .single-wp-parser-hook .feedback-editor-title,
-.devhub-wrap .single-wp-parser-hook .feedback-title,
-.devhub-wrap .single-wp-parser-class .feedback-editor-title,
+.devhub-wrap .single-wp-parser-function .feedback-title, .devhub-wrap .single-wp-parser-method .feedback-editor-title,
+.devhub-wrap .single-wp-parser-method .feedback-title, .devhub-wrap .single-wp-parser-hook .feedback-editor-title,
+.devhub-wrap .single-wp-parser-hook .feedback-title, .devhub-wrap .single-wp-parser-class .feedback-editor-title,
 .devhub-wrap .single-wp-parser-class .feedback-title {
-	font-size: 1.8rem;
-	font-weight: 300;
-	line-height: 2.2rem;
-	margin-bottom: 1em;
+  font-size: 1.8rem;
+  font-weight: 300;
+  line-height: 2.2rem;
+  margin-bottom: 1em;
 }
 
-.devhub-wrap .single-wp-parser-function .feedback-toggle,
-.devhub-wrap .single-wp-parser-method .feedback-toggle,
-.devhub-wrap .single-wp-parser-hook .feedback-toggle,
-.devhub-wrap .single-wp-parser-class .feedback-toggle {
-	margin: 0 0 0 1.5rem;
-	display: inline-block;
+.devhub-wrap .single-wp-parser-function .feedback-toggle, .devhub-wrap .single-wp-parser-method .feedback-toggle, .devhub-wrap .single-wp-parser-hook .feedback-toggle, .devhub-wrap .single-wp-parser-class .feedback-toggle {
+  margin: 0 0 0 1.5rem;
+  display: inline-block;
 }
 
-.devhub-wrap .single-wp-parser-function #wp-feedback-wrap,
-.devhub-wrap .single-wp-parser-method #wp-feedback-wrap,
-.devhub-wrap .single-wp-parser-hook #wp-feedback-wrap,
-.devhub-wrap .single-wp-parser-class #wp-feedback-wrap {
-	padding-bottom: 1em;
+.devhub-wrap .single-wp-parser-function #wp-feedback-wrap, .devhub-wrap .single-wp-parser-method #wp-feedback-wrap, .devhub-wrap .single-wp-parser-hook #wp-feedback-wrap, .devhub-wrap .single-wp-parser-class #wp-feedback-wrap {
+  padding-bottom: 1em;
 }
 
 .devhub-wrap .single-wp-parser-function #comment-preview,
-.js .devhub-wrap .single-wp-parser-function .comment-form-comment,
-.devhub-wrap .single-wp-parser-method #comment-preview,
-.js .devhub-wrap .single-wp-parser-method .comment-form-comment,
-.devhub-wrap .single-wp-parser-hook #comment-preview,
-.js .devhub-wrap .single-wp-parser-hook .comment-form-comment,
-.devhub-wrap .single-wp-parser-class #comment-preview,
+.js .devhub-wrap .single-wp-parser-function .comment-form-comment, .devhub-wrap .single-wp-parser-method #comment-preview,
+.js .devhub-wrap .single-wp-parser-method .comment-form-comment, .devhub-wrap .single-wp-parser-hook #comment-preview,
+.js .devhub-wrap .single-wp-parser-hook .comment-form-comment, .devhub-wrap .single-wp-parser-class #comment-preview,
 .js .devhub-wrap .single-wp-parser-class .comment-form-comment {
-	margin-top: 0;
-	border: 1px solid #ccc;
-	border-radius: 0 3px 3px 3px;
-	clear: both;
+  margin-top: 0;
+  border: 1px solid #ccc;
+  border-radius: 0 3px 3px 3px;
+  clear: both;
 }
 
-.devhub-wrap .single-wp-parser-function #comment-preview.tab-section-selected,
-.devhub-wrap .single-wp-parser-method #comment-preview.tab-section-selected,
-.devhub-wrap .single-wp-parser-hook #comment-preview.tab-section-selected,
-.devhub-wrap .single-wp-parser-class #comment-preview.tab-section-selected {
-	border-radius: 3px;
+.devhub-wrap .single-wp-parser-function #comment-preview.tab-section-selected, .devhub-wrap .single-wp-parser-method #comment-preview.tab-section-selected, .devhub-wrap .single-wp-parser-hook #comment-preview.tab-section-selected, .devhub-wrap .single-wp-parser-class #comment-preview.tab-section-selected {
+  border-radius: 3px;
 }
 
-.devhub-wrap .single-wp-parser-function #comment-preview .comment-content,
-.devhub-wrap .single-wp-parser-method #comment-preview .comment-content,
-.devhub-wrap .single-wp-parser-hook #comment-preview .comment-content,
-.devhub-wrap .single-wp-parser-class #comment-preview .comment-content {
-	min-height: 6em;
+.devhub-wrap .single-wp-parser-function #comment-preview .comment-content, .devhub-wrap .single-wp-parser-method #comment-preview .comment-content, .devhub-wrap .single-wp-parser-hook #comment-preview .comment-content, .devhub-wrap .single-wp-parser-class #comment-preview .comment-content {
+  min-height: 6em;
 }
 
-.devhub-wrap .single-wp-parser-function label[for='comment'],
+.devhub-wrap .single-wp-parser-function label[for=comment],
 .devhub-wrap .single-wp-parser-function .comment-form-comment,
-.devhub-wrap .single-wp-parser-function .comment-preview,
-.devhub-wrap .single-wp-parser-method label[for='comment'],
+.devhub-wrap .single-wp-parser-function .comment-preview, .devhub-wrap .single-wp-parser-method label[for=comment],
 .devhub-wrap .single-wp-parser-method .comment-form-comment,
-.devhub-wrap .single-wp-parser-method .comment-preview,
-.devhub-wrap .single-wp-parser-hook label[for='comment'],
+.devhub-wrap .single-wp-parser-method .comment-preview, .devhub-wrap .single-wp-parser-hook label[for=comment],
 .devhub-wrap .single-wp-parser-hook .comment-form-comment,
-.devhub-wrap .single-wp-parser-hook .comment-preview,
-.devhub-wrap .single-wp-parser-class label[for='comment'],
+.devhub-wrap .single-wp-parser-hook .comment-preview, .devhub-wrap .single-wp-parser-class label[for=comment],
 .devhub-wrap .single-wp-parser-class .comment-form-comment,
 .devhub-wrap .single-wp-parser-class .comment-preview {
-	margin-bottom: 1em;
+  margin-bottom: 1em;
 }
 
-.js .devhub-wrap .single-wp-parser-function .comment-form-comment,
-.js .devhub-wrap .single-wp-parser-method .comment-form-comment,
-.js .devhub-wrap .single-wp-parser-hook .comment-form-comment,
-.js .devhub-wrap .single-wp-parser-class .comment-form-comment {
-	padding: 0 0.7em 0.7em;
+.js .devhub-wrap .single-wp-parser-function .comment-form-comment, .js .devhub-wrap .single-wp-parser-method .comment-form-comment, .js .devhub-wrap .single-wp-parser-hook .comment-form-comment, .js .devhub-wrap .single-wp-parser-class .comment-form-comment {
+  padding: 0 .7em .7em;
 }
 
-.devhub-wrap .single-wp-parser-function .tablist .spinner,
-.devhub-wrap .single-wp-parser-method .tablist .spinner,
-.devhub-wrap .single-wp-parser-hook .tablist .spinner,
-.devhub-wrap .single-wp-parser-class .tablist .spinner {
-	background: url('/wp-includes/images/spinner-2x.gif') no-repeat scroll 0 50%;
-	-webkit-background-size: 20px 20px;
-	background-size: 20px 20px;
-	margin: 0 0.5em;
-	padding-left: 20px;
+.devhub-wrap .single-wp-parser-function .tablist .spinner, .devhub-wrap .single-wp-parser-method .tablist .spinner, .devhub-wrap .single-wp-parser-hook .tablist .spinner, .devhub-wrap .single-wp-parser-class .tablist .spinner {
+  background: url("/wp-includes/images/spinner-2x.gif") no-repeat scroll 0 50%;
+  -webkit-background-size: 20px 20px;
+  background-size: 20px 20px;
+  margin: 0 0.5em;
+  padding-left: 20px;
 }
 
-.devhub-wrap .single-wp-parser-function .comment-list .avatar,
-.devhub-wrap .single-wp-parser-method .comment-list .avatar,
-.devhub-wrap .single-wp-parser-hook .comment-list .avatar,
-.devhub-wrap .single-wp-parser-class .comment-list .avatar {
-	float: left;
-	margin: -2px 1em 0 0;
-	padding: 0.125em;
-	border: 1px solid #eee;
+.devhub-wrap .single-wp-parser-function .comment-list .avatar, .devhub-wrap .single-wp-parser-method .comment-list .avatar, .devhub-wrap .single-wp-parser-hook .comment-list .avatar, .devhub-wrap .single-wp-parser-class .comment-list .avatar {
+  float: left;
+  margin: -2px 1em 0 0;
+  padding: 0.125em;
+  border: 1px solid #eee;
 }
 
-.devhub-wrap .single-wp-parser-function .comment-meta,
-.devhub-wrap .single-wp-parser-method .comment-meta,
-.devhub-wrap .single-wp-parser-hook .comment-meta,
-.devhub-wrap .single-wp-parser-class .comment-meta {
-	padding: 0.5em 1em;
-	background-color: #f7f7f7;
-	overflow: auto;
+.devhub-wrap .single-wp-parser-function .comment-meta, .devhub-wrap .single-wp-parser-method .comment-meta, .devhub-wrap .single-wp-parser-hook .comment-meta, .devhub-wrap .single-wp-parser-class .comment-meta {
+  padding: .5em 1em;
+  background-color: #f7f7f7;
+  overflow: auto;
 }
 
-.devhub-wrap .single-wp-parser-function .comment-content,
-.devhub-wrap .single-wp-parser-method .comment-content,
-.devhub-wrap .single-wp-parser-hook .comment-content,
-.devhub-wrap .single-wp-parser-class .comment-content {
-	margin-left: 60px;
-	margin-left: 3.75rem;
-	margin-left: 0;
-	clear: both;
-	padding: 2rem 1.5rem 0.5rem;
+.devhub-wrap .single-wp-parser-function .comment-content, .devhub-wrap .single-wp-parser-method .comment-content, .devhub-wrap .single-wp-parser-hook .comment-content, .devhub-wrap .single-wp-parser-class .comment-content {
+  margin-left: 60px;
+  margin-left: 3.75rem;
+  margin-left: 0;
+  clear: both;
+  padding: 2rem 1.5rem .5rem;
 }
 
-.devhub-wrap .single-wp-parser-function .comment-content ol,
-.devhub-wrap .single-wp-parser-method .comment-content ol,
-.devhub-wrap .single-wp-parser-hook .comment-content ol,
-.devhub-wrap .single-wp-parser-class .comment-content ol {
-	list-style: decimal inside;
-	margin: 0 0 1.5em 0;
-	border-top: none;
-	margin: 0 0 1.5em 1.5em;
-	padding: 0;
+.devhub-wrap .single-wp-parser-function .comment-content ol, .devhub-wrap .single-wp-parser-method .comment-content ol, .devhub-wrap .single-wp-parser-hook .comment-content ol, .devhub-wrap .single-wp-parser-class .comment-content ol {
+  list-style: decimal inside;
+  margin: 0 0 1.5em 0;
+  border-top: none;
+  margin: 0 0 1.5em 1.5em;
+  padding: 0;
 }
 
-.devhub-wrap .single-wp-parser-function .comment-content ul,
-.devhub-wrap .single-wp-parser-method .comment-content ul,
-.devhub-wrap .single-wp-parser-hook .comment-content ul,
-.devhub-wrap .single-wp-parser-class .comment-content ul {
-	list-style: square inside;
-	margin: 0 0 1.5em 0;
-	border-top: none;
-	margin: 0 0 1.5em 1.5em;
-	padding: 0;
+.devhub-wrap .single-wp-parser-function .comment-content ul, .devhub-wrap .single-wp-parser-method .comment-content ul, .devhub-wrap .single-wp-parser-hook .comment-content ul, .devhub-wrap .single-wp-parser-class .comment-content ul {
+  list-style: square inside;
+  margin: 0 0 1.5em 0;
+  border-top: none;
+  margin: 0 0 1.5em 1.5em;
+  padding: 0;
 }
 
-.devhub-wrap .single-wp-parser-function .comment-content li,
-.devhub-wrap .single-wp-parser-method .comment-content li,
-.devhub-wrap .single-wp-parser-hook .comment-content li,
-.devhub-wrap .single-wp-parser-class .comment-content li {
-	border: none;
-	padding: 0;
+.devhub-wrap .single-wp-parser-function .comment-content li, .devhub-wrap .single-wp-parser-method .comment-content li, .devhub-wrap .single-wp-parser-hook .comment-content li, .devhub-wrap .single-wp-parser-class .comment-content li {
+  border: none;
+  padding: 0;
 }
 
-.devhub-wrap .single-wp-parser-function #respond,
-.devhub-wrap .single-wp-parser-method #respond,
-.devhub-wrap .single-wp-parser-hook #respond,
-.devhub-wrap .single-wp-parser-class #respond {
-	overflow: hidden;
+.devhub-wrap .single-wp-parser-function #respond, .devhub-wrap .single-wp-parser-method #respond, .devhub-wrap .single-wp-parser-hook #respond, .devhub-wrap .single-wp-parser-class #respond {
+  overflow: hidden;
 }
 
-.devhub-wrap .single-wp-parser-function #respond .log-in-out a,
-.devhub-wrap .single-wp-parser-method #respond .log-in-out a,
-.devhub-wrap .single-wp-parser-hook #respond .log-in-out a,
-.devhub-wrap .single-wp-parser-class #respond .log-in-out a {
-	font-style: italic;
+.devhub-wrap .single-wp-parser-function #respond .log-in-out a, .devhub-wrap .single-wp-parser-method #respond .log-in-out a, .devhub-wrap .single-wp-parser-hook #respond .log-in-out a, .devhub-wrap .single-wp-parser-class #respond .log-in-out a {
+  font-style: italic;
 }
 
-.devhub-wrap .single-wp-parser-function #reply-title small a,
-.devhub-wrap .single-wp-parser-method #reply-title small a,
-.devhub-wrap .single-wp-parser-hook #reply-title small a,
-.devhub-wrap .single-wp-parser-class #reply-title small a {
-	font-style: italic;
+.devhub-wrap .single-wp-parser-function #reply-title small a, .devhub-wrap .single-wp-parser-method #reply-title small a, .devhub-wrap .single-wp-parser-hook #reply-title small a, .devhub-wrap .single-wp-parser-class #reply-title small a {
+  font-style: italic;
 }
 
-.devhub-wrap .single-wp-parser-function #respond #submit,
-.devhub-wrap .single-wp-parser-method #respond #submit,
-.devhub-wrap .single-wp-parser-hook #respond #submit,
-.devhub-wrap .single-wp-parser-class #respond #submit {
-	float: left;
-	margin: 0 0 1.5em;
+.devhub-wrap .single-wp-parser-function #respond #submit, .devhub-wrap .single-wp-parser-method #respond #submit, .devhub-wrap .single-wp-parser-hook #respond #submit, .devhub-wrap .single-wp-parser-class #respond #submit {
+  float: left;
+  margin: 0 0 1.5em;
 }
 
-.devhub-wrap .single-wp-parser-function .comment-author,
-.devhub-wrap .single-wp-parser-method .comment-author,
-.devhub-wrap .single-wp-parser-hook .comment-author,
-.devhub-wrap .single-wp-parser-class .comment-author {
-	float: left;
-	line-height: 1.8;
+.devhub-wrap .single-wp-parser-function .comment-author, .devhub-wrap .single-wp-parser-method .comment-author, .devhub-wrap .single-wp-parser-hook .comment-author, .devhub-wrap .single-wp-parser-class .comment-author {
+  float: left;
+  line-height: 1.8;
 }
 
-.devhub-wrap .single-wp-parser-function #add-user-note,
-.devhub-wrap .single-wp-parser-method #add-user-note,
-.devhub-wrap .single-wp-parser-hook #add-user-note,
-.devhub-wrap .single-wp-parser-class #add-user-note {
-	font-size: 1.6rem;
+.devhub-wrap .single-wp-parser-function #add-user-note, .devhub-wrap .single-wp-parser-method #add-user-note, .devhub-wrap .single-wp-parser-hook #add-user-note, .devhub-wrap .single-wp-parser-class #add-user-note {
+  font-size: 1.6rem;
 }
 
-.devhub-wrap .single-wp-parser-function .text-button,
-.devhub-wrap .single-wp-parser-method .text-button,
-.devhub-wrap .single-wp-parser-hook .text-button,
-.devhub-wrap .single-wp-parser-class .text-button {
-	background: #fff none repeat scroll 0 0;
-	border-color: #ccc #ccc #bbb;
-	border-radius: 3px;
-	border-style: solid;
-	border-width: 1px;
-	padding: 0 5px;
+.devhub-wrap .single-wp-parser-function .text-button, .devhub-wrap .single-wp-parser-method .text-button, .devhub-wrap .single-wp-parser-hook .text-button, .devhub-wrap .single-wp-parser-class .text-button {
+  background: #fff none repeat scroll 0 0;
+  border-color: #ccc #ccc #bbb;
+  border-radius: 3px;
+  border-style: solid;
+  border-width: 1px;
+  padding: 0 5px;
 }
 
-.devhub-wrap .single-wp-parser-function .comment-form ul,
-.devhub-wrap .single-wp-parser-function .feedback-form ul,
-.devhub-wrap .single-wp-parser-method .comment-form ul,
-.devhub-wrap .single-wp-parser-method .feedback-form ul,
-.devhub-wrap .single-wp-parser-hook .comment-form ul,
-.devhub-wrap .single-wp-parser-hook .feedback-form ul,
-.devhub-wrap .single-wp-parser-class .comment-form ul,
-.devhub-wrap .single-wp-parser-class .feedback-form ul {
-	margin-left: 1.5em;
+.devhub-wrap .single-wp-parser-function .comment-form ul, .devhub-wrap .single-wp-parser-function .feedback-form ul, .devhub-wrap .single-wp-parser-method .comment-form ul, .devhub-wrap .single-wp-parser-method .feedback-form ul, .devhub-wrap .single-wp-parser-hook .comment-form ul, .devhub-wrap .single-wp-parser-hook .feedback-form ul, .devhub-wrap .single-wp-parser-class .comment-form ul, .devhub-wrap .single-wp-parser-class .feedback-form ul {
+  margin-left: 1.5em;
 }
 
-.devhub-wrap .single-wp-parser-function .feedback-form ul li,
-.devhub-wrap .single-wp-parser-method .feedback-form ul li,
-.devhub-wrap .single-wp-parser-hook .feedback-form ul li,
-.devhub-wrap .single-wp-parser-class .feedback-form ul li {
-	margin: 0;
-	overflow: visible;
+.devhub-wrap .single-wp-parser-function .feedback-form ul li, .devhub-wrap .single-wp-parser-method .feedback-form ul li, .devhub-wrap .single-wp-parser-hook .feedback-form ul li, .devhub-wrap .single-wp-parser-class .feedback-form ul li {
+  margin: 0;
+  overflow: visible;
 }
 
 .devhub-wrap.single-post .comment-list,
 .devhub-wrap.single-post .comment-list ol {
-	list-style: none;
-	margin: 1.5em 0;
-	padding: 0;
+  list-style: none;
+  margin: 1.5em 0;
+  padding: 0;
 }
 
 .devhub-wrap.single-post .comment-list li {
-	margin: 1.5em 0;
-	padding: 1em 0 0 0;
-	border-top: 1px solid #ddd;
+  margin: 1.5em 0;
+  padding: 1em 0 0 0;
+  border-top: 1px solid #ddd;
 }
 
 .devhub-wrap.single-post .comment-list p {
-	margin: 0 0 0 42px;
+  margin: 0 0 0 42px;
 }
 
 .devhub-wrap.single-post .comment-list .alt {
-	background: inherit;
+  background: inherit;
 }
 
 .devhub-wrap.single-post .comment-meta {
-	font-size: 0.65em;
-	color: #888;
-	float: right;
-	margin-top: -15px;
+  font-size: 0.65em;
+  color: #888;
+  float: right;
+  margin-top: -15px;
 }
 
 .devhub-wrap.single-post .comment-author img {
-	float: left;
-	margin: 0 10px 0 0;
+  float: left;
+  margin: 0 10px 0 0;
 }
 
 .devhub-wrap.single-post .comments-area {
-	margin: 1.5em 0 0 0;
+  margin: 1.5em 0 0 0;
 }
 
 .devhub-wrap #content-area.has-sidebar {
-	float: none;
-	margin: 0 auto;
-	width: 60em;
+  float: none;
+  margin: 0 auto;
+  width: 60em;
 }
 
 .devhub-wrap .has-sidebar main {
-	float: right;
-	width: 67%;
-	margin: 0;
-	clear: none;
-	padding: 0 12px;
-	padding: 0 1.2rem;
+  float: right;
+  width: 67%;
+  margin: 0;
+  clear: none;
+  padding: 0 12px;
+  padding: 0 1.2rem;
 }
 
 .devhub-wrap .has-sidebar .widget-area {
-	float: left;
-	overflow: hidden;
-	width: 27%;
-	margin-left: -55px;
-	margin: 0;
-	clear: none;
+  float: left;
+  overflow: hidden;
+  width: 27%;
+  margin-left: -55px;
+  margin: 0;
+  clear: none;
 }
 
 .devhub-wrap .has-sidebar .widget-area .widget {
-	width: 100%;
+  width: 100%;
 }
 
 .devhub-wrap nav.handbook-navigation {
-	margin-bottom: 3em;
+  margin-bottom: 3em;
 }
 
 .devhub-wrap nav.handbook-navigation .nav-links a {
-	width: 49%;
-	display: inline-block;
+  width: 49%;
+  display: inline-block;
 }
 
-.devhub-wrap nav.handbook-navigation .nav-links a[rel='prev'] {
-	text-align: left;
+.devhub-wrap nav.handbook-navigation .nav-links a[rel="prev"] {
+  text-align: left;
 }
 
-.devhub-wrap nav.handbook-navigation .nav-links a[rel='next'] {
-	text-align: right;
-	float: right;
+.devhub-wrap nav.handbook-navigation .nav-links a[rel="next"] {
+  text-align: right;
+  float: right;
 }
 
 .devhub-wrap .user-note-voting {
-	font-size: 1.2em;
-	clear: left;
-	float: left;
-	margin-right: 10px;
+  font-size: 1.2em;
+  clear: left;
+  float: left;
+  margin-right: 10px;
 }
 
-.devhub-wrap .user-note-voting-up .dashicons,
-.devhub-wrap .user-note-voting-down .dashicons {
-	font-size: 30px;
-	height: 30px;
-	width: 30px;
-	color: #000;
+.devhub-wrap .user-note-voting-up .dashicons, .devhub-wrap .user-note-voting-down .dashicons {
+  font-size: 30px;
+  height: 30px;
+  width: 30px;
+  color: #000;
 }
 
-.devhub-wrap .site-main .user-note-voting-down,
-.devhub-wrap .site-main .user-note-voting-up {
-	text-decoration: none;
+.devhub-wrap .site-main .user-note-voting-down, .devhub-wrap .site-main .user-note-voting-up {
+  text-decoration: none;
 }
 
 .devhub-wrap .user-note-voting-up {
-	margin-left: -9px;
+  margin-left: -9px;
 }
 
 .devhub-wrap span.user-note-voting-up,
 .devhub-wrap span.user-note-voting-down {
-	cursor: default;
+  cursor: default;
 }
 
 .devhub-wrap .user-note-voting-count {
-	margin-right: -2px;
+  margin-right: -2px;
 }
 
 .devhub-wrap .user-voted.user-note-voting-up .dashicons {
-	color: green;
+  color: green;
 }
 
 .devhub-wrap .user-voted.user-note-voting-down .dashicons {
-	color: red;
+  color: red;
 }
 
 .devhub-wrap .user-submitted-note .dashicons {
-	color: grey;
+  color: grey;
 }
 
 .devhub-wrap .syntaxhighlighter {
-	/* These are !important due to use of !important in SyntaxHighlighter Evolved plugin. */
-	max-width: 100% !important;
-	width: inherit !important;
-	padding-bottom: 0.5rem !important;
+  /* These are !important due to use of !important in SyntaxHighlighter Evolved plugin. */
+  max-width: 100% !important;
+  width: inherit !important;
+  padding-bottom: 0.5rem !important;
 }
 
-.devhub-wrap.archive .hentry,
-.devhub-wrap.blog .hentry {
-	padding: 0 0 1.5em 0;
-	border-bottom: 1px solid #ddd;
+.devhub-wrap.archive .hentry, .devhub-wrap.blog .hentry {
+  padding: 0 0 1.5em 0;
+  border-bottom: 1px solid #ddd;
 }
 
 /** Site Header **/
 .site-header {
-	background: #0073aa;
-	float: none;
-	margin: 0 0 4em;
-	padding: 18px 0;
-	width: auto;
-	margin: 0;
+  background: #0073aa;
+  float: none;
+  margin: 0 0 4em;
+  padding: 18px 0;
+  width: auto;
+  margin: 0;
 }
 
 .site-branding {
-	height: 32px;
-	box-sizing: border-box;
-	margin: 0 auto;
-	max-width: 960px;
-	padding: 0 10px;
-	position: relative;
+  height: 32px;
+  box-sizing: border-box;
+  margin: 0 auto;
+  max-width: 960px;
+  padding: 0 10px;
+  position: relative;
 }
 
 .site-title {
-	line-height: 1;
-	margin: 0;
-	padding: 0;
-	font-family: 'Open Sans', sans-serif;
-	display: inline-block;
-	text-align: left;
-	color: black;
+  line-height: 1;
+  margin: 0;
+  padding: 0;
+  font-family: 'Open Sans', sans-serif;
+  display: inline-block;
+  text-align: left;
+  color: black;
 }
 
 .site-title a {
-	color: #fff;
-	font-size: 28px;
-	font-weight: 300;
-	line-height: 1;
-	border-bottom: 0;
+  color: #fff;
+  font-size: 28px;
+  font-weight: 300;
+  line-height: 1;
+  border-bottom: 0;
 }
 
 @media screen and (max-width: 500px) {
-	.site-title a {
-		font-size: 17px;
-		font-size: 4.5vw;
-		vertical-align: middle;
-		vertical-align: -moz-middle-with-baseline;
-		vertical-align: -webkit-baseline-middle;
-	}
+  .site-title a {
+    font-size: 17px;
+    font-size: 4.5vw;
+    vertical-align: middle;
+    vertical-align: -moz-middle-with-baseline;
+    vertical-align: -webkit-baseline-middle;
+  }
 }
 
 @media screen and (max-width: 769px) {
-	.site-title {
-		margin-left: 10px;
-	}
+  .site-title {
+    margin-left: 10px;
+  }
 }
 
 .site-header.home {
-	padding: 28px 20px;
-	padding: 2.8rem 2rem;
-	text-align: center;
+  padding: 28px 20px;
+  padding: 2.8rem 2.0rem;
+  text-align: center;
 }
 
 .site-header.home .site-branding {
-	height: initial;
+  height: initial;
 }
 
 .site-header.home .site-title {
-	max-width: none;
-	font-weight: 300;
-	margin: 36px 0 11.25px;
-	margin: 3.6rem 0 1.125rem;
-	text-align: center;
-	display: inherit;
-	clear: both;
+  max-width: none;
+  font-weight: 300;
+  margin: 36px 0 11.25px;
+  margin: 3.6rem 0 1.125rem;
+  text-align: center;
+  display: inherit;
+  clear: both;
 }
 
 .site-header.home .site-title a {
-	font-size: 68.6646px;
-	font-size: 6.86646rem;
+  font-size: 68.6646px;
+  font-size: 6.86646rem;
 }
 
 @media (max-width: 500px) {
-	.site-header.home .site-title a {
-		font-size: 50px;
-		font-size: 5rem;
-	}
+  .site-header.home .site-title a {
+    font-size: 50px;
+    font-size: 5rem;
+  }
 }
 
 .site-header.home .site-description {
-	color: rgba(255, 255, 255, 0.8);
-	font-size: 2.25rem;
-	font-weight: 300;
-	text-align: center;
+  color: rgba(255, 255, 255, 0.8);
+  font-size: 2.25rem;
+  font-weight: 300;
+  text-align: center;
 }
 
 .menu-container {
-	background: #0073aa;
-	clear: both;
-	float: right;
-	width: 100%;
+  background: #0073aa;
+  clear: both;
+  float: right;
+  width: 100%;
 }
 
 .menu-container ul {
-	display: none;
-	list-style: none;
-	margin: 0;
-	padding-left: 0;
+  display: none;
+  list-style: none;
+  margin: 0;
+  padding-left: 0;
 }
 
 .menu-container ul li {
-	border-top: 1px solid rgba(255, 255, 255, 0.2);
-	padding: 16px;
+  border-top: 1px solid rgba(255, 255, 255, 0.2);
+  padding: 16px;
 }
 
 .menu-container a {
-	color: rgba(255, 255, 255, 0.8);
-	display: block;
-	text-decoration: none;
-	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',
-		'Oxygen-Sans', 'Ubuntu', 'Cantarell', 'Helvetica Neue', sans-serif;
-	font-size: 12.8px;
+  color: rgba(255, 255, 255, 0.8);
+  display: block;
+  text-decoration: none;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
+  font-size: 12.8px;
 }
 
-.menu-container a:hover,
-.menu-container a:active {
-	color: #fff;
-	border-bottom: 1px solid #fff;
+.menu-container a:hover, .menu-container a:active {
+  color: #fff;
+  border-bottom: 1px solid #fff;
 }
 
 @media screen and (max-width: 48em) {
-	.menu-container a:hover,
-	.menu-container a:active {
-		border-bottom: 0;
-	}
+  .menu-container a:hover, .menu-container a:active {
+    border-bottom: 0;
+  }
 }
 
 @media screen and (min-width: 48em) {
-	.menu-container {
-		float: right;
-		position: relative;
-		width: auto;
-		top: auto;
-		margin-right: 4px;
-	}
-	.menu-container ul {
-		display: inline-block;
-		font-size: 0;
-		margin-top: 5px;
-	}
-	.menu-container ul li {
-		border: 0;
-		display: inline-block;
-		font-size: 1.4rem;
-		margin-right: 2.1rem;
-		padding: 0;
-	}
-	.menu-container ul li:last-of-type {
-		margin: 0;
-	}
+  .menu-container {
+    float: right;
+    position: relative;
+    width: auto;
+    top: auto;
+    margin-right: 4px;
+  }
+  .menu-container ul {
+    display: inline-block;
+    font-size: 0;
+    margin-top: 5px;
+  }
+  .menu-container ul li {
+    border: 0;
+    display: inline-block;
+    font-size: 1.4rem;
+    margin-right: 2.1rem;
+    padding: 0;
+  }
+  .menu-container ul li:last-of-type {
+    margin: 0;
+  }
 }
 
 .main-navigation {
-	clear: both;
-	position: absolute;
-	left: 0;
-	width: 100%;
-	top: 50px;
-	z-index: 10;
+  clear: both;
+  position: absolute;
+  left: 0;
+  width: 100%;
+  top: 50px;
+  z-index: 10;
 }
 
 .main-navigation.toggled ul {
-	display: block;
+  display: block;
 }
 
 .menu-toggle.dashicons {
-	background: transparent;
-	border: none;
-	color: #fff;
-	font-size: 25px;
-	height: 5.5rem;
-	outline-style: none;
-	overflow: hidden;
-	position: absolute;
-	right: 0.5rem;
-	top: -60px;
-	width: 5.5rem;
-	-webkit-appearance: none;
+  background: transparent;
+  border: none;
+  color: #fff;
+  font-size: 25px;
+  height: 5.5rem;
+  outline-style: none;
+  overflow: hidden;
+  position: absolute;
+  right: 0.5rem;
+  top: -60px;
+  width: 5.5rem;
+  -webkit-appearance: none;
 }
 
 .toggled .menu-toggle.dashicons:before {
-	content: '\f343';
+  content: "\f343";
 }
 
 @media screen and (min-width: 48em) {
-	.menu-toggle.dashicons {
-		display: none;
-	}
-	.main-navigation {
-		float: right;
-		position: relative;
-		width: auto;
-		top: auto;
-	}
-	.main-navigation.toggled {
-		padding: 1px 0;
-	}
-	.main-navigation ul {
-		display: inline-block;
-		font-size: 0;
-	}
-	.main-navigation ul li {
-		border: 0;
-		display: inline-block;
-		font-size: 1rem;
-		margin-right: 1rem;
-		padding: 0;
-	}
-	.main-navigation ul li:last-of-type {
-		margin-right: 0;
-	}
-	.main-navigation button.button-search {
-		display: inline-block;
-	}
+  .menu-toggle.dashicons {
+    display: none;
+  }
+  .main-navigation {
+    float: right;
+    position: relative;
+    width: auto;
+    top: auto;
+  }
+  .main-navigation.toggled {
+    padding: 1px 0;
+  }
+  .main-navigation ul {
+    display: inline-block;
+    font-size: 0;
+  }
+  .main-navigation ul li {
+    border: 0;
+    display: inline-block;
+    font-size: 1rem;
+    margin-right: 1rem;
+    padding: 0;
+  }
+  .main-navigation ul li:last-of-type {
+    margin-right: 0;
+  }
+  .main-navigation button.button-search {
+    display: inline-block;
+  }
 }
 
 /** WP editor link button modal **/
 #wp-link-wrap {
-	height: 210px !important;
-	margin-top: -125px !important;
+  height: 210px !important;
+  margin-top: -125px !important;
 }
 
 @media screen and (max-height: 520px) {
-	#wp-link-wrap {
-		margin-top: inherit !important;
-	}
+  #wp-link-wrap {
+    margin-top: inherit !important;
+  }
 }
 
 #link-selector #search-panel,
 #link-selector #wplink-link-existing-content,
 #link-selector #link-options .link-target {
-	display: none;
+  display: none;
 }
 
 /** Handbook **/
-aside[id^='handbook'] .widget-title,
-aside[id^='nav_menu'] .widget-title {
-	font-size: 16px;
-	text-transform: uppercase;
-	letter-spacing: 1px;
-	background-color: transparent;
-	padding: 1rem 12px;
-	margin-bottom: 0;
-	color: inherit;
+aside[id^="handbook"] .widget-title,
+aside[id^="nav_menu"] .widget-title {
+  font-size: 16px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  background-color: transparent;
+  padding: 1rem 12px;
+  margin-bottom: 0;
+  color: inherit;
 }
 
 .widget-area .widget .searchform .button-search {
-	height: 100%;
+  height: 100%;
 }
 
 .post-type-archive-handbook .site-main .widget-area,
 .single-handbook .site-main .widget-area {
-	float: left;
-	margin-right: 4%;
+  float: left;
+  margin-right: 4%;
 }
 
 .handbook-header {
-	line-height: 2em;
+  line-height: 2em;
 }
 
 .handbook-header h1 {
-	margin-top: 0;
+  margin-top: 0;
 }
 
 .single-handbook {
-	font-size: 16px;
+  font-size: 16px;
 }
 
-.single-handbook p,
-.single-handbook ol,
-.single-handbook ul {
-	line-height: 1.6;
+.single-handbook p, .single-handbook ol, .single-handbook ul {
+  line-height: 1.6;
 }
 
-.single-handbook .site-main p,
-.single-handbook .site-main ol,
-.single-handbook .site-main ul {
-	color: #555;
+.single-handbook .site-main p, .single-handbook .site-main ol, .single-handbook .site-main ul {
+  color: #555;
 }
 
 .single-handbook .site-title {
-	margin-left: 0;
+  margin-left: 0;
 }
 
 .single-handbook .content-area h1 {
-	margin-top: 0;
-	padding-top: 0;
+  margin-top: 0;
+  padding-top: 0;
 }
 
 .single-handbook .o2-post {
-	border-top: none;
+  border-top: none;
 }
 
 .single-handbook .devhub-wrap main h2 {
-	margin-top: 4rem;
-	padding-top: 4rem;
-	border-top: 1px solid #aaa;
+  margin-top: 4rem;
+  padding-top: 4rem;
+  border-top: 1px solid #AAA;
 }
 
 .single-handbook .devhub-wrap main h3 {
-	margin-top: 4rem;
-	padding-top: 4rem;
-	border-top: 1px solid #ccc;
+  margin-top: 4rem;
+  padding-top: 4rem;
+  border-top: 1px solid #CCC;
 }
 
 .single-handbook .handbook-name-container + #primary {
-	padding-top: 5rem;
+  padding-top: 5rem;
 }
 
 .post-type-archive-handbook .handbook-name a:not(:hover),
 .single-handbook .handbook-name a:not(:hover) {
-	color: inherit;
+  color: inherit;
 }
 
 .handbook-name-container {
-	position: absolute;
-	right: 0;
-	width: 75%;
-	margin-left: 25%;
-	background-color: #fff;
+  position: absolute;
+  right: 0;
+  width: 75%;
+  margin-left: 25%;
+  background-color: #fff;
 }
 
 /** Table of Contents */
 .site-main .table-of-contents {
-	float: right;
-	width: 250px;
-	border: 1px solid #eee;
-	margin: 0 0 15px 15px;
-	z-index: 1;
-	position: relative;
-	color: #555d66;
-	background-color: #fff;
-	box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
-	border-radius: 3px;
+  float: right;
+  width: 250px;
+  border: 1px solid #eee;
+  margin: 0 0 15px 15px;
+  z-index: 1;
+  position: relative;
+  color: #555d66;
+  background-color: #fff;
+  box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
+  border-radius: 3px;
 }
 
 @media (min-width: 971px) {
-	.site-main .table-of-contents {
-		margin: 0 -30px 15px 15px;
-	}
+  .site-main .table-of-contents {
+    margin: 0 -30px 15px 15px;
+  }
 }
 
 .site-main .table-of-contents h2 {
-	margin: 0;
-	padding: 0.7rem 1.2rem;
-	font-family: 'HelveticaNeue-Light', 'Helvetica Neue Light', 'Helvetica Neue',
-		Helvetica, Arial, sans-serif;
-	font-size: 1.3em;
-	color: #32373c;
-	text-transform: uppercase;
-	border-bottom: 1px solid #eee;
-	margin-bottom: 0;
+  margin: 0;
+  padding: 0.7rem 1.2rem;
+  font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 1.3em;
+  color: #32373c;
+  text-transform: uppercase;
+  border-bottom: 1px solid #eee;
+  margin-bottom: 0;
 }
 
 .post-type-archive-handbook ul.items,
 .single-handbook ul.items,
 .table-of-contents ul.items {
-	margin: 0;
-	list-style-type: none;
-	padding: 1.2rem;
+  margin: 0;
+  list-style-type: none;
+  padding: 1.2rem;
 }
 
 .post-type-archive-handbook ul.items li,
 .single-handbook ul.items li,
 .table-of-contents ul.items li {
-	padding: 4px;
+  padding: 4px;
 }
 
 .post-type-archive-handbook ul.items li a,
 .single-handbook ul.items li a,
 .table-of-contents ul.items li a {
-	text-decoration: none;
+  text-decoration: none;
 }
 
 .post-type-archive-handbook ul.items li a:hover,
 .single-handbook ul.items li a:hover,
 .table-of-contents ul.items li a:hover {
-	color: #0073aa;
-	text-decoration: underline;
+  color: #0073aa;
+  text-decoration: underline;
 }
 
 .post-type-archive-handbook ul.items li ul li,
@@ -2784,937 +2420,841 @@ aside[id^='nav_menu'] .widget-title {
 .single-handbook ul.items li ul li ul li,
 .table-of-contents ul.items li ul li,
 .table-of-contents ul.items li ul li ul li {
-	list-style-type: circle;
-	padding-bottom: 0;
+  list-style-type: circle;
+  padding-bottom: 0;
 }
 
 /* Highlight current heading and adjust scroll position for fixed toolbar */
 .toc-heading:target {
-	position: initial;
-	padding-top: 50px;
-	margin-top: -50px;
+  position: initial;
+  padding-top: 50px;
+  margin-top: -50px;
 }
 
 /* Remove negative margin because there is no jump link before these headlines */
 .entry-content h2.toc-heading:first-of-type:target,
 .entry-content h3.toc-heading:first-of-type:target,
 h2.toc-heading + h3.toc-heading:target {
-	margin-top: 0;
+  margin-top: 0;
 }
 
 .toc-heading:target:before {
-	content: '';
-	position: absolute;
-	left: -10px;
-	top: 50px;
-	border-left: 5px solid #0073aa;
-	height: 50%;
-	height: calc(100% - 50px);
+  content: '';
+  position: absolute;
+  left: -10px;
+  top: 50px;
+  border-left: 5px solid #0073aa;
+  height: 50%;
+  height: calc(100% - 50px);
 }
 
 .toc-jump {
-	position: relative;
-	height: 50px;
+  position: relative;
+  height: 50px;
 }
 
 .toc-jump:after {
-	content: '';
-	display: table;
-	clear: both;
+  content: '';
+  display: table;
+  clear: both;
 }
 
 .toc-jump a {
-	z-index: 1;
+  z-index: 1;
 }
 
 @media (max-width: 480px) {
-	.table-of-contents {
-		display: none;
-	}
+  .table-of-contents {
+    display: none;
+  }
 }
 
 /** Menu */
 #secondary aside.widget_wporg_handbook_pages,
 #secondary aside.widget_nav_menu {
-	font-size: 16px;
-	height: 100%;
-	overflow-y: auto;
+  font-size: 16px;
+  height: 100%;
+  overflow-y: auto;
 }
 
 .widget_wporg_handbook_pages h1,
 .widget_nav_menu h1 {
-	font-size: 1.6em;
-	font-weight: bold;
-	margin-bottom: 0.6em;
+  font-size: 1.6em;
+  font-weight: bold;
+  margin-bottom: 0.6em;
 }
 
-div[class*='-table-of-contents-container'] {
-	font-size: 0.8em;
+div[class*="-table-of-contents-container"] {
+  font-size: 0.8em;
 }
 
-div[class*='-table-of-contents-container'] *:focus {
-	outline: 0;
+div[class*="-table-of-contents-container"] *:focus {
+  outline: 0;
 }
 
-div[class*='-table-of-contents-container'] ul {
-	margin-left: 0;
-	padding-left: 0;
-	list-style: none;
+div[class*="-table-of-contents-container"] ul {
+  margin-left: 0;
+  padding-left: 0;
+  list-style: none;
 }
 
-div[class*='-table-of-contents-container'] ul li .expandable {
-	display: flex;
-	flex-direction: row-reverse;
-	align-items: stretch;
-	position: relative;
+div[class*="-table-of-contents-container"] ul li .expandable {
+  display: flex;
+  flex-direction: row-reverse;
+  align-items: stretch;
+  position: relative;
 }
 
-div[class*='-table-of-contents-container'] ul li .dashicons {
-	position: absolute;
-	right: 0;
-	cursor: pointer;
-	padding: 8px 4px;
-	display: inline-block;
-	font-size: 20px;
-	width: auto;
-	height: 100%;
-	color: #0073aa;
-	background-color: #fafafa;
-	border: 0;
-	border-left: 1px solid rgba(0, 0, 0, 0.05);
-	border-radius: 0;
-	box-shadow: none;
-	-webkit-appearance: none;
+div[class*="-table-of-contents-container"] ul li .dashicons {
+  position: absolute;
+  right: 0;
+  cursor: pointer;
+  padding: 8px 4px;
+  display: inline-block;
+  font-size: 20px;
+  width: auto;
+  height: 100%;
+  color: #0073aa;
+  background-color: #fafafa;
+  border: 0;
+  border-left: 1px solid rgba(0, 0, 0, 0.05);
+  border-radius: 0;
+  box-shadow: none;
+  -webkit-appearance: none;
 }
 
-div[class*='-table-of-contents-container'] ul li .dashicons:hover,
-div[class*='-table-of-contents-container'] ul li .dashicons:focus {
-	color: #fff;
-	background-color: #0073aa;
+div[class*="-table-of-contents-container"] ul li .dashicons:hover,
+div[class*="-table-of-contents-container"] ul li .dashicons:focus {
+  color: #fff;
+  background-color: #0073aa;
 }
 
-div[class*='-table-of-contents-container'] ul li.open > div > .dashicons {
-	transform: rotate(180deg);
-	border-right: 1px solid rgba(0, 0, 0, 0.05);
-	border-left: none;
+div[class*="-table-of-contents-container"] ul li.open > div > .dashicons {
+  transform: rotate(180deg);
+  border-right: 1px solid rgba(0, 0, 0, 0.05);
+  border-left: none;
 }
 
-div[class*='-table-of-contents-container']
-	ul
-	li.menu-item-has-children
-	> .expandable
-	> a {
-	padding-right: 30px;
+div[class*="-table-of-contents-container"] ul li.menu-item-has-children > .expandable > a {
+  padding-right: 30px;
 }
 
-div[class*='-table-of-contents-container'] ul a {
-	display: block;
-	width: 100%;
-	font-size: 1.05em;
-	padding: 8px 8px 8px 13px;
-	text-decoration: none;
+div[class*="-table-of-contents-container"] ul a {
+  display: block;
+  width: 100%;
+  font-size: 1.05em;
+  padding: 8px 8px 8px 13px;
+  text-decoration: none;
 }
 
-div[class*='-table-of-contents-container'] ul a:hover,
-div[class*='-table-of-contents-container'] ul a:focus {
-	color: #fff;
-	background-color: #0073aa;
+div[class*="-table-of-contents-container"] ul a:hover, div[class*="-table-of-contents-container"] ul a:focus {
+  color: #fff;
+  background-color: #0073aa;
 }
 
-div[class*='-table-of-contents-container'] ul a.active {
-	color: #555;
-	background-color: #fff;
-	font-weight: bold;
+div[class*="-table-of-contents-container"] ul a.active {
+  color: #555;
+  background-color: #fff;
+  font-weight: bold;
 }
 
-div[class*='-table-of-contents-container'] ul.default-open {
-	display: block !important;
+div[class*="-table-of-contents-container"] ul.default-open {
+  display: block !important;
 }
 
-div[class*='-table-of-contents-container']
-	> ul
-	> li.open
-	> div
-	> a:not(:focus) {
-	color: #0073aa;
+div[class*="-table-of-contents-container"] > ul > li.open > div > a:not(:focus) {
+  color: #0073aa;
 }
 
-div[class*='-table-of-contents-container'] > ul > li.open > div > a:hover {
-	color: #fff;
-	background-color: #0073aa;
+div[class*="-table-of-contents-container"] > ul > li.open > div > a:hover {
+  color: #fff;
+  background-color: #0073aa;
 }
 
-div[class*='-table-of-contents-container'] .current-menu-item ul,
-div[class*='-table-of-contents-container'] .current-menu-ancestor ul {
-	display: block;
+div[class*="-table-of-contents-container"] .current-menu-item ul,
+div[class*="-table-of-contents-container"] .current-menu-ancestor ul {
+  display: block;
 }
 
-div[class*='-table-of-contents-container']
-	.current-menu-ancestor:not(.open)
-	.expandable
-	.dashicons:not(:focus),
-div[class*='-table-of-contents-container']
-	.current-menu-item
-	> .expandable
-	.dashicons:not(:focus) {
-	background: #fff;
-	color: #0073aa;
+div[class*="-table-of-contents-container"] .current-menu-ancestor:not(.open) .expandable .dashicons:not(:focus),
+div[class*="-table-of-contents-container"] .current-menu-item > .expandable .dashicons:not(:focus) {
+  background: #fff;
+  color: #0073aa;
 }
 
-div[class*='-table-of-contents-container']
-	.current-menu-ancestor
-	.expandable
-	.dashicons:hover,
-div[class*='-table-of-contents-container']
-	.current-menu-item
-	.expandable
-	.dashicons:hover {
-	background-color: #0073aa !important;
-	color: #fff !important;
+div[class*="-table-of-contents-container"] .current-menu-ancestor .expandable .dashicons:hover,
+div[class*="-table-of-contents-container"] .current-menu-item .expandable .dashicons:hover {
+  background-color: #0073aa !important;
+  color: #fff !important;
 }
 
-div[class*='-table-of-contents-container'] .children,
-div[class*='-table-of-contents-container'] .sub-menu {
-	overflow: hidden;
-	display: none;
+div[class*="-table-of-contents-container"] .children,
+div[class*="-table-of-contents-container"] .sub-menu {
+  overflow: hidden;
+  display: none;
 }
 
-#secondary div[class*='-table-of-contents-container'] ul li {
-	padding: 1px 0;
-	position: relative;
+#secondary div[class*="-table-of-contents-container"] ul li {
+  padding: 1px 0;
+  position: relative;
 }
 
-#secondary div[class*='-table-of-contents-container'] ul ul {
-	margin-left: 12px;
-	border-left: 2px solid #21759b;
+#secondary div[class*="-table-of-contents-container"] ul ul {
+  margin-left: 12px;
+  border-left: 2px solid #21759b;
 }
 
 /* New handbook design */
 .single-handbook #page {
-	background: linear-gradient(to right, #fafafa 35%, #fff 35%);
-	max-width: 100%;
-	padding: 0;
-	overflow: auto;
+  background: linear-gradient(to right, #fafafa 35%, #fff 35%);
+  max-width: 100%;
+  padding: 0;
+  overflow: auto;
 }
 
 .single-handbook #content {
-	max-width: 960px;
-	margin: 0 auto;
-	display: flex;
-	padding-top: 0;
+  max-width: 960px;
+  margin: 0 auto;
+  display: flex;
+  padding-top: 0;
 }
 
 .single-handbook header {
-	margin: 0;
+  margin: 0;
 }
 
 .single-handbook #secondary {
-	clear: left;
-	margin: 0;
-	background: #fafafa;
-	overflow: hidden;
-	width: 25%;
-	padding-top: 2rem;
+  clear: left;
+  margin: 0;
+  background: #fafafa;
+  overflow: hidden;
+  width: 25%;
+  padding-top: 2rem;
 }
 
 .single-handbook #primary {
-	padding: 4rem 0 4rem 4rem;
-	background: #fff;
-	box-sizing: border-box;
-	width: 72%;
+  padding: 4rem 0 4rem 4rem;
+  background: #fff;
+  box-sizing: border-box;
+  width: 72%;
 }
 
 @media (max-width: 876px) {
-	.single-handbook #primary {
-		padding: 4rem 20px;
-		width: 100%;
-	}
+  .single-handbook #primary {
+    padding: 4rem 20px;
+    width: 100%;
+  }
 }
 
-.single-handbook .widget_wporg_handbook_pages .widget_nav_menu {
-	background-color: transparent;
+.single-handbook .widget_wporg_handbook_pages
+.widget_nav_menu {
+  background-color: transparent;
 }
 
 .single-handbook nav.o2-post-actions button {
-	top: 10px;
+  top: 10px;
 }
 
 .single-handbook .make-welcome {
-	margin: 0 !important;
+  margin: 0 !important;
 }
 
 /** /Handbook **/
 .rest-api-handbook-reference .table-of-contents {
-	float: none;
-	overflow: hidden;
-	width: 100%;
-	margin: 0 auto 1em;
-	clear: both;
+  float: none;
+  overflow: hidden;
+  width: 100%;
+  margin: 0 auto 1em;
+  clear: both;
 }
 
 .rest-api-handbook-reference .table-of-contents ul.items li ul li {
-	display: inline;
+  display: inline;
 }
 
 .rest-api-handbook-reference .table-of-contents ul.items li ul li::after {
-	content: '; ';
+  content: '; ';
 }
 
-.rest-api-handbook-reference
-	.table-of-contents
-	ul.items
-	li
-	ul
-	li:last-child::after {
-	content: '';
+.rest-api-handbook-reference .table-of-contents ul.items li ul li:last-child::after {
+  content: '';
 }
 
 /* Menu toggle */
 #secondary-toggle {
-	display: none;
+  display: none;
 }
 
 body.responsive-show {
-	position: fixed;
-	top: 32px;
+  position: fixed;
+  top: 32px;
 }
 
 body.responsive-show #secondary {
-	left: 0;
-	overflow-y: scroll;
+  left: 0;
+  overflow-y: scroll;
 }
 
 body.responsive-show #secondary .search-section {
-	margin-top: 32px;
-	width: 100%;
+  margin-top: 32px;
+  width: 100%;
 }
 
 body.responsive-show #secondary-toggle {
-	height: 32px;
-	margin-left: 8px;
-	width: 100%;
+  height: 32px;
+  margin-left: 8px;
+  width: 100%;
 }
 
 body.responsive-show #primary-modal {
-	display: block;
+  display: block;
 }
 
 body.responsive-show #o2-expand-editor {
-	display: none;
+  display: none;
 }
 
 @media only screen and (max-width: 782px) {
-	#secondary {
-		top: 46px;
-	}
-	body.responsive-show {
-		position: fixed;
-		top: 46px;
-		left: 0;
-		right: 0;
-		bottom: 0;
-	}
-	body.responsive-show #secondary {
-		left: 0;
-	}
+  #secondary {
+    top: 46px;
+  }
+  body.responsive-show {
+    position: fixed;
+    top: 46px;
+    left: 0;
+    right: 0;
+    bottom: 0;
+  }
+  body.responsive-show #secondary {
+    left: 0;
+  }
 }
 
 @media only screen and (max-width: 480px) {
-	body.responsive-show #secondary {
-		top: 46px;
-	}
-	body.responsive-show #wpadminbar {
-		top: -46px;
-	}
+  body.responsive-show #secondary {
+    top: 46px;
+  }
+  body.responsive-show #wpadminbar {
+    top: -46px;
+  }
 }
 
 @media (max-width: 876px) {
-	#secondary {
-		position: fixed;
-		z-index: 10;
-		bottom: 0px;
-		overflow-y: auto;
-		transition: all 0.25s ease;
-		top: 32px;
-		left: -100%;
-		width: 60%;
-		min-width: 300px;
-		box-shadow: 0 0 20px rgba(0, 0, 0, 0.2);
-	}
-	#secondary-toggle {
-		display: block;
-		float: left;
-		margin-left: 17px;
-		margin-right: 0;
-		width: 48px;
-		height: 48px;
-		white-space: nowrap;
-		position: relative;
-		z-index: 1;
-	}
-	#secondary-toggle:before {
-		content: '\f333';
-		-webkit-font-smoothing: antialiased;
-		font: normal 32px/1 'dashicons';
-		position: relative;
-		top: 0;
-		color: #fff;
-	}
-	#secondary-toggle strong {
-		display: none;
-	}
-	#page {
-		overflow-x: hidden;
-	}
-	body.responsive-show {
-		overflow-y: visible;
-		position: static;
-	}
-	body.responsive-show #page {
-		overflow-x: visible;
-	}
-	body.responsive-show #secondary-toggle:before {
-		color: #0073aa;
-	}
-	.content-area {
-		width: 100%;
-	}
-	#primary,
-	#secondary {
-		-webkit-backface-visibility: hidden;
-	}
+  #secondary {
+    position: fixed;
+    z-index: 10;
+    bottom: 0px;
+    overflow-y: auto;
+    transition: all .25s ease;
+    top: 32px;
+    left: -100%;
+    width: 60%;
+    min-width: 300px;
+    box-shadow: 0 0 20px rgba(0, 0, 0, 0.2);
+  }
+  #secondary-toggle {
+    display: block;
+    float: left;
+    margin-left: 17px;
+    margin-right: 0;
+    width: 48px;
+    height: 48px;
+    white-space: nowrap;
+    position: relative;
+    z-index: 1;
+  }
+  #secondary-toggle:before {
+    content: '\f333';
+    -webkit-font-smoothing: antialiased;
+    font: normal 32px/1 'dashicons';
+    position: relative;
+    top: 0;
+    color: #fff;
+  }
+  #secondary-toggle strong {
+    display: none;
+  }
+  #page {
+    overflow-x: hidden;
+  }
+  body.responsive-show {
+    overflow-y: visible;
+    position: static;
+  }
+  body.responsive-show #page {
+    overflow-x: visible;
+  }
+  body.responsive-show #secondary-toggle:before {
+    color: #0073aa;
+  }
+  .content-area {
+    width: 100%;
+  }
+  #primary,
+  #secondary {
+    -webkit-backface-visibility: hidden;
+  }
 }
 
 @media (max-width: 59.999999em) {
-	.devhub-wrap {
-		max-width: 100%;
-		width: 100%;
-	}
-	.devhub-wrap #content,
-	.devhub-wrap #content-area,
-	.devhub-wrap .inner-wrap {
-		max-width: 100%;
-		padding: 0 13px;
-	}
-	.devhub-wrap #content-area .has-sidebar,
-	.devhub-wrap .inner-wrap .has-sidebar {
-		width: 100%;
-	}
-	.devhub-wrap #content-area {
-		padding-left: 2%;
-	}
-	.devhub-wrap.archive .meta,
-	.devhub-wrap.search .meta {
-		font-size: 100%;
-		margin-bottom: 1.5em;
-	}
-	.devhub-wrap.archive .meta a,
-	.devhub-wrap.search .meta a {
-		color: #21759b;
-	}
+  .devhub-wrap {
+    max-width: 100%;
+    width: 100%;
+  }
+  .devhub-wrap #content,
+  .devhub-wrap #content-area,
+  .devhub-wrap .inner-wrap {
+    max-width: 100%;
+    padding: 0 13px;
+  }
+  .devhub-wrap #content-area .has-sidebar,
+  .devhub-wrap .inner-wrap .has-sidebar {
+    width: 100%;
+  }
+  .devhub-wrap #content-area {
+    padding-left: 2%;
+  }
+  .devhub-wrap.archive .meta, .devhub-wrap.search .meta {
+    font-size: 100%;
+    margin-bottom: 1.5em;
+  }
+  .devhub-wrap.archive .meta a, .devhub-wrap.search .meta a {
+    color: #21759b;
+  }
 }
 
 @media (min-width: 43em) {
-	.devhub-wrap.archive .meta,
-	.devhub-wrap.search .meta {
-		float: right;
-	}
-	.devhub-wrap.archive .sourcefile,
-	.devhub-wrap.search .sourcefile {
-		float: left;
-	}
+  .devhub-wrap.archive .meta, .devhub-wrap.search .meta {
+    float: right;
+  }
+  .devhub-wrap.archive .sourcefile, .devhub-wrap.search .sourcefile {
+    float: left;
+  }
 }
 
 @media (min-width: 43em) and (max-width: 43em) {
-	.devhub-wrap #content-area {
-		padding-left: 2%;
-	}
+  .devhub-wrap #content-area {
+    padding-left: 2%;
+  }
 }
 
 @media (max-width: 43em) {
-	#content-area.has-sidebar main {
-		float: right;
-		width: 96%;
-		margin: 0 auto;
-		clear: both;
-		padding: 0 12px;
-		padding: 0 1.2rem;
-	}
-	#content-area.has-sidebar .widget-area {
-		float: none;
-		overflow: hidden;
-		width: 80%;
-		margin: 0 auto;
-		clear: both;
-	}
-	#content-area.has-sidebar .widget-area .widget {
-		width: 100%;
-	}
-	.devhub-wrap .three-columns .box,
-	.devhub-wrap .section .box,
-	.devhub-wrap .home-primary-content,
-	.devhub-wrap .reference-landing .section {
-		float: none;
-		width: 100%;
-		padding: 1.5em 2%;
-		clear: both;
-		text-align: center;
-		display: block;
-	}
-	.devhub-wrap .reference-landing .section .box,
-	.devhub-wrap .sidebar .box {
-		padding: 0;
-		margin-bottom: 1.5em;
-	}
-	.devhub-wrap .home-primary-content .entry-content,
-	.devhub-wrap .reference-landing .section {
-		text-align: left;
-	}
-	.devhub-wrap .horizontal-list li {
-		display: block;
-	}
-	.devhub-wrap .horizontal-list li a {
-		border-left: none;
-	}
-	.devhub-wrap .horizontal-list li:first-child a {
-		padding: 0 40px;
-		padding: 0 4rem;
-	}
-	.devhub-wrap .reference-landing .searchform {
-		text-alignment: center;
-	}
-	.devhub-wrap .reference-landing .searchform input[type='text'],
-	.devhub-wrap .reference-landing .searchform input[type='submit'] {
-		width: 100%;
-		margin-right: 0;
-		margin-bottom: 1em;
-		float: none;
-		clear: both;
-	}
-	.devhub-wrap .wp-parser-class h1,
-	.devhub-wrap .wp-parser-function h1,
-	.devhub-wrap .wp-parser-hook h1,
-	.devhub-wrap .wp-parser-method h1 {
-		padding-left: 45px;
-		text-indent: -45px;
-	}
-	.devhub-wrap .two-columns .box {
-		width: 99%;
-	}
+  #content-area.has-sidebar main {
+    float: right;
+    width: 96%;
+    margin: 0 auto;
+    clear: both;
+    padding: 0 12px;
+    padding: 0 1.2rem;
+  }
+  #content-area.has-sidebar .widget-area {
+    float: none;
+    overflow: hidden;
+    width: 80%;
+    margin: 0 auto;
+    clear: both;
+  }
+  #content-area.has-sidebar .widget-area .widget {
+    width: 100%;
+  }
+  .devhub-wrap .three-columns .box,
+  .devhub-wrap .section .box,
+  .devhub-wrap .home-primary-content,
+  .devhub-wrap .reference-landing .section {
+    float: none;
+    width: 100%;
+    padding: 1.5em 2%;
+    clear: both;
+    text-align: center;
+    display: block;
+  }
+  .devhub-wrap .reference-landing .section .box,
+  .devhub-wrap .sidebar .box {
+    padding: 0;
+    margin-bottom: 1.5em;
+  }
+  .devhub-wrap .home-primary-content .entry-content,
+  .devhub-wrap .reference-landing .section {
+    text-align: left;
+  }
+  .devhub-wrap .horizontal-list li {
+    display: block;
+  }
+  .devhub-wrap .horizontal-list li a {
+    border-left: none;
+  }
+  .devhub-wrap .horizontal-list li:first-child a {
+    padding: 0 40px;
+    padding: 0 4rem;
+  }
+  .devhub-wrap .reference-landing .searchform {
+    text-alignment: center;
+  }
+  .devhub-wrap .reference-landing .searchform input[type="text"],
+  .devhub-wrap .reference-landing .searchform input[type="submit"] {
+    width: 100%;
+    margin-right: 0;
+    margin-bottom: 1em;
+    float: none;
+    clear: both;
+  }
+  .devhub-wrap .wp-parser-class h1, .devhub-wrap .wp-parser-function h1, .devhub-wrap .wp-parser-hook h1, .devhub-wrap .wp-parser-method h1 {
+    padding-left: 45px;
+    text-indent: -45px;
+  }
+  .devhub-wrap .two-columns .box {
+    width: 99%;
+  }
 }
 
 @media (max-width: 32em) {
-	.devhub-wrap .table-of-contents {
-		float: none;
-		margin-left: 0;
-		width: 100%;
-	}
-	.devhub-wrap section {
-		overflow: inherit;
-	}
-	.devhub-wrap hr {
-		clear: both;
-	}
+  .devhub-wrap .table-of-contents {
+    float: none;
+    margin-left: 0;
+    width: 100%;
+  }
+  .devhub-wrap section {
+    overflow: inherit;
+  }
+  .devhub-wrap hr {
+    clear: both;
+  }
 }
 
 @media (max-width: 22em) {
-	ul,
-	ol {
-		margin-left: 1.2em;
-	}
-	.devhub-wrap .wp-parser-class h1,
-	.devhub-wrap .wp-parser-function h1,
-	.devhub-wrap .wp-parser-hook h1,
-	.devhub-wrap .wp-parser-method h1 {
-		padding-left: 20px;
-		line-height: 2rem;
-		text-indent: -20px;
-		font-size: 16px;
-	}
-	.devhub-wrap.single-wp-parser-function .comment-list li,
-	.devhub-wrap.single-wp-parser-method .comment-list li,
-	.devhub-wrap.single-wp-parser-hook .comment-list li {
-		padding-left: 0;
-		padding-right: 0;
-	}
-	.devhub-wrap.single-wp-parser-function .comment-list .avatar,
-	.devhub-wrap.single-wp-parser-method .comment-list .avatar,
-	.devhub-wrap.single-wp-parser-hook .comment-list .avatar {
-		margin: 0 1em 0 0;
-	}
-	.devhub-wrap .source-code-links {
-		margin-left: 0;
-	}
-	.devhub-wrap .source-code-links span:first-child {
-		margin-left: 0;
-	}
+  ul, ol {
+    margin-left: 1.2em;
+  }
+  .devhub-wrap .wp-parser-class h1, .devhub-wrap .wp-parser-function h1, .devhub-wrap .wp-parser-hook h1, .devhub-wrap .wp-parser-method h1 {
+    padding-left: 20px;
+    line-height: 2rem;
+    text-indent: -20px;
+    font-size: 16px;
+  }
+  .devhub-wrap.single-wp-parser-function .comment-list li, .devhub-wrap.single-wp-parser-method .comment-list li, .devhub-wrap.single-wp-parser-hook .comment-list li {
+    padding-left: 0;
+    padding-right: 0;
+  }
+  .devhub-wrap.single-wp-parser-function .comment-list .avatar, .devhub-wrap.single-wp-parser-method .comment-list .avatar, .devhub-wrap.single-wp-parser-hook .comment-list .avatar {
+    margin: 0 1em 0 0;
+  }
+  .devhub-wrap .source-code-links {
+    margin-left: 0;
+  }
+  .devhub-wrap .source-code-links span:first-child {
+    margin-left: 0;
+  }
 }
 
-.single-command #content h2,
-.single-command #content h3 {
-	margin-top: 4rem;
-	margin-bottom: 2.5rem;
-	font-size: 2.5rem;
+.single-command #content h2, .single-command #content h3 {
+  margin-top: 4rem;
+  margin-bottom: 2.5rem;
+  font-size: 2.5rem;
 }
 
 .single-command #content h2.entry-title {
-	padding: 0;
-	font-size: 3.5rem;
-	line-height: 4.5rem;
-	margin-top: 3rem;
-	margin-bottom: 1rem;
-	font-family: Monaco, Consolas, 'Andale Mono', 'DejaVu Sans Mono', monospace;
+  padding: 0;
+  font-size: 3.5rem;
+  line-height: 4.5rem;
+  margin-top: 3rem;
+  margin-bottom: 1rem;
+  font-family: Monaco, Consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
 }
 
 .single-command #content h2.entry-title a {
-	color: #000;
+  color: #000;
 }
 
 .single-command #content h2.entry-title a span {
-	color: #949494;
+  color: #949494;
 }
 
 .single-command #content .entry-content {
-	margin-top: 2rem;
+  margin-top: 2rem;
 }
 
 .single-command #content .excerpt {
-	margin-bottom: 1.3rem;
+  margin-bottom: 1.3rem;
 }
 
 .single-command #content .quick-links {
-	margin-left: 0.5rem;
-	color: #ababab;
+  margin-left: 0.5rem;
+  color: #ABABAB;
 }
 
 .single-command #content .quick-links a {
-	text-decoration: underline;
-	color: #ababab;
+  text-decoration: underline;
+  color: #ABABAB;
 }
 
 .single-command #content .quick-links a:hover {
-	color: #757575;
+  color: #757575;
 }
 
 .single-command #content .toc-jump {
-	float: right;
-	font-size: 75%;
-	margin-top: 11px;
+  float: right;
+  font-size: 75%;
+  margin-top: 11px;
 }
 
 .single-command #content table {
-	border-collapse: collapse;
-	border: 1px solid #eee;
-	padding: 0;
-	margin: 0 0 ms(0);
-	font-size: ms(-2);
-	width: 100%;
+  border-collapse: collapse;
+  border: 1px solid #eee;
+  padding: 0;
+  margin: 0 0 ms(0);
+  font-size: ms(-2);
+  width: 100%;
 }
 
 .single-command #content table thead {
-	background: #eee;
+  background: #eee;
 }
 
 .single-command #content table thead th {
-	font-weight: bold;
-	padding: 1em;
+  font-weight: bold;
+  padding: 1em;
 }
 
-.single-command #content table th,
-.single-command #content table td {
-	padding: 0.8em 1em;
-	margin: 0;
-	font-weight: normal;
-	text-align: left;
-	vertical-align: top;
-	border: 1px solid #eee;
+.single-command #content table th, .single-command #content table td {
+  padding: 0.8em 1em;
+  margin: 0;
+  font-weight: normal;
+  text-align: left;
+  vertical-align: top;
+  border: 1px solid #eee;
 }
 
 .single-command #content table tbody tr:nth-child(even) {
-	background: rgba(0, 0, 0, 0.025);
+  background: rgba(0, 0, 0, 0.025);
 }
 
-.single-command .devhub-wrap *,
-.single-command .devhub-wrap *::before,
-.single-command .devhub-wrap *::after {
-	-moz-box-sizing: border-box;
-	-webkit-box-sizing: border-box;
-	box-sizing: border-box;
+.single-command .devhub-wrap *, .single-command .devhub-wrap *::before, .single-command .devhub-wrap *::after {
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
 }
 
-.single-command .devhub-wrap a.button,
-.single-command .devhub-wrap button,
-.single-command .devhub-wrap input[type='button'],
-.single-command .devhub-wrap input[type='reset'],
-.single-command .devhub-wrap input[type='submit'] {
-	border: 1px solid;
-	border-color: #ccc;
-	border-radius: 3px;
-	background: #f7f7f7;
-	color: rgba(0, 0, 0, 0.8);
-	cursor: pointer;
-	font-size: 1.2rem;
-	line-height: 1;
-	float: none;
-	height: auto;
-	padding: 0.8rem 1.2rem;
-	margin: 0.4rem 0;
-	text-decoration: none;
-	-webkit-appearance: none;
+.single-command .devhub-wrap a.button, .single-command .devhub-wrap button, .single-command .devhub-wrap input[type="button"], .single-command .devhub-wrap input[type="reset"], .single-command .devhub-wrap input[type="submit"] {
+  border: 1px solid;
+  border-color: #ccc;
+  border-radius: 3px;
+  background: #f7f7f7;
+  color: rgba(0, 0, 0, 0.8);
+  cursor: pointer;
+  font-size: 1.2rem;
+  line-height: 1;
+  float: none;
+  height: auto;
+  padding: .8rem 1.2rem;
+  margin: .4rem 0;
+  text-decoration: none;
+  -webkit-appearance: none;
 }
 
-.single-command .devhub-wrap a.button:hover,
-.single-command .devhub-wrap button:hover,
-.single-command .devhub-wrap input[type='button']:hover,
-.single-command .devhub-wrap input[type='reset']:hover,
-.single-command .devhub-wrap input[type='submit']:hover {
-	border-color: #ccc #bbb #aaa #bbb;
-	background: #eee;
+.single-command .devhub-wrap a.button:hover, .single-command .devhub-wrap button:hover, .single-command .devhub-wrap input[type="button"]:hover, .single-command .devhub-wrap input[type="reset"]:hover, .single-command .devhub-wrap input[type="submit"]:hover {
+  border-color: #ccc #bbb #aaa #bbb;
+  background: #eee;
 }
 
-.single-command .devhub-wrap a.button:focus,
-.single-command .devhub-wrap a.button:active,
-.single-command .devhub-wrap button:focus,
-.single-command .devhub-wrap button:active,
-.single-command .devhub-wrap input[type='button']:focus,
-.single-command .devhub-wrap input[type='button']:active,
-.single-command .devhub-wrap input[type='reset']:focus,
-.single-command .devhub-wrap input[type='reset']:active,
-.single-command .devhub-wrap input[type='submit']:focus,
-.single-command .devhub-wrap input[type='submit']:active {
-	border-color: #bbb;
-	background: #eee;
-	-webkit-box-shadow: 0 0 4px rgba(0, 0, 0, 0.2);
-	box-shadow: 0 0 4px rgba(0, 0, 0, 0.2);
+.single-command .devhub-wrap a.button:focus, .single-command .devhub-wrap a.button:active, .single-command .devhub-wrap button:focus, .single-command .devhub-wrap button:active, .single-command .devhub-wrap input[type="button"]:focus, .single-command .devhub-wrap input[type="button"]:active, .single-command .devhub-wrap input[type="reset"]:focus, .single-command .devhub-wrap input[type="reset"]:active, .single-command .devhub-wrap input[type="submit"]:focus, .single-command .devhub-wrap input[type="submit"]:active {
+  border-color: #bbb;
+  background: #eee;
+  -webkit-box-shadow: 0 0 4px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.2);
 }
 
-.single-command .devhub-wrap a.button > span,
-.single-command .devhub-wrap button > span,
-.single-command .devhub-wrap input[type='button'] > span,
-.single-command .devhub-wrap input[type='reset'] > span,
-.single-command .devhub-wrap input[type='submit'] > span {
-	color: #757575;
+.single-command .devhub-wrap a.button > span, .single-command .devhub-wrap button > span, .single-command .devhub-wrap input[type="button"] > span, .single-command .devhub-wrap input[type="reset"] > span, .single-command .devhub-wrap input[type="submit"] > span {
+  color: #757575;
 }
 
-.single-command .devhub-wrap a.button > span.red,
-.single-command .devhub-wrap button > span.red,
-.single-command .devhub-wrap input[type='button'] > span.red,
-.single-command .devhub-wrap input[type='reset'] > span.red,
-.single-command .devhub-wrap input[type='submit'] > span.red {
-	color: #dc3232;
+.single-command .devhub-wrap a.button > span.red, .single-command .devhub-wrap button > span.red, .single-command .devhub-wrap input[type="button"] > span.red, .single-command .devhub-wrap input[type="reset"] > span.red, .single-command .devhub-wrap input[type="submit"] > span.red {
+  color: #dc3232;
 }
 
-.single-command .devhub-wrap a.button > span.green,
-.single-command .devhub-wrap button > span.green,
-.single-command .devhub-wrap input[type='button'] > span.green,
-.single-command .devhub-wrap input[type='reset'] > span.green,
-.single-command .devhub-wrap input[type='submit'] > span.green {
-	color: #46b450;
+.single-command .devhub-wrap a.button > span.green, .single-command .devhub-wrap button > span.green, .single-command .devhub-wrap input[type="button"] > span.green, .single-command .devhub-wrap input[type="reset"] > span.green, .single-command .devhub-wrap input[type="submit"] > span.green {
+  color: #46B450;
 }
 
 .single-command .btn-group {
-	display: inline;
+  display: inline;
 }
 
 .single-command .btn-group > a {
-	position: relative;
+  position: relative;
 }
 
 @media (min-width: 571px) {
-	.single-command .btn-group > a:first-child {
-		right: -6px;
-		border-radius: 3px 0 0 3px;
-	}
-	.single-command .btn-group > a:last-child {
-		border-radius: 0 3px 3px 0;
-	}
+  .single-command .btn-group > a:first-child {
+    right: -6px;
+    border-radius: 3px 0 0 3px;
+  }
+  .single-command .btn-group > a:last-child {
+    border-radius: 0 3px 3px 0;
+  }
 }
 
 .single-command .github-tracker {
-	margin-bottom: 2.5rem;
+  margin-bottom: 2.5rem;
 }
 
 .single-command .github-tracker img.icon-github {
-	width: 23px;
-	position: relative;
-	top: 6px;
-	margin-right: 5px;
-	cursor: pointer;
+  width: 23px;
+  position: relative;
+  top: 6px;
+  margin-right: 5px;
+  cursor: pointer;
 }
 
-code[class*='language-'],
-pre[class*='language-'] {
-	direction: ltr;
-	text-align: left;
-	white-space: pre;
-	word-spacing: normal;
-	word-break: normal;
-	-moz-tab-size: 4;
-	-o-tab-size: 4;
-	tab-size: 4;
-	-webkit-hyphens: none;
-	-moz-hyphens: none;
-	-ms-hyphens: none;
-	hyphens: none;
-	background: #2b303b;
-	color: #c0c5ce;
+code[class*="language-"], pre[class*="language-"] {
+  direction: ltr;
+  text-align: left;
+  white-space: pre;
+  word-spacing: normal;
+  word-break: normal;
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
+  tab-size: 4;
+  -webkit-hyphens: none;
+  -moz-hyphens: none;
+  -ms-hyphens: none;
+  hyphens: none;
+  background: #2b303b;
+  color: #c0c5ce;
 }
 
-pre[class*='language-']::-moz-selection,
-pre[class*='language-'] ::-moz-selection,
-code[class*='language-']::-moz-selection,
-code[class*='language-'] ::-moz-selection {
-	text-shadow: none;
-	background: #a7adba;
+pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection, code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
+  text-shadow: none;
+  background: #a7adba;
 }
 
-pre[class*='language-']::selection,
-pre[class*='language-'] ::selection,
-code[class*='language-']::selection,
-code[class*='language-'] ::selection {
-	text-shadow: none;
-	background: #a7adba;
+pre[class*="language-"]::selection, pre[class*="language-"] ::selection, code[class*="language-"]::selection, code[class*="language-"] ::selection {
+  text-shadow: none;
+  background: #a7adba;
 }
 
-pre[class*='language-'] {
-	overflow: auto;
+pre[class*="language-"] {
+  overflow: auto;
 }
 
-:not(pre) > code[class*='language-'] {
-	border-radius: 0.3em;
+:not(pre) > code[class*="language-"] {
+  border-radius: .3em;
 }
 
-.token.comment,
-.token.prolog,
-.token.doctype,
-.token.cdata {
-	color: #65737e;
+.token.comment, .token.prolog, .token.doctype, .token.cdata {
+  color: #65737e;
 }
 
 .token.punctuation {
-	color: #c0c5ce;
+  color: #c0c5ce;
 }
 
 .token.namespace {
-	opacity: 0.7;
+  opacity: .7;
 }
 
-.token.operator,
-.token.boolean,
-.token.number {
-	color: #d08770;
+.token.operator, .token.boolean, .token.number {
+  color: #d08770;
 }
 
 .token.property {
-	color: #ebcb8b;
+  color: #ebcb8b;
 }
 
 .token.tag {
-	color: #8fa1b3;
+  color: #8fa1b3;
 }
 
 .token.string {
-	color: #96b5b4;
+  color: #96b5b4;
 }
 
 .token.selector {
-	color: #b48ead;
+  color: #b48ead;
 }
 
 .token.attr-name {
-	color: #d08770;
+  color: #d08770;
 }
 
-.token.entity,
-.token.url,
-.language-css .token.string,
-.style .token.string {
-	color: #96b5b4;
+.token.entity, .token.url, .language-css .token.string, .style .token.string {
+  color: #96b5b4;
 }
 
-.token.attr-value,
-.token.keyword,
-.token.control,
-.token.directive,
-.token.unit {
-	color: #a3be8c;
+.token.attr-value, .token.keyword, .token.control, .token.directive, .token.unit {
+  color: #a3be8c;
 }
 
-.token.statement,
-.token.regex,
-.token.atrule {
-	color: #96b5b4;
+.token.statement, .token.regex, .token.atrule {
+  color: #96b5b4;
 }
 
-.token.placeholder,
-.token.variable {
-	color: #8fa1b3;
+.token.placeholder, .token.variable {
+  color: #8fa1b3;
 }
 
 .token.deleted {
-	text-decoration: line-through;
+  text-decoration: line-through;
 }
 
 .token.inserted {
-	border-bottom: 1px dotted #eff1f5;
-	text-decoration: none;
+  border-bottom: 1px dotted #eff1f5;
+  text-decoration: none;
 }
 
 .token.italic {
-	font-style: italic;
+  font-style: italic;
 }
 
-.token.important,
-.token.bold {
-	font-weight: bold;
+.token.important, .token.bold {
+  font-weight: bold;
 }
 
 .token.important {
-	color: #bf616a;
+  color: #bf616a;
 }
 
 .token.entity {
-	cursor: help;
+  cursor: help;
 }
 
 pre > code.highlight {
-	outline: 0.4em solid #bf616a;
-	outline-offset: 0.4em;
+  outline: 0.4em solid #bf616a;
+  outline-offset: .4em;
 }
 
 button.code-tab,
 button.code-tab:hover {
-	background: #fff;
-	border: none;
-	box-shadow: none;
-	text-shadow: none;
-	border: 1px solid #d0dfda;
-	border-radius: 30px 0 0 30px;
-	padding: 8px 20px;
+  background: #fff;
+  border: none;
+  box-shadow: none;
+  text-shadow: none;
+  border: 1px solid #D0DFDA;
+  border-radius: 30px 0 0 30px;
+  padding: 8px 20px;
 }
 
 button.code-tab + button.code-tab {
-	border-radius: 0 30px 30px 0;
+  border-radius: 0 30px 30px 0;
 }
 
 button.code-tab:focus,
 button.code-tab.is-active:focus {
-	outline: none;
-	border: 1px solid #222;
-	box-shadow: none;
+  outline: none;
+  border: 1px solid #222;
+  box-shadow: none;
 }
 
 button.code-tab.is-active {
-	background: #00b975;
-	border: 1px solid #00b975;
-	box-shadow: none;
-	color: #fff;
+  background: #00B975;
+  border: 1px solid #00B975;
+  box-shadow: none;
+  color: #fff;
 }
 
 .code-tab-block {
-	display: none;
+  display: none;
 }
 
 .code-tab-block.is-active {
-	display: block;
+  display: block;
 }


### PR DESCRIPTION
Increases the default font size from 13px up to a more accessible 16px.

Adds some spacing and slight borders around heading to delineate sections and make the text more readable.

Removes the back to top link that clutters documentation, particularly the API docs with numerous headings in a list. This makes it easier to read.

## Testing

I tested the style changes by adding the following CSS to the [Stylus browser plugin](https://chrome.google.com/webstore/detail/stylus/clngdbkpkpeebahjckkjfobafhncgmne) applied to developer.wordpress.org sites and then browsed the different handbooks.

```css
.single-handbook .devhub-wrap main h2 {
    margin-top: 4rem;
    padding-top: 4rem;
    border-top: 1px solid #AAA;
}

.single-handbook .devhub-wrap main h3 {
    margin-top: 4rem;
    padding-top: 4rem;
    border-top: 1px solid #CCC;
}

.single-handbook {
    font-size: 16px;
}

.single-handbook .site-main p,
.single-handbook .site-main ol,
.single-handbook .site-main ul {
    font-size: 16px;
}

.single-handbook .site-main li {
  margin-bottom: 2.0rem;
}

```

## Help

~~I might of messed up the main.scss file with an auto formatter.~~
~~How is that generated? Is there a build process?~~

I used the Grunt command. 👍 


