### PR TITLE
Use a <dialog> for the close form.

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins/client/components/_dialog.scss
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins/client/components/_dialog.scss
@@ -1,0 +1,25 @@
+dialog {
+	min-width: 30%;
+	min-height: 50%;
+
+	border: 0;
+	box-shadow: 6px 6px 6px rgba(0, 0, 0, 0.2);
+
+	@media (min-width:1280px) {
+		max-width: 55%;
+	}
+
+	&::backdrop {
+		background: #000;
+		opacity: 0.5;
+	}
+
+	.close {
+		position: absolute;
+		right: 1em;
+		top: 1em;
+		text-decoration: none !important;
+		cursor: pointer;
+		color: inherit;
+	}
+}

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins/client/components/plugin/style.scss
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins/client/components/plugin/style.scss
@@ -109,7 +109,7 @@
 			}
 		}
 
-		a:not(.button) {
+		a:not(.button), a:not(.dashicons) {
 			text-decoration: underline;
 		}
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins/client/styles/components/_components.scss
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins/client/styles/components/_components.scss
@@ -21,6 +21,7 @@
 @import "media";
 @import "site-title";
 @import "../../components/archive";
+@import "../../components/dialog";
 @import "../../components/main-navigation";
 @import "../../components/page";
 @import "../../components/plugin-card";

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins/inc/template-tags.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins/inc/template-tags.php
@@ -534,12 +534,48 @@ function the_plugin_self_close_button() {
 	}
 	echo '</p></div>';
 
-	if ( $close_link ) {
-		echo '<form method="POST" action="' . esc_url( $close_link ) . '" onsubmit="return confirm( jQuery(this).prev(\'.notice\').text() );">';
-		// Translators: %s is the plugin name, as defined by the plugin itself.
-		echo '<p><input class="button" type="submit" value="' . esc_attr( sprintf( __( 'I understand, please close %s.', 'wporg-plugins' ), get_the_title() ) ) . '" /></p>';
-		echo '</form>';
+	if ( ! $close_link ) {
+		return;
 	}
+
+	// Translators: %s is the plugin name, as defined by the plugin itself.
+	$close_button_text = sprintf( __( 'I understand, please close %s.', 'wporg-plugins' ), get_the_title() );
+	?>
+	<button class="show-dialog button" onclick="this.nextElementSibling.showModal()"><?php echo $close_button_text; ?></button>
+	<dialog>
+		<a onclick="this.parentNode.close()" class="close dashicons dashicons-no-alt"></a>
+		<strong><?php _e( 'Close your plugin?', 'wporg-plugins' ); ?></strong>
+		<div class="notice notice-warning notice-alt"><p>
+			<?php _e( '<strong>Warning:</strong> Closing a plugin is intended to be a <em>permanent</em> action. There is no way to reopen a plugin without contacting the plugins team.', 'wporg-plugins' ); ?>
+		</p></div>
+
+		<form method="POST" action="<?php echo esc_url( $close_link ); ?>">
+			<p>
+				<label>
+					<input type="checkbox" name="confirm" required />
+					<?php _e( 'Yes, I understand that this is intended on being permanent.', 'wporg-plugins' ); ?>
+				</label>
+			</p>
+			<p>
+				<label>
+					<input type="checkbox" name="confirm" required />
+					<?php printf( __( 'Yes, I wish to close %s with the slug %s.', 'wporg-plugins' ), '<code>' . get_the_title() . '</code>', '<code>' . esc_html( $post->post_name ) . '</code>' ); ?>
+				</label>
+			</p>
+			<p>
+				<label>
+					<input type="checkbox" name="confirm" required />
+					<?php _e( 'I am not working on a newer version to submit to the plugin directory.', 'wporg-plugins' ); ?>
+				</label>
+			</p>
+			<p>
+				<?php printf( __( 'If you have any questions, please contact <a href="mailto:%1$s">%1$s</a> before proceeding with a link to your plugin and your questions.', 'wporg-plugins' ), 'plugins@wordpress.org' ); ?>
+			<p>
+				<input class="button" type="submit" value="<?php echo esc_attr( $close_button_text ); ?>" />
+			</p>
+		</form>
+	</dialog>
+	<?php
 }
 
 /**


### PR DESCRIPTION
Some checkboxes are included that must be clicked:
> [ ] Yes, I understand that this is intended on being permanent.
> [ ] Yes, I wish to close %s with the slug %s.
> [ ] I am not working on a newer version to submit to the plugin directory.

The wording isn't perfect, the last one probably needs to be something like `I'm not intending on releasing any further updates to this plugin.`

Trac Ticket: [5667](https://meta.trac.wordpress.org/ticket/5667)