### PR TITLE
Sticky MetaNav styles fixing

### DIFF
--- a/wordpress.org/public_html/style/trac/wp-trac.css
+++ b/wordpress.org/public_html/style/trac/wp-trac.css
@@ -152,7 +152,6 @@ h3.change a {
 }
 #banner {
 	position: relative;
-	margin-bottom: 40px !important;
 }
 #metanav {
     position: absolute;
@@ -175,7 +174,7 @@ h3.change a {
     padding: 0 5px;
 }
 #metanav.nav li {
-	color: #000;
+	color: rgba(0, 0, 0, 0.8);
 	border-right: 0;
 }
 .build #metanav.nav li,
@@ -188,7 +187,7 @@ h3.change a {
 #metanav.nav a,
 #metanav.nav a:visited,
 #metanav form.trac-logout button {
-	color: #000;
+	color: rgba(0, 0, 0, 0.8);
 	background: inherit;
 	border: inherit;
 }
@@ -214,11 +213,6 @@ form#search {
 }
 form#search input {
 	font-size: 13px;
-}
-
-/* trac search */
-.trac form#search {
-	margin-top: 40px;
 }
 
 /* Everything should be 940px width, except for reports (too much tabular data for 940px) */
@@ -260,6 +254,14 @@ form#search input {
 /* When blame displays a changeset inline, override the inline style set by blame.js */
 #main ~ .message[style] {
 	width: auto !important;
+}
+
+/* Trac specific styles */
+.trac #banner {
+	margin-bottom: 40px;
+}
+.trac form#search {
+	margin-top: 40px;
 }
 
 /* =admin.css */
@@ -2237,6 +2239,24 @@ a.mention.me {
 	.listing.tickets thead tr th a,
 	.listing.tickets tbody .trac-columns th a {
 		font-size: 1.2em;
+	}
+
+	/* Trac specific styles */
+	.trac #banner {
+		margin-bottom: -45px;
+	}
+	.trac form#search {
+		margin-top: 0;
+	}
+	.trac #metanav {
+		background: none;
+		border: none;
+	}
+	.trac #metanav.nav li {
+		color: #fff;
+	}
+	#metanav.nav a, #metanav.nav a:hover, #metanav.nav a:visited, #metanav form.trac-logout button {
+		color: rgba(255, 255, 255, 0.8);
 	}
 }
 

--- a/wordpress.org/public_html/style/trac/wp-trac.css
+++ b/wordpress.org/public_html/style/trac/wp-trac.css
@@ -152,11 +152,16 @@ h3.change a {
 }
 #banner {
 	position: relative;
+	margin-bottom: 40px !important;
 }
 #metanav {
-	position: absolute;
-	top: -24px;
-	right: 6px;
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 100%;
+    background: #eff6f9;
+    border: 2px solid #21759b;
+    margin: 5px 0;
 }
 #headline.no-menu ~ #banner #metanav {
 	top: -40px;
@@ -166,9 +171,11 @@ h3.change a {
 }
 #metanav.nav ul {
 	font-size: 12px;
+	margin: 0;
+    padding: 0 5px;
 }
 #metanav.nav li {
-	color: #fff;
+	color: #000;
 	border-right: 0;
 }
 .build #metanav.nav li,
@@ -181,7 +188,7 @@ h3.change a {
 #metanav.nav a,
 #metanav.nav a:visited,
 #metanav form.trac-logout button {
-	color: rgba(255, 255, 255, 0.8);
+	color: #000;
 	background: inherit;
 	border: inherit;
 }
@@ -197,7 +204,7 @@ h3.change a {
 #metanav.nav a:active,
 #metanav form.trac-logout button:hover,
 #metanav form.trac-logout button:active {
-	color: #fff;
+	color: #000;
 	text-decoration: underline;
 	background-color: inherit;
 }
@@ -207,6 +214,11 @@ form#search {
 }
 form#search input {
 	font-size: 13px;
+}
+
+/* trac search */
+.trac form#search {
+	margin-top: 40px;
 }
 
 /* Everything should be 940px width, except for reports (too much tabular data for 940px) */
@@ -2279,7 +2291,7 @@ a.mention.me {
 	#filters td {
 		display: block;
 	}
-	#filters .trac-clause td:not(.actions td), 
+	#filters .trac-clause td:not(.actions td),
 	#filters .trac-clause th {
 		text-align:left;
 	}


### PR DESCRIPTION
Trac ticket: [#7043](https://meta.trac.wordpress.org/ticket/7043)

### Issue
Top right Menu has an anchor called "logged in as {userid}" and also "Logout" button is there. Both of them are sticked to the menu in Desktop Mode.

![old sticky style](https://github.com/WordPress/wordpress.org/assets/43903460/5d0cf683-6288-4d5c-8bd6-e57cdc73ddcf)

### Solution
Here in this css codes, Trac metaNav has been repositioned after the Main Nav. The changes are only for the Desktop Mode. In Responsive mode, previous styles are still there.

![desktop mode](https://github.com/WordPress/wordpress.org/assets/43903460/c3060d09-6e66-4cfd-8f57-de71e1b3165c)

![responsive mode](https://github.com/WordPress/wordpress.org/assets/43903460/01b9cdc8-41ca-4c21-a32c-9f4b22aaf216)

### Testing

Both Desktop and Responsive codes has been tested in browser with the changes styles.
