### PR TITLE
Add a new plugin to filter some tags at make.wordpress.org/polyglots

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/wporg-polyglots-posts/wporg-polyglots-posts.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-polyglots-posts/wporg-polyglots-posts.php
@@ -1,0 +1,46 @@
+<?php
+namespace WordPressdotorg\Plugin\Polyglots_Posts;
+
+/**
+ * Plugin Name: WordPress.org Polyglots Posts.
+ * Description: Filters the posts by their tags, excluding the posts with the
+ * 'editor-requests', 'request', 'clpte', 'locale-requests' tags in the
+ * https://make.wordpress.org/polyglots/?exclude=requests URL.
+ * License: GPLv2 or later
+ */
+
+/**
+ * The ids of the tags to be excluded.
+ * 'editor-requests', 'request', 'clpte', 'locale-requests' id tags.
+ *
+ * @var array
+ */
+const TAG_IDS = array( 1453, 307, 6039, 1999 );
+
+/**
+ * The URL where this plugin will work.
+ *
+ * @var string
+ */
+const URL = 'https://make.wordpress.org/polyglots/?exclude=requests';
+
+/**
+ * Excludes the tags from the main query.
+ *
+ * @param $query
+ *
+ * @return void
+ */
+function pre_get_posts( $query ) {
+	global $wp;
+
+	if ( URL != home_url( add_query_arg( $_GET, $wp->request ) ) ) {
+		return;
+	}
+
+	if ( $query->is_main_query() ) {
+		$query->set( 'tag__not_in', TAG_IDS );
+	}
+}
+
+add_filter( 'pre_get_posts', __NAMESPACE__ . '\\pre_get_posts' );


### PR DESCRIPTION
This new plugin filters the posts by their tags at https://make.wordpress.org/polyglots, excluding the posts with the 'editor-requests', 'request', 'clpte', 'locale-requests' tags in the https://make.wordpress.org/polyglots/?exclude=requests URL.

To test this new plugin, you have to install it and activate it, and you have to access to 2 different URL:
- https://make.wordpress.org/polyglots where you will see all posts.
- https://make.wordpress.org/polyglots/?exclude=requests where you will see the main posts, not under the 'editor-requests', 'request', 'clpte', 'locale-requests' tags.

Once we release the plugin, we have to add a link to https://make.wordpress.org/polyglots/?exclude=requests in the right sidebar.