### PR TITLE
Add robots header for hosting test results

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe/functions.php
@@ -51,6 +51,11 @@ function no_robots( $noindex ) {
 		$noindex = true;
 	}
 
+	// This is used by https://github.com/WordPress/phpunit-test-reporter/blob/master/src/class-display.php on the test reporter page
+	if ( isset( $_GET['rpage'] ) && $_GET['rpage'] > 1 ) {
+		$noindex = true;
+	}
+
 	return $noindex;
 }
 add_filter( 'wporg_noindex_request', __NAMESPACE__ . '\no_robots' );


### PR DESCRIPTION
Fixes https://meta.trac.wordpress.org/ticket/5398

This adds noindex on any p2 pages with a `rpage=` query string, where rpage > 1. That probably only affects the hosting page, but even if it affects something else that might be a good thing.