### PR TITLE
Update Commercial Page Description

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-themes/page-commercial.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-themes/page-commercial.php
@@ -38,6 +38,17 @@ if ( have_posts() ) :
 					<?php _e( 'Some of them you may pay to access, some of them are membership sites, some may give you the theme for zero-cost and just charge for support.', 'wporg-themes' ); ?>
 					<?php _e( 'What they all have in common is people behind them who support open source, WordPress, and its GPL license.', 'wporg-themes' ); ?>
 				</p>
+				
+				<p><?php _e( 'If you would like to be included in this list please send your info to themes at wordpress dot org. To be included, you should:', 'wporg-themes' ); ?></p>
+
+				<ul>
+					<li><?php _e( 'Distribute 100% GPL themes, including artwork and CSS.', 'wporg-themes' ); ?></li>
+					<li><?php printf( __( 'Have at least one theme in the WordPress.org <a href="%s">Theme Directory</a> that is actively maintained (i.e. updated within the last year).', 'wporg-themes' ), home_url( '/' ) ); ?></li>
+					<li><?php _e( 'Have professional support options, and optionally customization.', 'wporg-themes' ); ?></li>
+					<li><?php _e( 'Your site should be complete, well-designed, up to date, and professional looking.', 'wporg-themes' ); ?></li>
+					<li><?php _e( 'Provide and keep us up-to-date with a contact email address in the event we need to reach you.', 'wporg-themes' ); ?></li>
+					<li><?php printf( __( 'Provide a <a href="%s">haiku</a> (5-7-5) about yourself to be included.', 'wporg-themes' ), __( 'https://en.wikipedia.org/wiki/Haiku_in_English', 'wporg-themes' ) ); ?></li>
+				</ul>
 
 				<h2 class="screen-reader-text"><?php _e( 'Themes List', 'wporg-themes' ); ?></h2>
 
@@ -60,17 +71,6 @@ if ( have_posts() ) :
 						</div>
 					</div>
 				</div>
-
-				<p><?php _e( 'If you would like to be included in this list please send your info to themes at wordpress dot org. To be included, you should:', 'wporg-themes' ); ?></p>
-
-				<ul>
-					<li><?php _e( 'Distribute 100% GPL themes, including artwork and CSS.', 'wporg-themes' ); ?></li>
-					<li><?php printf( __( 'Have at least one theme in the WordPress.org <a href="%s">Theme Directory</a> that is actively maintained (i.e. updated within the last year).', 'wporg-themes' ), home_url( '/' ) ); ?></li>
-					<li><?php _e( 'Have professional support options, and optionally customization.', 'wporg-themes' ); ?></li>
-					<li><?php _e( 'Your site should be complete, well-designed, up to date, and professional looking.', 'wporg-themes' ); ?></li>
-					<li><?php _e( 'Provide and keep us up-to-date with a contact email address in the event we need to reach you.', 'wporg-themes' ); ?></li>
-					<li><?php printf( __( 'Provide a <a href="%s">haiku</a> (5-7-5) about yourself to be included.', 'wporg-themes' ), __( 'https://en.wikipedia.org/wiki/Haiku_in_English', 'wporg-themes' ) ); ?></li>
-				</ul>
 
 			</div><!-- .entry-content -->
 


### PR DESCRIPTION
While I was checking the terms of the commercial themes page, I was not able to figure it out at first.  I had to scroll the whole page to find it.

I think, it's better to move the description to the top of the page and it will be easy to access.

https://meta.trac.wordpress.org/ticket/5977