### PR TITLE
Sync fuzzy, rejected and changes requested translations in both dev and stable version

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-plugin-directory/inc/sync/class-translation-sync.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-plugin-directory/inc/sync/class-translation-sync.php
@@ -141,8 +141,6 @@ class Translation_Sync {
 			return;
 		}
 
-		do_action( 'wporg_translate_translation_synced', $translation );
-
 		$project = GP::$project->one(
 			"SELECT p.* FROM {$wpdb->gp_projects} AS p JOIN {$wpdb->gp_originals} AS o ON o.project_id = p.id WHERE o.id = %d",
 			$translation->original_id
@@ -267,6 +265,8 @@ class Translation_Sync {
 		if ( ! $translation ) {
 			return false;
 		}
+
+		do_action( 'wporg_translate_translation_synced', $copy, $translation );
 
 		$translation->set_status( $copy->status );
 		gp_clean_translation_set_cache( $new_translation_set->id );


### PR DESCRIPTION
Ticket - https://meta.trac.wordpress.org/ticket/5679

At the moment, translations are synced to both dev and stable versions only when it is approved on either versions. This implies that when a translation is approved and set to current in dev, the stable version is automatically updated with that approved translation but when a translation is rejected or set to fuzzy or changes requested on dev, the stable version is not updated and vice versa.

With this PR, when a translation is marked as fuzzy, rejected or changes requested on dev version, the same is applied/synced in the stable version and vice versa.

**How to test**
1. Suggest a translation on the dev branch if there are no waiting strings for a project.
2. As a PTE/GTE, set selected waiting translations to rejected, fuzzy or changes requested.
3. The translation rejected on the dev branch should also be rejected on the stable branch.
4. Repeat steps 1-3 starting with the stable branch in step 1.