### PR TITLE
Fix too small font on language selection under project

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/style.css
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/style.css
@@ -1567,6 +1567,7 @@ ul.projects-dropdown li > a > span {
 	text-align: center;
 	border-collapse: collapse;
 	table-layout: fixed;
+	font-size: 15px;
 }
 
 .stats-table table thead {


### PR DESCRIPTION
https://meta.trac.wordpress.org/ticket/6066

Note: 

15px may be ideal to retain consistency with other table that appears on sub projects table. 

![Screen Shot 2022-02-01 at 18 58 46](https://user-images.githubusercontent.com/1859092/151965133-36a9acb2-fe7e-47b6-b37d-e3716d2ccf36.png)

Screenshot taken from [WordPress 5.9.x - Development](https://translate.wordpress.org/locale/id/default/wp/dev/).
