### PR TITLE
Add alt attributes for profile images on Trac tickets

### DIFF
--- a/trac.wordpress.org/templates/site-ticket.html
+++ b/trac.wordpress.org/templates/site-ticket.html
@@ -48,7 +48,7 @@
 <!--! Gravatars for the ticket reporter -->
 <td py:match="td[@headers='h_reporter']" py:attrs="select('@*')" py:with="wporg_user = wporg_sanitize_user_nicename(ticket.reporter)">
   <a href="${profile_link + wporg_user}" data-nicename="${wporg_user}">
-    <img class="avatar" src="https://wordpress.org/grav-redirect.php?user=${wporg_user}&amp;s=48" srcset="https://wordpress.org/grav-redirect.php?user=${wporg_user}&amp;s=96 2x" height="48" width="48" />
+    <img class="avatar" src="https://wordpress.org/grav-redirect.php?user=${wporg_user}&amp;s=48" srcset="https://wordpress.org/grav-redirect.php?user=${wporg_user}&amp;s=96 2x" height="48" width="48" alt="${wporg_user} profile" />
   </a>
     ${select('*|comment()|text()')}
 </td>
@@ -56,7 +56,7 @@
 <!--! Gravatars for the ticket owner -->
 <td py:match="td[@headers='h_owner']" py:attrs="select('@*')">
   <a py:if="ticket.owner" py:with="wporg_user = wporg_sanitize_user_nicename(ticket.owner)" href="${profile_link + wporg_user}">
-    <img class="avatar" src="https://wordpress.org/grav-redirect.php?user=${wporg_user}&amp;s=48" srcset="https://wordpress.org/grav-redirect.php?user=${wporg_user}&amp;s=96 2x" height="48" width="48" />
+    <img class="avatar" src="https://wordpress.org/grav-redirect.php?user=${wporg_user}&amp;s=48" srcset="https://wordpress.org/grav-redirect.php?user=${wporg_user}&amp;s=96 2x" height="48" width="48" alt="${wporg_user} profile" />
   </a>
     ${select('*|comment()|text()')}
 </td>

--- a/trac.wordpress.org/templates/ticket_change.html
+++ b/trac.wordpress.org/templates/ticket_change.html
@@ -37,7 +37,7 @@ Arguments:
   <h3 class="change chat-bot">
     <span class="avatar" py:if="change">
       <span class="username-line">
-        <img src="https://wordpress.org/grav-redirect.php?user=${wporg_user}&amp;s=48" srcset="https://wordpress.org/grav-redirect.php?user=${wporg_user}&amp;s=96 2x" height="48" width="48" />
+        <img src="https://wordpress.org/grav-redirect.php?user=${wporg_user}&amp;s=48" srcset="https://wordpress.org/grav-redirect.php?user=${wporg_user}&amp;s=96 2x" height="48" width="48" alt="" />
         ${wiki_to_html(context, change.comment, escape_newlines=preserve_newlines)}
       </span>
       <br /><span class="time-ago">${dateinfo(change.date)} ago</span>
@@ -63,7 +63,7 @@ Arguments:
   <h3 class="change chat-bot ${prbot_class}">
     <span class="avatar">
       <span class="username-line">
-        <img src="https://wordpress.org/grav-redirect.php?user=${wporg_user}&amp;s=48" srcset="https://wordpress.org/grav-redirect.php?user=${wporg_user}&amp;s=96 2x" height="48" width="48" />
+        <img src="https://wordpress.org/grav-redirect.php?user=${wporg_user}&amp;s=48" srcset="https://wordpress.org/grav-redirect.php?user=${wporg_user}&amp;s=96 2x" height="48" width="48" alt="" />
         ${wiki_to_html(context, pr_byline, escape_newlines=preserve_newlines)}
       </span>
       <br /><span class="time-ago">${dateinfo(change.date)} ago</span>
@@ -115,7 +115,7 @@ Arguments:
       <py:when test="'author' in change" py:with="wporg_user = wporg_sanitize_user_nicename(change.author)">
         <span class="avatar" py:if="change">
           <span class="username-line"><a href="https://profiles.wordpress.org/${wporg_user}" class="profile-link">
-            <img src="https://wordpress.org/grav-redirect.php?user=${wporg_user}&amp;s=48" srcset="https://wordpress.org/grav-redirect.php?user=${wporg_user}&amp;s=96 2x" height="48" width="48" /> @<span class="username" data-username="${change.author}" data-nicename="${wporg_user}">${authorinfo(change.author)}</span></a></span>
+            <img src="https://wordpress.org/grav-redirect.php?user=${wporg_user}&amp;s=48" srcset="https://wordpress.org/grav-redirect.php?user=${wporg_user}&amp;s=96 2x" height="48" width="48" alt="" /> @<span class="username" data-username="${change.author}" data-nicename="${wporg_user}">${authorinfo(change.author)}</span></a></span>
           <py:if test="'date' in change">
             <br /><span class="time-ago">${dateinfo(change.date)} ago</span>
           </py:if>


### PR DESCRIPTION
- Add `alt="[username] profile"` for Reporter and Owner profile images.
- Add empty `alt=""` attribute for commenters' profile images and Slack/IRC notifications.

https://meta.trac.wordpress.org/ticket/6291