### PR TITLE
Update locale forwarding via path

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/.gitignore
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/.gitignore
@@ -3,3 +3,4 @@
 
 mu-plugins/
 vendor/
+wporg_locales.sql

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/js/iframe_nav.js
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/js/iframe_nav.js
@@ -5,7 +5,7 @@ document.addEventListener('DOMContentLoaded', () => {
     .toLocaleLowerCase()
     .replace(openverseSubpath, '')
     .replace(/^\/$/, ''); // Remove Openverse site subpath
-  iframePath = `${openverseUrl}${iframePath}${query}`; // Add domain and query
+  iframePath = `${openverseUrl}${localeSlug ? `/${localeSlug}` : ''}${iframePath}${query}`; // Add domain and query
 
   console.log(`Navigating iframe to ${iframePath}`);
   const iframe = document.getElementById('openverse_embed');

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/js/iframe_nav.js
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/js/iframe_nav.js
@@ -5,7 +5,12 @@ document.addEventListener('DOMContentLoaded', () => {
     .toLocaleLowerCase()
     .replace(openverseSubpath, '')
     .replace(/^\/$/, ''); // Remove Openverse site subpath
-  iframePath = `${openverseUrl}${localeSlug ? `/${localeSlug}` : ''}${iframePath}${query}`; // Add domain and query
+  const localePart = localeSlug
+    ? openverseUrl.endsWith('/')
+      ? localeSlug
+      : `/${localeSlug}`
+    : '';
+  iframePath = `${openverseUrl}${localePart}${iframePath}${query}`; // Add domain and query
 
   console.log(`Navigating iframe to ${iframePath}`);
   const iframe = document.getElementById('openverse_embed');

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/js/message.js
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/js/message.js
@@ -11,7 +11,10 @@
  */
 function updatePath(value) {
   const path = value.path;
-  const url = `${openverseSubpath}${path}`; // openverseSubpath defined in `index.php`
+  let url = `${openverseSubpath}${path}`; // openverseSubpath defined in `index.php`
+  if (localeSlug) {
+    url = url.replace(`openverse/${localeSlug}`, 'openverse');
+  }
 
   console.log(`Replacing state URL: ${url}`);
   history.replaceState(


### PR DESCRIPTION
https://meta.trac.wordpress.org/ticket/6105

Forwards the locale via the iframe's path rather than relying on a cookie.

To test, follow setup instructions in the README of the wporg-openverse theme. Set the "Use path based locale forwarding" setting to on by checking the box in the customizer. And redirect the iframe to use staging or localhost as production does not yet support path based locales.

Next, to test that the locales are working, replace [the call to `get_locale()` with a `wp_locale`](https://github.com/WordPress/wordpress.org/pull/61/files#diff-0456ab0b8c830deeba20a153962f28a381c93ccde52e9dce715009a7cb3381c0R90) string (like `pt_BR` etc) to verify that it is working to forward the locale as expected (as far as I know there's no way to test this "for real" locally as subdomain locale choosing isn't supported in the local wp-env when I tried it).

Be sure to navigate around the various pages of the application. Pay special attention to the URL being shown in the host frame. It should never include the locale slug.

Next, test it with the `en_US` locale and make sure everything works, again paying attention to the locale slug.

Finally, turn off the path based locale forwarding setting and switch the frame back to production. Ensure that it continues to work as expected, especially the host frame URL updates. I'm not sure how to test other locales other than again, manually replacing the call to `get_locale()` with a locale string of choice. I noticed that it takes at least one page navigation for the locale to actually propagate via the cookie. This is the same as the behavior on `trunk`.