### PR TITLE
Add Openverse to the list of external bug trackers

### DIFF
--- a/wordpress.org/public_html/style/trac/wp-trac.js
+++ b/wordpress.org/public_html/style/trac/wp-trac.js
@@ -93,6 +93,10 @@ var wpTrac, coreKeywordList, gardenerKeywordList, reservedTerms, coreFocusesList
 		'Pattern Directory': {
 			tracker: 'https://github.com/WordPress/pattern-directory/issues/new/choose',
 			tracker_text: 'WordPress.org Pattern Directory GitHub Repository',
+		},
+		'Openverse': {
+			tracker: 'https://github.com/WordPress/openverse/issues/new/choose',
+			tracker_text: 'Openverse GitHub Repository',
 		}
 	};
 


### PR DESCRIPTION
This PR adds Openverse to the list of external big trackers that should be redirected to from Trac.

https://meta.trac.wordpress.org/newticket

Note: There is not yet an Openverse component in the Trac component dropdown; that should accompany this PR.

Closes: https://meta.trac.wordpress.org/ticket/6045
Fixes: https://github.com/WordPress/openverse/issues/124