### PR TITLE
navigation menu accessibility enhancement

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-apps/header.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-apps/header.php
@@ -24,7 +24,7 @@
 		<h1 class="site-title">
 			<a class="wpcom-logo" href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a>
 		</h1>
-		<nav id="site-navigation" class="main-navigation" role="navigation">
+		<nav id="site-navigation" aria-label="<?php _e( 'Main menu', 'wpmobileapps' ); ?>" class="main-navigation" role="navigation">
 			<button class="menu-toggle"><span class="screen-reader-text"><?php _e( 'Primary Menu', 'wpmobileapps' ); ?></span></button>
 			<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'wpmobileapps' ); ?></a>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-learn-2020/header.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-learn-2020/header.php
@@ -55,7 +55,7 @@ $menu_items = array(
 						<span class="site-title--no-mobile"><?php echo esc_html( _x( 'WordPress', 'Site title', 'wporg-learn' ) ); ?></span>
 					</a>
 				</p>
-				<nav id="site-navigation" class="main-navigation" role="navigation">
+				<nav id="site-navigation" aria-label="<?php _e( 'Main menu', 'wporg-learn' ); ?>" class="main-navigation" role="navigation">
 					<button
 						class="menu-toggle dashicons dashicons-arrow-down-alt2"
 						aria-controls="primary-menu"
@@ -83,5 +83,5 @@ $menu_items = array(
 
 			</div><!-- .site-branding -->
 		</header><!-- #masthead -->
-		
+
 		<?php locale_notice(); ?>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-main/header-child-page.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-main/header-child-page.php
@@ -22,7 +22,7 @@ get_template_part( 'header', 'wporg' );
 				<p class="site-title"><a href="<?php echo esc_url( get_permalink( get_post()->post_parent ) ); ?>" rel="bookmark"><?php echo get_the_title( get_post()->post_parent ); ?></a></p>
 
 				<?php if ( ! empty( $menu_items ) ) : ?>
-				<nav id="site-navigation" class="main-navigation" role="navigation">
+				<nav id="site-navigation" aria-label="<?php _e( 'Main menu', 'wporg' ); ?>" class="main-navigation" role="navigation">
 					<button class="menu-toggle dashicons dashicons-arrow-down-alt2" aria-controls="primary-menu" aria-expanded="false" aria-label="<?php esc_attr_e( 'Primary Menu', 'wporg' ); ?>"></button>
 					<div id="primary-menu" class="menu">
 						<ul>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-patterns/header.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-patterns/header.php
@@ -59,7 +59,7 @@ get_template_part( 'header', 'wporg' );
 						</span>
 					</div>
 
-					<nav id="site-navigation" class="main-navigation" role="navigation">
+					<nav id="site-navigation" aria-label="<?php _e( 'Main menu', 'wporg-patterns' ); ?>" class="main-navigation" role="navigation">
 						<button
 							class="menu-toggle dashicons dashicons-arrow-down-alt2"
 							aria-controls="primary-menu"
@@ -74,7 +74,7 @@ get_template_part( 'header', 'wporg' );
 							'menu_id'        => 'primary-menu',
 						) );
 						?>
-						
+
 					</nav><!-- #site-navigation -->
 					<?php get_search_form(); ?>
 				<?php endif; ?>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-photos/header.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-photos/header.php
@@ -56,7 +56,7 @@ $show_full_header = is_home() && ! is_paged();
 						?>
 					</p>
 				<?php else : ?>
-					<nav id="site-navigation" class="main-navigation" role="navigation">
+					<nav id="site-navigation" class="main-navigation" aria-label="<?php _e( 'Main menu', 'wporg-photos' ); ?>" role="navigation">
 						<button class="menu-toggle dashicons dashicons-arrow-down-alt2" aria-controls="primary-menu" aria-expanded="false" aria-label="<?php esc_attr_e( 'Primary Menu', 'wporg-photos' ); ?>"></button>
 						<div id="primary-menu" class="menu">
 							<ul>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins/header.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins/header.php
@@ -59,7 +59,7 @@ echo do_blocks( '<!-- wp:wporg/global-header /-->' ); // phpcs:ignore
 				<?php else : ?>
 					<p class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php echo esc_html_x( 'Plugins', 'Site title', 'wporg-plugins' ); ?></a></p>
 
-					<nav id="site-navigation" class="main-navigation" role="navigation">
+					<nav id="site-navigation" class="main-navigation" aria-label="<?php _e( 'Main menu', 'wporg-plugins' ); ?>" role="navigation">
 						<button class="menu-toggle dashicons dashicons-arrow-down-alt2" aria-controls="primary-menu" aria-expanded="false" aria-label="<?php esc_attr_e( 'Primary Menu', 'wporg-plugins' ); ?>"></button>
 						<div id="primary-menu" class="menu">
 							<ul>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support/header.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support/header.php
@@ -44,7 +44,7 @@ echo do_blocks( '<!-- wp:wporg/global-header /-->' );
 				<?php else : ?>
 					<p class="site-title"><a href="<?php echo esc_url( home_url( '/forums/' ) ); ?>" rel="home"><?php _ex( 'Support', 'Site title', 'wporg-forums' ); ?></a></p>
 
-					<nav id="site-navigation" class="main-navigation" role="navigation">
+					<nav id="site-navigation" class="main-navigation" aria-label="<?php _e( 'Main menu', 'wporg-forums' ); ?>" role="navigation">
 						<button class="menu-toggle dashicons dashicons-arrow-down-alt2" aria-controls="primary-menu" aria-expanded="false" aria-label="<?php esc_attr_e( 'Primary Menu', 'wporg-forums' ); ?>"></button>
 						<div id="primary-menu" class="menu">
 							<ul>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-themes/header.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-themes/header.php
@@ -32,7 +32,7 @@ echo do_blocks( '<!-- wp:wporg/global-header /-->' );
 </header>
 
 <?php if ( ! is_page( 'upload' ) ) : ?>
-<nav id="site-navigation" class="main-navigation" role="navigation">
+<nav id="site-navigation" class="main-navigation" aria-label="<?php _e( 'Main menu', 'wporg-themes' ); ?>" role="navigation">
 	<ul id="menu-theme-directory" class="menu">
 		<li><a href="<?php echo home_url( '/commercial/' ); ?>"><?php _e( 'Commercial Themes', 'wporg-themes' ); ?></a></li>
 	</ul>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg/inc/header.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg/inc/header.php
@@ -35,24 +35,26 @@ namespace WordPressdotorg\Theme;
 		</div>
 		<div style="clear:both"></div>
 
-		<ul id="wporg-header-menu">
-			<li><a href='//wordpress.org/showcase/' title='See some of the sites built on WordPress.'>Showcase</a></li>
-			<li><a href='//wordpress.org/themes/' title='Find just the right look for your website.'>Themes</a></li>
-			<li><a href='//wordpress.org/plugins/' title='Plugins can extend WordPress to do almost anything you can imagine.'>Plugins</a></li>
-			<li><a href='//wordpress.org/mobile/' title='Take your website on the go!'>Mobile</a></li>
-			<li><a href='//wordpress.org/support/' title='Forums, documentation, help.'>Support</a>
-				<ul class="nav-submenu">
-					<li><a href='//wordpress.org/support/' title='Support and discussion forums.'>Forums</a></li>
-					<li><a href='//codex.wordpress.org/Main_Page' title='Documentation, tutorials, best practices.'>Documentation</a></li>
-				</ul>
-				<div class="uparrow"></div>
-			</li>
-			<li><a href='//make.wordpress.org/' title='Contribute your knowledge.'>Get Involved</a></li>
-			<li><a href='//wordpress.org/about/' title='About the WordPress Organization, and where we&#039;re going.'>About</a></li>
-			<li><a href='//wordpress.org/news/' title='Come here for the latest scoop.'>Blog</a></li>
-			<li><a href='//wordpress.org/hosting/' title='Find a home for your blog.'>Hosting</a></li>
-			<li id="download" class="button download-button"><a href='//wordpress.org/download/' title='Get it. Got it? Good.'>Get WordPress</a></li>
-		</ul>
+		<nav aria-label="Main menu">
+			<ul id="wporg-header-menu">
+				<li><a href='//wordpress.org/showcase/' title='See some of the sites built on WordPress.'>Showcase</a></li>
+				<li><a href='//wordpress.org/themes/' title='Find just the right look for your website.'>Themes</a></li>
+				<li><a href='//wordpress.org/plugins/' title='Plugins can extend WordPress to do almost anything you can imagine.'>Plugins</a></li>
+				<li><a href='//wordpress.org/mobile/' title='Take your website on the go!'>Mobile</a></li>
+				<li><a href='//wordpress.org/support/' title='Forums, documentation, help.'>Support</a>
+					<ul class="nav-submenu">
+						<li><a href='//wordpress.org/support/' title='Support and discussion forums.'>Forums</a></li>
+						<li><a href='//codex.wordpress.org/Main_Page' title='Documentation, tutorials, best practices.'>Documentation</a></li>
+					</ul>
+					<div class="uparrow"></div>
+				</li>
+				<li><a href='//make.wordpress.org/' title='Contribute your knowledge.'>Get Involved</a></li>
+				<li><a href='//wordpress.org/about/' title='About the WordPress Organization, and where we&#039;re going.'>About</a></li>
+				<li><a href='//wordpress.org/news/' title='Come here for the latest scoop.'>Blog</a></li>
+				<li><a href='//wordpress.org/hosting/' title='Find a home for your blog.'>Hosting</a></li>
+				<li id="download" class="button download-button"><a href='//wordpress.org/download/' title='Get it. Got it? Good.'>Get WordPress</a></li>
+			</ul>
+		</nav>
 		<div style="clear:both"></div>
 	</div>
 </div>


### PR DESCRIPTION
Trac ticket: [#4123](https://meta.trac.wordpress.org/ticket/4123)

### Proposal
`<nav>` elements are mapped to an ARIA role=navigation. Therefore, <nav> elements are perceived by screen readers and users can jump to them using dedicated keyboard shortcuts.

### Enhancement
`area-label` attribute is added into all the main header nav with relevant translation function for each wordpress.org project.