### PR TITLE
Org-README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# wordpress.org-1
+WordPress.org Meta, Git-ified. Synced from git://meta.git.wordpress.org/ This repository is just a mirror of the WordPress Meta subversion repository. Please include a link to a pre-existing ticket on https://meta.trac.wordpress.org/ with every pull request.


### PR DESCRIPTION
# wordpress.org-1
WordPress.org Meta, Git-ified. Synced from git://meta.git.wordpress.org/ This repository is just a mirror of the WordPress Meta subversion repository. Please include a link to a pre-existing ticket on https://meta.trac.wordpress.org/ with every pull request.