### PR TITLE
Add new robots.txt rules

### DIFF
--- a/wordpress.org/public_html/wp-content/mu-plugins/pub/wporg-robots.php
+++ b/wordpress.org/public_html/wp-content/mu-plugins/pub/wporg-robots.php
@@ -20,11 +20,20 @@ function wporg_robots_txt( $robots ) {
 		           "Allow: /locale/*/stats/plugins/$\n" .
 		           "Allow: /locale/*/stats/themes/$\n";
 
-	} elseif ( 'wordpress.org' === $blog_details->domain ) {
-		// WordPress.org/search/ should not be indexed.
-		$robots .= "\nUser-agent: *\n" .
-		           "Disallow: /search\n" .
-		           "Disallow: /?s=\n";
+	} elseif ( 'wordpress.org' === $blog_details->domain || defined( 'IS_ROSETTA_NETWORK' ) ) {
+		// WordPress.org/plugins/search/* should not be indexed for now. See https://meta.trac.wordpress.org/ticket/5323
+		$robots .= "Disallow: /?rest_route=\n" .
+				   "Disallow: /xmlrpc.php\n" .
+				   "Disallow: /plugins/search/\n" .
+				   "\n# Prevent crawling of search URLs\n" .
+				   "# --------------------------------\n" .
+				   "Disallow: /search/\n" .
+				   "Disallow: /*/search/\n" .
+				   "Disallow: /?s=\n" .
+				   "Disallow: /*/?s=\n" .
+				   "\n# Prevent crawling of leaky theme endpoints\n" .
+				   "# --------------------------------\n" .
+				   "Disallow: /plugins/wp-json/plugins/v1/locale-banner\n";
 
 	} elseif ( 's-origin.wordpress.org' === $blog_details->domain ) {
 		// Placeholder for the s.w.org domain. See https://meta.trac.wordpress.org/ticket/5668
@@ -34,18 +43,13 @@ function wporg_robots_txt( $robots ) {
 
 	}
 
-	// WordPress.org/plugins/search/* should not be indexed for now. See https://meta.trac.wordpress.org/ticket/5323
-	if ( 'wordpress.org' === $blog_details->domain || defined( 'IS_ROSETTA_NETWORK' ) ) {
-		$robots .= "\nUser-agent: *\n" .
-		           "Disallow: /plugins/search/\n";
-	}
-
 	// Allow access to the load-scripts.php & load-styles.php admin files.
 	$robots = str_replace(
 		"Allow: /wp-admin/admin-ajax.php\n",
+		"Disallow: /*/wp-admin/\n" .
 		"Allow: /wp-admin/admin-ajax.php\n" .
-			"Allow: /wp-admin/load-scripts.php\n" .
-			"Allow: /wp-admin/load-styles.php\n",
+		"Allow: /wp-admin/load-scripts.php\n" .
+		"Allow: /wp-admin/load-styles.php\n",
 		$robots
 	);
 


### PR DESCRIPTION
Trac ticket: https://meta.trac.wordpress.org/ticket/6763
Related (Add inline comments to the User-agent): https://github.com/WordPress/wordpress-develop/pull/4207

## Question
1 - In ticket 6763, 
```
Disallow: /plugins/search/
Allow: /wp-admin/admin-ajax.php
Allow: /wp-admin/load-scripts.php
Allow: /wp-admin/load-styles.php
```
seem to have been deleted, or maybe they were just omitted without being written down?

2 - Does [this](https://meta.trac.wordpress.org/ticket/5806#comment:2) still hold true that `wp-admin/load-*.php` should be upstreamed to Core?
Or it isn't required anymore (https://github.com/WordPress/wordpress.org/pull/121#discussion_r1109380766)

3 - I'm not sure where these directives came from. I was thinking they were from [this piece of code](https://github.com/WordPress/wordpress-develop/blob/b58973554da40b4965458d993a4703ec81e7ad28/src/wp-includes/sitemaps/class-wp-sitemaps.php#L228-L235), but they weren't. Are they from Jetpack? Since the ticket requested to add inline comments and also move the Sitemap references to the end of the file, gotta locate them.

```
Sitemap: https://wordpress.org/sitemap.xml
Sitemap: https://wordpress.org/news-sitemap.xml
```

## Before
```
Sitemap: https://wordpress.org/sitemap.xml
Sitemap: https://wordpress.org/news-sitemap.xml
Sitemap: https://wordpress.org/themes/sitemap.xml
Sitemap: https://wordpress.org/plugins/sitemap.xml
Sitemap: https://wordpress.org/news/sitemap.xml
Sitemap: https://wordpress.org/showcase/sitemap.xml
Sitemap: https://wordpress.org/documentation/sitemap.xml
User-agent: *
Disallow: /wp-admin/
Allow: /wp-admin/admin-ajax.php
Allow: /wp-admin/load-scripts.php
Allow: /wp-admin/load-styles.php

User-agent: *
Disallow: /search
Disallow: /?s=

User-agent: *
Disallow: /plugins/search/
``` 

## After
```
Sitemap: https://wordpress.org/sitemap.xml
Sitemap: https://wordpress.org/news-sitemap.xml
Sitemap: https://wordpress.org/themes/sitemap.xml
Sitemap: https://wordpress.org/plugins/sitemap.xml
Sitemap: https://wordpress.org/news/sitemap.xml
Sitemap: https://wordpress.org/showcase/sitemap.xml
Sitemap: https://wordpress.org/documentation/sitemap.xml
User-agent: *
Disallow: /wp-admin/
Disallow: /*/wp-admin/
Allow: /wp-admin/admin-ajax.php
Allow: /wp-admin/load-scripts.php
Allow: /wp-admin/load-styles.php
Disallow: /?rest_route=
Disallow: /xmlrpc.php
Disallow: /plugins/search/

# Prevent crawling of search URLs
# --------------------------------
Disallow: /search/
Disallow: /*/search/
Disallow: /?s=
Disallow: /*/?s=

# Prevent crawling of leaky theme endpoints
# --------------------------------
Disallow: /plugins/wp-json/plugins/v1/locale-banner
``` 

## Before (Rosetta)
```
User-agent: *
Disallow: /wp-admin/
Allow: /wp-admin/admin-ajax.php
Allow: /wp-admin/load-scripts.php
Allow: /wp-admin/load-styles.php

User-agent: *
Disallow: /plugins/search/
```

## After (Rosetta)
```
User-agent: *
Disallow: /wp-admin/
Disallow: /*/wp-admin/
Allow: /wp-admin/admin-ajax.php
Allow: /wp-admin/load-scripts.php
Allow: /wp-admin/load-styles.php
Disallow: /?rest_route=
Disallow: /xmlrpc.php
Disallow: /plugins/search/

# Prevent crawling of search URLs
# --------------------------------
Disallow: /search/
Disallow: /*/search/
Disallow: /?s=
Disallow: /*/?s=

# Prevent crawling of leaky theme endpoints
# --------------------------------
Disallow: /plugins/wp-json/plugins/v1/locale-banner
```