### PR TITLE
Add redirection to Openverse standalone site

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/.wp-env.json
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/.wp-env.json
@@ -1,5 +1,4 @@
 {
-  "core": "WordPress/WordPress#master",
   "themes": [
     ".",
     "../wporg"

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/README.md
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/README.md
@@ -8,8 +8,9 @@ Follow these steps to set up a local playground for the theme:
 
 0.  Install all the prerequisites.
 
-    1.  **Required:** Node.js 14.
-    2.  **Required:** Composer.
+    1.  **Required:** Node.js 14
+    2.  **Required:** Composer
+    3.  **Required:** Subversion
     3.  **Recommended:** Docker (to use the automatic setup)
 
 1.  Build the parent theme WordPress.org theme.
@@ -18,6 +19,12 @@ Follow these steps to set up a local playground for the theme:
         (i.e. `wordpress.org/wordpress.org/public_html/wp-content/themes/pub/wporg`).
     2.  Install all the required `npm` packages.
         ```bash
+        $ npm install
+        ```
+        If you face issues installing Sass, try the following command, and
+        `npm install` again.
+        ```bash
+        $ npm install node-sass@npm:sass
         $ npm install
         ```
     3.  Build the theme assets.
@@ -76,6 +83,12 @@ Follow these steps to set up a local playground for the theme:
         your WordPress install. This site will have the `wporg` (parent) and
         `wporg-openverse` (child) themes installed. For detailed instructions,
         please read [the wp-env docs](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/).
+    4.  Edit the `.htaccess` file to prevent Apache 404 errors.
+        ```bash
+        $ wp-env run cli bash
+        bash-5.1$ printf "RewriteEngine on\nFallbackResource /index.php\n" > .htaccess
+        bash-5.1$ exit
+        ```
 
     **Manual:**  
     If you prefer a manual approach, you can also set up your own WordPress
@@ -96,7 +109,8 @@ Follow these steps to set up a local playground for the theme:
 
 6.  Activate and customize the theme.
 
-    1.  Log into `/wp-admin`.
+    1.  Log into `/wp-admin`. If you used `@wordpress/env`, your username will
+        be 'admin' and password will be 'password'.
     2.  Under Appearance > Themes, activate the theme 'WordPress.org Openverse'.
     3.  To change the embed URL, open the customizer at Appearance > Customize
         and update the value in the 'Openverse embed' panel.
@@ -106,6 +120,17 @@ Follow these steps to set up a local playground for the theme:
     1.  Change the Openverse embed to
         `/wp-content/themes/wporg-openverse/js/message_test.html`.
     2.  Visit the site and interactively test the messages.
+
+8. Test redirects.
+
+    1.  Visit some test URLs.
+        1.  https://ru.wordpress.org/openverse → ...
+        2.  https://wordpress.org/openverse/search/?q=dog → ...
+    2.  See the target redirect URL as a comment inside the dev tools.
+        1.  ... → https://openverse.wordpress.net/ru/
+        2.  ... → https://openverse.wordpress.net/search/?q=dog
+    3.  Change the language in Settings > General to see how the locale factors
+        into the redirect path.
 
 ## Related links
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/README.md
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/README.md
@@ -11,7 +11,7 @@ Follow these steps to set up a local playground for the theme:
     1.  **Required:** Node.js 14
     2.  **Required:** Composer
     3.  **Required:** Subversion
-    3.  **Recommended:** Docker (to use the automatic setup)
+    4.  **Recommended:** Docker (to use the automatic setup)
 
 1.  Build the parent theme WordPress.org theme.
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/functions.php
@@ -253,11 +253,11 @@ if ( !defined( 'OPENVERSE_STANDALONE_URL' ) ) {
  * URL, the requested path and the current locale.
  *
  * Examples:
- * - https://ru.wordpress.org/openverse → {OPENVERSE_STANDALONE_URL}/ru/
- * - https://wordpress.org/openverse/search/?q=dog → {OPENVERSE_STANDALONE_URL}/search/?q=dog
+ * - https://ru.wordpress.org/openverse → {ov_redirect_url}/ru/
+ * - https://wordpress.org/openverse/search/?q=dog → {ov_redirect_url}/search/?q=dog
  */
 function get_target_url() {
-	$target_url = OPENVERSE_STANDALONE_URL;
+	$target_url = get_theme_mod( 'ov_redirect_url', OPENVERSE_STANDALONE_URL );
 
 	$curr_locale = get_locale();
 	$locale = get_locale_slug( $curr_locale );

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/functions.php
@@ -242,7 +242,8 @@ add_action( 'customize_register', __NAMESPACE__ . '\wporg_ov_customizer' );
  * redirect is enabled (see setting `ov_is_redirect_enabled`), the theme
  * redirects all incoming requests to the right URL on this domain.
  *
- * Note: Do not put a trailing slash '/' in this URL, as it will cause problems.
+ * Note: Do not put a trailing slash '/' in this URL. Paths start with a leading
+ * slash so a trailing slash here will lead to two slashes in the final URL.
  */
 if ( !defined( 'OPENVERSE_STANDALONE_URL' ) ) {
 	define( 'OPENVERSE_STANDALONE_URL', 'https://openverse.wordpress.net' );
@@ -294,6 +295,9 @@ function wporg_ov_redir_customizer( $wp_customize ) {
 		'capability' => 'edit_theme_options',
 		'default' => OPENVERSE_STANDALONE_URL,
 		'sanitize_callback' => function( $val, $setting ) {
+			if ( substr( $val, -1 ) == '/' ) { // If the last character is a slash '/',...
+				$val = substr( $val, 0, -1 );    // ...remove it.
+			}
 			if ( empty( $val ) ) {
 				return $setting->default;
 			}

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/functions.php
@@ -17,6 +17,9 @@ if ( !defined( 'OPENVERSE_URL' ) ) {
 /**
  * This is subdirectory on WordPress.org which loads the Openverse site. This is
  * prefixed in front of all path changes sent by the embedded `iframe`.
+ *
+ * When used with the standalone redirect, it is removed from the path forwarded
+ * to the standalone site.
  */
 if ( !defined( 'OPENVERSE_SUBPATH' ) ) {
     define( 'OPENVERSE_SUBPATH', '/openverse' );
@@ -150,6 +153,13 @@ function title_no_title( $title ) {
 	return $title;
 }
 add_filter( 'document_title_parts', __NAMESPACE__ . '\title_no_title' );
+
+/*
+	TODO: Delete this and everything related to it
+	======================
+	Openverse iframe embed
+	======================
+ */
 
 /**
  * Enable the option to set the URL for the Openverse embed via a GUI.

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/index.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/index.php
@@ -14,6 +14,22 @@
 
 namespace WordPressdotorg\Openverse\Theme;
 
+/*
+	If the theme mod `ov_is_redirect_enabled` is set to `true`, redirect to the
+	standalone site and exit immediately. If not, print what would have been the
+	redirect URL to the HTML as a comment.
+ */
+
+$is_redirect_enabled = get_theme_mod( 'ov_is_redirect_enabled' );
+$target_url = get_target_url();
+
+if ( $is_redirect_enabled ) {
+	wp_redirect( $target_url );
+	exit;
+} else {
+	echo "<!-- " . $target_url . " -->";
+}
+
 get_header();
 ?>
 


### PR DESCRIPTION
Fixes WordPress/openverse#308
Closes https://meta.trac.wordpress.org/ticket/6578

This PR updates the WordPress.org Openverse theme to add logic that redirects requests to https://wordpress.org/openverse to the new Openverse standalone site at https://openverse.wordpress.net (customisable). The redirection behaviour remains dormant unless enabled via a toggle.

It also updates the `README.md` file to include workarounds to some problems I faced during the setup.