### PR TITLE
Remove the Logo and Search nodes from the admin bar

### DIFF
--- a/wordpress.org/public_html/wp-content/mu-plugins/pub/wporg-admin-bar.php
+++ b/wordpress.org/public_html/wp-content/mu-plugins/pub/wporg-admin-bar.php
@@ -1,29 +1,20 @@
 <?php
+namespace WordPressdotorg\MU_Plugins\Admin_Bar;
 /**
  * Customizations to the Admin Bar across all networks.
  */
 
 /**
- * Makes Logo and About menu items link to the localised w.org/about/ page for all users.
+ * Removes the Search, Logo, and About menu from the admin bar for all users.
  *
  * @param WP_Admin_Bar $wp_admin_bar WP_Admin_Bar instance, passed by reference.
  */
-function wporg_about_links_in_admin_bar( $wp_admin_bar ) {
-	$nodes = [
-		$wp_admin_bar->get_node( 'wp-logo' ),
-		$wp_admin_bar->get_node( 'about' ),
-	];
-
-	$about_url = 'https://wordpress.org/about/';
-
-	if ( class_exists( 'Rosetta_Sites' ) && is_object( $GLOBALS['rosetta'] ) ) {
-		$about_url = 'https://' . $GLOBALS['rosetta']->current_site_domain . '/about/';
+function admin_bar_menu( $wp_admin_bar ) {
+	if ( is_admin() ) {
+		return;
 	}
 
-	foreach ( $nodes as $node ) {
-		$node->href = $about_url;
-
-		$wp_admin_bar->add_node( $node );
-	}
+	$wp_admin_bar->remove_node( 'wp-logo' );
+	$wp_admin_bar->remove_node( 'search' );
 }
-add_action( 'admin_bar_menu', 'wporg_about_links_in_admin_bar', 11 );
+add_action( 'admin_bar_menu', __NAMESPACE__ . '\admin_bar_menu', 11 );


### PR DESCRIPTION
See https://github.com/WordPress/wporg-mu-plugins/issues/252

This PR removes the W logo and Search items from the admin bar.

Logged out view:
| Before | After |
| --- | --- |
| <img width="893" alt="Screen Shot 2022-08-30 at 5 05 44 pm" src="https://user-images.githubusercontent.com/767313/187372175-0084efdf-061c-47bc-a857-bf7826094b3e.png"> | <img width="893" alt="Screen Shot 2022-08-30 at 5 05 56 pm" src="https://user-images.githubusercontent.com/767313/187372203-03ccc020-4105-4ff1-a749-3c01e7a496d6.png"> |

Logged in view:
| Before | After |
| --- | --- |
| <img width="893" alt="Screen Shot 2022-08-30 at 5 07 35 pm" src="https://user-images.githubusercontent.com/767313/187372405-15a4f043-a405-4437-9bba-6f9ea03fe22a.png"> | <img width="893" alt="Screen Shot 2022-08-30 at 5 07 20 pm" src="https://user-images.githubusercontent.com/767313/187372454-97703f86-9408-4bc8-bd4d-7413679f0187.png"> |

This doesn't go as far as suggested in https://github.com/WordPress/wporg-mu-plugins/issues/252 but is a stepping stone towards it. There's more implementation required in order to remove the admin bar entirely, and ensure that the toolbar items that are required by those with elevated WordPress.org access can still access the tools/features that we have present in the admin bar.