### PR TITLE
Add support for strikethrough on importing block editor

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-developer/inc/import-block-editor.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-developer/inc/import-block-editor.php
@@ -291,6 +291,14 @@ class DevHub_Block_Editor_Importer extends DevHub_Docs_Importer {
 			$markdown
 		);
 
+		// Support strikethrough.
+		// Transform ~~some text~~ to <s>some text</s>
+		$markdown = preg_replace(
+			'@~~(.*?)~~@i',
+			'<s>$1</s>',
+			$markdown
+		);
+
 		// Strip the trailing Code is Poetry footer from packages.
 		// See https://github.com/WordPress/gutenberg/blob/trunk/packages/README.md
 		$markdown = preg_replace(


### PR DESCRIPTION
Add support for strikethrough text wrapped with double-tilde
for importing of block editor documentation.

Adds to `wporg_markdown_before_transform` filter.


Trac ticket: https://meta.trac.wordpress.org/ticket/5989