### PR TITLE
Fix fuzzy rejection sync

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-plugin-directory/inc/sync/class-translation-sync.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-plugin-directory/inc/sync/class-translation-sync.php
@@ -135,8 +135,8 @@ class Translation_Sync {
 	public function queue_translation_for_sync( $translation ) {
 		global $wpdb;
 
-		$allowed_statuses = array( "current", "rejected", "changesrequested", "fuzzy" );
-		
+		$allowed_statuses = array( 'current', 'rejected', 'changesrequested', 'fuzzy' );
+	
 		// Do not propagate waiting translations and other translations with warnings.
 		if ( ! in_array( $translation->status, $allowed_statuses ) || ! empty( $translation->warnings ) ) {
 			return;
@@ -249,7 +249,7 @@ class Translation_Sync {
 					$_existing_translation->save();
 				}
 
-				$_existing_translation->set_as_current();
+				$_existing_translation->set_status( $translation->status );
 				gp_clean_translation_set_cache( $new_translation_set->id );
 
 				return true;
@@ -269,7 +269,7 @@ class Translation_Sync {
 
 		do_action( 'wporg_translate_translation_synced', $copy, $translation );
 
-		$translation->set_status($copy->status);
+		$translation->set_status( $copy->status );
 		gp_clean_translation_set_cache( $new_translation_set->id );
 
 		return true;


### PR DESCRIPTION
Trac ticket: https://meta.trac.wordpress.org/ticket/6788

When a fuzzy translation is rejected in one project(e.g dev) it appears in the other project(e.g stable) as current.

This PR fixes the issue and ensure that statuses are constant across projects even if the translation had been existing on either dev or stable.

To test, set a translation to fuzzy on dev(or stable), then reject that fuzzy translation on stable or (dev), the translation should appear as `rejected` on both dev and stable.