### PR TITLE
Update _normalize.scss, remove svg:not(:root) rule

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg/css/generic/_normalize.scss
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg/css/generic/_normalize.scss
@@ -97,10 +97,6 @@ img {
 	border: 0;
 }
 
-svg:not(:root) {
-	overflow: hidden;
-}
-
 figure {
 	margin: 1em 40px;
 }


### PR DESCRIPTION
Roughly 4 years ago, normalize.css dropped the rule below, suggesting that the rule supported MSIE < 10 browsers. Bootstrap also removed the rule around the same time.

This rule is causing a problem in a different WordPress.org Project: [Pattern Directory Issue](https://github.com/WordPress/pattern-directory/issues/402).

While I think updating normalize to its newest version would be ideal, it's probably too risky.

I suggest we pull out this rule and address any issues that come in, although I suspect it will have little effect. Because of the way our projects are set up, (need to build all of them) I admit I've done relatively little testing.

**Rule**
```
svg:not(:root) {
	overflow: hidden;
}
```

**Ref:**
https://github.com/twbs/bootstrap/pull/26927
https://github.com/necolas/normalize.css/commit/004d58b2f2e0ac3d03d075f8de46ce7c8234742f