### PR TITLE
Make all the requests async in the Translation Memory

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/class-plugin.php
@@ -127,16 +127,18 @@ class Plugin {
 		);
 
 		$gp_default_sort         = get_user_option( 'gp_default_sort' );
-		$get_openai_translations = empty( trim( gp_array_get( $gp_default_sort, 'openai_api_key' ) ) ) ? 'false' : 'true';
-		$get_deepl_translations  = empty( trim( gp_array_get( $gp_default_sort, 'deepl_api_key' ) ) ) ? 'false' : 'true';
+		$get_openai_translations = ! empty( trim( gp_array_get( $gp_default_sort, 'openai_api_key' ) ) );
+		$get_deepl_translations  = ! empty( trim( gp_array_get( $gp_default_sort, 'deepl_api_key' ) ) );
 
 		wp_localize_script(
 			'gp-translation-suggestions',
 			'gpTranslationSuggestions',
 			array(
-				'nonce'                   => wp_create_nonce( 'gp-translation-suggestions' ),
-				'get_openai_translations' => $get_openai_translations,
-				'get_deepl_translations'  => $get_deepl_translations,
+				'nonce'                     => wp_create_nonce( 'gp-translation-suggestions' ),
+				'get_external_translations' => array(
+					'get_openai_translations' => $get_openai_translations,
+					'get_deepl_translations'  => $get_deepl_translations,
+				),
 			)
 		);
 

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/class-plugin.php
@@ -17,7 +17,7 @@ class Plugin {
 	/**
 	 * @var array
 	 */
-	private $queue = [];
+	private $queue = array();
 
 	/**
 	 * Returns always the same instance of this plugin.
@@ -35,26 +35,26 @@ class Plugin {
 	 * Instantiates a new Plugin object.
 	 */
 	private function __construct() {
-		add_action( 'plugins_loaded', [ $this, 'plugins_loaded' ] );
+		add_action( 'plugins_loaded', array( $this, 'plugins_loaded' ) );
 	}
 
 	/**
 	 * Initializes the plugin.
 	 */
 	public function plugins_loaded() {
-		add_action( 'template_redirect', [ $this, 'register_routes' ], 5 );
-		add_action( 'gp_pre_tmpl_load', [ $this, 'pre_tmpl_load' ], 10, 2 );
-		add_action( 'wporg_translate_suggestions', [ $this, 'extend_translation_suggestions' ] );
+		add_action( 'template_redirect', array( $this, 'register_routes' ), 5 );
+		add_action( 'gp_pre_tmpl_load', array( $this, 'pre_tmpl_load' ), 10, 2 );
+		add_action( 'wporg_translate_suggestions', array( $this, 'extend_translation_suggestions' ) );
 
 		if ( 'cli' !== PHP_SAPI ) {
-			add_action( 'gp_translation_created', [ $this, 'translation_updated' ], 3 );
-			add_action( 'gp_translation_saved', [ $this, 'translation_updated' ], 3 );
+			add_action( 'gp_translation_created', array( $this, 'translation_updated' ), 3 );
+			add_action( 'gp_translation_saved', array( $this, 'translation_updated' ), 3 );
 
 			// DB Writes are delayed until shutdown to bulk-update the stats during imports.
-			add_action( 'shutdown', [ $this, 'schedule_tm_update' ], 3 );
+			add_action( 'shutdown', array( $this, 'schedule_tm_update' ), 3 );
 		}
 
-		add_action( self::TM_UPDATE_EVENT, [ Translation_Memory_Client::class, 'update' ] );
+		add_action( self::TM_UPDATE_EVENT, array( Translation_Memory_Client::class, 'update' ) );
 	}
 
 	/**
@@ -75,30 +75,32 @@ class Plugin {
 	 * Schedules a single event to update translation memory for new translations.
 	 */
 	public function schedule_tm_update() {
-		remove_action( 'gp_translation_created', [ $this, 'translation_updated' ], 3 );
-		remove_action( 'gp_translation_saved', [ $this, 'translation_updated' ], 3 );
+		remove_action( 'gp_translation_created', array( $this, 'translation_updated' ), 3 );
+		remove_action( 'gp_translation_saved', array( $this, 'translation_updated' ), 3 );
 
 		if ( ! $this->queue ) {
 			return;
 		}
 
-		wp_schedule_single_event( time() + 60, self::TM_UPDATE_EVENT, [ 'translations' => $this->queue ] );
+		wp_schedule_single_event( time() + 60, self::TM_UPDATE_EVENT, array( 'translations' => $this->queue ) );
 	}
 
 	/**
 	 * Registers custom routes.
 	 */
 	public function register_routes() {
-		$dir = '([^_/][^/]*)';
-		$path = '(.+?)';
+		$dir      = '([^_/][^/]*)';
+		$path     = '(.+?)';
 		$projects = 'projects';
-		$project = $projects . '/' . $path;
-		$locale = '(' . implode( '|', wp_list_pluck( GP_Locales::locales(), 'slug' ) ) . ')';
-		$set = "$project/$locale/$dir";
+		$project  = $projects . '/' . $path;
+		$locale   = '(' . implode( '|', wp_list_pluck( GP_Locales::locales(), 'slug' ) ) . ')';
+		$set      = "$project/$locale/$dir";
 
-		GP::$router->prepend( "/$set/-get-tm-suggestions", [ __NAMESPACE__ . '\Routes\Translation_Memory', 'get_suggestions' ] );
-		GP::$router->prepend( "/$set/-get-other-language-suggestions", [ __NAMESPACE__ . '\Routes\Other_Languages', 'get_suggestions' ] );
-		GP::$router->prepend( "/-save-external-suggestions", [ __NAMESPACE__ . '\Routes\Translation_Memory', 'update_external_translations' ], 'post' );
+		GP::$router->prepend( "/$set/-get-tm-suggestions", array( __NAMESPACE__ . '\Routes\Translation_Memory', 'get_suggestions' ) );
+		GP::$router->prepend( "/$set/-get-other-language-suggestions", array( __NAMESPACE__ . '\Routes\Other_Languages', 'get_suggestions' ) );
+		GP::$router->prepend( "/$set/-get-tm-openai-suggestions", array( __NAMESPACE__ . '\Routes\Translation_Memory', 'get_openai_suggestions' ) );
+		GP::$router->prepend( "/$set/-get-tm-deepl-suggestions", array( __NAMESPACE__ . '\Routes\Translation_Memory', 'get_deepl_suggestions' ) );
+		GP::$router->prepend( '/-save-external-suggestions', array( __NAMESPACE__ . '\Routes\Translation_Memory', 'update_external_translations' ), 'post' );
 	}
 
 	/**
@@ -112,7 +114,7 @@ class Plugin {
 		wp_register_style(
 			'gp-translation-suggestions',
 			plugins_url( 'css/translation-suggestions.css', PLUGIN_FILE ),
-			[],
+			array(),
 			'20220401'
 		);
 		gp_enqueue_style( 'gp-translation-suggestions' );
@@ -120,8 +122,22 @@ class Plugin {
 		wp_register_script(
 			'gp-translation-suggestions',
 			plugins_url( './js/translation-suggestions.js', PLUGIN_FILE ),
-			[ 'gp-editor' ],
+			array( 'gp-editor' ),
 			'20190510'
+		);
+
+		$gp_default_sort         = get_user_option( 'gp_default_sort' );
+		$get_openai_translations = empty( trim( gp_array_get( $gp_default_sort, 'openai_api_key' ) ) ) ? 'false' : 'true';
+		$get_deepl_translations  = empty( trim( gp_array_get( $gp_default_sort, 'deepl_api_key' ) ) ) ? 'false' : 'true';
+
+		wp_localize_script(
+			'gp-translation-suggestions',
+			'gpTranslationSuggestions',
+			array(
+				'nonce'                   => wp_create_nonce( 'gp-translation-suggestions' ),
+				'get_openai_translations' => $get_openai_translations,
+				'get_deepl_translations'  => $get_deepl_translations,
+			)
 		);
 
 		gp_enqueue_script( 'gp-translation-suggestions' );
@@ -129,8 +145,10 @@ class Plugin {
 		wp_add_inline_script(
 			'gp-translation-suggestions',
 			sprintf(
-				"window.WPORG_TRANSLATION_MEMORY_API_URL = %s;\nwindow.WPORG_OTHER_LANGUAGES_API_URL = %s;",
+				"window.WPORG_TRANSLATION_MEMORY_API_URL = %s;\nwindow.WPORG_TRANSLATION_MEMORY_OPENAI_API_URL = %s;\nwindow.WPORG_TRANSLATION_MEMORY_DEEPL_API_URL = %s;\nwindow.WPORG_OTHER_LANGUAGES_API_URL = %s;",
 				wp_json_encode( gp_url_project( $args['project'], gp_url_join( $args['locale_slug'], $args['translation_set_slug'], '-get-tm-suggestions' ) ) ),
+				wp_json_encode( gp_url_project( $args['project'], gp_url_join( $args['locale_slug'], $args['translation_set_slug'], '-get-tm-openai-suggestions' ) ) ),
+				wp_json_encode( gp_url_project( $args['project'], gp_url_join( $args['locale_slug'], $args['translation_set_slug'], '-get-tm-deepl-suggestions' ) ) ),
 				wp_json_encode( gp_url_project( $args['project'], gp_url_join( $args['locale_slug'], $args['translation_set_slug'], '-get-other-language-suggestions' ) ) )
 			)
 		);
@@ -146,7 +164,6 @@ class Plugin {
 		if ( ! isset( $entry->translation_set_id ) || ! GP::$permission->current_user_can( 'edit', 'translation-set', $entry->translation_set_id ) ) {
 			return;
 		}
-
 
 		// Prevent querying the TM for long strings which usually time out
 		// and have no results due to being too unique.

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/js/translation-suggestions.js
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/js/translation-suggestions.js
@@ -29,6 +29,7 @@
 
 		xhr.always( function() {
 			$container.removeClass( 'fetching' );
+			removeNoSuggestionsMessage( $container );
 		} );
 	}
 
@@ -51,6 +52,46 @@
 		fetchSuggestions( $container, window.WPORG_TRANSLATION_MEMORY_API_URL, originalId, translationId, nonce );
 	}
 
+	/**
+	 * Gets the suggestions from the OpenAI API.
+	 *
+	 * @return {void}
+	 **/
+	function maybeFetchOpenAISuggestions() {
+		maybeFetchExternalSuggestions( gpTranslationSuggestions.get_openai_translations, window.WPORG_TRANSLATION_MEMORY_OPENAI_API_URL );
+	}
+
+	/**
+	 * Gets the suggestions from the DeepL API.
+	 *
+	 * @return {void}
+	 **/
+	function maybeFetchDeeplSuggestions() {
+		maybeFetchExternalSuggestions( gpTranslationSuggestions.get_deepl_translations, window.WPORG_TRANSLATION_MEMORY_DEEPL_API_URL );
+	}
+
+	/**
+	 * Gets the suggestions from an external service.
+	 *
+	 * @param getExternalSuggestions
+	 * @param apiUrl
+	 */
+	function maybeFetchExternalSuggestions( getExternalSuggestions, apiUrl ) {
+		var $container = $gp.editor.current.find( '.suggestions__translation-memory' );
+		if ( !$container.length ) {
+			return;
+		}
+		if ( 'true' !== getExternalSuggestions ) {
+			return;
+		}
+
+		var originalId = $gp.editor.current.original_id;
+		var translationId = $gp.editor.current.translation_id;
+		var nonce = $container.data( 'nonce' );
+
+		fetchSuggestions( $container, apiUrl, originalId, translationId, nonce );
+	}
+
 	function maybeFetchOtherLanguageSuggestions() {
 		var $container = $gp.editor.current.find( '.suggestions__other-languages' );
 		if ( ! $container.length ) {
@@ -70,6 +111,45 @@
 		fetchSuggestions( $container, window.WPORG_OTHER_LANGUAGES_API_URL, originalId , translationId,  nonce );
 	}
 
+	/**
+	 * Removes the "No suggestions" message if there are suggestions.
+	 *
+	 * This is needed because the suggestions are loaded asynchronously.
+	 *
+	 * @param $container
+	 */
+	function removeNoSuggestionsMessage( $container ) {
+		var hasSuggestions = $container.find( '.translation-suggestion' ).length > 0;
+		if ( hasSuggestions ) {
+			$container.find( '.no-suggestions' ).hide();
+		} else {
+			$container = removeNoSuggestionsDuplicateMessage( $container );
+		}
+	}
+
+	/**
+	 * Removes duplicate "No suggestions" messages.
+	 *
+	 * @param $container
+	 * @returns {*|jQuery}
+	 */
+	function removeNoSuggestionsDuplicateMessage( $container ) {
+		var $html = $($container);
+		var $paragraphs = $html.find('p');
+		var uniqueParagraphs = [];
+
+		$paragraphs.each(function() {
+			var paragraphText = $(this).text().trim();
+
+			if (uniqueParagraphs.indexOf(paragraphText) === -1) {
+				uniqueParagraphs.push(paragraphText);
+			} else {
+				$(this).remove();
+			}
+		});
+
+		return $html.prop('outerHTML');
+	}
 	function copySuggestion( event ) {
 		if ( 'A' === event.target.tagName ) {
 			return;
@@ -96,8 +176,9 @@
 	$gp.editor.show = ( function( original ) {
 		return function() {
 			original.apply( $gp.editor, arguments );
-
 			maybeFetchTranslationMemorySuggestions();
+			maybeFetchOpenAISuggestions();
+			maybeFetchDeeplSuggestions();
 			maybeFetchOtherLanguageSuggestions();
 		}
 	})( $gp.editor.show );

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/js/translation-suggestions.js
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/js/translation-suggestions.js
@@ -58,7 +58,7 @@
 	 * @return {void}
 	 **/
 	function maybeFetchOpenAISuggestions() {
-		maybeFetchExternalSuggestions( gpTranslationSuggestions.get_openai_translations, window.WPORG_TRANSLATION_MEMORY_OPENAI_API_URL );
+		maybeFetchExternalSuggestions( gpTranslationSuggestions.get_external_translations.get_openai_translations, window.WPORG_TRANSLATION_MEMORY_OPENAI_API_URL );
 	}
 
 	/**
@@ -67,7 +67,7 @@
 	 * @return {void}
 	 **/
 	function maybeFetchDeeplSuggestions() {
-		maybeFetchExternalSuggestions( gpTranslationSuggestions.get_deepl_translations, window.WPORG_TRANSLATION_MEMORY_DEEPL_API_URL );
+		maybeFetchExternalSuggestions( gpTranslationSuggestions.get_external_translations.get_deepl_translations, window.WPORG_TRANSLATION_MEMORY_DEEPL_API_URL );
 	}
 
 	/**
@@ -81,7 +81,7 @@
 		if ( !$container.length ) {
 			return;
 		}
-		if ( 'true' !== getExternalSuggestions ) {
+		if ( true !== getExternalSuggestions ) {
 			return;
 		}
 

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/templates/translation-memory-suggestions.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/templates/translation-memory-suggestions.php
@@ -5,7 +5,7 @@ if ( empty( $suggestions ) ) {
 	echo '<ul class="suggestions-list">';
 	foreach ( $suggestions as $suggestion ) {
 		echo '<li>';
-		echo '<div class="translation-suggestion with-tooltip" tabindex="0" role="button" aria-pressed="false" aria-label="Copy translation">';
+		echo '<div class="translation-suggestion with-tooltip ' . esc_html( strtolower( $type ) ) . '" tabindex="0" role="button" aria-pressed="false" aria-label="Copy translation">';
 			echo '<span class="' . esc_html( strtolower( $type ) ) . '-suggestion__score">';
 		if ( 'Translation' == $type ) {
 			echo number_format( 100 * $suggestion['similarity_score'] ) . '%';

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/templates/translation-memory-suggestions.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/templates/translation-memory-suggestions.php
@@ -1,57 +1,24 @@
 <?php
-if ( empty( $suggestions ) && empty( $openai_suggestions ) && empty( $deepl_suggestions ) ) {
+if ( empty( $suggestions ) ) {
 	echo '<p class="no-suggestions">No suggestions.</p>';
 } else {
 	echo '<ul class="suggestions-list">';
 	foreach ( $suggestions as $suggestion ) {
 		echo '<li>';
 		echo '<div class="translation-suggestion with-tooltip" tabindex="0" role="button" aria-pressed="false" aria-label="Copy translation">';
-			echo '<span class="translation-suggestion__score">' . number_format( 100 * $suggestion['similarity_score'] ) . '%</span>';
-
-			echo '<span class="translation-suggestion__translation">';
-				echo esc_translation( $suggestion['translation'] );
-
-				if ( $suggestion['diff'] ) {
-					echo '<span class="translation-suggestion__original-diff">' . wp_kses_post( $suggestion['diff'] ) . '</span>';
-				}
+			echo '<span class="' . esc_html( strtolower( $type ) ) . '-suggestion__score">';
+		if ( 'Translation' == $type ) {
+			echo number_format( 100 * $suggestion['similarity_score'] ) . '%';
+		} else {
+			echo esc_html( $type );
+		}
 			echo '</span>';
-
-			echo '<span aria-hidden="true" class="translation-suggestion__translation-raw">' . esc_translation( $suggestion['translation'] ) . '</span>';
-
-			echo '<button type="button" class="button is-small copy-suggestion">Copy</button>';
-		echo '</div>';
-		echo '</li>';
-	}
-	foreach ( $openai_suggestions as $suggestion ) {
-		echo '<li>';
-		echo '<div class="translation-suggestion with-tooltip openai" tabindex="0" role="button" aria-pressed="false" aria-label="Copy translation">';
-			echo '<span class="openai-suggestion__score">OpenAI</span>';
-
 			echo '<span class="translation-suggestion__translation">';
 				echo esc_translation( $suggestion['translation'] );
 
-				if ( $suggestion['diff'] ) {
-					echo '<span class="translation-suggestion__original-diff">' . wp_kses_post( $suggestion['diff'] ) . '</span>';
-				}
-			echo '</span>';
-
-			echo '<span aria-hidden="true" class="translation-suggestion__translation-raw">' . esc_translation( $suggestion['translation'] ) . '</span>';
-
-			echo '<button type="button" class="button is-small copy-suggestion">Copy</button>';
-		echo '</div>';
-		echo '</li>';
-	}
-	foreach ( $deepl_suggestions as $suggestion ) {
-		echo '<li>';
-		echo '<div class="translation-suggestion with-tooltip deepl" tabindex="0" role="button" aria-pressed="false" aria-label="Copy translation">';
-			echo '<span class="deepl-suggestion__score">DeepL</span>';
-
-			echo '<span class="translation-suggestion__translation">';
-				echo esc_translation( $suggestion['translation'] );
-
-				if ( $suggestion['diff'] ) {
-					echo '<span class="translation-suggestion__original-diff">' . wp_kses_post( $suggestion['diff'] ) . '</span>';
-				}
+		if ( $suggestion['diff'] ) {
+			echo '<span class="translation-suggestion__original-diff">' . wp_kses_post( $suggestion['diff'] ) . '</span>';
+		}
 			echo '</span>';
 
 			echo '<span aria-hidden="true" class="translation-suggestion__translation-raw">' . esc_translation( $suggestion['translation'] ) . '</span>';


### PR DESCRIPTION
## Why?

In #134 we add the integration with OpenAI (ChatGPT) and DeepL. In that PR, the API calls were synchronous, so if any API takes a lot of time to respond, the whole response will be affected.

## What?

In this PR I have improved this approach, splitting the existing AJAX call in 3 calls (internal translation memory, OpenAI and DeepL). 

## Testing

1. Test with empty and wrong API keys for both external systems. You should get only the suggestions from the internal TM.
2. Add a good OpenAI key. You should get the suggestions from the internal TM and from OpenAI.
3. Add a good DeepL key. You should get the suggestions from the 3 systems: internal TM, from OpenAI and from DeepL.
4. Change the OpenAI key to a bad one. You should get the suggestions from the internal TM and from DeepL.
5. Change the DeepL key to a bad one. You should get the suggestions from the internal TM.

## Design decisions 
- If the response is incorrect or empty, the AJAX query responses with "No suggestions.".
- The new AJAX calls (OpenAI and DeepL) are only made if the user has a non-empty API key in her settings.
- If the user has an incorrect API key, the external query is made. 
- If all the responses are incorrect, I remove the "No suggestions." duplicates. 
- If at least one of the 3 queries has some content in the response, I remove the "No suggestions." replies from the other systems.

![image](https://user-images.githubusercontent.com/1667814/229540244-9de432ec-7a4f-4bf7-96e9-23d3cb3dcd81.png)
