### PR TITLE
Remove console logs when updating the url from the iframe

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/js/message.js
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/js/message.js
@@ -16,7 +16,6 @@ function updatePath(value) {
     url = url.replace(`openverse/${localeSlug}`, 'openverse');
   }
 
-  console.log(`Replacing state URL: ${url}`);
   history.replaceState(
     value.state,
     value.title ?? 'Openverse',
@@ -24,7 +23,6 @@ function updatePath(value) {
   );
 
   if (value.title) {
-    console.log(`Setting document title: ${value.title}`);
     document.title = value.title;
   }
 }


### PR DESCRIPTION
## Meta Track
https://meta.trac.wordpress.org/ticket/6205

## Description
Minor change to avoid printing extra info in [production](https://search.openverse.engineering/).