### PR TITLE
Add UI for ChatGPT settings

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/settings-edit.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/settings-edit.php
@@ -63,7 +63,11 @@ if ( ! is_array( $gp_default_sort ) ) {
 		<th><label for="default_sort[notifications_optin]"><?php _e( 'I want to receive notifications of discussions:', 'glotpress' ); ?></label></th>
 		<td><input type="checkbox" id="default_sort[notifications_optin]" name="default_sort[notifications_optin]" <?php gp_checked( 'on' == gp_array_get( $gp_default_sort, 'notifications_optin', 'off' ) ); ?> /></td>
 	</tr>
-	<tr><th><h4>ChatGPT Translation settings</h4></th></tr>
+	<tr>
+		<th>
+			<h4>ChatGPT Translation settings</h4>
+		</th>
+	</tr>
 	<tr>
 		<th><label><?php _e( 'OpenAI(ChatGPT) API Key', 'glotpress' ); ?></label></th>
 		<td><input type="text" class="openai_api_key" id="default_sort[openai_api_key]" name="default_sort[openai_api_key]" value="<?php echo esc_html( gp_array_get( $gp_default_sort, 'openai_api_key', '' ) ); ?>" /></td>

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/settings-edit.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/settings-edit.php
@@ -63,4 +63,13 @@ if ( ! is_array( $gp_default_sort ) ) {
 		<th><label for="default_sort[notifications_optin]"><?php _e( 'I want to receive notifications of discussions:', 'glotpress' ); ?></label></th>
 		<td><input type="checkbox" id="default_sort[notifications_optin]" name="default_sort[notifications_optin]" <?php gp_checked( 'on' == gp_array_get( $gp_default_sort, 'notifications_optin', 'off' ) ); ?> /></td>
 	</tr>
+	<tr><th><h4>ChatGPT Translation settings</h4></th></tr>
+	<tr>
+		<th><label><?php _e( 'OpenAI(ChatGPT) API Key', 'glotpress' ); ?></label></th>
+		<td><input type="text" class="openai_api_key" id="default_sort[openai_api_key]" name="default_sort[openai_api_key]" value="<?php echo esc_html( gp_array_get( $gp_default_sort, 'openai_api_key', '' ) ); ?>" /></td>
+	</tr>
+	<tr>
+		<th><label><?php _e( 'Custom Prompt for ChatGPT translations', 'glotpress' ); ?></label></th>
+		<td><textarea class="openai_custom_prompt" id="default_sort[openai_custom_prompt]" name="default_sort[openai_custom_prompt]" placeholder="Enter your custom prompt for ChatGPT translation suggestions"><?php echo esc_html( gp_array_get( $gp_default_sort, 'openai_custom_prompt', '' ) );?></textarea></td>
+	</tr>
 </table>

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/style.css
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/style.css
@@ -3191,3 +3191,14 @@ ul.sidebar-tabs {
 		vertical-align: top;
 	}
 }
+
+.openai_custom_prompt {
+    border:#7e7e7e thin solid !important; 
+	border-radius:3px; 
+	width:30em !important;
+	height:8em ;
+}
+
+.openai_api_key {
+	width: 32.2em !important;
+}


### PR DESCRIPTION
In this PR, we add the UI for storing a user's OpenAI credentials to be used for generating translation suggestions and for other implementations.

![Screenshot 2023-03-14 at 16 00 45](https://user-images.githubusercontent.com/2834132/225074108-5a9cceef-4bea-4933-8e9d-e45b73d805a3.png)
