### PR TITLE
WIP: Update the profile handler to log last contribution

### DIFF
--- a/profiles.wordpress.org/public_html/wp-content/plugins/wporg-profiles-activity-handler/wporg-profiles-activity-handler.php
+++ b/profiles.wordpress.org/public_html/wp-content/plugins/wporg-profiles-activity-handler/wporg-profiles-activity-handler.php
@@ -422,7 +422,7 @@ if ( ! class_exists( 'WPOrg_Profiles_Activity_Handler' ) ) {
 					'hide_sitewide'     => false,
 				);
 
-				return new SavedActivity( bp_activity_add( $args ), 'forum_activity', true );
+				return bp_activity_add( $args );
 
 			} elseif ( in_array( $type, array( 'forum_topic_remove', 'forum_reply_remove' ) ) ) {
 				// Remove activity related to a topic or reply.


### PR DESCRIPTION
Closes: https://github.com/WordPress/five-for-the-future/issues/189

This is a very early PR, mostly designed to discuss the strategy behind the code since I'm not incredibly familiar with all the inputs/outputs.

Also, the structure and format of these changes are not expected to be final, just designed to initiate the conversation.

## Notes:
- Can we update the meta value in `handle_activity`?
  - Are there any other paths that don't come through `handle_activity`? 
- I think we could use an object, called `SavedActivity` here, that returns whether the activity is _contribution_ worthy.
  - That would allow us to keep the logic specific to the input
    - IE: forum activity handler determines whether it's worthy
  - Does this make sense? Are there better approaches? 
  
