### PR TITLE
Add new robots.txt rules

### DIFF
--- a/wordpress.org/public_html/wp-content/mu-plugins/pub/wporg-robots.php
+++ b/wordpress.org/public_html/wp-content/mu-plugins/pub/wporg-robots.php
@@ -20,9 +20,12 @@ function wporg_robots_txt( $robots ) {
 		           "Allow: /locale/*/stats/plugins/$\n" .
 		           "Allow: /locale/*/stats/themes/$\n";
 
-	} elseif ( 'wordpress.org' === $blog_details->domain ) {
+	} elseif ( 'wordpress.org' === $blog_details->domain || 'developer.wordpress.org' === $blog_details->domain ) {
 		// WordPress.org/search/ should not be indexed.
 		$robots .= "\nUser-agent: *\n" .
+				   "Disallow: /wp-admin/\n" .
+				   "Disallow: /?rest_route=\n" .
+				   "Disallow: /xmlrpc.php\n" .
 		           "Disallow: /search\n" .
 		           "Disallow: /?s=\n";
 


### PR DESCRIPTION
See https://meta.trac.wordpress.org/ticket/6766

This adds new rules to both https://wordpress.org/robots.txt and https://developer.wordpress.org/robots.txt.

Before, main site:

```
Sitemap: https://wordpress.org/sitemap.xml
Sitemap: https://wordpress.org/news-sitemap.xml
Sitemap: https://wordpress.org/themes/sitemap.xml
Sitemap: https://wordpress.org/plugins/sitemap.xml
Sitemap: https://wordpress.org/news/sitemap.xml
Sitemap: https://wordpress.org/showcase/sitemap.xml
User-agent: *
Disallow: /wp-admin/
Allow: /wp-admin/admin-ajax.php
Allow: /wp-admin/load-scripts.php
Allow: /wp-admin/load-styles.php

User-agent: *
Disallow: /search
Disallow: /?s=

User-agent: *
Disallow: /plugins/search/
```

After, main site:

```
Sitemap: https://wordpress.org/sitemap.xml
Sitemap: https://wordpress.org/news-sitemap.xml
Sitemap: https://wordpress.org/themes/sitemap.xml
Sitemap: https://wordpress.org/plugins/sitemap.xml
Sitemap: https://wordpress.org/news/sitemap.xml
Sitemap: https://wordpress.org/showcase/sitemap.xml
User-agent: *
Disallow: /wp-admin/
Allow: /wp-admin/admin-ajax.php
Allow: /wp-admin/load-scripts.php
Allow: /wp-admin/load-styles.php

User-agent: *
Disallow: /wp-admin/
Disallow: /?rest_route=
Disallow: /xmlrpc.php
Disallow: /search
Disallow: /?s=

User-agent: *
Disallow: /plugins/search/
```

Before, developer:

```
User-agent: *
Disallow: /wp-admin/
Allow: /wp-admin/admin-ajax.php
Allow: /wp-admin/load-scripts.php
Allow: /wp-admin/load-styles.php
```

After, developer:

```
User-agent: *
Disallow: /wp-admin/
Allow: /wp-admin/admin-ajax.php
Allow: /wp-admin/load-scripts.php
Allow: /wp-admin/load-styles.php

User-agent: *
Disallow: /wp-admin/
Disallow: /?rest_route=
Disallow: /xmlrpc.php
Disallow: /search
Disallow: /?s=
```