### PR TITLE
Add the patterns project to the translation consistency tool

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-routes/inc/routes/class-consistency.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-routes/inc/routes/class-consistency.php
@@ -15,14 +15,14 @@ class Consistency extends GP_Route {
 
 	private $cache_group = 'wporg-translate';
 
-	const PROJECTS = [
-		1   => 'WordPress',
-		523 => 'Themes',
-		17  => 'Plugins',
-		487 => 'Meta',
-		281 => 'Apps',
-	];
-
+	const PROJECTS = array(
+		1      => 'WordPress',
+		523    => 'Themes',
+		17     => 'Plugins',
+		487    => 'Meta',
+		281    => 'Apps',
+		473698 => 'Patterns',
+	);
 	/**
 	 * Prints a search form and the search results for a consistency view.
 	 */


### PR DESCRIPTION
This PR adds the patterns project to the [translation consistency tool](https://translate.wordpress.org/consistency/).

To test it, you can try:
- A search with an [original that you can only find in the pattern's project](https://translate.wordpress.org/consistency/?search=%3Cstrong%3ETEAM%3C%2Fstrong%3E&set=gl%2Fdefault&project=).
- A search with an [original that you can find in the pattern's project and in another projects](https://translate.wordpress.org/consistency/?search=News&set=gl%2Fdefault&project=).

![image](https://user-images.githubusercontent.com/1667814/196475884-de7b2604-0f46-4479-84e9-8272facc1838.png)


![image](https://user-images.githubusercontent.com/1667814/196475707-3d07fc54-8226-4848-ba6a-ba8401fe3d41.png)

Fixes https://meta.trac.wordpress.org/ticket/6448