### PR TITLE
Openverse: Update the environment to use composer for managing required `mu-plugins`.

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/.gitignore
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/.gitignore
@@ -1,4 +1,5 @@
 # IDE artefacts
 .idea/
 
-wporg-mu-plugins/
+mu-plugins/
+vendor/

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/.wp-env.json
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/.wp-env.json
@@ -5,8 +5,7 @@
     "../wporg"
   ],
   "mappings": {
-    "wp-content/mu-plugins": "./wporg-mu-plugins/mu-plugins",
-    "wp-content/mu-plugins/mu-plugins.php": "./mu-plugins.php"
+    "wp-content/mu-plugins": "./mu-plugins"
   },
   "config": {
     "FEATURE_2021_GLOBAL_HEADER_FOOTER": true

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/README.md
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/README.md
@@ -46,7 +46,7 @@ Follow these steps to set up a local playground for the theme:
     5.  `cd` back to the Openverse theme directory at `../..`
         (i.e. `wordpress.org/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse`).
 
-4.  Set up the locale database. The plugin was installed in the previous step, but it pulls from a separate database of locale data.
+3.  Set up the locale database. The plugin was installed in the previous step, but it pulls from a separate database of locale data.
 
     1.  Download the SQL file [wporg_locales.sql](https://raw.githubusercontent.com/WordPress/pattern-directory/trunk/.wp-env/data/wporg_locales.sql) to the theme directory.
     2.  Import the file.
@@ -54,7 +54,7 @@ Follow these steps to set up a local playground for the theme:
         $ wp-env run cli "wp db import wp-content/themes/wporg-openverse/wporg_locales.sql"
         ```
 
-5.  Tell WordPress to load the `mu-plugins`. Since these are in nested folders, they're not loaded automatically. You'll need to create a new file and `require` them.
+4.  Tell WordPress to load the `mu-plugins`. Since these are in nested folders, they're not loaded automatically. You'll need to create a new file and `require` them.
 
     1.  Create a new file `.mu-plugins/loader.php`
     2.  Add the following to this new file:
@@ -65,7 +65,7 @@ Follow these steps to set up a local playground for the theme:
         require_once WPMU_PLUGIN_DIR . '/wporg-mu-plugins/mu-plugins/skip-to/skip-to.php';
         ```
 
-6.  You can choose to set up a new environment automatically or work in an
+5.  You can choose to set up a new environment automatically or work in an
     existing environment with manual setup.
 
     **Automatic:**  
@@ -91,14 +91,14 @@ Follow these steps to set up a local playground for the theme:
     themes into the `wp-content/themes` directory. You must also load the MU
     plugins and activate them using the `mu-plugins.php` file.
 
-7.  Activate and customize the theme.
+6.  Activate and customize the theme.
 
     1.  Log into `/wp-admin`.
     2.  Under Appearance > Themes, activate the theme 'WordPress.org Openverse'.
     3.  To change the embed URL, open the customizer at Appearance > Customize
         and update the value in the 'Openverse embed' panel.
 
-8.  Test message passing.
+7.  Test message passing.
 
     1.  Change the Openverse embed to
         `/wp-content/themes/wporg-openverse/js/message_test.html`.

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/README.md
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/README.md
@@ -54,7 +54,18 @@ Follow these steps to set up a local playground for the theme:
         $ wp-env run cli "wp db import wp-content/themes/wporg-openverse/wporg_locales.sql"
         ```
 
-3.  You can choose to set up a new environment automatically or work in an
+5.  Tell WordPress to load the `mu-plugins`. Since these are in nested folders, they're not loaded automatically. You'll need to create a new file and `require` them.
+
+    1.  Create a new file `.mu-plugins/loader.php`
+    2.  Add the following to this new file:
+        ```php
+        <?php
+        require_once __DIR__ . '/pub/locales.php';
+        require_once WPMU_PLUGIN_DIR . '/wporg-mu-plugins/mu-plugins/blocks/global-header-footer/blocks.php';
+        require_once WPMU_PLUGIN_DIR . '/wporg-mu-plugins/mu-plugins/skip-to/skip-to.php';
+        ```
+
+6.  You can choose to set up a new environment automatically or work in an
     existing environment with manual setup.
 
     **Automatic:**  
@@ -80,14 +91,14 @@ Follow these steps to set up a local playground for the theme:
     themes into the `wp-content/themes` directory. You must also load the MU
     plugins and activate them using the `mu-plugins.php` file.
 
-4.  Activate and customize the theme.
+7.  Activate and customize the theme.
 
     1.  Log into `/wp-admin`.
     2.  Under Appearance > Themes, activate the theme 'WordPress.org Openverse'.
     3.  To change the embed URL, open the customizer at Appearance > Customize
         and update the value in the 'Openverse embed' panel.
 
-5.  Test message passing.
+8.  Test message passing.
 
     1.  Change the Openverse embed to
         `/wp-content/themes/wporg-openverse/js/message_test.html`.

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/README.md
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/README.md
@@ -46,18 +46,7 @@ Follow these steps to set up a local playground for the theme:
     5.  `cd` back to the Openverse theme directory at `../..`
         (i.e. `wordpress.org/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse`).
 
-3.  Set up the locale database. The plugin was installed in the previous step, but it pulls from a separate database of locale data.
-
-    1.  Download the SQL file [wporg_locales.sql](https://raw.githubusercontent.com/WordPress/pattern-directory/trunk/.wp-env/data/wporg_locales.sql) to the theme directory.
-    ```bash
-    curl -O https://raw.githubusercontent.com/WordPress/pattern-directory/trunk/.wp-env/data/wporg_locales.sql
-    ```
-    2.  Import the file.
-        ```bash
-        $ wp-env run cli "wp db import wp-content/themes/wporg-openverse/wporg_locales.sql"
-        ```
-
-4.  Tell WordPress to load the `mu-plugins`. Since these are in nested folders, they're not loaded automatically. You'll need to create a new file and `require` them.
+3.  Tell WordPress to load the `mu-plugins`. Since these are in nested folders, they're not loaded automatically. You'll need to create a new file and `require` them.
 
     1.  Create a new file `./mu-plugins/loader.php`
     2.  Add the following to this new file:
@@ -68,7 +57,7 @@ Follow these steps to set up a local playground for the theme:
         require_once WPMU_PLUGIN_DIR . '/wporg-mu-plugins/mu-plugins/skip-to/skip-to.php';
         ```
 
-5.  You can choose to set up a new environment automatically or work in an
+4.  You can choose to set up a new environment automatically or work in an
     existing environment with manual setup.
 
     **Automatic:**  
@@ -93,6 +82,17 @@ Follow these steps to set up a local playground for the theme:
     instance and load both the `wporg` (parent) and `wporg-openverse` (child)
     themes into the `wp-content/themes` directory. You must also load the MU
     plugins and activate them using the `mu-plugins.php` file.
+
+5.  Set up the locale database. The plugin was installed in step 2, but it pulls from a separate database of locale data.
+
+    1.  Download the SQL file [wporg_locales.sql](https://raw.githubusercontent.com/WordPress/pattern-directory/trunk/.wp-env/data/wporg_locales.sql) to the theme directory.
+        ```bash
+        curl -O https://raw.githubusercontent.com/WordPress/pattern-directory/trunk/.wp-env/data/wporg_locales.sql
+        ```
+    2.  Import the file.
+        ```bash
+        $ wp-env run cli "wp db import wp-content/themes/wporg-openverse/wporg_locales.sql"
+        ```
 
 6.  Activate and customize the theme.
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/README.md
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/README.md
@@ -59,7 +59,7 @@ Follow these steps to set up a local playground for the theme:
 
 4.  Tell WordPress to load the `mu-plugins`. Since these are in nested folders, they're not loaded automatically. You'll need to create a new file and `require` them.
 
-    1.  Create a new file `.mu-plugins/loader.php`
+    1.  Create a new file `./mu-plugins/loader.php`
     2.  Add the following to this new file:
         ```php
         <?php

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/README.md
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/README.md
@@ -9,7 +9,8 @@ Follow these steps to set up a local playground for the theme:
 0.  Install all the prerequisites.
 
     1.  **Required:** Node.js.
-    2.  **Recommended:** Docker (to use the automatic setup)
+    2.  **Required:** Composer.
+    3.  **Recommended:** Docker (to use the automatic setup)
 
 1.  Build the parent theme WordPress.org theme.
 
@@ -28,23 +29,30 @@ Follow these steps to set up a local playground for the theme:
 
 2.  Build the MU plugins.
 
-    1.  Clone the `WordPress/wporg-mu-plugins` repo right into this directory.
-        It's `.gitignored` so it shouldn't affect anything.
+    1.  The mu-plugins are set up as composer dependencies, so install those:
         ```bash
-        $ git clone https://github.com/WordPress/wporg-mu-plugins.git
+        $ composer install
         ```
-    2.  `cd` into this directory at `./wporg-mu-plugins`
-        (i.e. `wordpress.org/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/wporg-mu-plugins`).
+    2.  `cd` into the directory at `./mu-plugins/wporg-mu-plugins`
+        (i.e. `wordpress.org/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/mu-plugins/wporg-mu-plugins/`).
     3.  Install all the required `npm` packages.
         ```bash
         $ npm install
         ```
-    4.  Build the theme assets.
+    4.  Build the plugin assets.
         ```bash
         $ npm run build
         ```
-    5.  `cd` back to the Openverse theme directory at `..`
+    5.  `cd` back to the Openverse theme directory at `../..`
         (i.e. `wordpress.org/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse`).
+
+4.  Set up the locale database. The plugin was installed in the previous step, but it pulls from a separate database of locale data.
+
+    1.  Download the SQL file [wporg_locales.sql](https://raw.githubusercontent.com/WordPress/pattern-directory/trunk/.wp-env/data/wporg_locales.sql) to the theme directory.
+    2.  Import the file.
+        ```bash
+        $ wp-env run cli "wp db import wp-content/themes/wporg-openverse/wporg_locales.sql"
+        ```
 
 3.  You can choose to set up a new environment automatically or work in an
     existing environment with manual setup.
@@ -64,7 +72,7 @@ Follow these steps to set up a local playground for the theme:
     3.  Follow the instructions in the console, and then your browser, to set up
         your WordPress install. This site will have the `wporg` (parent) and
         `wporg-openverse` (child) themes installed. For detailed instructions,
-        please read [their docs](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/).
+        please read [the wp-env docs](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/).
 
     **Manual:**  
     If you prefer a manual approach, you can also set up your own WordPress

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/README.md
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/README.md
@@ -49,6 +49,9 @@ Follow these steps to set up a local playground for the theme:
 3.  Set up the locale database. The plugin was installed in the previous step, but it pulls from a separate database of locale data.
 
     1.  Download the SQL file [wporg_locales.sql](https://raw.githubusercontent.com/WordPress/pattern-directory/trunk/.wp-env/data/wporg_locales.sql) to the theme directory.
+    ```bash
+    curl -O https://raw.githubusercontent.com/WordPress/pattern-directory/trunk/.wp-env/data/wporg_locales.sql
+    ```
     2.  Import the file.
         ```bash
         $ wp-env run cli "wp db import wp-content/themes/wporg-openverse/wporg_locales.sql"

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/README.md
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/README.md
@@ -60,7 +60,7 @@ Follow these steps to set up a local playground for the theme:
     2.  Add the following to this new file:
         ```php
         <?php
-        require_once __DIR__ . '/pub/locales.php';
+        require_once WPMU_PLUGIN_DIR . '/pub/locales.php';
         require_once WPMU_PLUGIN_DIR . '/wporg-mu-plugins/mu-plugins/blocks/global-header-footer/blocks.php';
         require_once WPMU_PLUGIN_DIR . '/wporg-mu-plugins/mu-plugins/skip-to/skip-to.php';
         ```

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/README.md
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/README.md
@@ -8,7 +8,7 @@ Follow these steps to set up a local playground for the theme:
 
 0.  Install all the prerequisites.
 
-    1.  **Required:** Node.js.
+    1.  **Required:** Node.js 14.
     2.  **Required:** Composer.
     3.  **Recommended:** Docker (to use the automatic setup)
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/composer.json
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/composer.json
@@ -1,0 +1,55 @@
+{
+  "name": "wporg/wporg-openverse",
+  "description": "",
+  "homepage": "https://wordpress.org",
+  "license": "GPL-2.0-or-later",
+  "support": {
+    "issues": "https://github.com/WordPress/wordpress.org/issues"
+  },
+  "config": {
+    "platform": {
+      "php": "7.4"
+    },
+    "allow-plugins": {
+      "composer/installers": true
+    }
+  },
+  "extra": {
+    "installer-paths": {
+      "mu-plugins/{$name}/": [
+        "type:wordpress-muplugin"
+      ]
+    }
+  },
+  "repositories": [
+    {
+      "type": "composer",
+      "url": "https://wpackagist.org/"
+    },
+    {
+      "type": "package",
+      "package": [
+        {
+          "name": "wordpress-meta/pub",
+          "type": "wordpress-muplugin",
+          "version": "1",
+          "source": {
+            "type": "svn",
+            "url": "https://meta.svn.wordpress.org/sites/",
+            "reference": "trunk/wordpress.org/public_html/wp-content/mu-plugins/pub/"
+          }
+        }
+      ]
+    },
+    {
+      "type": "vcs",
+      "url": "git@github.com:WordPress/wporg-mu-plugins.git"
+    }
+  ],
+  "require": {},
+  "require-dev": {
+    "composer/installers": "~1.0",
+    "wordpress-meta/pub": "1",
+    "wporg/wporg-mu-plugins": "dev-trunk"
+  }
+}

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/composer.lock
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/composer.lock
@@ -1,0 +1,225 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "3294598a8f116842137bf585c5ffe0f6",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "composer/installers",
+            "version": "v1.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/installers.git",
+                "reference": "d20a64ed3c94748397ff5973488761b22f6d3f19"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/installers/zipball/d20a64ed3c94748397ff5973488761b22f6d3f19",
+                "reference": "d20a64ed3c94748397ff5973488761b22f6d3f19",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "roundcube/plugin-installer": "*",
+                "shama/baton": "*"
+            },
+            "require-dev": {
+                "composer/composer": "1.6.* || ^2.0",
+                "composer/semver": "^1 || ^3",
+                "phpstan/phpstan": "^0.12.55",
+                "phpstan/phpstan-phpunit": "^0.12.16",
+                "symfony/phpunit-bridge": "^4.2 || ^5",
+                "symfony/process": "^2.3"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Composer\\Installers\\Plugin",
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Installers\\": "src/Composer/Installers"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kyle Robinson Young",
+                    "email": "kyle@dontkry.com",
+                    "homepage": "https://github.com/shama"
+                }
+            ],
+            "description": "A multi-framework Composer library installer",
+            "homepage": "https://composer.github.io/installers/",
+            "keywords": [
+                "Craft",
+                "Dolibarr",
+                "Eliasis",
+                "Hurad",
+                "ImageCMS",
+                "Kanboard",
+                "Lan Management System",
+                "MODX Evo",
+                "MantisBT",
+                "Mautic",
+                "Maya",
+                "OXID",
+                "Plentymarkets",
+                "Porto",
+                "RadPHP",
+                "SMF",
+                "Starbug",
+                "Thelia",
+                "Whmcs",
+                "WolfCMS",
+                "agl",
+                "aimeos",
+                "annotatecms",
+                "attogram",
+                "bitrix",
+                "cakephp",
+                "chef",
+                "cockpit",
+                "codeigniter",
+                "concrete5",
+                "croogo",
+                "dokuwiki",
+                "drupal",
+                "eZ Platform",
+                "elgg",
+                "expressionengine",
+                "fuelphp",
+                "grav",
+                "installer",
+                "itop",
+                "joomla",
+                "known",
+                "kohana",
+                "laravel",
+                "lavalite",
+                "lithium",
+                "magento",
+                "majima",
+                "mako",
+                "mediawiki",
+                "miaoxing",
+                "modulework",
+                "modx",
+                "moodle",
+                "osclass",
+                "pantheon",
+                "phpbb",
+                "piwik",
+                "ppi",
+                "processwire",
+                "puppet",
+                "pxcms",
+                "reindex",
+                "roundcube",
+                "shopware",
+                "silverstripe",
+                "sydes",
+                "sylius",
+                "symfony",
+                "tastyigniter",
+                "typo3",
+                "wordpress",
+                "yawik",
+                "zend",
+                "zikula"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/installers/issues",
+                "source": "https://github.com/composer/installers/tree/v1.12.0"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-09-13T08:19:44+00:00"
+        },
+        {
+            "name": "wordpress-meta/pub",
+            "version": "1",
+            "source": {
+                "type": "svn",
+                "url": "https://meta.svn.wordpress.org/sites/",
+                "reference": "trunk/wordpress.org/public_html/wp-content/mu-plugins/pub/"
+            },
+            "type": "wordpress-muplugin"
+        },
+        {
+            "name": "wporg/wporg-mu-plugins",
+            "version": "dev-trunk",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/wporg-mu-plugins.git",
+                "reference": "993c85dc99f54a872101ff86adbc2925283e6d73"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress/wporg-mu-plugins/zipball/993c85dc99f54a872101ff86adbc2925283e6d73",
+                "reference": "993c85dc99f54a872101ff86adbc2925283e6d73",
+                "shasum": ""
+            },
+            "require": {
+                "composer/installers": "~1.0"
+            },
+            "require-dev": {
+                "wporg/wporg-repo-tools": "dev-trunk"
+            },
+            "default-branch": true,
+            "type": "wordpress-muplugin",
+            "extra": {
+                "sync-svn": {
+                    "main-branch": "trunk",
+                    "paths": {
+                        "mu-plugins/": "https://dotorg.svn.wordpress.org/wordpress/website/wp-content/mu-plugins/pub-sync/"
+                    }
+                }
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "`mu-plugins` for the WordPress.org network",
+            "support": {
+                "source": "https://github.com/WordPress/wporg-mu-plugins/tree/trunk",
+                "issues": "https://github.com/WordPress/wporg-mu-plugins/issues"
+            },
+            "time": "2022-02-08T18:10:12+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {
+        "wporg/wporg-mu-plugins": 20
+    },
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "7.4"
+    },
+    "plugin-api-version": "2.0.0"
+}


### PR DESCRIPTION
Update the Openverse theme setup process to use `composer` for installing the required `mu-plugins`. Openverse needs both the [wporg-mu-plugins](https://github.com/WordPress/wporg-mu-plugins/) (for the header/footer) & [mu-plugins/pub](https://meta.trac.wordpress.org/browser/sites/trunk/wordpress.org/public_html/wp-content/mu-plugins/pub) (for the locales library). Now these are both installed in a local `mu-plugins` folder, which is gitignored (along with `vendor`, a composer artifact). Neither of these folders should be synced to SVN.

This fixes an issue where syncing a single file causes issues with docker - either outright breaking the boot process, or just creating duplicate empty files - by mapping the whole `mu-plugins` folder and hand-creating the loader file.

This also adds steps for setting up the locale database so that the `WordPressdotorg\Locales\*` functions can be used.

See discussion in #neso on a8c slack for more background & troubleshooting.

cc @sarayourfriend 