### PR TITLE
Turn on notifications for developer network.

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-developer/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-developer/functions.php
@@ -168,6 +168,7 @@ function init() {
 	add_filter( 'breadcrumb_trail_items',  __NAMESPACE__ . '\\breadcrumb_trail_items_for_handbook_root', 10, 2 );
 
 	add_filter( 'syntaxhighlighter_htmlresult', __NAMESPACE__ . '\\syntaxhighlighter_htmlresult' );
+	add_filter( 'wporg_profiles_wp_activity-is_post_notifiable','__return_true' );
 }
 
 /**


### PR DESCRIPTION
Related to https://github.com/WordPress/five-for-the-future/issues/178.

We want to turn on `Tracking code examples or user contributed notes, both for the submitter and the reviewer` on developers.wordpress.org. Currently, developer.wordpress.org posts are not considered [notifiable](https://github.com/WordPress/wordpress.org/blob/58668f17c7870eaa251e3c2ee1f2a7b0405dc55b/wordpress.org/public_html/wp-content/plugins/wporg-profiles-wp-activity-notifier/wporg-profiles-wp-activity-notifier.php#L85).

This PR updates the developer theme to return `true` when the `wporg_profiles_wp_activity-is_post_notifiable` filter is applied.

### Considerations
Although our specific goal is to track comments on posts, specifically `wp-parser-hook`, `wp-parser-class`, `wp-parser-method`, `wp-parse-function` posts, this PR will turn on notifications for updates to all posts on developer.wordpress.org. As an alternative, we could add logic to make sure it's specific to the post types above and only for comments but I can't see a good reason why we shouldn't notify for all updates. The code already protects again [missing authors](https://github.com/WordPress/wordpress.org/blob/58668f17c7870eaa251e3c2ee1f2a7b0405dc55b/wordpress.org/public_html/wp-content/plugins/wporg-profiles-wp-activity-notifier/wporg-profiles-wp-activity-notifier.php#L114) and [imports](https://github.com/WordPress/wordpress.org/blob/58668f17c7870eaa251e3c2ee1f2a7b0405dc55b/wordpress.org/public_html/wp-content/plugins/wporg-profiles-wp-activity-notifier/wporg-profiles-wp-activity-notifier.php#L158), which I think should remove any potential issue since those posts types are unique (although I haven't tested this assumption). So other updates should also be considered activity & [5ftf](https://wordpress.org/five-for-the-future/) worthy.

