### PR TITLE
Fix old url so redirect not needed

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-developer/inc/import-block-editor.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-developer/inc/import-block-editor.php
@@ -273,21 +273,21 @@ class DevHub_Block_Editor_Importer extends DevHub_Docs_Importer {
 		// Handle /packages/compomnents(/README.md)
 		$markdown = preg_replace(
 			'@(\[.*?\])\(/packages/components/?(#.*?)?\)@i',
-			'$1(https://developer.wordpress.org/block-editor/designers-developers/developers/components/$2)',
+			'$1(https://developer.wordpress.org/block-editor/reference-guide/components/$2)',
 			$markdown
 		);
 
 		// Handle /packages/components/(src/)(.+)(/README.md)
 		$markdown = preg_replace(
 			'@(\[.*?\])\(/packages/components/(src/)?(.*?)/?(#.*?)?\)@i',
-			'$1(https://developer.wordpress.org/block-editor/designers-developers/developers/components/$3/$4)',
+			'$1(https://developer.wordpress.org/block-editor/reference-guide/components/$3/$4)',
 			$markdown
 		);
 
 		// Handle /packages/(.+)(/README.md)
 		$markdown = preg_replace(
 			'@(\[.*?\])\(/packages/(.*?)/?(#.*?)?\)@i',
-			'$1(https://developer.wordpress.org/block-editor/designers-developers/developers/packages/packages-$2/$3)',
+			'$1(https://developer.wordpress.org/block-editor/reference-guide/packages/packages-$2/$3)',
 			$markdown
 		);
 


### PR DESCRIPTION
The replacement in the code goes to the older designers-developers/developers link which then redirects to the reference-guide location.

This PR updates to the reference-guide location so an extra redirect is not needed and the link refers to the proper spot which is better for SEO.

https://meta.trac.wordpress.org/ticket/6018