### PR TITLE
Profiles: Add activity when added as a presenter for Learn workshop

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/wporg-profiles-wp-activity-notifier/wporg-profiles-wp-activity-notifier.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-profiles-wp-activity-notifier/wporg-profiles-wp-activity-notifier.php
@@ -223,10 +223,9 @@ class WPOrg_WP_Activity_Notifier {
 				'item_id'      => $post->ID,
 				'content'      => $content,
 				'message'      => sprintf(
-					'Assigned presenter to the tutorial, <i><a href="%s">%s</a></i>, on the site %s',
+					'Assigned as a presenter on the Learn WordPress tutorial, <i><a href="%s">%s</a></i>',
 					$permalink,
 					$title,
-					get_bloginfo( 'name' )
 				),
 			);
 

--- a/wordpress.org/public_html/wp-content/plugins/wporg-profiles-wp-activity-notifier/wporg-profiles-wp-activity-notifier.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-profiles-wp-activity-notifier/wporg-profiles-wp-activity-notifier.php
@@ -292,7 +292,6 @@ class WPOrg_WP_Activity_Notifier {
 	 * @param WP_Comment $comment Comment.
 	 */
 	public function insert_comment( $id, $comment ) {
-		if ( 1 == $comment->comment_approved ) {
 		if ( 1 === $comment->comment_approved ) {
 			$this->maybe_notify_new_approved_comment( 'approved', '', $comment );
 		}

--- a/wordpress.org/public_html/wp-content/plugins/wporg-profiles-wp-activity-notifier/wporg-profiles-wp-activity-notifier.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-profiles-wp-activity-notifier/wporg-profiles-wp-activity-notifier.php
@@ -223,7 +223,7 @@ class WPOrg_WP_Activity_Notifier {
 				'item_id'      => $post->ID,
 				'content'      => $content,
 				'message'      => sprintf(
-					'Assigned presenter to the workshop, <i><a href="%s">%s</a></i>, on the site %s',
+					'Assigned presenter to the tutorial, <i><a href="%s">%s</a></i>, on the site %s',
 					$permalink,
 					$title,
 					get_bloginfo( 'name' )


### PR DESCRIPTION
Issue: https://github.com/WordPress/five-for-the-future/issues/179 - Add activity when added as a presenter for Learn workshop

## Question
1. If an author published a post, then switched back to draft, and published again, there'll be two identical activities on assigned presenters' profiles, is it expected behavior?

2. The icon before the assigned presenter activity is also changed as the screencast below shows, but I can't locate the `style.css` of profiles in the repo. How do we usually modify this file, do we directly modify `themes/profiles.wordpress.org/style.css` on the sandbox?

## Screencast of results
https://user-images.githubusercontent.com/18050944/178162081-1670a4e6-6fa1-4b99-9276-173840ce3b74.mov


