### PR TITLE
Add optional attributes to the wpcredits shortcode

### DIFF
--- a/api.wordpress.org/public_html/core/credits/shortcode.php
+++ b/api.wordpress.org/public_html/core/credits/shortcode.php
@@ -4,7 +4,29 @@ defined( 'WPINC' ) or exit;
 
 add_shortcode( 'wpcredits', 'wporg_wordpress_credits_shortcode' );
 
-function wporg_wordpress_credits_shortcode( $attrs, $content = null ) {
+/**
+ * Shortcode callback to render a list of props names, given a WP version.
+ *
+ * Example: [wpcredits 5.9 separator="bullet"]
+ *
+ * @param array $attrs
+ *     @type string            Required. Nameless parameter specifying the WP version. Must be the first parameter.
+ *     @type string $class     Optional. Space-separated list of class names to add to the container element.
+ *     @type string $exclude   Optional. Comma-separated list of props names to exclude.
+ *     @type string $separator Optional. Style of separator to use between props names. 'bullet' or 'comma'. Default 'bullet'.
+ *
+ * @return string
+ */
+function wporg_wordpress_credits_shortcode( $attrs ) {
+	$attrs = wp_parse_args(
+		$attrs,
+		array(
+			'class'     => 'is-style-wporg-props-long alignfull',
+			'exclude'   => '',
+			'separator' => 'bullet',
+		)
+	);
+
 	if ( ! isset( $attrs[0] ) ) {
 		return '';
 	}
@@ -24,7 +46,7 @@ function wporg_wordpress_credits_shortcode( $attrs, $content = null ) {
 		}
 	}
 
-	if ( isset( $attrs['exclude'] ) ) {
+	if ( ! empty( $attrs['exclude'] ) ) {
 		$exclude = explode( ',', strtolower( $attrs['exclude'] ) );
 		$props = array_diff_key( $props, array_flip( $exclude ) );
 	}
@@ -35,5 +57,22 @@ function wporg_wordpress_credits_shortcode( $attrs, $content = null ) {
 		$output[] = '<a href="' . sprintf( $results['data']['profiles'], $username ) . '/">' . $name . '</a>';
 	}
 
-	return '<p>' . wp_sprintf( '%l.', $output ) . '</p>';
+	$container_atts = '';
+	if ( ! empty( $attrs['class'] ) ) {
+		$container_atts .= ' class="' . esc_attr( $attrs['class'] ) . '"';
+	}
+
+	$content = '';
+	switch ( $attrs['separator'] ) {
+		case 'comma':
+		default:
+			$content .= wp_sprintf( '%l.', $output );
+			break;
+
+		case 'bullet':
+			$content .= implode( ' · ', $output );
+			break;
+	}
+
+	return "<p{$container_atts}>" . $content . '</p>';
 }


### PR DESCRIPTION
Adds `class` and `separator` attributes to the shortcode callback function so that the string of props names can better be styled to match the new design for the WordPress.org News site.

The defaults for these attributes are set so that all existing uses of the shortcode on the News site will be able to match the design without having to go back and edit a lot of posts.

See:
* https://github.com/WordPress/wporg-news-2021/issues/355 
* https://github.com/WordPress/wporg-news-2021/pull/363

### To test

1. Upload this to your sandbox.
2. While sandboxing wp.org, try viewing [a major release post](https://wordpress.org/news/2022/01/josephine/) and finding the credits.
3. You can try out different values for the attributes without editing the actual post by changing the defaults and re-uploading.