### PR TITLE
Official WordPress Events: Sort events by UTC time

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/official-wordpress-events/official-events-online.php
+++ b/wordpress.org/public_html/wp-content/plugins/official-wordpress-events/official-events-online.php
@@ -38,13 +38,22 @@ function get_synced_online_events() {
 	foreach ( $raw_events as $event ) {
 		// The `date_utc` is not actually a UTC timestamp, it's the local time as Y-m-d H:i:s.
 		// We need to convert it back to UTC by subtracting the UTC offset.
-		$timestamp = strtotime( $event->date_utc ) - $event->date_utc_offset;
+		$timestamp       = strtotime( $event->date_utc ) - $event->date_utc_offset;
 		$cached_events[] = array(
 			'title'           => $event->title,
 			'url'             => $event->url,
 			'start_timestamp' => $timestamp,
 		);
 	}
+
+	// As the original data was sorted by local time (`date_utc`),
+	// we need to reorder the events after it's converted back to UTC.
+	usort(
+		$cached_events,
+		function( $a, $b ) {
+			return $a['start_timestamp'] <=> $b['start_timestamp'];
+		}
+	);
 
 	return $cached_events;
 }
@@ -83,7 +92,7 @@ function enqueue_scripts() {
  * Inject JS templates into page.
  */
 function render_online_templates() {
-	require_once( __DIR__ . '/template-events-online.php' );
+	require_once __DIR__ . '/template-events-online.php';
 }
 
 /**


### PR DESCRIPTION
Fixes https://meta.trac.wordpress.org/ticket/7071.

This PR proposes a code change that sorts all events according to their UTC time on [the online events list page](https://make.wordpress.org/community/events/online/), to achieve a globally unified event order.

## Screenshot

| Before | After |
| -------| ----- |
| ![Screen Shot 2023-06-15 at 11 07 59 PM](https://github.com/WordPress/wordpress.org/assets/18050944/105ee503-c6b0-4b86-887b-acc9573bbd73) | ![Screen Shot 2023-06-15 at 11 34 03 PM](https://github.com/WordPress/wordpress.org/assets/18050944/3b4dd2f9-dd15-4473-ac40-6e1858476a67)  |

## Testing Steps

1. Apply the changes.
2. Go to https://make.wordpress.org/community/events/online/ and see if the order is correct.

## Note

We could also fix it by adding `events.sort((a, b) => a.start_timestamp - b.start_timestamp);` to [getSortedEvents](https://github.com/WordPress/wordpress.org/blob/376bdd6e4866a8600a757d89496c0fc5bc97f096/wordpress.org/public_html/wp-content/plugins/official-wordpress-events/official-events-online.js#L7), but I assume an events array sorted by UTC would be convenient for most cases.