### PR TITLE
WIP: Add plugin that updates meta value for 5ftf

### DIFF
--- a/api.wordpress.org/public_html/dotorg/github/activity.php
+++ b/api.wordpress.org/public_html/dotorg/github/activity.php
@@ -71,6 +71,22 @@ function github_user_to_user_id( $user ) {
 	return $user_id ? intval( $user_id ) : false;
 }
 
+/**
+ * Save github activity to database.
+ *
+ * @param array $data
+ *
+ * @uses apply_filters() Calls 'wporg_github_added_activity'
+ */
+function save_github_activity( $data ) {
+	$wpdb->insert(
+		'wporg_github_activity',
+		$data
+	);
+
+	apply_filters( 'wporg_github_added_activity', $data );
+}
+
 $event   = $_SERVER['HTTP_X_GITHUB_EVENT'];
 $payload = get_signed_payload_or_die();
 
@@ -144,8 +160,7 @@ switch ( $event ) {
 		}
 
 		// Pushed commits.
-		$wpdb->insert(
-			'wporg_github_activity',
+		save_github_activity(
 			( $user_id     ? compact( 'user_id' )     : [] ) + // Leave user_id as null if not known.
 			( $github_user ? compact( 'github_user' ) : [] ) + // Leave github_user as null if not known.
 			[
@@ -195,8 +210,7 @@ switch ( $event ) {
 		// Can use Sender here, as they'll be the one to create/close the Issue.
 		$user_id = github_user_to_user_id( $payload->sender->login );
 
-		$wpdb->insert(
-			'wporg_github_activity',
+		save_github_activity(
 			( $user_id ? compact( 'user_id' ) : [] ) + // Leave user_id as null if not known.
 			[
 				'ts'          => gmdate( 'Y-m-d H:i:s' ),
@@ -243,8 +257,7 @@ switch ( $event ) {
 			$event = 'pr_merge';
 		}
 
-		$wpdb->insert(
-			'wporg_github_activity',
+		save_github_activity(
 			( $user_id ? compact( 'user_id' ) : [] ) + // Leave user_id as null if not known.
 			[
 				'ts'          => gmdate( 'Y-m-d H:i:s' ),

--- a/api.wordpress.org/public_html/dotorg/github/activity.php
+++ b/api.wordpress.org/public_html/dotorg/github/activity.php
@@ -84,7 +84,7 @@ function save_github_activity( $data ) {
 		$data
 	);
 
-	apply_filters( 'wporg_github_added_activity', $data );
+	do_action( 'wporg_github_added_activity', $data );
 }
 
 $event   = $_SERVER['HTTP_X_GITHUB_EVENT'];

--- a/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/tests/test.php
+++ b/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/tests/test.php
@@ -18,7 +18,6 @@ if ( 'staging' !== wp_get_environment_type() || 'cli' !== php_sapi_name() ) {
 }
 
 const TEST_USERNAME = 'dufresnesteven';
-const TEST_USERID   = '17657928';
 
 /** @var array $args */
 main( $args[0] );
@@ -27,9 +26,9 @@ function main( string $case ) : void {
 
 	require_once dirname( __DIR__ ) . '/wporg-5ftf-activity-handler.php';
 
-	call_user_func( __NAMESPACE__ . "\\test_$case", WPOrg_5ftf_Activity_Handler::get_instance() );
+	$user = get_user_by( 'slug', TEST_USERNAME );
 
-	// echo "\nThere should be new activity on https://profiles.wordpress.org/$user->user_nicename/ \n";
+	call_user_func( __NAMESPACE__ . "\\test_$case", WPOrg_5ftf_Activity_Handler::get_instance(), $user );
 }
 
 function expect( $fail, $result ) {
@@ -50,19 +49,19 @@ function expectFalse( $result ) {
  * Tests the handling of GitHub activities
  */
 
-function test_github_filter( WPOrg_5ftf_Activity_Handler $handler ) : void {
-	test_github_filter_success( $handler );
+function test_github_filter( WPOrg_5ftf_Activity_Handler $handler, $user ) : void {
+	test_github_filter_success( $handler, $user );
 	test_github_filter_no_user_id( $handler );
-	test_github_filter_unsupported_category( $handler );
+	test_github_filter_unsupported_category( $handler, $user );
 }
 
-function test_github_filter_success( WPOrg_5ftf_Activity_Handler $handler ) : void {
+function test_github_filter_success( WPOrg_5ftf_Activity_Handler $handler, $user ) : void {
 	expectTrue(
 		$handler->handle_github_activity(
 			array(
 				'category' => 'pr_merged',
 				'repo'     => 'wordpress.org',
-				'user_id'  => TEST_USERID,
+				'user_id'  => $user->ID,
 			)
 		)
 	);
@@ -79,13 +78,13 @@ function test_github_filter_no_user_id( WPOrg_5ftf_Activity_Handler $handler ) :
 	);
 }
 
-function test_github_filter_unsupported_category( WPOrg_5ftf_Activity_Handler $handler ) : void {
+function test_github_filter_unsupported_category( WPOrg_5ftf_Activity_Handler $handler, $user ) : void {
 	expectFalse(
 		$handler->handle_github_activity(
 			array(
 				'category' => 'not_supported',
 				'repo'     => 'wordpress.org',
-				'user_id'  => TEST_USERID,
+				'user_id'  => $user->ID,
 			)
 		)
 	);

--- a/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/tests/test.php
+++ b/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/tests/test.php
@@ -17,7 +17,7 @@ if ( 'staging' !== wp_get_environment_type() || 'cli' !== php_sapi_name() ) {
 	die( 'Error: Wrong environment.' );
 }
 
-const TEST_USERNAME = 'dufresnesteven';
+const TEST_USERNAME = 'metatestaccount';
 
 /** @var array $args */
 main( $args[0] );
@@ -46,7 +46,6 @@ function expectTrue( $result ) {
 function expectFalse( $result ) {
 	expect( substr( $result, 0, 2 ) !== '-1', $result );
 }
-
 
 /**
  * Tests the handling of `bp_activity_add` activities

--- a/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/tests/test.php
+++ b/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/tests/test.php
@@ -8,6 +8,7 @@
  */
 
 namespace WordPressdotorg\WPORG_5ftf_Activity_Notifier\Tests;
+
 use WPOrg_5ftf_Activity_Handler;
 
 ini_set( 'display_errors', 'On' ); // won't do anything if fatal errors
@@ -17,7 +18,7 @@ if ( 'staging' !== wp_get_environment_type() || 'cli' !== php_sapi_name() ) {
 }
 
 const TEST_USERNAME = 'dufresnesteven';
-const TEST_USERID = '17657928';
+const TEST_USERID   = '17657928';
 
 /** @var array $args */
 main( $args[0] );
@@ -28,22 +29,21 @@ function main( string $case ) : void {
 
 	call_user_func( __NAMESPACE__ . "\\test_$case", WPOrg_5ftf_Activity_Handler::get_instance() );
 
-
-	//echo "\nThere should be new activity on https://profiles.wordpress.org/$user->user_nicename/ \n";
+	// echo "\nThere should be new activity on https://profiles.wordpress.org/$user->user_nicename/ \n";
 }
 
 function expect( $fail, $result ) {
-	if( $fail) {
-		echo 'Test Error: ' . PHP_EOL . ' Received:' . PHP_EOL . $result  . PHP_EOL;
+	if ( $fail ) {
+		echo 'Test Error: ' . PHP_EOL . ' Received:' . PHP_EOL . $result . PHP_EOL;
 	}
 }
 
 function expectTrue( $result ) {
-	expect( ( $result !== true || substr($result, 0, 1) !== '1' ), $result);
+	expect( ( $result !== true || substr( $result, 0, 1 ) !== '1' ), $result );
 }
 
 function expectFalse( $result ) {
-	expect(substr($result, 0, 2) !== '-1', $result);
+	expect( substr( $result, 0, 2 ) !== '-1', $result );
 }
 
 /**
@@ -57,24 +57,36 @@ function test_github_filter( WPOrg_5ftf_Activity_Handler $handler ) : void {
 }
 
 function test_github_filter_success( WPOrg_5ftf_Activity_Handler $handler ) : void {
-	expectTrue( $handler->handle_github_activity( [
-		"category" => "pr_merged",
-		"repo" => "wordpress.org",
-		"user_id" => TEST_USERID
-	] ) );
+	expectTrue(
+		$handler->handle_github_activity(
+			array(
+				'category' => 'pr_merged',
+				'repo'     => 'wordpress.org',
+				'user_id'  => TEST_USERID,
+			)
+		)
+	);
 }
 
 function test_github_filter_no_user_id( WPOrg_5ftf_Activity_Handler $handler ) : void {
-	expectFalse( $handler->handle_github_activity( [
-		"category" => "pr_merged",
-		"repo" => "wordpress.org",
-	] ) );
+	expectFalse(
+		$handler->handle_github_activity(
+			array(
+				'category' => 'pr_merged',
+				'repo'     => 'wordpress.org',
+			)
+		)
+	);
 }
 
 function test_github_filter_unsupported_category( WPOrg_5ftf_Activity_Handler $handler ) : void {
-	expectFalse( $handler->handle_github_activity( [
-		"category" => "not_supported",
-		"repo" => "wordpress.org",
-		"user_id" => TEST_USERID
-	] ) );
+	expectFalse(
+		$handler->handle_github_activity(
+			array(
+				'category' => 'not_supported',
+				'repo'     => 'wordpress.org',
+				'user_id'  => TEST_USERID,
+			)
+		)
+	);
 }

--- a/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/tests/test.php
+++ b/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/tests/test.php
@@ -22,6 +22,8 @@ const TEST_USERNAME = 'dufresnesteven';
 /** @var array $args */
 main( $args[0] );
 
+
+// Test Helper functions
 function main( string $case ) : void {
 
 	require_once dirname( __DIR__ ) . '/wporg-5ftf-activity-handler.php';
@@ -45,16 +47,87 @@ function expectFalse( $result ) {
 	expect( substr( $result, 0, 2 ) !== '-1', $result );
 }
 
+
+/**
+ * Tests the handling of `bp_activity_add` activities
+ *
+ * Source: https://github.com/WordPress/wordpress.org/blob/trunk/profiles.wordpress.org/public_html/wp-content/plugins/wporg-profiles-activity-handler/wporg-profiles-activity-handler.php
+ */
+function test_bp_filter( WPOrg_5ftf_Activity_Handler $handler, $user ) : void {
+	test_bp_filter_success( $handler, $user );
+	test_bp_filter_missing_user_id( $handler, $user );
+	test_bp_filter_missing_type( $handler, $user );
+	test_bp_filter_not_supported_type( $handler, $user );
+}
+
+/**
+ * Should update database.
+ */
+function test_bp_filter_success( WPOrg_5ftf_Activity_Handler $handler, $user ) : void {
+	expectTrue(
+		$handler->handle_activity(
+			array(
+				'type'    => 'blog_post_create',
+				'user_id' => $user->ID,
+			)
+		)
+	);
+}
+
+/**
+ * Should return error message due to missing user id.
+ */
+function test_bp_filter_missing_user_id( WPOrg_5ftf_Activity_Handler $handler, $user ) : void {
+	expectFalse(
+		$handler->handle_activity(
+			array(
+				'type' => 'blog_post_create',
+			)
+		)
+	);
+}
+
+/**
+ * Should return error message due to missing type.
+ */
+function test_bp_filter_missing_type( WPOrg_5ftf_Activity_Handler $handler, $user ) : void {
+	expectFalse(
+		$handler->handle_activity(
+			array(
+				'user_id' => $user->ID,
+			)
+		)
+	);
+}
+
+/**
+ * Should return error message due to type not being a contribution.
+ */
+function test_bp_filter_not_supported_type( WPOrg_5ftf_Activity_Handler $handler, $user ) : void {
+	expectFalse(
+		$handler->handle_activity(
+			array(
+				'type'    => 'not_supported',
+				'user_id' => $user->ID,
+			)
+		)
+	);
+}
+
 /**
  * Tests the handling of GitHub activities
+ *
+ * Source: https://github.com/WordPress/wordpress.org/blob/trunk/api.wordpress.org/public_html/dotorg/github/activity.php
  */
-
 function test_github_filter( WPOrg_5ftf_Activity_Handler $handler, $user ) : void {
 	test_github_filter_success( $handler, $user );
 	test_github_filter_no_user_id( $handler );
 	test_github_filter_unsupported_category( $handler, $user );
 }
 
+/**
+ * Should update database.
+ */
 function test_github_filter_success( WPOrg_5ftf_Activity_Handler $handler, $user ) : void {
 	expectTrue(
 		$handler->handle_github_activity(
@@ -67,6 +140,9 @@ function test_github_filter_success( WPOrg_5ftf_Activity_Handler $handler, $user
 	);
 }
 
+/**
+ * Should return error message due to missing user id.
+ */
 function test_github_filter_no_user_id( WPOrg_5ftf_Activity_Handler $handler ) : void {
 	expectFalse(
 		$handler->handle_github_activity(
@@ -78,6 +154,9 @@ function test_github_filter_no_user_id( WPOrg_5ftf_Activity_Handler $handler ) :
 	);
 }
 
+/**
+ * Should return error message due to unsupported category.
+ */
 function test_github_filter_unsupported_category( WPOrg_5ftf_Activity_Handler $handler, $user ) : void {
 	expectFalse(
 		$handler->handle_github_activity(

--- a/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/tests/test.php
+++ b/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/tests/test.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * ⚠️️ These tests run against the production database and object cache on profiles.w.org.
+ * Make sure that any modifications are hardcoded to only affect test sites and test user accounts.
+ *
+ * usage: wp eval-file test.php test_name
+ */
+
+namespace WordPressdotorg\WPORG_5ftf_Activity_Notifier\Tests;
+use WPOrg_5ftf_Activity_Handler;
+
+ini_set( 'display_errors', 'On' ); // won't do anything if fatal errors
+
+if ( 'staging' !== wp_get_environment_type() || 'cli' !== php_sapi_name() ) {
+	die( 'Error: Wrong environment.' );
+}
+
+const TEST_USERNAME = 'dufresnesteven';
+const TEST_USERID = '17657928';
+
+/** @var array $args */
+main( $args[0] );
+
+function main( string $case ) : void {
+
+	require_once dirname( __DIR__ ) . '/wporg-5ftf-activity-handler.php';
+
+	call_user_func( __NAMESPACE__ . "\\test_$case", WPOrg_5ftf_Activity_Handler::get_instance() );
+
+
+	//echo "\nThere should be new activity on https://profiles.wordpress.org/$user->user_nicename/ \n";
+}
+
+function expect( $fail, $result ) {
+	if( $fail) {
+		echo 'Test Error: ' . PHP_EOL . ' Received:' . PHP_EOL . $result  . PHP_EOL;
+	}
+}
+
+function expectTrue( $result ) {
+	expect( ( $result !== true || substr($result, 0, 1) !== '1' ), $result);
+}
+
+function expectFalse( $result ) {
+	expect(substr($result, 0, 2) !== '-1', $result);
+}
+
+/**
+ * Tests the handling of GitHub activities
+ */
+
+function test_github_filter( WPOrg_5ftf_Activity_Handler $handler ) : void {
+	test_github_filter_success( $handler );
+	test_github_filter_no_user_id( $handler );
+	test_github_filter_unsupported_category( $handler );
+}
+
+function test_github_filter_success( WPOrg_5ftf_Activity_Handler $handler ) : void {
+	expectTrue( $handler->handle_github_activity( [
+		"category" => "pr_merged",
+		"repo" => "wordpress.org",
+		"user_id" => TEST_USERID
+	] ) );
+}
+
+function test_github_filter_no_user_id( WPOrg_5ftf_Activity_Handler $handler ) : void {
+	expectFalse( $handler->handle_github_activity( [
+		"category" => "pr_merged",
+		"repo" => "wordpress.org",
+	] ) );
+}
+
+function test_github_filter_unsupported_category( WPOrg_5ftf_Activity_Handler $handler ) : void {
+	expectFalse( $handler->handle_github_activity( [
+		"category" => "not_supported",
+		"repo" => "wordpress.org",
+		"user_id" => TEST_USERID
+	] ) );
+}

--- a/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/wporg-5ftf-activity-handler.php
+++ b/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/wporg-5ftf-activity-handler.php
@@ -53,7 +53,7 @@ class WPOrg_5ftf_Activity_Handler {
 	public function __construct() {
 		if ( 'profiles.wordpress.org' === site_url() ) {
 			add_filter( 'bp_activity_add', array( $this, 'handle_activity' ) );
-		} elseif ( str_ends_with( 'wordpress.org', site_url() ) ) {
+		} elseif ( str_ends_with( 'wordpress.org', site_url() ) && constant( 'IS_WPORG_MULTINETWORK' ) ) {
 			add_filter( 'wporg_github_added_activity', array( $this, 'handle_github_activity' ) );
 		}
 	}

--- a/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/wporg-5ftf-activity-handler.php
+++ b/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/wporg-5ftf-activity-handler.php
@@ -54,7 +54,7 @@ class WPOrg_5ftf_Activity_Handler {
 
 		if ( 'profiles.wordpress.org' === site_url() ) {
 			add_filter( 'bp_activity_add', array( $this, 'handle_activity' ) );
-		} elseif ( str_ends_with( 'wordpress.org', site_url() ) && defined( 'IS_WPORG_MULTINETWORK' ) ) {
+		} elseif ( defined( 'IS_WPORG_MULTINETWORK' ) && IS_WPORG_MULTINETWORK ) {
 			add_filter( 'wporg_github_added_activity', array( $this, 'handle_github_activity' ) );
 		}
 	}

--- a/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/wporg-5ftf-activity-handler.php
+++ b/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/wporg-5ftf-activity-handler.php
@@ -53,9 +53,20 @@ if ( ! class_exists( 'WPOrg_5ftf_Activity_Handler' ) ) {
 		 * Saves meta value if it qualifies as a contribution.
 		 */
 		public function handle_activity( $args ) {
-			if ( self::is_5ftf_contribution( $args['type'] ) ) {
-				self::update_last_contribution_meta( $args['user_id'] );
+
+			if ( empty( $args['user_id'] ) ) {
+				return '-1 WordPress.org user id is missing';
 			}
+
+			if ( ! isset( $args['type'] ) ) {
+				return '-1 Activity type is missing';
+			}
+
+			if ( ! self::is_5ftf_contribution( $args['type'] ) ) {
+				return '-1 Activity is not considered a contribution';
+			}
+
+			return self::update_last_contribution_meta( $args['user_id'] );
 		}
 
 		/**

--- a/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/wporg-5ftf-activity-handler.php
+++ b/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/wporg-5ftf-activity-handler.php
@@ -24,15 +24,36 @@ if ( ! class_exists( 'WPOrg_5ftf_Activity_Handler' ) ) {
 		 * Constructor.
 		 */
 		public function __construct() {
-			add_filter( 'bp_activity_add', array( $this, 'handle_contribution' ) );
+			add_filter( 'bp_activity_add', array( $this, 'handle_activity' ) );
+			add_filter( 'wporg_github_added_activity', array( $this, 'handle_github_activity' ) );
 		}
 
 		/**
 		 * Saves meta value if it qualifies as a contribution.
 		 */
-		public function handle_contribution( $args ) {
+		public function handle_activity( $args ) {
 			if ( self::is_5ftf_contribution( $args['type'] ) ) {
 				self::update_last_contribution_meta( $args['user_id'] );
+			}
+		}
+
+		/**
+		 * Saves meta value if it qualifies as a github contribution.
+		 */
+		public function handle_github_activity( $args ) {
+			/**
+			* $args.category string Type of github event
+			* $args.repo string Name of the public repository
+			* $args.user_id string|null Name of the public repository
+			*/
+
+			$valid_actions = array( 'pr_opened', 'pr_merged', 'issue_opened' );
+
+			if ( in_array( $args['category'], $valid_actions, true ) ) {
+				// user_id may be null
+				if ( $args['user_id'] ) {
+					update_last_contribution_meta( $args['user_id'] );
+				}
 			}
 		}
 

--- a/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/wporg-5ftf-activity-handler.php
+++ b/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/wporg-5ftf-activity-handler.php
@@ -51,9 +51,10 @@ class WPOrg_5ftf_Activity_Handler {
 	 * Constructor.
 	 */
 	public function __construct() {
+
 		if ( 'profiles.wordpress.org' === site_url() ) {
 			add_filter( 'bp_activity_add', array( $this, 'handle_activity' ) );
-		} elseif ( str_ends_with( 'wordpress.org', site_url() ) && constant( 'IS_WPORG_MULTINETWORK' ) ) {
+		} elseif ( str_ends_with( 'wordpress.org', site_url() ) && defined( 'IS_WPORG_MULTINETWORK' ) ) {
 			add_filter( 'wporg_github_added_activity', array( $this, 'handle_github_activity' ) );
 		}
 	}

--- a/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/wporg-5ftf-activity-handler.php
+++ b/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/wporg-5ftf-activity-handler.php
@@ -60,36 +60,36 @@ if ( ! class_exists( 'WPOrg_5ftf_Activity_Handler' ) ) {
 
 		/**
 		 * Saves meta value if it qualifies as a github contribution.
-		 * 
+		 *
 		 * $args.category string Type of github event
 		 * $args.repo string Name of the public repository
 		 * $args.user_id string|null Name of the public repository
-		 * 
+		 *
 		 * @return int|bool
 		 */
 		public function handle_github_activity( $args ) {
 			$valid_actions = array( 'pr_opened', 'pr_closed', 'pr_merged', 'issue_opened', 'pr_reopened' );
 
-			if( empty( $args['user_id'] ) ) {	
+			if ( empty( $args['user_id'] ) ) {
 				// user_id may be null if the user didn't connect their github account to their wordpress.org account
-				return  '-1 WordPress.org user id is missing';
+				return '-1 WordPress.org user id is missing';
 			}
 
-			if( ! in_array( $args['category'], $valid_actions, true ) ) {
-				return  '-1 Category: ' . sanitize_text_field( $args['category'] ) . ' is not a contribution.';
+			if ( ! in_array( $args['category'], $valid_actions, true ) ) {
+				return '-1 Category: ' . sanitize_text_field( $args['category'] ) . ' is not a contribution.';
 			}
 
-			return self::update_last_contribution_meta( $args['user_id'] );	
+			return self::update_last_contribution_meta( $args['user_id'] );
 		}
 
 		/**
 		 * Returns whether action is considered a contribution.
-		 * 
+		 *
 		 * @return boolean True if action == contribution
 		 */
 		public function is_5ftf_contribution( $action ) {
 			$wordpress_actions = array( 'blog_post_create' );
-			$wordcamp_actions = array( 'wordcamp_speaker_add', 'wordcamp_organizer_add' );
+			$wordcamp_actions  = array( 'wordcamp_speaker_add', 'wordcamp_organizer_add' );
 
 			$valid_actions = array_merge( $wordpress_actions, $wordcamp_actions );
 
@@ -98,7 +98,7 @@ if ( ! class_exists( 'WPOrg_5ftf_Activity_Handler' ) ) {
 
 		/**
 		 * Updates meta value to current timestamp indicating the user's last contribution.
-		 * 
+		 *
 		 * @return int|bool result of update_user_meta();
 		 */
 		protected function update_last_contribution_meta( $user_id ) {

--- a/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/wporg-5ftf-activity-handler.php
+++ b/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/wporg-5ftf-activity-handler.php
@@ -4,23 +4,7 @@ Plugin Name: WordPress.org 5ftf Activity Handler
 Plugin URI: http://wordpress.org
 License: GPL2
 Version: 1.1
-Description: Handles saving of last 5ftf 
-*/
-
-/*  Copyright 2013
-
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License, version 2, as
-    published by the Free Software Foundation.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+Description: Handles saving of last 5ftf contribution.
 */
 
 defined( 'ABSPATH' ) or die();
@@ -45,7 +29,6 @@ if ( ! class_exists( 'WPOrg_5ftf_Activity_Handler' ) ) {
 
 		/**
 		 * Saves contribution if it qualifies as a contribution.
-		 * 
 		 */
 		public function handle_contribution( $args ) {
 			if( self::is_5ftf_contribution( $args['type'] ) ) {

--- a/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/wporg-5ftf-activity-handler.php
+++ b/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/wporg-5ftf-activity-handler.php
@@ -9,115 +9,116 @@ Description: Handles saving of last 5ftf contribution.
 
 defined( 'ABSPATH' ) or die();
 
-if ( ! class_exists( 'WPOrg_5ftf_Activity_Handler' ) ) {
+if ( class_exists( 'WPOrg_5ftf_Activity_Handler' ) ) {
+	return;
+}
 
-	class WPOrg_5ftf_Activity_Handler {
+class WPOrg_5ftf_Activity_Handler {
 
-		/**
-		 * @var WPOrg_5ftf_Activity_Handler The singleton instance.
-		 */
-		private static $instance;
+	/**
+	 * @var WPOrg_5ftf_Activity_Handler The singleton instance.
+	 */
+	private static $instance;
 
-		/**
-		 *  Name of meta key that tracks last contribution as a unix timestamp.
-		 *
-		 * @var string
-		 */
-		const last_contribution_meta_key = 'wporg_5ftf_last_contribution';
+	/**
+	 *  Name of meta key that tracks last contribution as a unix timestamp.
+	 *
+	 * @var string
+	 */
+	const last_contribution_meta_key = 'wporg_5ftf_last_contribution';
 
-		/**
-		 * Returns always the same instance of this plugin.
-		 *
-		 * @return WPOrg_5ftf_Activity_Handler
-		 */
-		public static function get_instance() {
-			if ( ! self::$instance ) {
-				self::$instance = new self();
-			}
-
-			return self::$instance;
+	/**
+	 * Returns always the same instance of this plugin.
+	 *
+	 * @return WPOrg_5ftf_Activity_Handler
+	 */
+	public static function get_instance() {
+		if ( ! self::$instance ) {
+			self::$instance = new self();
 		}
 
-		/**
-		 * Constructor.
-		 */
-		public function __construct() {
-			if ( 'profiles.wordpress.org' === site_url() ) {
-				add_filter( 'bp_activity_add', array( $this, 'handle_activity' ) );
-			} elseif ( str_ends_with( 'wordpress.org', site_url() ) ) {
-				add_filter( 'wporg_github_added_activity', array( $this, 'handle_github_activity' ) );
-			}
+		return self::$instance;
+	}
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		if ( 'profiles.wordpress.org' === site_url() ) {
+			add_filter( 'bp_activity_add', array( $this, 'handle_activity' ) );
+		} elseif ( str_ends_with( 'wordpress.org', site_url() ) ) {
+			add_filter( 'wporg_github_added_activity', array( $this, 'handle_github_activity' ) );
+		}
+	}
+
+	/**
+	 * Saves meta value if it qualifies as a contribution.
+	 */
+	public function handle_activity( $args ) {
+
+		if ( empty( $args['user_id'] ) ) {
+			return '-1 WordPress.org user id is missing';
 		}
 
-		/**
-		 * Saves meta value if it qualifies as a contribution.
-		 */
-		public function handle_activity( $args ) {
-
-			if ( empty( $args['user_id'] ) ) {
-				return '-1 WordPress.org user id is missing';
-			}
-
-			if ( ! isset( $args['type'] ) ) {
-				return '-1 Activity type is missing';
-			}
-
-			if ( ! self::is_5ftf_contribution( $args['type'] ) ) {
-				return '-1 Activity is not considered a contribution';
-			}
-
-			return self::update_last_contribution_meta( $args['user_id'] );
+		if ( ! isset( $args['type'] ) ) {
+			return '-1 Activity type is missing';
 		}
 
-		/**
-		 * Saves meta value if it qualifies as a github contribution.
-		 *
-		 * $args.category string Type of github event
-		 * $args.repo string Name of the public repository
-		 * $args.user_id string|null Name of the public repository
-		 *
-		 * @return int|bool
-		 */
-		public function handle_github_activity( $args ) {
-			$valid_actions = array( 'pr_opened', 'pr_closed', 'pr_merged', 'issue_opened', 'pr_reopened' );
-
-			if ( empty( $args['user_id'] ) ) {
-				// user_id may be null if the user didn't connect their github account to their wordpress.org account
-				return '-1 WordPress.org user id is missing';
-			}
-
-			if ( ! in_array( $args['category'], $valid_actions, true ) ) {
-				return '-1 Category: ' . sanitize_text_field( $args['category'] ) . ' is not a contribution.';
-			}
-
-			return self::update_last_contribution_meta( $args['user_id'] );
+		if ( ! self::is_5ftf_contribution( $args['type'] ) ) {
+			return '-1 Activity is not considered a contribution';
 		}
 
-		/**
-		 * Returns whether action is considered a contribution.
-		 *
-		 * @return boolean True if action == contribution
-		 */
-		public function is_5ftf_contribution( $action ) {
-			$wordpress_actions = array( 'blog_post_create' );
-			$wordcamp_actions  = array( 'wordcamp_speaker_add', 'wordcamp_organizer_add' );
+		return self::update_last_contribution_meta( $args['user_id'] );
+	}
 
-			$valid_actions = array_merge( $wordpress_actions, $wordcamp_actions );
+	/**
+	 * Saves meta value if it qualifies as a github contribution.
+	 *
+	 * $args.category string Type of github event
+	 * $args.repo string Name of the public repository
+	 * $args.user_id string|null Name of the public repository
+	 *
+	 * @return int|bool
+	 */
+	public function handle_github_activity( $args ) {
+		$valid_actions = array( 'pr_opened', 'pr_merged', 'issue_opened', 'issue_closed' );
 
-			return in_array( $action, $valid_actions, true );
+		if ( empty( $args['user_id'] ) ) {
+			// user_id may be null if the user didn't connect their github account to their wordpress.org account
+			return '-1 WordPress.org user id is missing';
 		}
 
-		/**
-		 * Updates meta value to current timestamp indicating the user's last contribution.
-		 *
-		 * @return int|bool result of update_user_meta();
-		 */
-		protected function update_last_contribution_meta( $user_id ) {
-			return update_user_meta( $user_id, self::last_contribution_meta_key, time() );
+		if ( ! in_array( $args['category'], $valid_actions, true ) ) {
+			return '-1 Category: ' . sanitize_text_field( $args['category'] ) . ' is not a contribution.';
 		}
 
-	} /* /class WPOrg_5ftf_Activity_Handler */
-} /* if class_exists */
+		return self::update_last_contribution_meta( $args['user_id'] );
+	}
+
+	/**
+	 * Returns whether action is considered a contribution.
+	 *
+	 * @return boolean True if action == contribution
+	 */
+	public function is_5ftf_contribution( $action ) {
+		$wordpress_actions = array( 'blog_post_create' );
+		$wordcamp_actions  = array( 'wordcamp_speaker_add', 'wordcamp_organizer_add' );
+
+		$valid_actions = array_merge( $wordpress_actions, $wordcamp_actions );
+
+		return in_array( $action, $valid_actions, true );
+	}
+
+	/**
+	 * Updates meta value to current timestamp indicating the user's last contribution.
+	 *
+	 * @return int|bool result of update_user_meta();
+	 */
+	protected function update_last_contribution_meta( $user_id ) {
+		return update_user_meta( $user_id, self::last_contribution_meta_key, time() );
+	}
+
+} /* /class WPOrg_5ftf_Activity_Handler */
 
 if ( class_exists( 'WPOrg_5ftf_Activity_Handler' ) ) {
 	WPOrg_5ftf_Activity_Handler::get_instance();

--- a/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/wporg-5ftf-activity-handler.php
+++ b/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/wporg-5ftf-activity-handler.php
@@ -24,14 +24,17 @@ if ( ! class_exists( 'WPOrg_5ftf_Activity_Handler' ) ) {
 		 * Constructor.
 		 */
 		public function __construct() {
-			add_filter( 'bp_activity_add', array( $this, 'handle_activity' ) );
-			add_filter( 'wporg_github_added_activity', array( $this, 'handle_github_activity' ) );
+			if ( 'profiles.wordpress.org' === site_url() ) {
+				add_filter( 'bp_activity_add', array( $this, 'handle_wordpress_activity' ) );
+			} elseif ( str_ends_with( 'wordpress.org', site_url() ) ) {
+				add_filter( 'wporg_github_added_activity', array( $this, 'handle_github_activity' ) );
+			}
 		}
 
 		/**
 		 * Saves meta value if it qualifies as a contribution.
 		 */
-		public function handle_activity( $args ) {
+		public function handle_wordpress_activity( $args ) {
 			if ( self::is_5ftf_contribution( $args['type'] ) ) {
 				self::update_last_contribution_meta( $args['user_id'] );
 			}
@@ -50,7 +53,7 @@ if ( ! class_exists( 'WPOrg_5ftf_Activity_Handler' ) ) {
 			$valid_actions = array( 'pr_opened', 'pr_merged', 'issue_opened' );
 
 			if ( in_array( $args['category'], $valid_actions, true ) ) {
-				// user_id may be null
+				// user_id may be null if the user didn't connect their github account to their wordpress.org account
 				if ( $args['user_id'] ) {
 					update_last_contribution_meta( $args['user_id'] );
 				}

--- a/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/wporg-5ftf-activity-handler.php
+++ b/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/wporg-5ftf-activity-handler.php
@@ -1,0 +1,79 @@
+<?php
+/*
+Plugin Name: WordPress.org 5ftf Activity Handler
+Plugin URI: http://wordpress.org
+License: GPL2
+Version: 1.1
+Description: Handles saving of last 5ftf 
+*/
+
+/*  Copyright 2013
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License, version 2, as
+    published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+defined( 'ABSPATH' ) or die();
+
+if ( ! class_exists( 'WPOrg_5ftf_Activity_Handler' ) ) {
+
+	class WPOrg_5ftf_Activity_Handler {
+
+		/**
+		 *  Name of meta key that tracks last contribution as a unix timestamp.
+		 *
+		 * @var string
+		 */
+		const last_contribution_meta_key = 'wporg_5ftf_last_contribution';
+
+		/**
+		 * Constructor.
+		 */
+		public function __construct() {
+			add_filter( 'bp_activity_add', array( $this, 'handle_contribution' ) );
+		}
+
+		/**
+		 * Saves contribution if it qualifies as a contribution.
+		 * 
+		 */
+		public function handle_contribution( $args ) {
+			if( self::is_5ftf_contribution( $args['type'] ) ) {
+				self::update_last_contribution_meta( $args['user_id'] );
+			}
+		}
+
+		/**
+		 * Returns whether action is considered a contribution.
+		 */
+		public function is_5ftf_contribution( $action ) {
+			$valid_actions = array( 'forum_topic_create' );
+
+			return in_array( $action, $valid_actions, true );
+		}
+
+		/**
+		 * Updates meta value to current timestamp indicating the user's last contribution.
+		 * 
+		 * @return int|bool result of update_user_meta();
+		 */
+		protected function update_last_contribution_meta( $user_id ) {
+			return update_user_meta( $user_id, self::last_contribution_meta_key, time() );
+		}
+
+	} /* /class WPOrg_5ftf_Activity_Handler */
+} /* if class_exists */
+
+if ( class_exists( 'WPOrg_5ftf_Activity_Handler' ) ) {
+	new WPOrg_5ftf_Activity_Handler();
+}

--- a/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/wporg-5ftf-activity-handler.php
+++ b/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/wporg-5ftf-activity-handler.php
@@ -31,7 +31,7 @@ if ( ! class_exists( 'WPOrg_5ftf_Activity_Handler' ) ) {
 		 * Saves contribution if it qualifies as a contribution.
 		 */
 		public function handle_contribution( $args ) {
-			if( self::is_5ftf_contribution( $args['type'] ) ) {
+			if ( self::is_5ftf_contribution( $args['type'] ) ) {
 				self::update_last_contribution_meta( $args['user_id'] );
 			}
 		}
@@ -40,14 +40,17 @@ if ( ! class_exists( 'WPOrg_5ftf_Activity_Handler' ) ) {
 		 * Returns whether action is considered a contribution.
 		 */
 		public function is_5ftf_contribution( $action ) {
-			$valid_actions = array( 'forum_topic_create' );
+			$wordpress_actions = array( 'blog_post_create' );
+			$wordcamp_actions  = array( 'wordcamp_speaker_add', 'wordcamp_organizer_add' );
+
+			$valid_actions = array_merge( $wordpress_actions, $wordcamp_actions );
 
 			return in_array( $action, $valid_actions, true );
 		}
 
 		/**
 		 * Updates meta value to current timestamp indicating the user's last contribution.
-		 * 
+		 *
 		 * @return int|bool result of update_user_meta();
 		 */
 		protected function update_last_contribution_meta( $user_id ) {

--- a/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/wporg-5ftf-activity-handler.php
+++ b/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/wporg-5ftf-activity-handler.php
@@ -28,7 +28,7 @@ if ( ! class_exists( 'WPOrg_5ftf_Activity_Handler' ) ) {
 		}
 
 		/**
-		 * Saves contribution if it qualifies as a contribution.
+		 * Saves meta value if it qualifies as a contribution.
 		 */
 		public function handle_contribution( $args ) {
 			if ( self::is_5ftf_contribution( $args['type'] ) ) {

--- a/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/wporg-5ftf-activity-handler.php
+++ b/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/wporg-5ftf-activity-handler.php
@@ -27,7 +27,6 @@ class WPOrg_5ftf_Activity_Handler {
 	 */
 	const last_contribution_meta_key = 'wporg_5ftf_last_contribution';
 
-
 	/**
 	 *  Name of meta key that stores information about the last_contribution_meta_key.
 	 *

--- a/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/wporg-5ftf-activity-handler.php
+++ b/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/wporg-5ftf-activity-handler.php
@@ -27,6 +27,14 @@ class WPOrg_5ftf_Activity_Handler {
 	 */
 	const last_contribution_meta_key = 'wporg_5ftf_last_contribution';
 
+
+	/**
+	 *  Name of meta key that stores information about the last_contribution_meta_key.
+	 *
+	 * @var string
+	 */
+	const last_contribution_info_meta_key = 'last_contribution_info_meta_key';
+
 	/**
 	 * Returns always the same instance of this plugin.
 	 *
@@ -68,7 +76,7 @@ class WPOrg_5ftf_Activity_Handler {
 			return '-1 Activity is not considered a contribution';
 		}
 
-		return self::update_last_contribution_meta( $args['user_id'] );
+		return self::update_last_contribution_meta( $args['user_id'], $args );
 	}
 
 	/**
@@ -92,7 +100,7 @@ class WPOrg_5ftf_Activity_Handler {
 			return '-1 Category: ' . sanitize_text_field( $args['category'] ) . ' is not a contribution.';
 		}
 
-		return self::update_last_contribution_meta( $args['user_id'] );
+		return self::update_last_contribution_meta( $args['user_id'], $args );
 	}
 
 	/**
@@ -114,7 +122,11 @@ class WPOrg_5ftf_Activity_Handler {
 	 *
 	 * @return int|bool result of update_user_meta();
 	 */
-	protected function update_last_contribution_meta( $user_id ) {
+	protected function update_last_contribution_meta( $user_id, $args ) {
+
+		// Save information about what updates the value
+		update_user_meta( $user_id, self::last_contribution_info_meta_key, json_encode( $args ) );
+
 		return update_user_meta( $user_id, self::last_contribution_meta_key, time() );
 	}
 

--- a/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/wporg-5ftf-activity-handler.php
+++ b/profiles.wordpress.org/public_html/wp-content/plugins/wporg-5ftf-activity-handler/wporg-5ftf-activity-handler.php
@@ -43,7 +43,7 @@ if ( ! class_exists( 'WPOrg_5ftf_Activity_Handler' ) ) {
 		 */
 		public function __construct() {
 			if ( 'profiles.wordpress.org' === site_url() ) {
-				add_filter( 'bp_activity_add', array( $this, 'handle_wordpress_activity' ) );
+				add_filter( 'bp_activity_add', array( $this, 'handle_activity' ) );
 			} elseif ( str_ends_with( 'wordpress.org', site_url() ) ) {
 				add_filter( 'wporg_github_added_activity', array( $this, 'handle_github_activity' ) );
 			}
@@ -52,7 +52,7 @@ if ( ! class_exists( 'WPOrg_5ftf_Activity_Handler' ) ) {
 		/**
 		 * Saves meta value if it qualifies as a contribution.
 		 */
-		public function handle_wordpress_activity( $args ) {
+		public function handle_activity( $args ) {
 			if ( self::is_5ftf_contribution( $args['type'] ) ) {
 				self::update_last_contribution_meta( $args['user_id'] );
 			}


### PR DESCRIPTION
Addresses: https://github.com/WordPress/five-for-the-future/issues/189

# Summary
We need to store a timestamp of the last five for the future contribution to be used later to make more efficient SQL queries in [soon-to-be-written](https://github.com/WordPress/five-for-the-future/milestone/9) code. [Read More](https://github.com/WordPress/five-for-the-future/issues/189).

# Inputs
### Activities in WordPress & WordPress communities
Activities that happen on WordPress.org and other adjacent WordPress communities get added to the database via `bp_activity_add`.

Most of this logic is handled in [profiles.wordpress.org/wporg-profiles-activity-handler.php](https://github.com/WordPress/wordpress.org/blob/trunk/profiles.wordpress.org/public_html/wp-content/plugins/wporg-profiles-activity-handler/wporg-profiles-activity-handler.php)

### Activity on GitHub
Activities that happen on GitHub get stored in `wporg_github_activity` via an [API endpoint](https://github.com/WordPress/wordpress.org/blob/trunk/api.wordpress.org/public_html/dotorg/github/activity.php).
### Trac commits
// TODO Not sure what happens here. 

# Context
In its simplest form, we need to run `update_user_meta( $user_id, 'key_name', time() )` when a valid contribution is _detected_. 

We have the option to detect contributions in 2 ways:
- Active -> When the activity is being logged to the database (used in this PR) 
  -  Maybe it's not logged but we detect it in an event
- Passive -> Using a task that runs periodically and queries for all the relevant data sources.

This PR uses an active approach and listens for filters that indicate new activities were saved to the database. 

Making sure the timestamp is up-to-date is important, seeing that it will be used to initiate downstream notifications. A cron job would theoretically introduce an edge case where a contribution could be missed, albeit temporarily.

The potential downside of using this approach is that our input list could grow horizontally and we would need to make 5ftf-related code updates to code that shouldn't know about it. In other words, we should be able to remove all 5ftf code without side effects or remaining technical debt. 

The last consideration is that this code will be the only place where 5ftf contributions are clearly defined. So while we could call `update_user_meta` wherever an activity occurs, keeping track of the contribution list (or logic) in one spot will give us the ability to audit/add/remove contributions more easily, and since missing contributions could result in _extra_ pledge correspondence, we'll want to be able to see the landscape in one frame.

# Approach

Most of the wp actions are currently stored by BuddyPress via `bp_activity_add`. After discussion with @iandunn, we've decided its probably best to hook into the BuddyPress filter `bp_activity_add`. I think we can also take that approach for all inputs by creating our own filters.

- `apply_filter( 'make_relevant_filter_name', $data )` for all inputs when activities are saved or detected
- Activate this plugin on all sites where inputs exist
- Add a filter for the relevant input in this plugin
- Handle the `update_user_meta` in this file only

# Tasks

- [ ] Identify the relevant `type`s that are considered contributions
  - Some of these will be conditional and vary per site/team
- [ ] Identify the relevant GitHub `category`
  - Some of these will be conditional and vary per site/team
- [ ] Update the contribution based on trac commits?
- [ ] other stuff, not sure yet 
 
