### PR TITLE
HelpHub: Fix the regex to help the table of content plugin to work with headings attributes.

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/support-helphub/inc/table-of-contents-lite/includes/class-table-of-contents-lite.php
+++ b/wordpress.org/public_html/wp-content/plugins/support-helphub/inc/table-of-contents-lite/includes/class-table-of-contents-lite.php
@@ -274,7 +274,7 @@ class Table_Of_Contents_Lite {
 		if ( empty( $content ) ) {
 			$content = get_the_content();
 		}
-		preg_match_all( "/(<{$tag}>)(.*)(<\/{$tag}>)/", $content, $matches, PREG_SET_ORDER );
+		preg_match_all( "/<{$tag}(?:\"(?:[^\\\"]|\\\.)*\"|\'(?:[^\\\\\']|\\\.)*\'|[^\'\">])*>(.*?)<\/{$tag}>/", $content, $matches, PREG_SET_ORDER );
 
 		return $matches;
 	}


### PR DESCRIPTION
This addresses ticket #5979
https://meta.trac.wordpress.org/ticket/5979

The new regex was tested here: http://sandbox.onlinephpfunctions.com/code/ff48352bda8f2ec3500856b6c18a0b3f4ffeeb9e