### PR TITLE
Switching to allowlist for inclusivity

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-upload-handler.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-upload-handler.php
@@ -361,7 +361,7 @@ class Upload_Handler {
 
 		$message .= sprintf(
 			/* translators: 1: plugins@wordpress.org */
-			__( 'We&rsquo;ve sent you an email verifying this submission. Please make sure to whitelist our email address - <a href="mailto:%1$s">%1$s</a> - to ensure you receive all our communications.' ),
+			__( 'We&rsquo;ve sent you an email verifying this submission. Please make sure to allowlist our email address - <a href="mailto:%1$s">%1$s</a> - to ensure you receive all our communications.' ),
 			'plugins@wordpress.org'
 		) . '</p><p>';
 


### PR DESCRIPTION
Ensure that the success message after submitting a plugin includes inclusive language.

Fixes https://meta.trac.wordpress.org/ticket/6540 