### PR TITLE
Translate: Add Warnings for Special Originals (i.e. quasi-Settings) in WordPress Core

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -517,8 +517,8 @@ class Plugin {
 				if ( is_numeric( $translation ) && $translation >= -12 && $translation <= 14 ) {
 					return true;
 				}
-
-				if ( preg_match( '/^[A-Za-z]+/[A-Za-z_]+/$', $translation ) ) {
+				// or a valid timezone string (America/New_York).
+				if ( preg_match( '#^[A-Z][A-Za-z_]+/[A-Za-z_]+$#', $translation ) ) {
 					return true;
 				}
 

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -503,12 +503,12 @@ class Plugin {
 	 * @return string|true True if check is OK, otherwise warning message.
 	 */
 	public function gp_core_setting_warning( $original, $translation, $locale, $meta = array() ) {
-		if ( empty( $meta ) ) {
+		if ( empty( $meta ) || ! isset( $meta['project_id'] ) ) {
 			// unable to check.
 			return true;
 		}
 
-		if ( isset( $meta['project_id'] ) || 78 === $meta['project_id'] ) { // wp/dev/admin
+		if ( 78 === $meta['project_id'] ) { // wp/dev/admin
 			if (
 				'0' === $original &&
 				'default GMT offset or timezone string' === $meta['context']

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -514,11 +514,12 @@ class Plugin {
 				'default GMT offset or timezone string' === $meta['context']
 				) {
 				// Must be either a valid offset (-12 to 14).
-				if ( is_numeric( $translation ) && $translation >= -12 && $translation <= 14 ) {
+				if ( is_numeric( $translation ) && round( $translation ) === intval( $translation ) && $translation >= -12 && $translation <= 14 ) {
+					// Countries with half-hour offsets or similar need to use a timezone string.
 					return true;
 				}
 				// or a valid timezone string (America/New_York).
-				if ( preg_match( '#^[A-Z][A-Za-z_]+/[A-Za-z_]+$#', $translation ) ) {
+				if ( preg_match( '#^[A-Z][A-Za-z_]+/[A-Z][A-Za-z_]+$#', $translation ) ) {
 					return true;
 				}
 

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -503,28 +503,26 @@ class Plugin {
 	 * @return string|true True if check is OK, otherwise warning message.
 	 */
 	public function gp_core_setting_warning( $original, $translation, $locale, $meta = array() ) {
-		if ( empty( $meta ) || ! isset( $meta['project_id'] ) ) {
+		if ( empty( $meta ) ) {
 			// unable to check.
 			return true;
 		}
 
-		if ( 78 === $meta['project_id'] ) { // wp/dev/admin
-			if (
-				'0' === $original &&
-				'default GMT offset or timezone string' === $meta['context']
-				) {
-				// Must be either a valid offset (-12 to 14).
-				if ( is_numeric( $translation ) && round( $translation ) === intval( $translation ) && $translation >= -12 && $translation <= 14 ) {
-					// Countries with half-hour offsets or similar need to use a timezone string.
-					return true;
-				}
-				// or a valid timezone string (America/New_York).
-				if ( preg_match( '#^[A-Z][A-Za-z_]+/[A-Z][A-Za-z_]+$#', $translation ) ) {
-					return true;
-				}
-
-				return 'Must be either a valid offset (-12 to 14) or a valid timezone string (America/New_York)';
+		if (
+			'0' === $original &&
+			'default GMT offset or timezone string' === $meta['context']
+			) {
+			// Must be either a valid offset (-12 to 14).
+			if ( is_numeric( $translation ) && round( $translation ) === intval( $translation ) && $translation >= -12 && $translation <= 14 ) {
+				// Countries with half-hour offsets or similar need to use a timezone string.
+				return true;
 			}
+			// or a valid timezone string (America/New_York).
+			if ( preg_match( '#^[A-Z][A-Za-z_]+/[A-Z][A-Za-z_]+$#', $translation ) ) {
+				return true;
+			}
+
+			return 'Must be either a valid offset (-12 to 14) or a valid timezone string (America/New_York)';
 		}
 
 		return true;

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -496,22 +496,22 @@ class Plugin {
 	 * @since 1.0.0
 	 * @access public
 	 *
-	 * @param string    $original_string    The source string.
+	 * @param string    $original    The source string.
 	 * @param string    $translation The translation.
 	 * @param GP_Locale $locale      The locale of the translation.
-	 * @param object $original|null      The original object.
+	 * @param array     $meta        Original metadata.
 	 * @return string|true True if check is OK, otherwise warning message.
 	 */
-	public function gp_core_setting_warning( $original_string, $translation, $locale, $original = null ) {
-		if ( is_null( $original ) ) {
+	public function gp_core_setting_warning( $original, $translation, $locale, $meta = array() ) {
+		if ( empty( $meta ) ) {
 			// unable to check.
 			return true;
 		}
 
-		if ( 78 === $original->project_id ) { // wp/dev/admin
+		if ( isset( $meta['project_id'] ) || 78 === $meta['project_id'] ) { // wp/dev/admin
 			if (
-				'0' === $original_string &&
-				'default GMT offset or timezone string' === $original->context
+				'0' === $original &&
+				'default GMT offset or timezone string' === $meta['context']
 				) {
 				// Must be either a valid offset (-12 to 14).
 				if ( is_numeric( $translation ) && $translation >= -12 && $translation <= 14 ) {


### PR DESCRIPTION
There are some originals in WordPress core that need to be translated in special ways, see @zodiac1978's [gist](https://gist.github.com/Zodiac1978/1d1bd363d5ba7d1ea68e3ffe352008f1).

A way to solve this would be to add specialized warnings in GlotPress which are implemted in this PR, pending some changes in GlotPress core https://github.com/GlotPress/GlotPress/pull/1636.
<img width="986" alt="Screenshot 2023-06-09 at 12 50 55" src="https://github.com/WordPress/wordpress.org/assets/203408/d68a6a60-e0c1-4c89-a1f6-d1de7173b096">
