### PR TITLE
Post Translation: Add translation of posts based on GlotPress

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/glotpress-translate-bridge.php
+++ b/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/glotpress-translate-bridge.php
@@ -135,9 +135,6 @@ class GlotPress_Translate_Bridge {
 		$sql_plural   = isset( $strings['plural'] )   ? $wpdb->prepare( "o.plural = %s",   $strings['plural']   ) : 'o.plural IS NULL';
 		$sql_context  = !empty( $strings['context'] ) ? $wpdb->prepare( "o.context = %s",  $strings['context']  ) : 'o.context IS NULL';
 
-		// TODO: HackyHackhack. This is temporary, this class matches on the context field matching OR being null, when testing some existing strings have a context set that we're unaware of
-		$sql_context = '1=1';
-
 		$sql_locale = $wpdb->prepare( "s.locale = %s AND s.slug = %s", $locale['locale'], $locale['slug'] );
 
 		$translation = $wpdb->get_row(
@@ -189,6 +186,10 @@ class GlotPress_Translate_Bridge {
 
 		if ( 'en_US' === $wp_locale ) {
 			return false;
+		}
+
+		if ( 'pirate' === $wp_locale ) {
+			return [ 'locale' => 'pirate', 'slug' => 'default' ];
 		}
 
 		preg_match( '!^([a-z]{2,3})(_([A-Z]{2}))?(_([a-z0-9]+))?$!', $wp_locale, $matches );

--- a/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/glotpress-translate-bridge.php
+++ b/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/glotpress-translate-bridge.php
@@ -39,10 +39,12 @@ class GlotPress_Translate_Bridge {
 	 *
 	 * @return string The translated string if it exists, else, the existing string.
 	 */
-	static function translate( $singular, $project_path, $context = null ) {
+	static function translate( $singular, $project_path, $context = null, & $found = null ) {
 		$t = self::instance();
 
 		$translation = $t->find_translation( compact( 'singular', 'context' ), $project_path );
+
+		$found = (bool) $translation;
 
 		return $translation ? $translation[0] : $singular;
 	}

--- a/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/glotpress-translate-bridge.php
+++ b/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/glotpress-translate-bridge.php
@@ -135,6 +135,9 @@ class GlotPress_Translate_Bridge {
 		$sql_plural   = isset( $strings['plural'] )   ? $wpdb->prepare( "o.plural = %s",   $strings['plural']   ) : 'o.plural IS NULL';
 		$sql_context  = !empty( $strings['context'] ) ? $wpdb->prepare( "o.context = %s",  $strings['context']  ) : 'o.context IS NULL';
 
+		// TODO: HackyHackhack. This is temporary, this class matches on the context field matching OR being null, when testing some existing strings have a context set that we're unaware of
+		$sql_context = '1=1';
+
 		$sql_locale = $wpdb->prepare( "s.locale = %s AND s.slug = %s", $locale['locale'], $locale['slug'] );
 
 		$translation = $wpdb->get_row(
@@ -226,6 +229,7 @@ class GlotPress_Translate_Bridge {
 	 * @return string The cache key.
 	 */
 	private function cache_key( $strings, $project_path ) {
+		// TODO: This needs to respect the 255char limit of Memcache????????
 		return strtolower( get_locale() ) . ':' . $project_path . ':' . serialize( array_filter( $strings ) );
 	}
 }

--- a/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/glotpress-translate-bridge.php
+++ b/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/glotpress-translate-bridge.php
@@ -36,6 +36,7 @@ class GlotPress_Translate_Bridge {
 	 * @param $singular     The string to translate.
 	 * @param $project_path The GlotPress project path.
 	 * @param $context      The strings context. Default: null.
+	 * @param $found        Whether the translation was found. Passed by reference.
 	 *
 	 * @return string The translated string if it exists, else, the existing string.
 	 */
@@ -56,13 +57,16 @@ class GlotPress_Translate_Bridge {
 	 * @param $plural       The plural form of the string.
 	 * @param $project_path The GlotPress project path.
 	 * @param $context      The strings context. Default: null
+	 * @param $found        Whether the translation was found. Passed by reference.
 	 *
 	 * @return array The translated plural forms of the string.
 	 */
-	static function translate_plural( $singular, $plural, $project_path, $context = null ) {
+	static function translate_plural( $singular, $plural, $project_path, $context = null, & $found = null ) {
 		$t = self::instance();
 
 		$translation = $t->find_translation( compact( 'singular', 'plural', 'context' ), $project_path );
+
+		$found = (bool) $translation;
 
 		return $translation ?: array( $singular, $plural );
 	}
@@ -116,9 +120,10 @@ class GlotPress_Translate_Bridge {
 		}
 
 		$cache_key = $this->cache_key( $strings, $project_path );
-		$cache_not_found = '__NONE__';
+		$cache_not_found = '__NONE__'; // TODO: remove in preference of $cache_found.
 
-		if ( false !== ( $cache = wp_cache_get( $cache_key, $this->cache_group ) ) ) {
+		$cache = wp_cache_get( $cache_key, $this->cache_group, false, $cache_found );
+		if ( $cache_found ) {
 			if ( $cache === $cache_not_found ) {
 				return false;
 			}

--- a/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/admin.php
+++ b/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/admin.php
@@ -2,8 +2,8 @@
 namespace WordPressdotorg\Post_Translation;
 
 add_action( 'save_post', function( $post_id, $post ) {
-	// Only need to process published posts.
-	if ( 'publish' != $post->post_status ) {
+	// Only need to process published pages.
+	if ( 'publish' != $post->post_status || 'page' !== $post->post_type ) {
 		return;
 	}
 
@@ -25,7 +25,7 @@ add_action( 'post_translation_import_to_glotpress', function( $post_id ) {
 	include_once __DIR__ . '/class-makepot.php';
 
 	$post = get_post( $post_id );
-	if ( ! $post || 'publish' != $post->post_status ) {
+	if ( ! $post || 'publish' != $post->post_status || 'page' != $post->post_type ) {
 		return;
 	}
 

--- a/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/admin.php
+++ b/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/admin.php
@@ -14,7 +14,9 @@ add_action( 'save_post', function( $post_id, $post ) {
 
 	// Import any changes into GlotPress.
 	if ( ! wp_next_scheduled( 'post_translation_import_to_glotpress', array( $post_id ) ) ) {
-		wp_schedule_single_event( time() + MINUTE_IN_SECONDS, 'post_translation_import_to_glotpress', array( $post_id ) );
+	//	wp_schedule_single_event( time() + MINUTE_IN_SECONDS, 'post_translation_import_to_glotpress', array( $post_id ) );
+	// TEMP HACKERY: Run the import now, rather than queueing a cron task that won't actually do anything in production.
+		do_action( 'post_translation_import_to_glotpress', $post_id );
 	}
 }, 10, 2 );
 

--- a/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/admin.php
+++ b/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/admin.php
@@ -1,0 +1,40 @@
+<?php
+namespace WordPressdotorg\Post_Translation;
+
+add_action( 'save_post', function( $post_id, $post ) {
+	// Only need to process published posts.
+	if ( 'publish' != $post->post_status ) {
+		return;
+	}
+
+	$project = get_post_translation_project( $post );
+	if ( ! $project ) {
+		return;
+	}
+
+	// Import any changes into GlotPress.
+	if ( ! wp_next_scheduled( 'post_translation_import_to_glotpress', array( $post_id ) ) ) {
+		wp_schedule_single_event( time() + MINUTE_IN_SECONDS, 'post_translation_import_to_glotpress', array( $post_id ) );
+	}
+}, 10, 2 );
+
+// Import into GlotPress for the changed post.
+add_action( 'post_translation_import_to_glotpress', function( $post_id ) {
+	include_once __DIR__ . '/class-makepot.php';
+
+	$post = get_post( $post_id );
+	if ( ! $post || 'publish' != $post->post_status ) {
+		return;
+	}
+
+	$project = get_post_translation_project( $post );
+	if ( ! $project ) {
+		return;
+	}
+
+var_dump( $project );
+
+	// Import changes to GlotPress.
+	$makepot  = new Makepot( $project, array( $post ) );
+	echo $makepot->import( true ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+} );

--- a/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/class-makepot.php
+++ b/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/class-makepot.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace WordPressdotorg\Post_Translation;
+use Translation_Entry, PO;
+use GP;
+
+class MakePot {
+	public $project;
+	public $posts;
+
+	public function __construct( string $project, array $posts ) {
+		$this->project = $project;
+		$this->posts   = $posts;
+	}
+
+	public function import( $save = false ) {
+		// Avoid attempting to import strings when no patterns are found.
+		// This is a precautionary check to ensure we don't accidentally remove all translations.
+		if ( empty( $this->posts ) ) {
+			return 'No posts found: skipping import.';
+		}
+
+		// Load GlotPress for the API.
+		switch_to_blog( WPORG_TRANSLATE_BLOGID );
+		$this->load_glotpress();
+
+		$this->project_obj = GP::$project->by_path( $this->project );
+
+		// Switch back, so we can create proper referenced originals.
+		restore_current_blog();
+
+		if ( ! $this->project_obj ) {
+			return 'Project not found!';
+		}
+
+		$po = $this->makepo();
+
+		if ( true !== $save ) {
+			var_dump( $po );
+
+			return sprintf( 'dry-run: %s translations would be imported into %s', count( $po->entries ), $this->project );
+		}
+
+		// Switch to GlotPress to import..
+		switch_to_blog( WPORG_TRANSLATE_BLOGID );
+
+		list( $added, $existing, $fuzzied, $obsoleted, $error ) = GP::$original->import_for_project( $this->project_obj, $po );
+
+		$notice = sprintf(
+			'%s: %s new strings added, %s updated, %s fuzzied, and %s obsoleted.',
+			$this->project,
+			$added,
+			$existing,
+			$fuzzied,
+			$obsoleted
+		);
+
+		if ( $error ) {
+			$notice .= ' ' . sprintf(
+				'%s new string(s) were not imported due to an error.',
+				$error
+			);
+		}
+
+		restore_current_blog();
+
+		return $notice;
+	}
+
+	public function makepo( $revision_time = null ) : \PO {
+		require_once ABSPATH . '/wp-includes/pomo/po.php';
+
+		$po = new PO();
+
+		$po->set_header( 'PO-Revision-Date', gmdate( 'Y-m-d H:i:s', $revision_time ?? time() ) . '+0000' );
+		$po->set_header( 'MIME-Version', '1.0' );
+		$po->set_header( 'Content-Type', 'text/plain; charset=UTF-8' );
+		$po->set_header( 'Content-Transfer-Encoding', '8bit' );
+		$po->set_header( 'X-Generator', 'wporg_post_translation_makepot' );
+
+		foreach ( $this->entries() as $entry ) {
+			$po->add_entry( $entry );
+		}
+
+		return $po;
+	}
+
+	public function entries() : array {
+		$entries = [];
+
+		$import_references = array_map( 'get_permalink', $this->posts );
+
+		foreach ( $this->posts as $post ) {
+
+			$reference = get_permalink( $post );
+			$strings   = Post_Parser::post_to_strings( $post );
+
+			foreach ( $strings as $string ) {
+				if ( ! isset( $entries[ $string ] ) ) {
+					$entries[ $string ] = new Translation_Entry(
+						[
+							'singular' => $string,
+							'references' => [
+								$reference,
+							],
+						]
+					);
+				} elseif ( ! in_array( $url, $entries[ $string ]->references ) ) {
+					$entries[ $string ]->references[] = $url;
+
+					sort( $entries[ $string ]->references );
+				}
+			}
+		}
+
+		// Now add any originals with references that we haven't imported.
+		$all_originals = GP::$original->many_no_map( 'SELECT * FROM ' . GP::$original->table . ' WHERE project_id = %d AND status != "-obsolete"', $this->project_obj->id );
+
+		foreach ( $all_originals as $original ) {
+			$original_references = array_diff( explode( ' ', $original->references ), $import_references );
+			// If the only references were to one of the posts being imported now, skip, that string will be obsoleted.
+			if ( empty( $original_references ) ) {
+				continue;
+			}
+
+			// Add new, or add reference to existing string.
+			// We're taking a shortcut here, as we're using `singular` as the key, rather than `{context}\004{singular}({plural})?`
+			if ( ! isset( $entries[ $original->singular ] ) ) {
+				$entries[ $original->singular ] = new Translation_Entry(
+					[
+						'singular'           => $original->singular,
+						'plural'             => $original->plural,
+						'context'            => $original->context,
+						'extracted_comments' => $original->comment,
+						'references'         => $original_references,
+					]
+				);
+			} else {
+				// String is set, make sure it has the originals references.
+				$entries[ $original->singular ]->references = array_merge( $entries[ $string ]->references, $original_references );
+
+				sort( $entries[ $original->singular ]->references );
+			}
+		}
+
+		return array_values( $entries );
+	}
+
+	/**
+	 * Load GlotPress so that we can interact with the GlotPress APIs.
+	 */
+	public function load_glotpress() {
+		// TODO: Figure out how to properly do the following stuff.
+		// This might be better be done as a two-part process;
+		// 1. Generate the partial .po here on the individual sites
+		// 2. POST it to translate.w.org, have it handle ensuring the originals unrelated to this reference are set.
+		// 3. Profit, by not loading GlotPress & it's plugins on random sites.
+
+		$GLOBALS['gp_table_prefix'] = GLOTPRESS_TABLE_PREFIX;
+
+		// Load any GlotPress plugins as needed.
+		$plugins = get_option( 'active_plugins', [] );
+		array_walk( $plugins, function( $plugin ) {
+			include_once trailingslashit( WP_PLUGIN_DIR ) . $plugin;
+		} );
+
+		// Run the GlotPress init routines.
+		if ( ! did_action( 'gp_init' ) ) {
+			gp_init();
+		}
+	}
+}

--- a/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/front-end.php
+++ b/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/front-end.php
@@ -35,7 +35,7 @@ function get_frontend_translation_project( $id ) {
  * Translate the Post title.
  */
 function the_title( $title, $id = 0 ) {
-	return translate_string_for_post( $title, $post );
+	return translate_string_for_post( $title, $id );
 }
 
 /**

--- a/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/front-end.php
+++ b/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/front-end.php
@@ -81,6 +81,36 @@ function the_content( $content, $post = null ) {
 }
 
 /**
+ * Translate any postmeta fields specified.
+ */
+add_filter( 'get_post_metadata', __NAMESPACE__ . '\post_meta_filter', 100, 4 );
+function post_meta_filter( $value, $post_id, $meta_key, $single ) {
+	$translatable_post_meta = apply_filters( 'translatable_post_meta', [] );
+
+	if ( ! in_array( $meta_key, $translatable_post_meta, true ) ) {
+		return $value;
+	}
+
+	$project = get_frontend_translation_project( $post );
+
+	remove_filter( 'get_post_metadata', __NAMESPACE__ . '\\' . __FUNCTION__ );
+
+	$value = get_post_meta( $post_id, $meta_key, $single );
+
+	if ( $single ) {
+		$value = translate_string( $value, $project );
+	} else {
+		foreach ( $value as $i => $vv ) {
+			$value[ $i ] = translate_string( $vv, $project );
+		}
+	}
+
+	add_filter( 'get_post_metadata', __NAMESPACE__ . '\\' . __FUNCTION__, 100, 4 );
+
+	return $value;
+}
+
+/**
  * Translate a given string in the context of a post.
  */
 function translate_string_for_post( $string, $post ) {

--- a/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/front-end.php
+++ b/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/front-end.php
@@ -1,0 +1,125 @@
+<?php
+namespace WordPressdotorg\Post_Translation;
+use GlotPress_Translate_Bridge;
+
+const CACHE_GROUP = 'translated-post';
+
+// Filter `get_the_title()`, and `the_title()`.
+add_filter( 'the_title', __NAMESPACE__ . '\the_title', 2, 2 );
+
+// Filter `get_the_except()` and `the_excerpt()`.
+add_filter( 'get_the_excerpt', __NAMESPACE__ . '\get_the_excerpt', 2, 2 );
+
+// Filter `the_content()` output, not `$post->post_content` or `get_the_content()`, as neither have filters.
+// Before Block parsing at priority 9
+add_filter( 'the_content', __NAMESPACE__ . '\the_content', 2, 2 );
+
+/**
+ * Get the translation post for use on the front-end, returns false for English(US) and admin contexts.
+ * 
+ * @return bool|string False on translation disabled / no project, or the translation project on success.
+ */
+function get_frontend_translation_project( $id ) {
+	if ( 'en_US' === get_locale() || is_admin() ) {
+		if ( 'https://wordpress.org/main-test/' === home_url( '/' ) ) {
+			// fall through.. en_US but we want to affect it..
+		} else {
+			return false;
+		}
+	}
+
+	return get_post_translation_project( $id );
+}
+
+/**
+ * Translate the Post title.
+ */
+function the_title( $title, $id = 0 ) {
+	return translate_string_for_post( $title, $post );
+}
+
+/**
+ * Translate the Post except.
+ */
+function get_the_excerpt( $excerpt, $post = null ) {
+	return translate_string_for_post( $excerpt, $post );
+}
+
+/**
+ * Translate the Post content.
+ */
+function the_content( $content, $post = null ) {
+	$post    = get_post( $post );
+	$locale  = get_locale();
+	$project = get_frontend_translation_project( $post );
+
+	if ( ! $project || ! $post || ! $locale ) {
+		return $content;
+	}
+
+	// FOR DEBUG ONLY
+	wp_cache_add_non_persistent_groups( CACHE_GROUP );
+
+	// Check the cache.
+	$last_changed = wp_cache_get_last_changed( 'posts' );
+	$cache_key    = "{$post->ID}:{$locale}:{$last_changed}";
+	$cached       = wp_cache_get( $cache_key, CACHE_GROUP, false, $found );
+	if ( $cached || $found ) {
+		return $cached ?: $content;
+	}
+
+	$translated_content = Post_Parser::translate_blocks(
+		$content,
+		function( $string ) use( $project ) {
+			return translate_string( $string, $project );
+		}
+	);
+
+	wp_cache_set( $cache_key, $translated_content, CACHE_GROUP, 6 * HOUR_IN_SECONDS );
+
+	return $translated_content ?: $content;
+}
+
+/**
+ * Translate a given string in the context of a post.
+ */
+function translate_string_for_post( $string, $post ) {
+	// Note: No caching is present in this function, as it's assumed the caching within `GlotPress_Translate_Bridge::translate()` is enough for singular strings.
+	$translated = false;
+	$project    = get_frontend_translation_project( $post );
+
+	if ( $project ) {
+		$translated = translate_string( $string, $project );
+	}
+
+	return $translated ?: $string;
+}
+
+function translate_string( $string, $project ) {
+
+	// 1. Direct translation.
+	$translated = GlotPress_Translate_Bridge::translate( $string, $project, null, $found );
+	if ( $found ) {
+		return apply_filters( 'gettext', $translated, $string, TEXTDOMAIN_PREFIX . $project );
+	}
+
+	// Try variations - These are only really here for testing purposes, they shouldn't be needed in production usually.
+	// 2. Wrapping tags.
+	//  TODO: This is only really needed due to a difference between the existing /gutenberg/ page and the Post_Parser extractions.
+	if ( preg_match( '#^(?P<start><([a-z]+)[^>]*>)(?P<content>.*?)(?P<end></\\2>)$#i', $string, $m ) ) {
+		$html_less = GlotPress_Translate_Bridge::translate( $m['content'], $project, null, $found );
+		if ( $found ) {
+			$translated = $m['start'] . $html_less . $m['end'];
+
+			return apply_filters( 'gettext', $translated, $string, TEXTDOMAIN_PREFIX . $project );
+		}
+	}
+
+	// 3. HTML entities.
+	$translated = GlotPress_Translate_Bridge::translate( htmlentities( $string ), $project, null, $found );
+	if ( $found ) {
+		return apply_filters( 'gettext', $translated, $string, TEXTDOMAIN_PREFIX . $project );
+	}
+
+	return apply_filters( 'gettext', $string, $string, TEXTDOMAIN_PREFIX . $project );
+}

--- a/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/parsers/BasicText.php
+++ b/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/parsers/BasicText.php
@@ -1,0 +1,58 @@
+<?php
+namespace WordPressdotorg\Post_Translation\Parsers;
+
+class BasicText implements BlockParser {
+	use DomUtils;
+	use TextNodesXPath;
+
+	public function to_strings( array $block ) : array {
+		$dom   = $this->get_dom( $block['innerHTML'] );
+		$xpath = new \DOMXPath( $dom );
+
+		$strings = [];
+
+		foreach ( $xpath->query( $this->text_nodes_xpath_query() ) as $text ) {
+			if ( trim( $text->nodeValue ) ) {
+				$strings[] = $text->nodeValue;
+			}
+		}
+
+		return $strings;
+	}
+
+	public function replace_strings( array $block, array $replacements ) : array {
+		$dom         = $this->get_dom( $block['innerHTML'] );
+		$xpath       = new \DOMXPath( $dom );
+		$xpath_query = $this->text_nodes_xpath_query();
+
+		foreach ( $xpath->query( $xpath_query ) as $text ) {
+			if ( trim( $text->nodeValue ) && isset( $replacements[ $text->nodeValue ] ) ) {
+				$text->parentNode->replaceChild( $dom->createCDATASection( $replacements[ $text->nodeValue ] ), $text );
+			}
+		}
+
+		$block['innerHTML'] = $this->removeHtml( $dom->saveHTML() );
+
+		foreach ( $block['innerContent'] as &$inner_content ) {
+			if ( is_string( $inner_content ) ) {
+				$dom = $this->get_dom( $inner_content );
+				$xpath = new \DOMXPath( $dom );
+
+				$text_nodes = $xpath->query( $xpath_query );
+
+				// Only update text matches that are found outside of HTML tags.
+				// This approach does not use $dom->saveHTML because innerContent includes
+				// unclosed HTML tags, and saveHTML adds extra closed tags.
+				foreach ( $text_nodes as $text ) {
+					if ( trim( $text->nodeValue ) && isset( $replacements[ $text->nodeValue ] ) ) {
+						$regex = '#(<([^>]*)>)?' . preg_quote( $text->nodeValue, '#' ) . '(<([^>]*)>)?#s';
+						$inner_content = preg_replace( $regex, '${1}' . $replacements[ $text->nodeValue ] . '${3}', $inner_content );
+					}
+				}
+			}
+		}
+
+		return $block;
+	}
+
+}

--- a/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/parsers/BlockParser.php
+++ b/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/parsers/BlockParser.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Block Parser interface and traits to be used by individual block parsers.
+ *
+ * Each block parser needs to implement a to_strings and replace_strings method.
+ * The traits are provided here as helper functions for specific tasks, such as
+ * dealing with wrapping markup in html tags, getting and setting block attributes,
+ * and encoding and decoding tags.
+ *
+ * @phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
+ */
+
+namespace WordPressdotorg\Post_Translation\Parsers;
+
+// A block transform is specific to a certain block type and contains
+// the know-how of how to both extract and replace strings
+interface BlockParser {
+	public function to_strings( array $block ) : array;
+	public function replace_strings( array $block, array $replacements ) : array;
+}
+
+// DomDocument::loadHTML with LIBXML_HTML_NOIMPLIED causes dom doc settings to format / strip whitespace from our html
+// Add/remove html tags to avoid the need for noimplied html
+trait DomUtils {
+	// phpcs:disable WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+	private function addHtml( string $html ) : string {
+		return "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\"></head><body>$html</body></html>";
+	}
+
+	private function removeHtml( string $html ) : string {
+		return preg_replace(
+			[
+				'/^\s*<html><head><meta http-equiv="Content-Type" content="text\/html; charset=utf-8"><\/head><body>/sm',
+				// $dom->saveHTML() can have a trailing newline after the closing </html>, match to the real end of the document.
+				'/<\/body><\/html>\s*$/sm',
+			],
+			'',
+			$html
+		);
+	}
+
+	private function get_dom( string $html ) : \DOMDocument {
+		$previous = libxml_use_internal_errors( true );
+		$dom      = new \DomDocument();
+		$dom->loadHTML( $this->addHtml( $html ), LIBXML_HTML_NODEFDTD | LIBXML_COMPACT );
+		libxml_clear_errors();
+		libxml_use_internal_errors( $previous );
+		return $dom;
+	}
+	// phpcs:enable WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+}
+
+trait GetSetAttribute {
+	private function get_attribute( string $attribute_name, array $block ) : array {
+		if ( isset( $block['attrs'][ $attribute_name ] ) && is_string( $block['attrs'][ $attribute_name ] ) ) {
+			return [ $block['attrs'][ $attribute_name ] ];
+		}
+		return [];
+	}
+
+	private function set_attribute( string $attribute_name, array &$block, array $replacements ) {
+		if ( isset( $block['attrs'][ $attribute_name ] ) && is_string( $block['attrs'][ $attribute_name ] ) ) {
+			if ( isset( $replacements[ $block['attrs'][ $attribute_name ] ] ) ) {
+				$block['attrs'][ $attribute_name ] = $replacements[ $block['attrs'][ $attribute_name ] ];
+			}
+		}
+	}
+}
+
+trait SwapTags {
+	private $safe_tags = [
+		'strong',
+		'em',
+	];
+
+	private function encode_tags( string $raw_html ) : string {
+		foreach ( $this->safe_tags as $tag ) {
+			$raw_html = preg_replace(
+				'#(<' . $tag . '([^>]*)>)(.*)(</' . $tag . '>)#',
+				'{' . $tag . '$2' . '}$3' . '{/' . $tag . '}', // phpcs:ignore Generic.Strings.UnnecessaryStringConcat.Found
+				$raw_html
+			);
+		}
+		return $raw_html;
+	}
+
+	private function decode_tags( string $encoded_html ) : string {
+		foreach ( $this->safe_tags as $tag ) {
+			$encoded_html = preg_replace(
+				'#({' . $tag . '([^}]*)})(.*)({/' . $tag . '})#',
+				'<' . $tag . '$2' . '>$3' . '</' . $tag . '>', // phpcs:ignore Generic.Strings.UnnecessaryStringConcat.Found
+				$encoded_html
+			);
+		}
+		return $encoded_html;
+	}
+}
+
+trait TextNodesXPath {
+	private $xpaths = [
+		'//text()',   // Visible Text nodes.
+		'//img/@alt', // Image alt="" text.
+		'//*/@title', // title="" text.
+	];
+
+	protected function text_nodes_xpath_query() {
+		return implode( ' | ', $this->xpaths );
+	}
+}

--- a/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/parsers/Button.php
+++ b/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/parsers/Button.php
@@ -1,0 +1,54 @@
+<?php
+namespace WordPressdotorg\Post_Translation\Parsers;
+
+class Button implements BlockParser {
+	use DomUtils;
+	use SwapTags;
+	use GetSetAttribute;
+	use TextNodesXPath;
+
+	public function to_strings( array $block ) : array {
+		$strings = $this->get_attribute( 'placeholder', $block );
+
+		$encoded_html = $this->encode_tags( $block['innerHTML'] );
+
+		$dom   = $this->get_dom( $encoded_html );
+		$xpath = new \DOMXPath( $dom );
+
+		foreach ( $xpath->query( $this->text_nodes_xpath_query() ) as $text ) {
+			if ( trim( $text->nodeValue ) ) {
+				$strings[] = $this->decode_tags( $text->nodeValue );
+			}
+		}
+
+		return $strings;
+	}
+
+	public function replace_strings( array $block, array $replacements ) : array {
+		$this->set_attribute( 'placeholder', $block, $replacements );
+
+		$encoded_html = $this->encode_tags( $block['innerHTML'] );
+
+		$dom   = $this->get_dom( $encoded_html );
+		$xpath = new \DOMXPath( $dom );
+
+		foreach ( $xpath->query( $this->text_nodes_xpath_query() ) as $text ) {
+			if ( trim( $text->nodeValue ) && isset( $replacements[ $this->decode_tags( $text->nodeValue ) ] ) ) {
+				$text->parentNode->replaceChild(
+					$dom->createCDATASection(
+						$this->encode_tags(
+							$replacements[ $this->decode_tags( $text->nodeValue ) ]
+						)
+					),
+					$text
+				);
+			}
+		}
+
+		$decoded_html = $this->decode_tags( $this->removeHtml( $dom->saveHTML() ) );
+		$block['innerHTML']    = $decoded_html;
+		$block['innerContent'] = [ $decoded_html ];
+
+		return $block;
+	}
+}

--- a/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/parsers/HTMLParser.php
+++ b/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/parsers/HTMLParser.php
@@ -1,0 +1,94 @@
+<?php
+namespace WordPressdotorg\Post_Translation\Parsers;
+
+class HTMLParser implements BlockParser {
+	use GetSetAttribute;
+
+	public $tags = [];
+	public $attributes = [];
+
+	public function __construct( $tags = array(), $attributes = array() ) {
+		$this->tags       = (array) $tags;
+		$this->attributes = (array) $attributes;
+	}
+
+	public function to_strings( array $block ) : array {
+		$strings = $this->get_attribute( 'placeholder', $block );
+
+		foreach ( $this->tags as $tag ) {
+			$tag = $this->escape_tag( $tag, '#' );
+
+			if ( preg_match_all( "#<{$tag}[^>]*>\s*(?P<string>.+?)\s*</{$tag}>#is", $block['innerHTML'], $matches ) ) {
+				$strings = array_merge( $strings, $matches['string'] );
+			}
+		}
+
+		foreach ( $this->attributes as $attr ) {
+			$attr = $this->escape_attr( $attr, '#' );
+
+			if (
+				str_contains( $block['innerHTML'], "='" ) &&
+				preg_match_all( "#{$attr}='(?P<string>[^']+?)'#is", $block['innerHTML'], $matches )
+			) {
+				$strings = array_merge( $strings, $matches['string'] );
+			}
+
+			if (
+				str_contains( $block['innerHTML'], '="' ) &&
+				preg_match_all( "#{$attr}=\"(?P<string>[^\"]+?)\"#is", $block['innerHTML'], $matches )
+			) {
+				$strings = array_merge( $strings, $matches['string'] );
+			}
+		}
+
+		return $strings;
+	}
+
+	// todo: this needs a fix to properly rebuild innerContent - see ParagraphParserTest
+	public function replace_strings( array $block, array $replacements ) : array {
+		$this->set_attribute( 'placeholder', $block, $replacements );
+
+		$html = $block['innerHTML'];
+
+		foreach ( $this->to_strings( $block ) as $original ) {
+			if ( empty( $original ) || ! isset( $replacements[ $original ] ) ) {
+				continue;
+			}
+
+			// TODO: Potentially this should be more specific for tags/attribute replacements as needed.
+			$regex = '#([>"\'])\s*' . preg_quote( $original, '#' ) . '\s*([\'"<])#s';
+			$html  = preg_replace( $regex, '$1' . addcslashes( $replacements[ $original ], '\\$' ) . '$2', $html );
+		}
+
+		$block['innerHTML']    = $html;
+		$block['innerContent'] = [ $html ];
+
+		return $block;
+	}
+
+	/**
+	 * Escape a tag/attribute to use in a regex.
+	 */
+	protected function escape_tag( $string, $delim ) {
+		return $this->escape( $string, $delim );
+	}
+	protected function escape_attr( $string, $delim ) {
+		return $this->escape( $string, $delim );
+	}
+	protected function escape( $string, $delim ) {
+		return preg_quote( $string, $delim );
+	}
+}
+
+class HTMLRegexParser extends HTMLParser {
+	/**
+	 * Maybe escape a string for a regex match, unless it looks like regex (ie. /..../) then use as-is.
+	 */
+	protected function escape_tag( $string, $delim ) {
+		if ( str_starts_with( $string, '/' ) && str_ends_with( $string, '/' ) ) {
+			return trim( $string, '/' );
+		}
+
+		return parent::escape_tag( $string, $delim );
+	}
+}

--- a/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/parsers/Noop.php
+++ b/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/parsers/Noop.php
@@ -1,0 +1,12 @@
+<?php
+namespace WordPressdotorg\Post_Translation\Parsers;
+
+class Noop implements BlockParser {
+	public function to_strings( array $block ) : array {
+		return [];
+	}
+
+	public function replace_strings( array $block, array $replacements ) : array {
+		return $block;
+	}
+}

--- a/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/parsers/ShortcodeBlock.php
+++ b/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/parsers/ShortcodeBlock.php
@@ -1,0 +1,83 @@
+<?php
+namespace WordPressdotorg\Post_Translation\Parsers;
+
+/*
+ * Handle blocks with attributes present in the attributes that are also used
+ * in a shortcode within the block content.
+ *
+ * Example: new Parsers\ShortcodeBlock( [ 'subscribePlaceholder', 'submitButtonText' ] );
+ */
+class ShortcodeBlock implements BlockParser {
+	use GetSetAttribute;
+
+	public $attribute_names = [];
+
+	public function __construct( array $attribute_names ) {
+		$this->attribute_names = $attribute_names;
+	}
+
+	public function to_strings( array $block ) : array {
+		$strings = [];
+		foreach ( $this->attribute_names as $attribute_name ) {
+			$strings = array_merge( $strings, $this->get_attribute( $attribute_name, $block ) );
+		}
+
+		return $strings;
+	}
+
+	public function replace_strings( array $block, array $replacements ) : array {
+		foreach ( $this->attribute_names as $attribute_name ) {
+			$this->set_attribute( $attribute_name, $block, $replacements );
+
+			foreach ( $block['innerContent'] as $i => &$inner_content ) {
+				if ( is_string( $inner_content ) ) {
+					$shortcode_param_regex = '/(\b' . $this->snake_case( $attribute_name ) . ')="(.*?)("\n?)/';
+
+					$block['innerContent'][ $i ] = preg_replace_callback(
+						$shortcode_param_regex,
+						function( $matches ) use ( $replacements ) {
+							return $this->preg_replace_gutenberg_attributes_handler( $matches, $replacements );
+						},
+						$inner_content
+					);
+				}
+			}
+		}
+
+		$regex              = '/\b(\w*?)="(.*?)(")/';
+		$block['innerHTML'] = preg_replace_callback(
+			$regex,
+			function( $matches ) use ( $replacements ) {
+				return $this->preg_replace_gutenberg_attributes_handler( $matches, $replacements );
+			},
+			$block['innerHTML']
+		);
+		return $block;
+	}
+
+	// phpcs:disable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	protected function snake_case( $camelCaseString ) {
+		return ltrim(
+			preg_replace_callback(
+				'/([A-Z]+)/',
+				function( $matches ) {
+					return '_' . strtolower( $matches[1] ); },
+				$camelCaseString
+			),
+			'_'
+		);
+	}
+	// phpcs:enable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+
+	public function preg_replace_gutenberg_attributes_handler( array $matches, array $replacements ) {
+		$current_value = $matches[2];
+
+		if ( ! isset( $replacements[ $current_value ] ) ) {
+			return $matches[0];
+		}
+
+		$new_value = $replacements[ $current_value ];
+		$property  = $matches[1];
+		return "$property=\"$new_value" . $matches[3];
+	}
+}

--- a/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/parsers/ShortcodeBlock.php
+++ b/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/parsers/ShortcodeBlock.php
@@ -5,18 +5,28 @@ namespace WordPressdotorg\Post_Translation\Parsers;
  * Handle blocks with attributes present in the attributes that are also used
  * in a shortcode within the block content.
  *
+ * Example: new Parsers\ShortcodeBlock();
  * Example: new Parsers\ShortcodeBlock( [ 'subscribePlaceholder', 'submitButtonText' ] );
+ *
+ * TODO: Figure out how to make the second case selectable per-shortcode, if it's even needed..
  */
 class ShortcodeBlock implements BlockParser {
 	use GetSetAttribute;
 
 	public $attribute_names = [];
 
-	public function __construct( array $attribute_names ) {
+	public function __construct( array $attribute_names = [] ) {
 		$this->attribute_names = $attribute_names;
 	}
 
 	public function to_strings( array $block ) : array {
+		// The entire shortcode is a string.
+		if ( ! $this->attribute_names ) {
+			return [
+				trim( $block['innerHTML'] )
+			];
+		}
+
 		$strings = [];
 		foreach ( $this->attribute_names as $attribute_name ) {
 			$strings = array_merge( $strings, $this->get_attribute( $attribute_name, $block ) );
@@ -26,6 +36,12 @@ class ShortcodeBlock implements BlockParser {
 	}
 
 	public function replace_strings( array $block, array $replacements ) : array {
+		if ( ! $this->attribute_names ) {
+			$block['innerHTML'] = $replacements[ trim( $block['innerHTML'] ) ];
+
+			return $block;
+		}
+
 		foreach ( $this->attribute_names as $attribute_name ) {
 			$this->set_attribute( $attribute_name, $block, $replacements );
 

--- a/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/parsers/TextNode.php
+++ b/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/parsers/TextNode.php
@@ -1,0 +1,34 @@
+<?php
+namespace WordPressdotorg\Post_Translation\Parsers;
+
+class TextNode implements BlockParser {
+	use DomUtils;
+
+	public function to_strings( array $block ) : array {
+		$dom   = $this->get_dom( serialize_block( $block ) );
+		$xpath = new \DOMXPath( $dom );
+
+		$strings = [];
+
+		foreach ( $xpath->query( '//text()' ) as $text ) {
+			if ( trim( $text->nodeValue ) ) {
+				$strings[] = $text->nodeValue;
+			}
+		}
+
+		return $strings;
+	}
+
+	public function replace_strings( array $block, array $replacements ) : array {
+		$dom   = $this->get_dom( serialize_block( $block ) );
+		$xpath = new \DOMXPath( $dom );
+
+		foreach ( $xpath->query( '//text()' ) as $text ) {
+			if ( trim( $text->nodeValue ) && isset( $replacements[ $text->nodeValue ] ) ) {
+				$text->parentNode->replaceChild( $dom->createCDATASection( $replacements[ $text->nodeValue ] ), $text );
+			}
+		}
+
+		return parse_blocks( $this->removeHtml( $dom->saveHTML() ) )[0] ?? [];
+	}
+}

--- a/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/post-parser.php
+++ b/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/post-parser.php
@@ -28,20 +28,22 @@ class Post_Parser {
 			'core/quote'       => new Parsers\HTMLParser( [ 'p', 'cite' ] ),
 			'core/heading'     => new Parsers\HTMLRegexParser( '/h[1-6]/' ),
 
-			'core/button'      => new Parsers\Button(),
+			//'core/button'      => new Parsers\Button(),
+			//'core/buttons'     => new Parsers\BasicText(),
+			'core/button'      => new Parsers\HTMLParser( 'a', [ 'href', 'title' ] ),
+
+			// Generic shortcode handler..
+			'core/shortcode'   => new Parsers\ShortcodeBlock(),
+
 			'core/spacer'      => new Parsers\Noop(),
 
 			// Common core blocks that use the default parser.
-			'core/buttons'     => new Parsers\BasicText(),
 			'core/column'      => new Parsers\BasicText(),
 			'core/columns'     => new Parsers\BasicText(),
 			'core/cover'       => new Parsers\BasicText(),
 			'core/group'       => new Parsers\BasicText(),
 			'core/media-text'  => new Parsers\BasicText(),
 			'core/social-link' => new Parsers\BasicText(),
-
-			// Generic shortcode handler..
-			'core/shortcode'   => new Parsers\ShortcodeBlock(),
 		];
 	}
 

--- a/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/post-parser.php
+++ b/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/post-parser.php
@@ -39,6 +39,9 @@ class Post_Parser {
 			'core/group'       => new Parsers\BasicText(),
 			'core/media-text'  => new Parsers\BasicText(),
 			'core/social-link' => new Parsers\BasicText(),
+
+			// Generic shortcode handler..
+			'core/shortcode'   => new Parsers\ShortcodeBlock(),
 		];
 	}
 

--- a/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/post-parser.php
+++ b/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/post-parser.php
@@ -36,12 +36,12 @@ class Post_Parser {
 			'core/shortcode'   => new Parsers\ShortcodeBlock(),
 
 			'core/spacer'      => new Parsers\Noop(),
+			// These contain other blocks to be parsed.
+			'core/column'      => new Parsers\Noop(),
+			'core/columns'     => new Parsers\Noop(),
+			'core/group'       => new Parsers\Noop(),
 
 			// Common core blocks that use the default parser.
-			'core/column'      => new Parsers\BasicText(),
-			'core/columns'     => new Parsers\BasicText(),
-			'core/cover'       => new Parsers\BasicText(),
-			'core/group'       => new Parsers\BasicText(),
 			'core/media-text'  => new Parsers\BasicText(),
 			'core/social-link' => new Parsers\BasicText(),
 		];

--- a/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/post-parser.php
+++ b/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/post-parser.php
@@ -1,0 +1,193 @@
+<?php
+//phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- DomDocument/DOMXPath returns classes that use camelCasing
+
+namespace WordPressdotorg\Post_Translation;
+use WP_Post;
+
+require_once __DIR__ . '/parsers/BlockParser.php';
+require_once __DIR__ . '/parsers/HTMLParser.php';
+require_once __DIR__ . '/parsers/BasicText.php';
+require_once __DIR__ . '/parsers/Button.php';
+require_once __DIR__ . '/parsers/Noop.php';
+require_once __DIR__ . '/parsers/ShortcodeBlock.php';
+require_once __DIR__ . '/parsers/TextNode.php'; // Unused
+
+class Post_Parser {
+	public $content;
+	public $parsers = [];
+	public $fallback;
+
+	public function __construct( string $content ) {
+		$this->content  = $content;
+		$this->fallback = new Parsers\BasicText();
+		$this->parsers  = [
+			// Blocks that have custom parsers.
+			'core/paragraph'   => new Parsers\HTMLParser( 'p' ),
+			'core/image'       => new Parsers\HTMLParser( 'figcaption', [ 'alt', 'title' ] ),
+			'core/list'        => new Parsers\HTMLParser( 'li' ),
+			'core/quote'       => new Parsers\HTMLParser( [ 'p', 'cite' ] ),
+			'core/heading'     => new Parsers\HTMLRegexParser( '/h[1-6]/' ),
+
+			'core/button'      => new Parsers\Button(),
+			'core/spacer'      => new Parsers\Noop(),
+
+			// Common core blocks that use the default parser.
+			'core/buttons'     => new Parsers\BasicText(),
+			'core/column'      => new Parsers\BasicText(),
+			'core/columns'     => new Parsers\BasicText(),
+			'core/cover'       => new Parsers\BasicText(),
+			'core/group'       => new Parsers\BasicText(),
+			'core/media-text'  => new Parsers\BasicText(),
+			'core/social-link' => new Parsers\BasicText(),
+		];
+	}
+
+	public static function post_to_strings( $post ) {
+		$self    = new self( $post->post_content );
+		$strings = $self->to_strings();
+
+		if ( $post->post_title ) {
+			$strings[] = $post->post_title;
+		}
+		if ( $post->post_excerpt ) {
+			$strings[] = $post->post_excerpt;
+		}
+
+		return $strings;
+	}
+
+	public static function translate_post( $post, callable $callback_translate ) {
+		$post->post_content = self::translate_blocks( $post->post_content, $callback_translate ) ?: $post->post_content;
+		$post->post_title   = $callback_translate( $post->post_title ) ?: $post->post_title;
+		$post->post_excerpt = $callback_translate( $post->post_excerpt ) ?: $post->post_excerpt;
+
+		return $post;
+	}
+
+	public static function translate_blocks( string $content, callable $callback_translate ) /*: bool|string*/ {
+		$self         = new self( $content );
+
+		$translations = [];
+		$translated   = false;
+		$strings      = $self->to_strings();
+
+//		var_dump( $strings );
+		foreach ( $strings as $string ) {
+			$translations[ $string ] = $callback_translate( $string );
+	
+			$translated = $translated || ( $string !== $translations[ $string ] );
+		}
+
+		// Are there any translations?
+		if ( ! $translated ) {
+			return false;
+		}
+
+		return $self->replace_strings_with_kses( $translations );
+	}
+
+	public function block_parser_to_strings( array $block ) : array {
+		$parser = $this->parsers[ $block['blockName'] ] ?? $this->fallback;
+
+		$strings = $parser->to_strings( $block );
+//var_dump( [ $block['blockName'], $parser, $strings ] );
+
+		foreach ( $block['innerBlocks'] as $inner_block ) {
+			$strings = array_merge( $strings, $this->block_parser_to_strings( $inner_block ) );
+		}
+
+		return $strings;
+	}
+
+	public function block_parser_replace_strings( array &$block, array $replacements ) : array {
+		$parser = $this->parsers[ $block['blockName'] ] ?? $this->fallback;
+		$block = $parser->replace_strings( $block, $replacements );
+
+		foreach ( $block['innerBlocks'] as &$inner_block ) {
+			$inner_block = $this->block_parser_replace_strings( $inner_block, $replacements );
+		}
+
+		return $block;
+	}
+
+	public function to_strings() : array {
+		$strings = [];
+
+		$blocks = parse_blocks( $this->content );
+		//var_Dump( $blocks, $this->content ); die();
+		foreach ( $blocks as $block ) {
+			$strings = array_merge( $strings, $this->block_parser_to_strings( $block ) );
+		}
+
+		return array_unique( $strings );
+	}
+
+	public function replace_strings_with_kses( array $replacements ) : string {
+		// Sanitize replacement strings before injecting them into blocks and block attributes.
+		$sanitized_replacements = $replacements;
+		foreach ( $sanitized_replacements as &$replacement ) {
+			$replacement = wp_kses_post( $replacement );
+		}
+		return $this->replace_strings( $sanitized_replacements );
+	}
+
+	public function replace_strings( array $replacements ) : string {
+		$translated = $this->content;
+
+		$blocks = parse_blocks( $translated );
+		foreach ( $blocks as &$block ) {
+			$block = $this->block_parser_replace_strings( $block, $replacements );
+		}
+
+		// If we pass `serialize_blocks` a block that includes unicode characters in the
+		// attributes, these attributes will be encoded with a unicode escape character, e.g.
+		// "subscribePlaceholder":"😀" becomes "subscribePlaceholder":"\ud83d\ude00".
+		// After we get the serialized blocks back from `serialize_blocks` we need to convert these
+		// characters back to their unicode form so that we don't break blocks in the editor.
+		$translated = $this->decode_unicode_characters( serialize_blocks( $blocks ) );
+
+		return $translated;
+	}
+
+	/**
+	 * Decode a string containing unicode escape sequences.
+	 * Excludes decoding characters not allowed within block attributes.
+	 *
+	 * @param string $string A string containing serialized blocks.
+	 * @return string A string containing decoded unicode characters.
+	 */
+	public function decode_unicode_characters( string $string ): string {
+
+		// In WordPress core, `serialize_block_attributes` intentionally leaves some characters
+		// in the block attributes encoded in their unicode form. These are characters that would
+		// interfere with characters in block comments e.g. consider potential values entered
+		// in the placeholder attribute: <!-- wp:paragraph {"placeholder":"dangerous characters go here"} -->
+		// Reference: https://github.com/WordPress/WordPress/blob/HEAD/wp-includes/blocks.php#L367
+
+		$excluded_characters = [
+			'\\u002d\\u002d', // '--'
+			'\\u003c',        // '<'
+			'\\u003e',        // '>'
+			'\\u0026',        // '&'
+			'\\u0022',        // '"'
+		];
+
+		// Match any uninterrupted sequence of \u escaped unicode characters.
+		$decoded_string = preg_replace_callback(
+			'#(\\\\u[a-zA-Z0-9]{4})+#',
+			function ( $matches ) use ( $excluded_characters ) {
+				// If we encounter any excluded characters, don't decode this match.
+				foreach ( $excluded_characters as $excluded_character ) {
+					if ( false !== mb_stripos( $matches[0], $excluded_character ) ) {
+						return $matches[0];
+					}
+				}
+				// If we didn't encounter excluded characters, use json_decode to do the heavy lifting.
+				return json_decode( '"' . $matches[0] . '"' );
+			},
+			$string
+		);
+
+		return $decoded_string;
+	}
+}

--- a/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/post-parser.php
+++ b/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/inc/post-parser.php
@@ -56,6 +56,11 @@ class Post_Parser {
 			$strings[] = $post->post_excerpt;
 		}
 
+		$post_meta_to_include = apply_filters( 'translatable_post_meta', [] );
+		foreach ( $post_meta_to_include as $meta_key ) {
+			$strings[] = get_post_meta( $post->ID, $meta_key, true );
+		}
+
 		return $strings;
 	}
 

--- a/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/post-translation.php
+++ b/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/post-translation.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: GlotPress Post Translation
  * Description: This plugin allows for a post to be translated into another locale, through GlotPress.
- * Version: 0.1
+ * Version: 0.2
  * Plugin URI: https://meta.trac.wordpress.org/browser/sites/trunk/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/
  * Author: WordPress.org Contributors
  * License: GPLv2

--- a/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/post-translation.php
+++ b/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/post-translation.php
@@ -1,0 +1,112 @@
+<?php
+/*
+ * Plugin Name: GlotPress Post Translation
+ * Description: This plugin allows for a post to be translated into another locale, through GlotPress.
+ * Version: 0.1
+ * Plugin URI: https://meta.trac.wordpress.org/browser/sites/trunk/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/
+ * Author: WordPress.org Contributors
+ * License: GPLv2
+ */
+
+namespace WordPressdotorg\Post_Translation;
+use GlotPress_Translate_Bridge;
+
+/*
+ * TODO:
+ *  - Create GlotPress projects within a parent-project scope for translations
+ *  - Re-evaluate how it selects projects for where to pull a string from,
+ *    currently this is done through post_meta and filtered, but this should
+ *    probably be defined per-site rather than per-post or be 100% automatically
+ *    selected.
+ *  - Some Block Templates are known to not be caught by the `the_content` filters.
+ *  - Test
+ *  - Test
+ * 
+ * Notes:
+ *  - Enable the 'test' functions at the bottom of this file, but changing `/*` to `//*`.
+ */
+
+const TEXTDOMAIN_PREFIX     = 'dynamic-glotpress/';
+const DEFAULT_PROJECT       = 'disabled/posttranslation';
+const META_KEY_PROJECT      = 'glotpress_translation_project';
+const META_KEY_TRANSLATABLE = 'glotpress_translated';
+
+function init() {
+	if ( ! class_exists( 'GlotPress_Translate_Bridge' ) ) {
+		require_once __DIR__ . '/glotpress-translate-bridge.php';
+	}
+
+	include_once __DIR__ . '/inc/post-parser.php';
+	include_once __DIR__ . '/inc/front-end.php';
+
+	if ( is_admin() || wp_doing_cron() ) {
+		include_once __DIR__ . '/inc/admin.php';
+	}
+
+}
+add_action( 'init', __NAMESPACE__ . '\init', 9 );
+
+/**
+ * Get the project for a posts translation project.
+ */
+function get_post_translation_project( $post ) {
+	$post = get_post( $post );
+
+	// Filter: pass translation status, post as context.
+	if ( ! apply_filters( 'post_translation_enabled', (bool) $post->{ META_KEY_TRANSLATABLE }, $post ) ) {
+		return false;
+	}
+
+	// Filter: project, post as context
+	return apply_filters( 'post_translation_project', ( $post->{ META_KEY_PROJECT } ?: DEFAULT_PROJECT ), $post );
+}
+
+
+// Temp hackery - this is for debugging and enabling this.
+add_filter( 'post_translation_enabled', '__return_true' );
+add_filter( 'post_translation_project', function( $project, $post ) {
+	if (
+		'https://wordpress.org/gutenberg/' === home_url( '/' ) &&
+		97589 === $post->ID
+	) {
+		$project = 'meta/wordpress-org';
+	}
+
+	if (
+		'https://wordpress.org/main-test/' === home_url( '/' )
+	) {
+		$project = DEFAULT_PROJECT . '/wordpress-org-main-test';
+	}
+
+	// TODO: This filter might deserve to be set to select the appropriate GlotPress project automatically.
+
+	return $project;
+}, 10, 2 );
+
+/* Reverse all strings that should be translated, for visibility during test & review
+add_filter( 'gettext', function( $translated, $original, $domain ) {
+	if ( str_starts_with( $domain, TEXTDOMAIN_PREFIX ) && $translated === $original ) {
+		// strrev that supports multibyte..
+		$translated = (function( $string ) {
+			$chars = mb_str_split( $string, 1, $encoding ?: mb_internal_encoding() );
+			return implode( '', array_reverse( $chars ) );
+		})($original);
+	}
+
+	return $translated;
+}, 20, 3 );
+//*/
+
+/* CoNvErT aLl StRiNgS tO sTuPiDcAsE fOr ViSiBiLiTy
+add_filter( 'gettext', function( $translated, $original, $domain ) {
+	if ( str_starts_with( $domain, TEXTDOMAIN_PREFIX ) && $translated === $original ) {
+		$translated = preg_replace_callback( '/[a-z]/i', function( $m ) {
+			static $last = 0;
+			$last = $last ? 0 : 1;
+			return $last ? strtoupper( $m[0] ) : strtolower( $m[0] );
+		}, $translated );
+	}
+
+	return $translated;
+}, 20, 3 );
+//*/

--- a/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/post-translation.php
+++ b/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/post-translation.php
@@ -13,11 +13,9 @@ use GlotPress_Translate_Bridge;
 
 /*
  * TODO:
- *  - Create GlotPress projects within a parent-project scope for translations
- *  - Re-evaluate how it selects projects for where to pull a string from,
- *    currently this is done through post_meta and filtered, but this should
- *    probably be defined per-site rather than per-post or be 100% automatically
- *    selected.
+ *  - Re-evaluate how the GlotPress interaction in MakePot happens. Other projects
+ *    on WordPress.org install that as a helper-plugin to translate.w.org and call
+ *    a WP-CLI method instead.
  *  - Some Block Templates are known to not be caught by the `the_content` filters.
  *  - Some strings from post content include `&nbsp;` and `<br>` tags, it might be
  *    better to standardise some of these prior to inserting into GlotPress,
@@ -33,6 +31,7 @@ const TEXTDOMAIN_PREFIX     = 'dynamic-glotpress/';
 const PROJECT_BASE          = 'disabled/posttranslation';
 const META_KEY_PROJECT      = 'glotpress_translation_project';
 const META_KEY_TRANSLATABLE = 'glotpress_translated';
+const PROJECT_INHERIT_SETS  = PROJECT_BASE; // 'wp/dev'; // The project to inherit (copy) translation sets from.
 
 function init() {
 	if ( ! class_exists( 'GlotPress_Translate_Bridge' ) ) {

--- a/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/post-translation.php
+++ b/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/post-translation.php
@@ -19,7 +19,10 @@ use GlotPress_Translate_Bridge;
  *    probably be defined per-site rather than per-post or be 100% automatically
  *    selected.
  *  - Some Block Templates are known to not be caught by the `the_content` filters.
- *  - Test
+ *  - Some strings from post content include `&nbsp;` and `<br>` tags, it might be
+ *    better to standardise some of these prior to inserting into GlotPress,
+ *    for example, replacing `<br>` with a literal `\n`, although that will make
+ *    retrieving them harder.
  *  - Test
  * 
  * Notes:

--- a/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/post-translation.php
+++ b/wordpress.org/public_html/wp-content/plugins/glotpress-translate-bridge/post-translation.php
@@ -41,7 +41,7 @@ function init() {
 	include_once __DIR__ . '/inc/post-parser.php';
 	include_once __DIR__ . '/inc/front-end.php';
 
-	if ( is_admin() || wp_doing_cron() ) {
+	if ( is_admin() || wp_doing_cron() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
 		include_once __DIR__ . '/inc/admin.php';
 	}
 


### PR DESCRIPTION
This PR is a combination of the work done to translate Patterns, WordPress.org/gutenberg/, and now https://github.com/WordPress/wporg-main-2022

The block parsing classes in this PR differ from that which is used for Patterns (See https://github.com/WordPress/pattern-directory/tree/trunk/public_html/wp-content/plugins/pattern-translations/includes) as in testing I found issue with it and started writing my own parsers that seemed to work more reliably for the purpose of post translation.

The strings for the wporg-main-2022 theme are currently in this project:
https://translate.wordpress.org/projects/disabled/posttranslation/wordpress-org-main-test
(The cron job is not run upon post update, it must be run manually through CLI)

See https://github.com/WordPress/wporg-main-2022/issues/15

A list of TODOs from code and review:
 - [x] Create GlotPress projects within a parent-project scope for translations
 - [x] Re-evaluate how it selects projects for where to pull a string from, currently this is done through post_meta and filtered, but this should probably be defined per-site rather than per-post or be 100% automatically selected.
 - [ ] Re-evaluate how the GlotPress interaction in MakePot happens. Other projects on WordPress.org install that as a helper-plugin to translate.w.org and call a WP-CLI method instead.
 - [ ] Some Block Templates are known to not be caught by the `the_content` filters.
 - [ ] Some strings from post content include `&nbsp;` and `<br>` tags, it might be better to standardise some of these prior to inserting into GlotPress, for example, replacing `<br>` with a literal `\n`, although that will make retrieving them harder.
 - [ ] Importing these strings directly into GlotPress results in a lot of HTML and class/href attributes. It might be nice if we could replace `<a href="https://...../">` and `<span class="has-many-attributes">` with `<a>` and `<span>` respectfully in translations, filling them back in on retrieval. This is likely a v2/v3 feature though.. but ties in to the above reference to `<br>` in the content.
