### PR TITLE
Adds support for lists to callout blocks

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/handbook/scripts/src/blocks/callout/edit.js
+++ b/wordpress.org/public_html/wp-content/plugins/handbook/scripts/src/blocks/callout/edit.js
@@ -7,7 +7,7 @@ const CalloutEdit = ( { attributes } ) => {
 	const className = `callout callout-${ attributes.type }`;
 	return (
 		<div className={ className }>
-			<InnerBlocks allowedBlocks={ [ 'core/paragraph' ] } />
+			<InnerBlocks allowedBlocks={ [ 'core/paragraph', 'core/list' ] } />
 		</div>
 	);
 };


### PR DESCRIPTION
When using callout blocks on learn.wordpress.org, it would be ideal if they supported lists as well as paragraphs. Sometimes it is necessary to use lists of instructions in a callout block, for a tutorial or lesson, and adding list support would greatly improve the benefit of using a callout.