### PR TITLE
Show patterns in theme directory.

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-themes-api.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-themes-api.php
@@ -64,6 +64,7 @@ class Themes_API {
 		'requires'           => false,
 		'requires_php'       => false,
 		'trac_tickets'       => false,
+		'patterns'           => false,
 	);
 
 	/**
@@ -892,6 +893,33 @@ class Themes_API {
 				$phil->sections['description'] = GlotPress_Translate_Bridge::translate( $phil->sections['description'], $glotpress_project );
 			}
 
+		}
+
+		if ( $this->fields['patterns'] ) {
+			$pattern_meta = get_post_meta( $theme->ID, '_patterns', true );
+			$patterns_data = array();
+
+			if ( ! empty( $pattern_meta ) ) {
+				switch_to_blog( 699 ); // Pattern Directory
+
+				$args = array(
+					'post_name__in' => $pattern_meta,
+					'post_type'     => 'wporg-pattern',
+					'post_status'   => 'publish',
+				);
+
+				foreach ( get_posts( $args ) as $pattern_post ) {
+					$p = array();
+					$p['name'] = $pattern_post->post_title;
+					$p['link'] = get_permalink( $pattern_post );
+
+					$patterns_data[] = $p;
+				}
+
+				restore_current_blog();
+			}
+
+			$phil->patterns = $patterns_data;
 		}
 
 		wp_cache_set( $cache_key, $phil, $this->cache_group, $this->cache_life );

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/theme-directory.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/theme-directory.php
@@ -889,6 +889,7 @@ function wporg_themes_get_themes_for_query() {
 		'active_installs' => true,
 		'requires' => true,
 		'requires_php' => true,
+		'patterns' => true,
 	);
 
 	$api_result = wporg_themes_query_api( 'query_themes', $request );
@@ -930,6 +931,7 @@ function wporg_themes_theme_information( $slug ) {
 			'active_installs' => true,
 			'requires' => true,
 			'requires_php' => true,
+			'patterns' => true
 		)
 	) );
 }

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-themes/css/components/_main.scss
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-themes/css/components/_main.scss
@@ -563,6 +563,10 @@ body.author .theme-browser .theme .theme-author  {
 	font-size: 13px;
 }
 
+.theme-wrap .theme-patterns {
+	font-size: 13px;
+}
+
 .theme-wrap .theme-downloads .total-downloads {
 	color: #555;
 	font-size: 14px;

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-themes/js/theme.js
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-themes/js/theme.js
@@ -355,6 +355,7 @@ window.wp = window.wp || {};
 					photon_screenshots: true,
 					active_installs: true,
 					requires_php: true,
+ 					patterns: true,
 				}
 			}, request);
 
@@ -522,6 +523,11 @@ window.wp = window.wp || {};
 			data.tags = _.map( data.tags, function( tag, slug ) {
 				var translated_tag = l10n.tags[ slug ] || tag;
 				return '<a href="' + themes.data.settings.path + themes.router.baseUrl( 'tags/' + slug ) + '">' + translated_tag + '</a>';
+			}).join( ', ' );
+
+			// Make patterns click-able and separated by a comma.
+			data.patterns = _.map( data.patterns, function( pattern ) {
+				return '<a href="'+ pattern.link + '">' + pattern.name + '</a>';
 			}).join( ', ' );
 
 			data.path = themes.data.settings.path;

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-themes/theme-single.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-themes/theme-single.php
@@ -111,6 +111,25 @@
 				</div><!-- .theme-tags -->
 				<?php } ?>
 
+				<?php if ( $theme->patterns ) { ?>
+				<div class="theme-patterns">
+					<h2><?php _e( 'Patterns:', 'wporg-themes' ); ?></h2>
+					<div><?php
+					$pattern_links = array();
+
+					foreach ( $theme->patterns as $pattern ) {
+						$pattern_links[] = sprintf(
+							"<a href='%s'>%s</a>",
+							esc_url( $pattern['link'] ),
+							esc_html( $pattern['name'] )
+						);
+					}
+					echo implode( ', ', $pattern_links );
+					?>
+					</div>
+				</div><!-- .theme-patterns -->
+				<?php } ?>
+
 				<div class="theme-downloads">
 				</div><!-- .theme-downloads -->
 			</div>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-themes/view-templates/theme-single.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-themes/view-templates/theme-single.php
@@ -79,6 +79,13 @@
 				</div><!-- .theme-tags -->
 				<# } #>
 
+				<# if ( data.patterns ) { #>
+				<div class="theme-patterns">
+					<h3><?php _e( 'Patterns:', 'wporg-themes' ); ?></h3>
+					<div>{{{ data.patterns }}}</div>
+				</div><!-- .theme-patterns -->
+				<# } #>
+
 				<div class="theme-downloads">
 					<h3><?php _e( 'Downloads Per Day', 'wporg-themes' ); ?></h3>
 					<div id="theme-download-stats-{{data.id}}" class="chart"></div>


### PR DESCRIPTION
I've opened up this PR as a place for discussion on https://meta.trac.wordpress.org/ticket/5995. While this PR comes with code updates, it's purely experimental and not necessarily the best implementation or experience. I would have preferred to use an issue but they are closed for this repository and having the discussion in [trac](https://meta.trac.wordpress.org) feels a bit limiting.

# Assumption
It would be helpful for users to be able to preview patterns that are bundled with themes in the theme directory.

# Details
## How can we detect patterns?
### Static code analysis
- Search for:
  - `register_block_pattern` ([JS](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-patterns/#register_block_pattern), [PHP](https://developer.wordpress.org/reference/functions/register_block_pattern/))
  - `theme.json` ([Link](https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-json/#patterns))
  - `/patterns` ([Link](https://github.com/WordPress/gutenberg/pull/36751))

### Dynamic analysis (with running environment)
 -  JS: `wp.data.select('core').getBlockPatterns()` ([Link](https://developer.wordpress.org/block-editor/reference-guides/data/data-core/#getblockpatterns))
 - PHP: `WP_Block_Patterns_Registry::get_all_registered()` ([Link](https://developer.wordpress.org/reference/classes/wp_block_patterns_registry/get_all_registered/)) 

 
## When can we detect patterns?
- Theme Upload
  - `class-wporg-themes-upload.php` (Static) ([Link](https://github.com/WordPress/wordpress.org/blob/trunk/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php))
   - Get Results from Theme Review Action (Dynamic) ([Link](https://github.com/WordPress/theme-review-action))
- Cron Job
  - I don't think any exist yet  
  
... store results in meta for `repopackage`...

- Dynamically on page load
  - This would only work for the `Theme Preview` since it has a running environment when the user interacts with it.

## Where could we show patterns?
### Theme Directory
 - Directory View ([Link](https://wordpress.org/themes/))
 - Single Theme View ([Link](https://wordpress.org/themes/twentytwentytwo/))
 - Theme Preview ([Link](https://wordpress.org/themes/twentytwentytwo/) -> Click "Preview Button")

## Ideas
The theme directory is likely to undergo a redesign in the next year or so. If we want to get something up before that completes, which probably makes sense, we should aim to make the most minimal changes.

### Directory View
We could add Icons to the theme tile to denote that a theme bundles patterns.
| A  | B |
| --- | --- |
| <img width="148" alt="Screen Shot 2022-07-08 at 8 24 15 AM" src="https://user-images.githubusercontent.com/1657336/177887771-5f2dffc7-601a-4892-8d15-d9a459a0aa9c.png"> | <img width="148" alt="Screen Shot 2022-07-08 at 8 36 13 AM" src="https://user-images.githubusercontent.com/1657336/177888603-39f96fbd-cd21-4a53-b4f9-b49e6c9dfd77.png"> |

### Single Theme View 

We can add a section below the tags. It could be a list of the pattern names or could also use [pattern directory previewer](https://github.com/WordPress/pattern-directory/tree/trunk/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview).  If so, It would have to have some sort pagination control experience since some themes bundle 10+ patterns.

<img width="357" alt="Screen Shot 2022-07-08 at 8 46 25 AM" src="https://user-images.githubusercontent.com/1657336/177889546-89aff1a1-b099-46d2-9dba-fbab51ab038f.png"> 

### Theme Preview
What if we give a navigation item that users can click that loads a dynamically generated page with all the patterns? I've added blocks to the menu just as an example.

<img width="533" alt="Screen Shot 2022-07-08 at 9 10 36 AM" src="https://user-images.githubusercontent.com/1657336/177891860-88f92901-9d92-446c-8a26-839bb44e03b8.png">

