### PR TITLE
Translate: Add CSS to convert translate.wordpress.org to full width

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/style.css
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/style.css
@@ -176,8 +176,8 @@ select.is-small {
 
 .site-header .site-branding {
 	margin: 0 auto;
-	max-width: 1200px;
-	padding: 0 10px;
+	max-width: 100%;
+	padding: 0 20px;
 }
 
 .site-header.home {
@@ -238,7 +238,7 @@ p.site-title a {
 
 .navigation-main {
 	background: transparent;
-	max-width: 1200px;
+	max-width: 100%;
 	height: 32px;
 	margin: -32px auto 0 auto;
 	text-align: right;
@@ -478,8 +478,8 @@ table.translations tr.editor:hover {
 
 .gp-content {
 	margin: 20px auto;
-	max-width: 1200px;
-	padding: 0 10px;
+	max-width: 100%;
+	padding: 0 20px;
 }
 
 .gp-content h2 {
@@ -905,6 +905,27 @@ ul.filter-header-links {
 			grid-template-columns: repeat(3, 1fr);
 		}
 	}
+
+	@media screen and (min-width: 900px) {
+		.locales {
+			-ms-grid-columns: 1fr 30px 1fr 30px 1fr;
+			grid-template-columns: repeat(4, 1fr);
+		}
+	}
+
+	@media screen and (min-width: 1100px) {
+		.locales {
+			-ms-grid-columns: 1fr 30px 1fr 30px 1fr;
+			grid-template-columns: repeat(5, 1fr);
+		}
+	}
+
+	@media screen and (min-width: 1300px) {
+		.locales {
+			-ms-grid-columns: 1fr 30px 1fr 30px 1fr;
+			grid-template-columns: repeat(6, 1fr);
+		}
+	}
 }
 
 /* Clearfix */
@@ -1078,6 +1099,24 @@ ul.filter-header-links {
 @media screen and (min-width: 1219px) {
 	.projects {
 		grid-template-columns: repeat( 3, minmax( 0, 1fr ) );
+	}
+}
+
+@media screen and (min-width: 1419px) {
+	.projects {
+		grid-template-columns: repeat( 4, minmax( 0, 1fr ) );
+	}
+}
+
+@media screen and (min-width: 1619px) {
+	.projects {
+		grid-template-columns: repeat( 5, minmax( 0, 1fr ) );
+	}
+}
+
+@media screen and (min-width: 2019px) {
+	.projects {
+		grid-template-columns: repeat( 6, minmax( 0, 1fr ) );
 	}
 }
 
@@ -1414,6 +1453,18 @@ ul.projects-dropdown li > a > span {
 }
 
 /* Sub Projects table */
+table.gp-table.locale-sub-projects {
+	max-width: 1000px;
+}
+
+table.locale-sub-projects thead th:nth-child( 1 ) {
+	width: 35%;
+}
+
+table.locale-sub-projects thead th:nth-child( n+2 ) {
+	width: 16.25%;
+}
+
 .locale-sub-projects .sub-project-status {
 	font-size: 90%;
 	color: #a0a5aa;
@@ -1422,6 +1473,10 @@ ul.projects-dropdown li > a > span {
 
 .locale-sub-projects .sub-project-status.percent-90 {
 	color: #509040;
+}
+
+.gp-table.locale-project-contributors-table {
+	max-width: 1000px;
 }
 
 @media screen and (max-width: 500px) {
@@ -1988,7 +2043,7 @@ ul.ct-legend {
 }
 
 .locale-project-contributors-table .contributor-details {
-	width: 40%;
+	width: 35%;
 	overflow: hidden;
 }
 
@@ -2401,6 +2456,7 @@ table.translations tr.editor td {
 		position: sticky;
 		top: 0;
 		z-index: 10;
+		min-width: 40%;
 	}
 }
 


### PR DESCRIPTION
We are working to [bring some new tabs in the GlotPress right sidebar](https://github.com/GlotPress/gp-translation-helpers/pull/148), so we think it is interesting to convert translate.wordpress.org to full width. Below, you can see some screenshot from the new draft design.

These screenshots were taken in a screen with a 1920x1080 resolution.

![image](https://user-images.githubusercontent.com/1667814/204518899-2a8fb2c3-25e3-4084-b9be-e20003f514e0.png)

![image](https://user-images.githubusercontent.com/1667814/204518939-ea6b977b-d5cd-4565-b4b2-bfdd31447e00.png)

![image](https://user-images.githubusercontent.com/1667814/204518966-66698255-c834-4c64-bb14-467be138ea4f.png)

![image](https://user-images.githubusercontent.com/1667814/204518994-b877c5f2-cd35-449f-936f-74f3c72478bb.png)

![image](https://user-images.githubusercontent.com/1667814/204519027-8f332d15-2308-4bd0-8686-c561080358d4.png)

![image](https://user-images.githubusercontent.com/1667814/204519062-a4ccdb77-01cd-4f5a-abff-deeadc583661.png)

![image](https://user-images.githubusercontent.com/1667814/204519105-79deb687-6182-4f12-91fb-cc27476541af.png)

![image](https://user-images.githubusercontent.com/1667814/204519136-51945c0a-e381-49b8-9458-56edc58be5dc.png)

![image](https://user-images.githubusercontent.com/1667814/204519164-521c79cb-96f1-430e-9aac-1f171c227393.png)


