### PR TITLE
Add style-variations tag to themes files.

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-themes-api.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-themes-api.php
@@ -295,6 +295,7 @@ class Themes_API {
 				'post-formats'          => __( 'Post Formats' ),
 				'rtl-language-support'  => __( 'RTL Language Support' ),
 				'sticky-post'           => __( 'Sticky Post' ),
+				'style-variations'      => __( 'Style Variations', 'wporg-themes' ),
 				'theme-options'         => __( 'Theme Options' ),
 				'threaded-comments'     => __( 'Threaded Comments' ),
 				'translation-ready'     => __( 'Translation Ready' ),

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-themes/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-themes/functions.php
@@ -407,6 +407,7 @@ function wporg_themes_get_feature_list( $include = 'active' ) {
 				'post-formats'          => __( 'Post Formats', 'wporg-themes' ),
 				'rtl-language-support'  => __( 'RTL Language Support', 'wporg-themes' ),
 				'sticky-post'           => __( 'Sticky Post', 'wporg-themes' ),
+				'style-variations'      => __( 'Style Variations', 'wporg-themes' ),
 				'template-editing'      => __( 'Template Editing', 'wporg-themes' ),
 				'theme-options'         => __( 'Theme Options', 'wporg-themes' ),
 				'threaded-comments'     => __( 'Threaded Comments', 'wporg-themes' ),


### PR DESCRIPTION
Addresses: https://meta.trac.wordpress.org/ticket/6545

This PR adds `style-variations` to the relevant wordpress.org files.

## Other Places that need updating:
**Docs**: https://make.wordpress.org/themes/handbook/review/required/theme-tags/
**Core**: https://github.com/WordPress/wordpress-develop/blob/04e8bb4bb5ed37dade1b1ddda634e45f7503820d/src/wp-admin/includes/theme.php#L337
**Theme-Check**: https://github.com/WordPress/theme-check/blob/83fde0f6dd53ca104a5588fcfa1c1da72163941b/checks/class-style-tags-check.php#L141

Any other ones?

## Testing Notes:
- This API would need to return it: https://api.wordpress.org/themes/info/1.1/?action=feature_list
- When viewing the theme directory, it should show up as feature to filter on
- Theme checks should not error on the inclusion of that tag.
- Not sure how core uses it, seems like an API fallback, but where is it used I wonder....need to look into this.