### PR TITLE
Update "Update PHP" support page

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
@@ -86,6 +86,18 @@ function wporg_support_filter_update_php_content( $content ) {
 	$content .= '</ul>';
 	$content .= '<p>' . __( 'These benefits are good for you, and good for your website&#8217;s visitors. These are the reasons you should update PHP today. The next section will show you how to do this.', 'wporg-forums' ) . '</p>';
 
+	// Section "How to check your PHP version".
+	$content .= '<h3>' . __( 'How to check your PHP version', 'wporg-forums' ) . '</h3>';
+	$content .= '<p>' . __( 'To check what version of PHP your WordPress site is using, from the WordPress Dashboard, select <em>Tools &gt; Site Health</em> from the sidebar menu, and then select the Info tab. Expand the Server section and scroll down until you see <strong>PHP version</strong>.', 'wporg-forums' ) . '</p>';
+	$content .= '<p>';
+	$content .= sprintf(
+		/* translators: %s: recommended PHP version */
+		__( 'If this number is at or higher than PHP %s, then you don&#8217;t need to update PHP at this time!' ),
+		RECOMMENDED_PHP
+	);
+	$content .= '</p>';
+	$content .= '<p>' . __( 'However, if your site is lower than the recommended version, running on an outdated and insecure version of PHP, then it&#8217;s time to update. You also may have noticed a warning such as "PHP Update Required" or "PHP Update Recommended" on the Dashboard or in Site Health – these serve as important reminders to update PHP and make your site more secure.', 'wporg-forums' ) . '</p>';
+
 	// Section "Before you update your PHP version".
 	$content .= '<h3>' . __( 'Before you update your PHP version', 'wporg-forums' ) . '</h3>';
 	$content .= '<p>' . __( 'This section starts off with some warnings, but don&#8217;t be afraid! As with most things technical, we just need to cover some background before we can get to the part where you update your PHP version.', 'wporg-forums' ) . '</p>';

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
@@ -56,7 +56,7 @@ function wporg_support_filter_update_php_content( $content ) {
 	$content .= '<p>';
 	$content .= sprintf(
 		/* translators: %s: link URL about keeping WordPress up to date */
-		__( 'PHP is one of the programming languages that WordPress is built on. The PHP version used on your website is usually set by your hosting company, but may be an option you can adjust yourself. Whilst you may be familiar with the importance of <a href="%s">keeping WordPress, and your themes and plugins up-to-date</a>, keeping PHP up-to-date is just as important.', 'wporg-forums' ),
+		__( 'PHP is one of the programming languages that WordPress is built on. The PHP version used on your website is usually set by your hosting company, but may be an option you can adjust yourself. And while you may be familiar with the importance of <a href="%s">keeping WordPress, and your themes and plugins up-to-date</a>, keeping PHP up-to-date is just as important.', 'wporg-forums' ),
 		esc_url( _x( 'https://wordpress.org/support/article/administration-screens/#updates', 'link URL about keeping WordPress up to date', 'wporg-forums' ) )
 	);
 	$content .= '</p>';

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
@@ -103,10 +103,9 @@ function wporg_support_filter_update_php_content( $content ) {
 	$content .= '<p>' . __( 'This section starts off with some warnings, but don&#8217;t be afraid! As with most things technical, we just need to cover some background before we can get to the part where you update your PHP version.', 'wporg-forums' ) . '</p>';
 	$content .= '<p>';
 	$content .= sprintf(
-		/* translators: 1: minimum required PHP version, 2: recommended PHP version */
-		__( 'Updating your PHP version should not be a problem, but we can&#8217;t <em>guarantee</em> that it&#8217;s not. WordPress itself works with PHP as far back as version %1$s (we&#8217;re currently recommending version %2$s, so this is <em>great</em> backward compatibility!), but we don&#8217;t know if your themes or plugins will work. They should, and popular or reputable ones almost certainly will be, but we can&#8217;t guarantee it.', 'wporg-forums' ),
-		MINIMUM_PHP,
-		RECOMMENDED_PHP
+		/* translators: %s: minimum required PHP version */
+		__( 'Updating your PHP version should not be a problem, but we can&#8217;t <em>guarantee</em> that it&#8217;s not. WordPress itself works with PHP as far back as version %s, but we don&#8217;t know if your themes or plugins will work. They should, and popular or reputable ones almost certainly will be, but we can&#8217;t guarantee it.', 'wporg-forums' ),
+		MINIMUM_PHP
 	);
 	$content .= '</p>';
 	$content .= '<p>' . __( 'There are a couple of steps you should take to mitigate any risk before proceeding:', 'wporg-forums' ) . '</p>';

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
@@ -65,7 +65,7 @@ function wporg_support_filter_update_php_content( $content ) {
 	$content .= '<li>';
 	$content .= sprintf(
 		/* translators: 1: link URL to WordPress requirements page, 2: recommended PHP version */
-		__( '<strong>Your website will be faster</strong> because the latest version of PHP is more efficient. Updating to <a href="%1$s">WordPress&#8217;s recommended PHP version</a> (currently %2$s or higher) can deliver a huge performance increase; up to 3 or 4x faster than older versions.', 'wporg-forums' ),
+		__( '<strong>Your website may be faster</strong> because PHP becomes more efficient with each new version. Updating to <a href="%1$s">WordPress&#8217;s recommended PHP version</a> (currently %2$s or higher) can deliver a performance increase that will benefit all visitors to your website.', 'wporg-forums' ),
 		esc_url( _x( 'https://wordpress.org/about/requirements/', 'link URL to WordPress requirements page', 'wporg-forums' ) ),
 		RECOMMENDED_PHP
 	);

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
@@ -56,7 +56,7 @@ function wporg_support_filter_update_php_content( $content ) {
 	$content .= '<p>';
 	$content .= sprintf(
 		/* translators: %s: link URL about keeping WordPress up to date */
-		__( 'PHP is one of the programming languages that WordPress is built on. The PHP version used on your website is usually determined by your hosting company, but may be an option you can change yourself. And while you may be familiar with the importance of <a href="%s">keeping WordPress, and your themes and plugins up-to-date</a>, keeping PHP up-to-date is just as important.', 'wporg-forums' ),
+		__( 'PHP is one of the programming languages that WordPress is built on. The PHP version used for your website is usually determined by your hosting company, but may be an option you can change yourself. And while you may be familiar with the importance of <a href="%s">keeping WordPress, and your themes and plugins up-to-date</a>, keeping PHP up-to-date is just as important.', 'wporg-forums' ),
 		esc_url( _x( 'https://wordpress.org/support/article/administration-screens/#updates', 'link URL about keeping WordPress up to date', 'wporg-forums' ) )
 	);
 	$content .= '</p>';

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
@@ -56,7 +56,7 @@ function wporg_support_filter_update_php_content( $content ) {
 	$content .= '<p>';
 	$content .= sprintf(
 		/* translators: %s: link URL about keeping WordPress up to date */
-		__( 'PHP is one of the programming languages that WordPress is built on, and its version is set at the server-level by your hosting company. Whilst you may be familiar with the importance of <a href="%s">keeping WordPress, and your themes and plugins up-to-date</a>, keeping PHP up-to-date is just as important.', 'wporg-forums' ),
+		__( 'PHP is one of the programming languages that WordPress is built on. The PHP version used on your website is usually set by your hosting company, but may be an option you can adjust yourself. Whilst you may be familiar with the importance of <a href="%s">keeping WordPress, and your themes and plugins up-to-date</a>, keeping PHP up-to-date is just as important.', 'wporg-forums' ),
 		esc_url( _x( 'https://wordpress.org/support/article/administration-screens/#updates', 'link URL about keeping WordPress up to date', 'wporg-forums' ) )
 	);
 	$content .= '</p>';

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
@@ -104,7 +104,7 @@ function wporg_support_filter_update_php_content( $content ) {
 	$content .= '<p>';
 	$content .= sprintf(
 		/* translators: %s: minimum required PHP version */
-		__( 'Updating your PHP version should not be a problem, but we can&#8217;t <em>guarantee</em> that it&#8217;s not. WordPress itself works with PHP as far back as version %s, but we don&#8217;t know if your themes or plugins will work. They should, and popular or reputable ones almost certainly will be, but we can&#8217;t guarantee it.', 'wporg-forums' ),
+		__( 'Updating your PHP version should not be a problem, but we can&#8217;t <em>guarantee</em> that it&#8217;s not. WordPress itself works with PHP as far back as version %s, but we don&#8217;t know if your themes or plugins will work on newer versions. They should, and popular or reputable ones almost certainly will be, but we can&#8217;t guarantee it.', 'wporg-forums' ),
 		MINIMUM_PHP
 	);
 	$content .= '</p>';

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
@@ -117,7 +117,7 @@ function wporg_support_filter_update_php_content( $content ) {
 		esc_url( _x( 'https://wordpress.org/plugins/search/backup/', 'link URL for free backup plugins', 'wporg-forums' ) )
 	);
 	$content .= '</li>';
-	$content .= '<li>' . __( '<strong>Update WordPress, themes, and plugins:</strong> from your WordPress Dashboard, head to the Updates page under the <em>Dashboard &gt; Updates</em> menu, and then update everything. You should do this regularly anyway :). When done, check your site is working as expected.', 'wporg-forums' ) . '</li>';
+	$content .= '<li>' . __( '<strong>Update WordPress, themes, and plugins:</strong> from your WordPress Dashboard, head to the Updates page under the <em>Dashboard &gt; Updates</em> menu, and then update everything. You should do this regularly anyway :). When done, check that your site is working as expected.', 'wporg-forums' ) . '</li>';
 	$content .= '<li>';
 	$content .= sprintf(
 		/* translators: %s: link URL to the PHP Compatibility Checker plugin */

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
@@ -108,7 +108,7 @@ function wporg_support_filter_update_php_content( $content ) {
 		MINIMUM_PHP
 	);
 	$content .= '</p>';
-	$content .= '<p>' . __( 'There are a couple of steps you should take to mitigate any risk before proceeding:', 'wporg-forums' ) . '</p>';
+	$content .= '<p>' . __( 'There are a couple of steps you should take to avoid problems before proceeding:', 'wporg-forums' ) . '</p>';
 	$content .= '<ul>';
 	$content .= '<li>';
 	$content .= sprintf(

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
@@ -56,7 +56,7 @@ function wporg_support_filter_update_php_content( $content ) {
 	$content .= '<p>';
 	$content .= sprintf(
 		/* translators: %s: link URL about keeping WordPress up to date */
-		__( 'PHP is one of the programming languages that WordPress is built on. The PHP version used on your website is usually determined by your hosting company, but may be an option you can adjust yourself. And while you may be familiar with the importance of <a href="%s">keeping WordPress, and your themes and plugins up-to-date</a>, keeping PHP up-to-date is just as important.', 'wporg-forums' ),
+		__( 'PHP is one of the programming languages that WordPress is built on. The PHP version used on your website is usually determined by your hosting company, but may be an option you can change yourself. And while you may be familiar with the importance of <a href="%s">keeping WordPress, and your themes and plugins up-to-date</a>, keeping PHP up-to-date is just as important.', 'wporg-forums' ),
 		esc_url( _x( 'https://wordpress.org/support/article/administration-screens/#updates', 'link URL about keeping WordPress up to date', 'wporg-forums' ) )
 	);
 	$content .= '</p>';

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
@@ -149,7 +149,7 @@ function wporg_support_filter_update_php_content( $content ) {
 	);
 	$content .= '</p>';
 	$content .= '<p>' . __( 'If you can&#8217;t find your host on this list, then email your hosting company and ask them to help! Here&#8217;s some template text you can use:', 'wporg-forums' ) . '</p>';
-	$content .= '<pre>' . __( 'Dear Hosting Provider,<br><br>I want my website to be as performant and secure as<br>possible with the latest version of PHP. For the server<br>my WordPress site is hosted on, I want to ensure that<br>is the case. If I am not already on the latest version<br>of PHP, please let me know what steps I need to take<br>to update.<br><br>Thanks!', 'wporg-forums' ) . '</pre>';
+	$content .= '<pre>' . __( 'Dear Hosting Provider,<br><br>I want my WordPress website to be as performant and<br>secure as possible with the latest version of PHP.<br>If the server my site is hosted on is not already on<br>the latest version of PHP, please let me know what<br>steps I need to take to update it.<br><br>Thanks!', 'wporg-forums' ) . '</pre>';
 	$content .= '<p>' . __( 'If you run into any issues at this stage, either change the PHP version back yourself, contact your hosting company or a professional web developer. In the unlikely event something goes wrong and you need to restore your backup, contact your host and ask them to restore the previous version of PHP you had running. You can then restore your backup.', 'wporg-forums' ) . '</p>';
 	$content .= '<p>' . __( 'You should now have all the information you need to update! Nice work! With an up-to-date version of PHP you&#8217;ll enjoy a faster, more secure website and happier visitors.', 'wporg-forums' ) . '</p>';
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
@@ -144,7 +144,7 @@ function wporg_support_filter_update_php_content( $content ) {
 	$content .= '<p>';
 	$content .= sprintf(
 		/* translators: %s: link URL to hosting-specific update resources */
-		__( 'Thus, exactly <em>how</em> to do the update depends on your hosting company. We&#8217;ve asked hosting companies to submit instructions on how to update your PHP version on their hosting, and <a href="%s">you&#8217;ll find a list of hosts who have instructions available here</a>.', 'wporg-forums' ),
+		__( 'Exactly <em>how</em> to do the update depends on your hosting company. We&#8217;ve asked hosting companies to submit instructions on how to update your PHP version on their hosting, and <a href="%s">you&#8217;ll find a list of hosts who have instructions available here</a>.', 'wporg-forums' ),
 		esc_url( _x( 'https://github.com/WordPress/servehappy-resources/blob/master/tutorials/hosting-specific/tutorials-en.md', 'link URL to hosting-specific update resources', 'wporg-forums' ) )
 	);
 	$content .= '</p>';

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
@@ -64,8 +64,9 @@ function wporg_support_filter_update_php_content( $content ) {
 	$content .= '<ul>';
 	$content .= '<li>';
 	$content .= sprintf(
-		/* translators: %s: recommended PHP version */
-		__( '<strong>Your website will be faster</strong> as the latest version of PHP is more efficient. Updating to the latest supported version (currently %s) can deliver a huge performance increase; up to 3 or 4x faster for older versions.', 'wporg-forums' ),
+		/* translators: 1: link URL to WordPress requirements page, 2: recommended PHP version */
+		__( '<strong>Your website will be faster</strong> because the latest version of PHP is more efficient. Updating to <a href="%1$s">WordPress&#8217;s recommended PHP version</a> (currently %2$s or higher) can deliver a huge performance increase; up to 3 or 4x faster than older versions.', 'wporg-forums' ),
+		esc_url( _x( 'https://wordpress.org/about/requirements/', 'link URL to WordPress requirements page', 'wporg-forums' ) ),
 		RECOMMENDED_PHP
 	);
 	$content .= '</li>';

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
@@ -104,7 +104,7 @@ function wporg_support_filter_update_php_content( $content ) {
 	$content .= '<p>';
 	$content .= sprintf(
 		/* translators: %s: minimum required PHP version */
-		__( 'Updating your PHP version should not be a problem, but we can&#8217;t <em>guarantee</em> that it&#8217;s not. WordPress itself works with PHP as far back as version %s, but we don&#8217;t know if your themes or plugins will work on newer versions. They should, and popular or reputable ones almost certainly will, but we can&#8217;t guarantee it.', 'wporg-forums' ),
+		__( 'Updating your PHP version should not be a problem, but we can&#8217;t <em>guarantee</em> that it&#8217;s not. WordPress itself works with PHP as far back as version %s, but we don&#8217;t know if your themes or plugins will work on newer versions. They should, and popular or reputable ones almost certainly will, but they should be tested to make sure.', 'wporg-forums' ),
 		MINIMUM_PHP
 	);
 	$content .= '</p>';

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
@@ -104,7 +104,7 @@ function wporg_support_filter_update_php_content( $content ) {
 	$content .= '<p>';
 	$content .= sprintf(
 		/* translators: 1: minimum required PHP version, 2: recommended PHP version */
-		__( 'Updating your PHP version should not be a problem, but we can&#8217;t <em>guarantee</em> that it&#8217;s not. WordPress itself works with PHP versions as far back as %1$s (we&#8217;re currently recommending version %2$s, so this is <em>great</em> backward compatibility!), but we don&#8217;t know if your themes or plugins will work. They should, and popular or reputable ones almost certainly will be, but we can&#8217;t guarantee it.', 'wporg-forums' ),
+		__( 'Updating your PHP version should not be a problem, but we can&#8217;t <em>guarantee</em> that it&#8217;s not. WordPress itself works with PHP as far back as version %1$s (we&#8217;re currently recommending version %2$s, so this is <em>great</em> backward compatibility!), but we don&#8217;t know if your themes or plugins will work. They should, and popular or reputable ones almost certainly will be, but we can&#8217;t guarantee it.', 'wporg-forums' ),
 		MINIMUM_PHP,
 		RECOMMENDED_PHP
 	);

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
@@ -70,7 +70,13 @@ function wporg_support_filter_update_php_content( $content ) {
 		RECOMMENDED_PHP
 	);
 	$content .= '</li>';
-	$content .= '<li>' . __( '<strong>Your website will be more secure.</strong> PHP, like WordPress, is maintained by its community. Because PHP is so popular, it is a target for hackers – but the latest version will have the latest security features. Older versions of PHP <em>do not have this</em>, so updating is essential to keep your WordPress site secure.', 'wporg-forums' ) . '</li>';
+	$content .= '<li>';
+	$content .= sprintf(
+		/* translators: %s: recommended PHP version */
+		__( '<strong>Your website will be more secure.</strong> PHP, like WordPress, is maintained by its community. Because PHP is so popular, it is a target for hackers – but the latest version will have the latest security features. Older versions of PHP (lower than %s) <em>do not have this</em>, so updating is essential to keep your WordPress site secure.', 'wporg-forums' ),
+		RECOMMENDED_PHP
+	);
+	$content .= '</li>';
 	$content .= '</ul>';
 	$content .= '<p>' . __( 'And then there are a number of secondary benefits:', 'wporg-forums' ) . '</p>';
 	$content .= '<ul>';

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
@@ -117,7 +117,7 @@ function wporg_support_filter_update_php_content( $content ) {
 		esc_url( _x( 'https://wordpress.org/plugins/search/backup/', 'link URL for free backup plugins', 'wporg-forums' ) )
 	);
 	$content .= '</li>';
-	$content .= '<li>' . __( '<strong>Update WordPress, themes, and plugins:</strong> from your WordPress Dashboard, head to Updates, and then update all. You should do this regularly anyway. :) When done, check your site is working as expected.', 'wporg-forums' ) . '</li>';
+	$content .= '<li>' . __( '<strong>Update WordPress, themes, and plugins:</strong> from your WordPress Dashboard, head to the Updates page under the <em>Dashboard &gt; Updates</em> menu, and then update everything. You should do this regularly anyway. :) When done, check your site is working as expected.', 'wporg-forums' ) . '</li>';
 	$content .= '<li>';
 	$content .= sprintf(
 		/* translators: %s: link URL to the PHP Compatibility Checker plugin */

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
@@ -117,7 +117,7 @@ function wporg_support_filter_update_php_content( $content ) {
 		esc_url( _x( 'https://wordpress.org/plugins/search/backup/', 'link URL for free backup plugins', 'wporg-forums' ) )
 	);
 	$content .= '</li>';
-	$content .= '<li>' . __( '<strong>Update WordPress, themes, and plugins:</strong> from your WordPress Dashboard, head to the Updates page under the <em>Dashboard &gt; Updates</em> menu, and then update everything. You should do this regularly anyway. :) When done, check your site is working as expected.', 'wporg-forums' ) . '</li>';
+	$content .= '<li>' . __( '<strong>Update WordPress, themes, and plugins:</strong> from your WordPress Dashboard, head to the Updates page under the <em>Dashboard &gt; Updates</em> menu, and then update everything. You should do this regularly anyway :). When done, check your site is working as expected.', 'wporg-forums' ) . '</li>';
 	$content .= '<li>';
 	$content .= sprintf(
 		/* translators: %s: link URL to the PHP Compatibility Checker plugin */

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
@@ -104,7 +104,7 @@ function wporg_support_filter_update_php_content( $content ) {
 	$content .= '<p>';
 	$content .= sprintf(
 		/* translators: %s: minimum required PHP version */
-		__( 'Updating your PHP version should not be a problem, but we can&#8217;t <em>guarantee</em> that it&#8217;s not. WordPress itself works with PHP as far back as version %s, but we don&#8217;t know if your themes or plugins will work on newer versions. They should, and popular or reputable ones almost certainly will be, but we can&#8217;t guarantee it.', 'wporg-forums' ),
+		__( 'Updating your PHP version should not be a problem, but we can&#8217;t <em>guarantee</em> that it&#8217;s not. WordPress itself works with PHP as far back as version %s, but we don&#8217;t know if your themes or plugins will work on newer versions. They should, and popular or reputable ones almost certainly will, but we can&#8217;t guarantee it.', 'wporg-forums' ),
 		MINIMUM_PHP
 	);
 	$content .= '</p>';

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
@@ -140,7 +140,7 @@ function wporg_support_filter_update_php_content( $content ) {
 	// Section "How to update your website's PHP version for a faster, more secure website".
 	$content .= '<h3>' . __( 'How to update your website&#8217;s PHP version for a faster, more secure website', 'wporg-forums' ) . '</h3>';
 	$content .= '<p>' . __( 'You&#8217;re now ready to update your website&#8217;s PHP version! You&#8217;ve done due diligence, got backups, and are in the best possible shape to do the update.', 'wporg-forums' ) . '</p>';
-	$content .= '<p>' . __( 'As the PHP version is set at the server level by your hosting company, updating involves either interacting with your host&#8217;s settings or asking them to do it.', 'wporg-forums' ) . '</p>';
+	$content .= '<p>' . __( 'PHP is installed on your website&#8217;s server, so updating it involves either interacting with your host&#8217;s settings or asking your provider to do it for you.', 'wporg-forums' ) . '</p>';
 	$content .= '<p>';
 	$content .= sprintf(
 		/* translators: %s: link URL to hosting-specific update resources */

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
@@ -24,7 +24,7 @@ function wporg_support_filter_update_php_title( $title, $id ) {
 		return $title;
 	}
 
-	return __( 'Get a faster, more secure website: update your PHP today', 'wporg-forums' );
+	return __( 'Get a faster, more secure website: update PHP today', 'wporg-forums' );
 }
 add_filter( 'the_title', 'wporg_support_filter_update_php_title', 5, 2 );
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
@@ -56,7 +56,7 @@ function wporg_support_filter_update_php_content( $content ) {
 	$content .= '<p>';
 	$content .= sprintf(
 		/* translators: %s: link URL about keeping WordPress up to date */
-		__( 'PHP is one of the programming languages that WordPress is built on. The PHP version used for your website is usually determined by your hosting company, but may be an option you can change yourself. And while you may be familiar with the importance of <a href="%s">keeping WordPress, and your themes and plugins up-to-date</a>, keeping PHP up-to-date is just as important.', 'wporg-forums' ),
+		__( 'PHP is one of the programming languages that WordPress is built on. Your hosting company determines which versions of PHP are available for your site, and many hosters let you change this yourself. And while you may be familiar with the importance of <a href="%s">keeping WordPress, and your themes and plugins up-to-date</a>, keeping PHP up-to-date is just as important.', 'wporg-forums' ),
 		esc_url( _x( 'https://wordpress.org/support/article/administration-screens/#updates', 'link URL about keeping WordPress up to date', 'wporg-forums' ) )
 	);
 	$content .= '</p>';

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
@@ -56,7 +56,7 @@ function wporg_support_filter_update_php_content( $content ) {
 	$content .= '<p>';
 	$content .= sprintf(
 		/* translators: %s: link URL about keeping WordPress up to date */
-		__( 'PHP is one of the programming languages that WordPress is built on. The PHP version used on your website is usually set by your hosting company, but may be an option you can adjust yourself. And while you may be familiar with the importance of <a href="%s">keeping WordPress, and your themes and plugins up-to-date</a>, keeping PHP up-to-date is just as important.', 'wporg-forums' ),
+		__( 'PHP is one of the programming languages that WordPress is built on. The PHP version used on your website is usually determined by your hosting company, but may be an option you can adjust yourself. And while you may be familiar with the importance of <a href="%s">keeping WordPress, and your themes and plugins up-to-date</a>, keeping PHP up-to-date is just as important.', 'wporg-forums' ),
 		esc_url( _x( 'https://wordpress.org/support/article/administration-screens/#updates', 'link URL about keeping WordPress up to date', 'wporg-forums' ) )
 	);
 	$content .= '</p>';

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support/helphub-update-php-strings.php
@@ -56,7 +56,7 @@ function wporg_support_filter_update_php_content( $content ) {
 	$content .= '<p>';
 	$content .= sprintf(
 		/* translators: %s: link URL about keeping WordPress up to date */
-		__( 'PHP is the coding language WordPress is built on, and its version is set at the server-level by your hosting company. Whilst you may be familiar with the importance of <a href="%s">keeping WordPress, and your themes and plugins up-to-date</a>, keeping PHP up-to-date is just as important.', 'wporg-forums' ),
+		__( 'PHP is one of the programming languages that WordPress is built on, and its version is set at the server-level by your hosting company. Whilst you may be familiar with the importance of <a href="%s">keeping WordPress, and your themes and plugins up-to-date</a>, keeping PHP up-to-date is just as important.', 'wporg-forums' ),
 		esc_url( _x( 'https://wordpress.org/support/article/administration-screens/#updates', 'link URL about keeping WordPress up to date', 'wporg-forums' ) )
 	);
 	$content .= '</p>';


### PR DESCRIPTION
Brings parts of the "Update PHP" support page up to date. See Trac ticket for additional details.

Meta Trac ticket: https://meta.trac.wordpress.org/ticket/6516