### PR TITLE
correction of icon code for 'dashicons-align-full-width'

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-developer/inc/dashicons.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-developer/inc/dashicons.php
@@ -490,7 +490,7 @@ class Devhub_Dashicons {
 				'label' => __( 'Block Editor', 'wporg' ),
 				'icons' => [
 					'dashicons-align-full-width' => [
-						'code'     => 'f134',
+						'code'     => 'f114',
 						'label'    => 'align full width',
 						'keywords' => 'align full width block',
 					],


### PR DESCRIPTION
Hi, 

this is correction for icon code that is visible on public page for this icon and it's wrong.. 

<img src="https://i.imgur.com/BdxNF87.png"/>

https://meta.trac.wordpress.org/ticket/5959