### PR TITLE
Themes: Add Block tab to filter list

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/query-modifications.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/query-modifications.php
@@ -121,6 +121,15 @@ function wporg_themes_pre_get_posts( $query ) {
 			$query->query_vars['orderby'] = 'meta_value DESC';
 			break;
 
+		// List themes tagged as 'full-site-editing' under 'Block'
+		// Ordered by date added
+		case 'block':
+			$query->query_vars['browse'] = 'block';
+			$query->query_vars['tag'] = 'full-site-editing';
+			$query->query_vars['orderby'] = 'post_date';
+			$query->query_vars['order'] = 'DESC';
+			break;
+
 		default:
 			// Force a 404 for anything else.
 			if ( $query->query_vars['browse'] ) {
@@ -136,7 +145,7 @@ function wporg_themes_pre_get_posts( $query ) {
 	if (
 		empty( $query->query_vars['name'] ) &&
 		empty( $query->query_vars['author_name'] ) &&
-		! in_array( $query->query_vars['browse'], array( 'favorites', 'new', 'updated' ) ) &&
+		! in_array( $query->query_vars['browse'], array( 'favorites', 'new', 'updated', 'block' ) ) &&
 		empty( $query->query_vars['meta_query']['trac_sync_ticket_id'] ) && // jobs/class-trac-sync.php - Always needs to find the post, and looks up via a meta search.
 		empty( $query->query_vars['meta_query']['theme_uri_search'] ) // class-wporg-themes-upload.php - Searching all known themes by meta value.
 	) {
@@ -149,7 +158,7 @@ function wporg_themes_pre_get_posts( $query ) {
 	// Prioritize translated themes for localized requests, except when viewing a specific ordered themes.
 	if (
 		'en_US' !== get_locale() &&
-		! in_array( $query->query_vars['browse'], array( 'favorites', 'new', 'updated' ) )
+		! in_array( $query->query_vars['browse'], array( 'favorites', 'new', 'updated', 'block' ) )
 	) {
 		add_filter( 'posts_clauses', 'wporg_themes_prioritize_translated_posts_clauses', 11 );
 	}
@@ -214,7 +223,7 @@ function wporg_themes_prioritize_exact_matches_clauses( $clauses, $query ) {
  */
 function wporg_themes_parse_request( $wp ) {
 	$sections = array(
-		'new', 'updated', /*'featured',*/ 'favorites', 'popular'
+		'new', 'updated', /*'featured',*/ 'favorites', 'popular', 'block'
 	);
 
 	if ( !empty( $wp->query_vars['browse'] ) && ! in_array( $wp->query_vars['browse'], $sections ) ) {

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-themes/index.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-themes/index.php
@@ -23,6 +23,7 @@ get_header();
 			<ul class="filter-links">
 				<li><a href="<?php echo esc_url( home_url( '/' ) ); ?>" data-sort="popular" <?php if ( (is_front_page() && !get_query_var('browse') ) || 'popular' == get_query_var('browse') ) { echo 'class="current"'; } ?>><?php _ex( 'Popular', 'themes', 'wporg-themes' ); ?></a></li>
 				<li><a href="<?php echo esc_url( home_url( 'browse/new/' ) ); ?>" data-sort="new" <?php if ( 'new' == get_query_var('browse') ) { echo 'class="current"'; } ?>><?php _ex( 'Latest', 'themes', 'wporg-themes' ); ?></a></li>
+				<li><a href="<?php echo esc_url( home_url( 'browse/block/' ) ); ?>" data-sort="block" <?php if ( 'block' == get_query_var('browse') ) { echo 'class="current"'; } ?>><?php _ex( 'Block', 'themes', 'wporg-themes' ); ?></a></li>
 				<?php if ( is_user_logged_in() ) { ?>
 					<li><a href="<?php echo esc_url( home_url( 'browse/favorites/' ) ); ?>" data-sort="favorites" <?php if ( 'favorites' == get_query_var('browse') ) { echo 'class="current"'; } ?>><?php _ex( 'Favorites', 'themes', 'wporg-themes' ); ?></a></li>
 				<?php } ?>


### PR DESCRIPTION
This PR adds a 'Block' tab to the Theme Directory filter list. This will filter the themes list using the `full-site-editing` feature tag. This works in the same way as using the Feature Filter to filter by 'Full Site Editing'.

<img width="959" alt="image" src="https://user-images.githubusercontent.com/1645628/178309174-0042250a-2304-4139-b3ca-2c5c306077cb.png">

These types of themes are more commonly referred to as block themes, so by adding this tag, we are reducing the confusion between these terms and making it clearer how to filter by block themes in the directory.

Please see this discussion for more details: https://meta.trac.wordpress.org/ticket/6330