### PR TITLE
Switch from using hard-coded skip-to links and old-header globals to using a wrapper function.

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/gutenberg/header.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/gutenberg/header.php
@@ -8,11 +8,13 @@
  *
  * @package Gutenbergtheme
  */
+
+\WordPressdotorg\skip_to( '#content' );
+
 require WPORGPATH . 'header.php';
 ?>
 
 <div id="page" class="site">
-	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'gutenbergtheme' ); ?></a>
 		<header id="masthead" class="site-header">
 			<div class="site-branding">
 				<?php

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe/header.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe/header.php
@@ -1,12 +1,10 @@
 <?php
 
+\WordPressdotorg\skip_link( '#content' );
+
 if ( FEATURE_2021_GLOBAL_HEADER_FOOTER ) {
 	echo do_blocks( '<!-- wp:wporg/global-header /-->' );
 } else {
-	global $wporg_global_header_options;
-	if ( !isset( $wporg_global_header_options['in_wrapper'] ) )
-		$wporg_global_header_options['in_wrapper'] = '';
-	$wporg_global_header_options['in_wrapper'] .= '<a class="skip-link screen-reader-text" href="#content">' . esc_html__( 'Skip to content', 'wporg' ) . '</a>';
 	require WPORGPATH . 'header.php';
 }
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe/header.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe/header.php
@@ -1,6 +1,6 @@
 <?php
 
-\WordPressdotorg\skip_link( '#content' );
+\WordPressdotorg\skip_to( '#content' );
 
 if ( FEATURE_2021_GLOBAL_HEADER_FOOTER ) {
 	echo do_blocks( '<!-- wp:wporg/global-header /-->' );

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-learn-2020/header.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-learn-2020/header.php
@@ -13,15 +13,12 @@ namespace WordPressdotorg\Theme;
 
 use function WPOrg_Learn\Locale\{ locale_notice };
 
+\WordPressdotorg\skip_to( '#main' );
+
 if ( FEATURE_2021_GLOBAL_HEADER_FOOTER ) {
 	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	echo do_blocks( '<!-- wp:wporg/global-header /-->' );
 } else {
-	global $wporg_global_header_options;
-	if ( ! isset( $wporg_global_header_options['in_wrapper'] ) ) {
-		$wporg_global_header_options['in_wrapper'] = '';
-	}
-	$wporg_global_header_options['in_wrapper'] .= '<a class="skip-link screen-reader-text" href="#content">' . esc_html__( 'Skip to content', 'wporg-learn' ) . '</a>';
 	wporg_get_global_header();
 }
 
@@ -36,8 +33,6 @@ $menu_items = array(
 ?>
 
 <div id="page" class="site">
-	<a class="skip-link screen-reader-text" href="#main"><?php esc_html_e( 'Skip to content', 'wporg-learn' ); ?></a>
-
 	<div id="content">
 		<header id="masthead" class="site-header <?php echo is_front_page() ? 'home' : ''; ?>" role="banner">
 			<div class="site-branding">

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-learn/header.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-learn/header.php
@@ -9,9 +9,9 @@
  * @package WordPressdotorg\Learn
  */
 
+\WordPressdotorg\skip_to( '#main' );
+
 get_header( 'wporg' );
 ?>
 <div id="page" class="site">
-	<a class="skip-link screen-reader-text" href="#main"><?php esc_html_e( 'Skip to content', 'wporg' ); ?></a>
-
 	<div id="content" class="site-content">

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-main/front-page.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-main/front-page.php
@@ -34,10 +34,7 @@ if ( is_object( $rosetta ) && $rosetta->showcase instanceof \Rosetta_Showcase ) 
 $swag_class = $showcase ? 'col-4' : 'col-2';
 $user_class = $showcase ? 'col-12' : 'col-2';
 
-// Temporarily add a Skip-to-content selector for front pages.
-if ( ! isset( $wporg_global_header_options['in_wrapper'] ) ) {
-	$wporg_global_header_options['in_wrapper'] = '<a class="skip-link screen-reader-text" href="#masthead">' . __( 'Skip to content', 'wporg' ) . '</a>';
-}
+\WordPressdotorg\skip_to( '#masthead' );
 
 get_header( 'wporg' );
 ?>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-main/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-main/functions.php
@@ -37,6 +37,11 @@ function setup() {
 	 * to use them via open graph tags when a page is shared.
 	 */
 	add_theme_support( 'post-thumbnails' );
+
+	/*
+	 * Enable WordPress.org skip-to links.
+	 */
+	add_action( 'wp_head', '\WordPressdotorg\skip_to_main' );
 }
 add_action( 'after_setup_theme', __NAMESPACE__ . '\setup' );
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-main/header-child-page.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-main/header-child-page.php
@@ -16,8 +16,6 @@ global $menu_items;
 get_template_part( 'header', 'wporg' );
 ?>
 <div id="page" class="site">
-	<a class="skip-link screen-reader-text" href="#main"><?php esc_html_e( 'Skip to content', 'wporg' ); ?></a>
-
 	<div id="content" class="site-content row gutters">
 		<header id="masthead" class="site-header col-12" role="banner">
 			<div class="site-branding">

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-main/header-top-level-page.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-main/header-top-level-page.php
@@ -29,10 +29,6 @@ switch ( $post->page_template ) {
 ?>
 
 <div id="page" class="site">
-	<a class="skip-link screen-reader-text" href="#main">
-		<?php esc_html_e( 'Skip to content', 'wporg' ); ?>
-	</a>
-
 	<div id="content" class="site-content row gutters">
 		<header id="masthead" class="site-header home col-12" role="banner">
 			<div class="site-branding">

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-makehome/header.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-makehome/header.php
@@ -1,13 +1,10 @@
 <?php
 
+\WordPressdotorg\skip_to( '#headline' );
+
 if ( FEATURE_2021_GLOBAL_HEADER_FOOTER ) {
 	echo do_blocks( '<!-- wp:wporg/global-header /-->' );
 } else {
-	global $wporg_global_header_options;
-	if ( !isset( $wporg_global_header_options['in_wrapper'] ) ) {
-		$wporg_global_header_options['in_wrapper'] = '';
-	}
-	$wporg_global_header_options['in_wrapper'] .= '<a class="skip-link screen-reader-text" href="#headline">' . esc_html( 'Skip to content', 'make-wporg' ) . '</a>';
 	require( WPORGPATH . 'header.php' );
 }
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/header.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/header.php
@@ -11,15 +11,11 @@
 
 namespace WordPressdotorg\Openverse\Theme;
 
+\WordPressdotorg\skip_to( '#content' );
+
 if ( FEATURE_2021_GLOBAL_HEADER_FOOTER ) {
 	echo do_blocks( '<!-- wp:wporg/global-header /-->' );
 } else {
-	global $wporg_global_header_options;
-	if ( ! isset( $wporg_global_header_options['in_wrapper'] ) ) {
-		$wporg_global_header_options['in_wrapper'] = '';
-	}
-	$wporg_global_header_options['in_wrapper'] .= '<a class="skip-link screen-reader-text" href="#content">' . esc_html__( 'Skip to content', 'wporg' ) . '</a>';
-
 	get_template_part( 'header', 'wporg' );
 }
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-patterns/header.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-patterns/header.php
@@ -13,11 +13,7 @@ namespace WordPressdotorg\Pattern_Directory\Theme;
 
 use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE;
 
-global $wporg_global_header_options;
-if ( ! isset( $wporg_global_header_options['in_wrapper'] ) ) {
-	$wporg_global_header_options['in_wrapper'] = '';
-}
-$wporg_global_header_options['in_wrapper'] .= '<a class="skip-link screen-reader-text" href="#content">' . esc_html__( 'Skip to content', 'wporg-patterns' ) . '</a>';
+\WordPressdotorg\skip_to( '#content' );
 
 get_template_part( 'header', 'wporg' );
 ?>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins/header.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins/header.php
@@ -11,6 +11,8 @@
 
 namespace WordPressdotorg\Plugin_Directory\Theme;
 
+\WordPressdotorg\skip_to( '#main' );
+
 $menu_items = array(
 	'/browse/favorites/' => __( 'My Favorites', 'wporg-plugins' ),
 	'/browse/beta/'      => __( 'Beta Testing', 'wporg-plugins' ),
@@ -20,10 +22,6 @@ $menu_items = array(
 if ( FEATURE_2021_GLOBAL_HEADER_FOOTER ) {
 	echo do_blocks( '<!-- wp:wporg/global-header /-->' );
 } else {
-	global $wporg_global_header_options;
-	if ( !isset( $wporg_global_header_options['in_wrapper'] ) )
-		$wporg_global_header_options['in_wrapper'] = '';
-	$wporg_global_header_options['in_wrapper'] .= '<a class="skip-link screen-reader-text" href="#main">' . esc_html__( 'Skip to content', 'wporg-plugins' ) . '</a>';
 	require WPORGPATH . 'header.php';
 }
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/header.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/header.php
@@ -1,12 +1,10 @@
 <?php
 
+\WordPressdotorg\skip_to( '#pagebody' );
+
 if ( FEATURE_2021_GLOBAL_HEADER_FOOTER ) {
 	echo do_blocks( '<!-- wp:wporg/global-header /-->' );
 } else {
-	global $wporg_global_header_options;
-	if ( !isset( $wporg_global_header_options['in_wrapper'] ) )
-		$wporg_global_header_options['in_wrapper'] = '';
-	$wporg_global_header_options['in_wrapper'] .= '<a class="skip-link screen-reader-text" href="#pagebody">' . esc_html__( 'Skip to content', 'wporg-showcase' ) . '</a>';
 	require WPORGPATH . 'header.php';
 }
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support/header.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support/header.php
@@ -19,13 +19,11 @@ $menu_items = array(
 	_x( 'https://make.wordpress.org/support/handbook/', 'header menu', 'wporg-forums' ) => _x( 'Get Involved', 'header menu', 'wporg-forums' ),
 );
 
+\WordPressdotorg\skip_to( '#content' );
+
 if ( FEATURE_2021_GLOBAL_HEADER_FOOTER ) {
 	echo do_blocks( '<!-- wp:wporg/global-header /-->' );
 } else {
-	global $wporg_global_header_options;
-	if ( !isset( $wporg_global_header_options['in_wrapper'] ) )
-		$wporg_global_header_options['in_wrapper'] = '';
-	$wporg_global_header_options['in_wrapper'] .= '<a class="skip-link screen-reader-text" href="#content">' . esc_html__( 'Skip to content', 'wporg-forums' ) . '</a>';
 	wporg_get_global_header();
 }
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-themes/header.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-themes/header.php
@@ -5,13 +5,11 @@
  * @package wporg-themes
  */
 
+\WordPressdotorg\skip_to( '#themes' );
+
 if ( FEATURE_2021_GLOBAL_HEADER_FOOTER ) {
 	echo do_blocks( '<!-- wp:wporg/global-header /-->' );
 } else {
-	global $wporg_global_header_options;
-	if ( !isset( $wporg_global_header_options['in_wrapper'] ) )
-		$wporg_global_header_options['in_wrapper'] = '';
-	$wporg_global_header_options['in_wrapper'] .= '<a class="skip-link screen-reader-text" href="#themes">' . esc_html__( 'Skip to content', 'wporg-themes' ) . '</a>';
 	require WPORGPATH . 'header.php';
 }
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg/header-page.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg/header-page.php
@@ -11,9 +11,9 @@
 
 namespace WordPressdotorg\Theme;
 
+\WordPressdotorg\skip_to( '#main' );
+
 get_template_part( 'header', 'wporg' );
 ?>
 <div id="page" class="site">
-	<a class="skip-link screen-reader-text" href="#main"><?php esc_html_e( 'Skip to content', 'wporg' ); ?></a>
-
 	<div id="content" class="site-content row gutters">

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg/header.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg/header.php
@@ -11,14 +11,7 @@
 
 namespace WordPressdotorg\Theme;
 
-if ( ! FEATURE_2021_GLOBAL_HEADER_FOOTER ) {
-	global $wporg_global_header_options;
-
-	if ( ! isset( $wporg_global_header_options['in_wrapper'] ) ) {
-		$wporg_global_header_options['in_wrapper'] = '';
-	}
-	$wporg_global_header_options['in_wrapper'] .= '<a class="skip-link screen-reader-text" href="#content">' . esc_html__( 'Skip to content', 'wporg' ) . '</a>';
-}
+\WordPressdotorg\skip_to( '#content' );
 
 get_template_part( 'header', 'wporg' );
 ?>


### PR DESCRIPTION
The `$wporg_global_header_options` global is being deprecated with a new header, this removes the use of it for skip-to links and standardises onto a wrapper mu-plugin function.

See https://github.com/WordPress/wporg-mu-plugins/pull/70 for the plugin.

See https://github.com/WordPress/wporg-mu-plugins/issues/42 for removing.