### PR TITLE
Fix Openverse footer from being cut off

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/css/openverse.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/css/openverse.css
@@ -18,6 +18,7 @@ body {
 .site,
 .site-content {
     width: 100% !important;
+    height: calc(100vh - var(--wp-global-header-height)) !important;
     padding: 0 !important;
     max-width: 100% !important;
 }

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/css/openverse.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/css/openverse.css
@@ -2,7 +2,7 @@
     display: block;
 
     width: 100%;
-    height: calc(100vh - var(--wp-global-header-height) - var(--wp-admin--admin-bar--height))
+    height: calc(100vh - var(--wp-global-header-height) - var(--wp-admin--admin-bar--height, 0px))
 }
 
     border: none;

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/css/openverse.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/css/openverse.css
@@ -19,7 +19,6 @@ body {
 .site,
 .site-content {
     width: 100% !important;
-    height: calc(100vh - var(--wp-global-header-height) - var(--wp-admin--admin-bar--height))
     padding: 0 !important;
     max-width: 100% !important;
 }

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/css/openverse.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/css/openverse.css
@@ -2,7 +2,8 @@
     display: block;
 
     width: 100%;
-    height: calc(100vh - var(--wp-global-header-height));
+    height: calc(100vh - var(--wp-global-header-height) - var(--wp-admin--admin-bar--height))
+}
 
     border: none;
 }

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/css/openverse.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/css/openverse.css
@@ -19,7 +19,7 @@ body {
 .site,
 .site-content {
     width: 100% !important;
-    height: calc(100vh - var(--wp-global-header-height)) !important;
+    height: calc(100vh - var(--wp-global-header-height) - var(--wp-admin--admin-bar--height))
     padding: 0 !important;
     max-width: 100% !important;
 }


### PR DESCRIPTION
This should prevent the website from cutting off . See issue #1583 https://github.com/WordPress/openverse-frontend/issues/1583

[Ticket](https://meta.trac.wordpress.org/ticket/6450#ticket)