### PR TITLE
Use str_starts_with instead of substr

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tools/class-svn.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tools/class-svn.php
@@ -444,7 +444,7 @@ class SVN {
 			}
 
 			// Prefix options with `-` or `--` if they're longer than 2 characters.
-			if ( '-' != substr( $key, 0, 1 ) ) {
+			if ( ! str_starts_with( $key, '-' ) ) {
 				$key = '-' . ( strlen( $key ) > 2 ? '-' : '' ) . $key;
 			}
 


### PR DESCRIPTION
Optimize the syntax for judging whether to add "-" when preparing parameters in the SVN tool in the plugin directory

https://meta.trac.wordpress.org/ticket/6364