### PR TITLE
Use global header height variable

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/css/openverse.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/css/openverse.css
@@ -1,19 +1,8 @@
-:root {
-    --header-height: 117px;
-}
-
-@media (min-width: 890px) {
-    :root {
-        --header-height: 104.453px;
-    }
-}
-
-
 #openverse_embed {
     display: block;
 
     width: 100%;
-    height: calc(100vh - var(--header-height));
+    height: calc(100vh - var(--wp-global-header-height));
 
     border: none;
 }

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/css/openverse.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/css/openverse.css
@@ -7,6 +7,13 @@
     border: none;
 }
 
+/*
+Remove the scrollbar for the footer which is re-implemented in Openverse itself.
+*/
+body {
+    overflow:hidden;
+}
+
 #main,
 .site,
 .site-content {


### PR DESCRIPTION
Fixes https://github.com/WordPress/openverse-frontend/issues/834

https://meta.trac.wordpress.org/ticket/6128

## Testing instructions

Follow the guide in the wporg-openverse README to set up the theme locally. Verify that it uses the correct variable to calculate the iframe height and that it updates when you change the vertical height of the viewport to get the narrower WP org header.