### PR TITLE
Wordpress.Org README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# wordpress.org
+WordPress.org Meta, Git-ified. Synced from git://meta.git.wordpress.org/ This repository is just a mirror of the WordPress Meta subversion repository. Please include a link to a pre-existing ticket on https://meta.trac.wordpress.org/ with every pull request.


### PR DESCRIPTION
wordpress.org
WordPress.org Meta၊ Git-ified။ git://meta.git.wordpress.org/ မှ စင့်ခ်လုပ်ထားသော ဤသိုလှောင်မှုသည် WordPress Meta အဖျက်အမှောင့် သိုလှောင်မှု၏ မှန်တစ်ချပ်မျှသာ ဖြစ်သည်။ ဆွဲယူတောင်းဆိုမှုတိုင်းနှင့်အတူ https://meta.trac.wordpress.org/ တွင် နဂိုရှိပြီးသား လက်မှတ်တစ်စောင်၏ လင့်ခ်ကို ထည့်သွင်းပါ ။