### PR TITLE
Add filter to allow skipping of slack message being posted, which allows Matrix to override it and post a message

### DIFF
--- a/common/includes/slack/send.php
+++ b/common/includes/slack/send.php
@@ -122,6 +122,11 @@ class Send {
 			// $payload['reply_broadcast'] = true;
 		}
 
+		// Filter to allow short-circuit by Matrix
+		if ( apply_filters( 'skip_slack_posting', false, $channel, $payload[ 'text' ] ) ) {
+			return;
+		}
+
 		# error_log( print_r( $payload, true ) );
 		$payload = json_encode( $payload );
 		$content = http_build_query( compact( 'payload' ) );


### PR DESCRIPTION
This PR (meant for a quick review) introduces a `skip_slack_posting` filter when posting message via Slack so that it can be overriden by Matrix related code, to post the message and also control whether Slack message should be posted or skipped.