### PR TITLE
Fixes 6676 - Some pattern previews are not working.

### DIFF
--- a/wp-themes.com/public_html/wp-content/plugins/pattern-page/inc/page-intercept.php
+++ b/wp-themes.com/public_html/wp-content/plugins/pattern-page/inc/page-intercept.php
@@ -133,3 +133,23 @@ function modify_pattern_page_query( $query ) {
 	}
 }
 add_action( 'pre_get_posts', __NAMESPACE__ . '\modify_pattern_page_query', 5 );
+
+/**
+ * Updates query block 'inherit' parameter to false to fix post loading.
+ * See: https://meta.trac.wordpress.org/ticket/6676
+ *
+ * @param array         $context
+ * @param array         $parsed_block
+ * @param WP_Block|null $parent_block
+ * @return array
+ */
+function modify_query_block_context( $context, $parsed_block, $parent_block ) {
+
+	if ( 'core/query' === $parent_block->parsed_block['blockName'] ) {
+		$context['query']['inherit'] = false;
+	}
+
+	return $context;
+}
+
+add_filter( 'render_block_context', __NAMESPACE__ . '\modify_query_block_context', 10, 3 );


### PR DESCRIPTION
Source: https://meta.trac.wordpress.org/ticket/6676

### Summary

This PR updates the context for query block previews to make sure it's not relying on the global WP Query. 

### Background
We want to render patterns in the context of the theme. As a result, we need the Theme to load its default page template (so it has all the right assets) and then inject the pattern. This works pretty well for all patterns except those that use the query block and have that block set to `inherit:true` [which loads the global query](https://github.com/WordPress/wordpress-develop/blob/365efb13c2f2f9de572e53a4c115a0d59232e54f/src/wp-includes/blocks/post-template.php#L48), which in our case is used to render a page and inject the template and therefore no posts are returned. 


## Screenshots
| Before | After |
| --- | --- |
| ![wp-themes com_poe__page_id=9999 pattern_name=poe_blog-list-compact (1)](https://user-images.githubusercontent.com/1657336/220507216-71a2cd99-aa83-4f5c-bc25-d3f6822f62ec.png) | ![wp-themes com_poe__page_id=9999 pattern_name=poe_blog-list-compact](https://user-images.githubusercontent.com/1657336/220507221-f4e2f86d-9557-4c70-a210-491272c018dc.png) |

Note the layout is not perfectly center aligned on this preview page, because of the theme's code. The preview thumbnail looks better because it lacks the title. You can see it by adding `&preview` to the URL in `#2` of the **How To Test** section.

### How To Test
Uses Sandbox

1. Download https://downloads.wordpress.org/theme/poe.0.3.zip into sandbox
2. Visit: https://wp-themes.com/poe/?page_id=9999&pattern_name=poe/blog-list-compact
3. Expect to see no content
4. Apply Patch
5. Expect to see post list

 
