### PR TITLE
Adjust the offset after parent containers are set.

### DIFF
--- a/wp-themes.com/public_html/wp-content/plugins/pattern-page/js/index.js
+++ b/wp-themes.com/public_html/wp-content/plugins/pattern-page/js/index.js
@@ -53,8 +53,8 @@ const init = () => {
     }
 
     makeVisible( container.children );
-    adjustOffset( container );
     setParentDisplay( container );
+    adjustOffset( container );
 }   
 
 window.addEventListener( 'load', init );


### PR DESCRIPTION
Closes: https://meta.trac.wordpress.org/ticket/6676

This fixes pattern previews for themes that use `flex` layouts in their templates.

## Background
To create a pattern preview, we inject patterns into the theme's default page template. This gives us what the pattern would look like if it were added to a regular theme page. However for theme previews, we want to display a thumbnail of what the pattern looks like without non-pattern elements like the header, footer or a sidebar. In order to do so but still inherit all the theme's style, we do the following:
1. Make all elements `visibility:hidden` so we can't see them
   - We don't want to set them `display:none` because we could break some logic 
2. Inject the pattern into a container
3. Make all the elements in our container `visibility:visible`
4. Move our pattern container to the middle of the screen
5. Set all the parents of the pattern container to `display:block` so they stretch full screen
   - Otherwise we get patterns that extend only halfway through the screen.

## Problem/Solution

This PR changes the order of `#4` and `#5` because themes that use `display:flex` containers side by side in their page template, say a sidebar on the left and the main container on the right, when we change that to `display:block` the offset top calculation is incorrect because it was calculated when the containers were side by side and not stacked, which they are in the final resting place.




