### PR TITLE
Slack: Grant Birgit slack Slack announce permissions for #core-dev-blog

### DIFF
--- a/common/includes/slack/announce/config.php
+++ b/common/includes/slack/announce/config.php
@@ -156,6 +156,9 @@ function get_whitelist() {
 			'voldemortensen',
 			'westonruter',
 		) ),
+		'core-dev-blog' => array(
+			'bph',
+		),
 		'core-docs' => array_merge( get_committers(), array(
 			'DrewAPicture', // @drew on Slack
 			'Kenshino',


### PR DESCRIPTION
Adds #core-dev-blog channel to list and grants announce access to Birgit