### PR TITLE
Log translation source

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -313,12 +313,12 @@ class Plugin {
 					if ( isset( $_POST['openAITranslationsUsed'] ) ) {
 						$suggestion_source     = 'openai';
 						$suggested_translation = sanitize_text_field( $_POST['openAITranslationsUsed'] );
-						$this->update_translation_source_meta( $translation, $suggested_translation, $suggestion_source );
+						$this->save_translation_suggestion_source( $translation, $suggested_translation, $suggestion_source );
 					}
 					if ( isset( $_POST['deeplTranslationsUsed'] ) ) {
 						$suggestion_source     = 'deepl';
 						$suggested_translation = sanitize_text_field( $_POST['deeplTranslationsUsed'] );
-						$this->update_translation_source_meta( $translation, $suggested_translation, $suggestion_source );
+						$this->save_translation_suggestion_source( $translation, $suggested_translation, $suggestion_source );
 					}
 				}
 			}
@@ -329,7 +329,7 @@ class Plugin {
 	}
 
 	/**
-	 * Updates translation source meta.
+	 * Save the source of a translation suggestion.
 	 *
 	 * @param object $translation Translation object.
 	 * @param string $suggested_translation Suggested translation string.
@@ -337,7 +337,7 @@ class Plugin {
 	 *
 	 * @return void
 	 */
-	private function update_translation_source_meta( $translation, $suggested_translation, $suggestion_source ) {
+	private function save_translation_suggestion_source( $translation, $suggested_translation, $suggestion_source ) {
 		$source_meta = $suggestion_source;
 		if ( $translation->translation_0 !== $suggested_translation ) {
 			$source_meta .= '_modified';

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -289,11 +289,13 @@ class Plugin {
 		global $wpdb;
 
 		$gp_external_translations = get_user_option( 'gp_external_translations', get_current_user_id() );
-		$gp_external_translations['last_translation_source'];
+		if ( ! $gp_external_translations['last_translation_source'] && ! $translation->id ) {
+			return;
+		}
 		$result = $wpdb->insert(
 			'translate_meta',
 			array(
-				'meta_key'   => $translation_id,
+				'meta_key'   => $translation->id,
 				'meta_value' => $gp_external_translations['last_translation_source'],
 			)
 		);

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -307,14 +307,14 @@ class Plugin {
 				if ( isset( $_POST['source'] ) && 'translate-live' == $_POST['source'] ) {
 					$this->imported_source = 'playground';
 				} elseif ( ! isset( $_POST['source'] ) && 'Import' == $_POST['submit'] ) {
-					$this->imported_source = 'frontend';
+					$this->imported_source = 'import';
 				} else {
 					return;
 				}
 			}
 			if ( 'translations_post' === GP::$current_route->last_method_called ) {
-				if ( isset( $_POST['translation_source'] ) ) {
-					$source = sanitize_text_field( $_POST['translation_source'] );
+				if ( isset( $_POST['translation_source'] ) && 'frontend' == $_POST['translation_source'] ) {
+					$source = 'frontend';
 				}
 			}
 		}

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -344,12 +344,12 @@ class Plugin {
 	 * @return void
 	 */
 	private function save_translation_suggestion_source( $translation, $suggested_translation, $suggestion_source ) {
-		$source_meta = $suggestion_source;
+		$suggestion_used = $suggestion_source;
 		if ( $translation->translation_0 !== $suggested_translation ) {
-			$source_meta .= '_modified';
+			$suggestion_used .= '_modified';
 		}
-		if ( $source_meta ) {
-			gp_update_meta( $translation->id, 'suggestion-used', $source_meta, 'translation' );
+		if ( $suggestion_used ) {
+			gp_update_meta( $translation->id, 'suggestion-used', $suggestion_used, 'translation' );
 		}
 
 	}

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -299,7 +299,7 @@ class Plugin {
 	 * @return void
 	 */
 	public function log_translation_source( GP_Translation $translation ) {
-		$source = '';
+		$source = $source_meta = '';
 		if ( $translation && 'GP_Route_Translation' === GP::$current_route->class_name ) {
 			if ( 'import_translations_post' === GP::$current_route->last_method_called ) {
 				$this->imported_translation_ids[] = $translation->id;
@@ -315,12 +315,45 @@ class Plugin {
 			if ( 'translations_post' === GP::$current_route->last_method_called ) {
 				if ( isset( $_POST['translation_source'] ) && 'frontend' == $_POST['translation_source'] ) {
 					$source = 'frontend';
+					if ( isset( $_POST['openAITranslationsUsed'] ) ) {
+						$suggestion_source     = 'openai';
+						$suggested_translation = sanitize_text_field( $_POST['openAITranslationsUsed'] );
+						$this->update_translation_source_meta( $translation, $suggested_translation, $suggestion_source );
+					}
+					if ( isset( $_POST['deeplTranslationsUsed'] ) ) {
+						$suggestion_source     = 'deepl';
+						$suggested_translation = sanitize_text_field( $_POST['deeplTranslationsUsed'] );
+						$this->update_translation_source_meta( $translation, $suggested_translation, $suggestion_source );
+					}
 				}
 			}
 		}
 		if ( $source ) {
 			gp_update_meta( $translation->id, 'source', $source, 'translation' );
 		}
+	}
+
+	/**
+	 * Updates translation source meta.
+	 *
+	 * @param object $translation Translation object.
+	 * @param string $suggested_translation Suggested translation string.
+	 * @param string $suggestion_source Suggestion source.
+	 *
+	 * @return void
+	 */
+	private function update_translation_source_meta( $translation, $suggested_translation, $suggestion_source ) {
+		$source_meta  = '';
+		$_translation = $translation->translation_0;
+		if ( $_translation === $suggested_translation ) {
+			$source_meta = $suggestion_source;
+		} else {
+			$source_meta = $suggestion_source . '_modified';
+		}
+		if ( $source_meta ) {
+			gp_update_meta( $translation->id, 'source_meta', $source_meta, 'translation' );
+		}
+
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -343,12 +343,9 @@ class Plugin {
 	 * @return void
 	 */
 	private function update_translation_source_meta( $translation, $suggested_translation, $suggestion_source ) {
-		$source_meta  = '';
-		$_translation = $translation->translation_0;
-		if ( $_translation === $suggested_translation ) {
-			$source_meta = $suggestion_source;
-		} else {
-			$source_meta = $suggestion_source . '_modified';
+		$source_meta = $suggestion_source;
+		if ( $translation->translation_0 !== $suggested_translation ) {
+			$source_meta .= '_modified';
 		}
 		if ( $source_meta ) {
 			gp_update_meta( $translation->id, 'suggestion-used', $source_meta, 'translation' );

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -289,25 +289,18 @@ class Plugin {
 	public function log_translation_source( GP_Translation $translation ) {
 		$source = '';
 		if ( 'GP_Route_Translation' === GP::$current_route->class_name ) {
-			if ( 'translations_post' === GP::$current_route->last_method_called ) {
-				$source = 'frontend';
-			}
 			if ( 'import_translations_post' === GP::$current_route->last_method_called ) {
 				$source = 'import';
 			}
-		}
-
-		if ( 'frontend' === $source ) {
-			$gp_external_translations = get_user_option( 'gp_external_translations', get_current_user_id() );
-			if ( $gp_external_translations['last_translation_source'] && $translation->id ) {
-				$source = $gp_external_translations['last_translation_source'];
-				unset( $gp_external_translations['last_translation_source'] );
-				update_user_option( get_current_user_id(), 'gp_external_translations', $gp_external_translations );
-			} else {
-				$source = 'frontend';
+			if ( 'translations_post' === GP::$current_route->last_method_called ) {
+				if ( isset( $_POST['translation_source'] ) ) {
+					$source = sanitize_text_field( $_POST['translation_source'] );
+				}
 			}
 		}
-
+		if ( ! $source ) {
+			return;
+		}
 		gp_update_meta( 0, $translation->id, $source, 'gp_option' );
 	}
 

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -56,6 +56,7 @@ class Plugin {
 		add_filter( 'gp_translation_prepare_for_save', array( $this, 'auto_reject_already_rejected' ), 10, 2 );
 		add_action( 'gp_translation_created', array( $this, 'auto_reject_replaced_suggestions' ) );
 		add_action( 'gp_translation_created', array( $this, 'log_translation_source' ) );
+		add_action( 'gp_translation_saved', array( $this, 'log_translation_source' ) );
 
 		add_filter( 'gp_for_translation_clauses', array( $this, 'allow_searching_for_no_author_translations' ), 10, 3 );
 

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -303,7 +303,7 @@ class Plugin {
 		if ( 'GP_Route_Translation' === GP::$current_route->class_name ) {
 			if ( 'import_translations_post' === GP::$current_route->last_method_called ) {
 				$this->imported_translation_ids[] = $translation->id;
-				$source                           = $_POST['source'];
+
 				if ( isset( $_POST['source'] ) && 'translate-live' == $_POST['source'] ) {
 					$this->imported_source = 'playground';
 				} elseif ( ! isset( $_POST['source'] ) && 'Import' == $_POST['submit'] ) {
@@ -318,10 +318,9 @@ class Plugin {
 				}
 			}
 		}
-		if ( ! $source ) {
-			return;
+		if ( $source ) {
+			gp_update_meta( $translation->id, 'source', $source, 'translation' );
 		}
-		gp_update_meta( $translation->id, 'source', $source, 'translation' );
 	}
 
 	/**
@@ -332,7 +331,9 @@ class Plugin {
 	public function log_imported_translations() {
 		global $wpdb;
 		$source = $this->imported_source;
-
+		if ( ! $source && ! $this->imported_translation_ids ) {
+			return;
+		}
 		$sql        = 'INSERT INTO ' . $wpdb->gp_meta . ' (object_type, object_id, meta_key, meta_value) VALUES ';
 		$sql_vars   = array();
 		$sql_values = array_map(

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -329,15 +329,17 @@ class Plugin {
 		$source = $this->imported_source;
 
 		$sql = 'INSERT INTO ' . $wpdb->gp_meta . ' (meta_key, meta_value) VALUES ';
-
+		$sql_vars = array();
 		$sql_values = array_map(
-			function( $value ) use ( $source ) {
-				return "($value, '$source')";
+			function( $value ) use ( $source, $sql_vars ) {
+				$sql_vars[] = $value;
+				$sql_vars[] = $source;
+				return '( %d, %s )';
 			},
 			$this->imported_translation_ids
 		);
 		$sql       .= implode( ', ', $sql_values );
-		$wpdb->query( $sql );
+		$wpdb->query( $wpdb->prepare( $sql, $sql_vars ) );
 
 	}
 

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -351,7 +351,7 @@ class Plugin {
 			$source_meta = $suggestion_source . '_modified';
 		}
 		if ( $source_meta ) {
-			gp_update_meta( $translation->id, 'source_meta', $source_meta, 'translation' );
+			gp_update_meta( $translation->id, 'suggestion-used', $source_meta, 'translation' );
 		}
 
 	}

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -57,6 +57,7 @@ class Plugin {
 		add_action( 'gp_translation_created', array( $this, 'auto_reject_replaced_suggestions' ) );
 		add_action( 'gp_translation_created', array( $this, 'log_translation_source' ) );
 		add_action( 'gp_translation_saved', array( $this, 'log_translation_source' ) );
+		add_action( 'gp_translations_imported', array( $this, 'log_translation_source' ) );
 
 		add_filter( 'gp_for_translation_clauses', array( $this, 'allow_searching_for_no_author_translations' ), 10, 3 );
 

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -292,13 +292,7 @@ class Plugin {
 		if ( ! $gp_external_translations['last_translation_source'] && ! $translation->id ) {
 			return;
 		}
-		$result = $wpdb->insert(
-			'translate_meta',
-			array(
-				'meta_key'   => $translation->id,
-				'meta_value' => $gp_external_translations['last_translation_source'],
-			)
-		);
+		gp_update_meta( 0, $translation->id, $gp_external_translations['last_translation_source'], 'gp_option' );
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -316,7 +316,7 @@ class Plugin {
 		if ( ! $source ) {
 			return;
 		}
-		gp_update_meta( 0, $translation->id, $source, 'gp_option' );
+		gp_update_meta( $translation->id, 'source', $source, 'translation' );
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -57,7 +57,6 @@ class Plugin {
 		add_action( 'gp_translation_created', array( $this, 'auto_reject_replaced_suggestions' ) );
 		add_action( 'gp_translation_created', array( $this, 'log_translation_source' ) );
 		add_action( 'gp_translation_saved', array( $this, 'log_translation_source' ) );
-		add_action( 'gp_translations_imported', array( $this, 'log_translation_source' ) );
 
 		add_filter( 'gp_for_translation_clauses', array( $this, 'allow_searching_for_no_author_translations' ), 10, 3 );
 

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -337,7 +337,7 @@ class Plugin {
 		$sql        = 'INSERT INTO ' . $wpdb->gp_meta . ' (object_type, object_id, meta_key, meta_value) VALUES ';
 		$sql_vars   = array();
 		$sql_values = array_map(
-			function( $translation_id ) use ( $source, $sql_vars ) {
+			function( $translation_id ) use ( $source, &$sql_vars ) {
 				$sql_vars[] = $translation_id;
 				$sql_vars[] = $source;
 				return '( "translation", %d, "source", %s )';

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -56,7 +56,6 @@ class Plugin {
 		add_filter( 'gp_translation_prepare_for_save', array( $this, 'auto_reject_already_rejected' ), 10, 2 );
 		add_action( 'gp_translation_created', array( $this, 'auto_reject_replaced_suggestions' ) );
 		add_action( 'gp_translation_created', array( $this, 'log_translation_source' ) );
-		add_action( 'gp_translation_saved', array( $this, 'log_translation_source' ) );
 
 		add_filter( 'gp_for_translation_clauses', array( $this, 'allow_searching_for_no_author_translations' ), 10, 3 );
 
@@ -278,6 +277,26 @@ class Plugin {
 		}
 
 		return $args;
+	}
+
+	/**
+	 * Store source of a translation in database.
+	 *
+	 * @param GP_Translation $translation Translation instance.
+	 * @return void
+	 */
+	public function log_translation_source( GP_Translation $translation ) {
+		global $wpdb;
+
+		$gp_external_translations = get_user_option( 'gp_external_translations', get_current_user_id() );
+		$gp_external_translations['last_translation_source'];
+		$result = $wpdb->insert(
+			'translate_meta',
+			array(
+				'meta_key'   => $translation_id,
+				'meta_value' => $gp_external_translations['last_translation_source'],
+			)
+		);
 	}
 
 	/**
@@ -659,17 +678,5 @@ class Plugin {
 
 		$reasons = isset( $locale_reasons[ $locale ] ) ? $locale_reasons[ $locale ] : array();
 		return array_merge( $default_reasons, $reasons );
-	}
-
-	public function log_translation_source( $translation ) {
-		global $wpdb;
-		$translation_source = 'frontend'; // just a placeholder for now.
-		$result             = $wpdb->insert(
-			'translate_meta',
-			array(
-				'meta_key'   => $translation_id,
-				'meta_value' => $translation_source,
-			)
-		);
 	}
 }

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -280,19 +280,32 @@ class Plugin {
 	}
 
 	/**
-	 * Store source of a translation in database.
+	 * Stores source of a translation in database.
 	 *
 	 * @param GP_Translation $translation Translation instance.
 	 * @return void
 	 */
 	public function log_translation_source( GP_Translation $translation ) {
-		global $wpdb;
-
-		$gp_external_translations = get_user_option( 'gp_external_translations', get_current_user_id() );
-		if ( ! $gp_external_translations['last_translation_source'] && ! $translation->id ) {
-			return;
+		$source = '';
+		if ( 'GP_Route_Translation' === GP::$current_route->class_name ) {
+			if ( 'translations_post' === GP::$current_route->last_method_called ) {
+				$source = 'frontend';
+			}
+			if ( 'import_translations_post' === GP::$current_route->last_method_called ) {
+				$source = 'import';
+			}
 		}
-		gp_update_meta( 0, $translation->id, $gp_external_translations['last_translation_source'], 'gp_option' );
+
+		if ( 'frontend' === $source ) {
+			$gp_external_translations = get_user_option( 'gp_external_translations', get_current_user_id() );
+			if ( $gp_external_translations['last_translation_source'] && $translation->id ) {
+				$source = $gp_external_translations['last_translation_source'];
+			}
+		}
+		unset( $gp_external_translations['last_translation_source'] );
+		update_user_option( get_current_user_id(), 'gp_external_translations', $gp_external_translations );
+
+		gp_update_meta( 0, $translation->id, $source, 'gp_option' );
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -302,10 +302,15 @@ class Plugin {
 		$source = '';
 		if ( 'GP_Route_Translation' === GP::$current_route->class_name ) {
 			if ( 'import_translations_post' === GP::$current_route->last_method_called ) {
-				$http_referer                     = stripslashes( $_POST['_wp_http_referer'] );
 				$this->imported_translation_ids[] = $translation->id;
-				$this->imported_source            = preg_match( '/^\.\.\/\?sort/', $http_referer ) ? 'import_from_playground' : 'import_from_frontend';
-				return;
+				$source                           = $_POST['source'];
+				if ( isset( $_POST['source'] ) && 'translate-live' == $_POST['source'] ) {
+					$this->imported_source = 'playground';
+				} elseif ( ! isset( $_POST['source'] ) && 'Import' == $_POST['submit'] ) {
+					$this->imported_source = 'frontend';
+				} else {
+					return;
+				}
 			}
 			if ( 'translations_post' === GP::$current_route->last_method_called ) {
 				if ( isset( $_POST['translation_source'] ) ) {
@@ -328,8 +333,8 @@ class Plugin {
 		global $wpdb;
 		$source = $this->imported_source;
 
-		$sql = 'INSERT INTO ' . $wpdb->gp_meta . ' (object_type, object_id, meta_key, meta_value) VALUES ';
-		$sql_vars = array();
+		$sql        = 'INSERT INTO ' . $wpdb->gp_meta . ' (object_type, object_id, meta_key, meta_value) VALUES ';
+		$sql_vars   = array();
 		$sql_values = array_map(
 			function( $translation_id ) use ( $source, $sql_vars ) {
 				$sql_vars[] = $translation_id;

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -299,6 +299,7 @@ class Plugin {
 			if ( 'import_translations_post' === GP::$current_route->last_method_called ) {
 				$source                           = 'import';
 				$this->imported_translation_ids[] = $translation->id;
+				return;
 			}
 			if ( 'translations_post' === GP::$current_route->last_method_called ) {
 				if ( isset( $_POST['translation_source'] ) ) {

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -55,16 +55,18 @@ class Plugin {
 
 		add_filter( 'gp_translation_prepare_for_save', array( $this, 'auto_reject_already_rejected' ), 10, 2 );
 		add_action( 'gp_translation_created', array( $this, 'auto_reject_replaced_suggestions' ) );
+		add_action( 'gp_translation_created', array( $this, 'log_translation_source' ) );
+		add_action( 'gp_translation_saved', array( $this, 'log_translation_source' ) );
 
 		add_filter( 'gp_for_translation_clauses', array( $this, 'allow_searching_for_no_author_translations' ), 10, 3 );
 
 		add_filter( 'gp_custom_reasons', array( $this, 'get_custom_reasons' ), 10, 2 );
 
 		// Cron.
-		add_filter( 'cron_schedules', [ $this, 'register_cron_schedules' ] );
-		add_action( 'init', [ $this, 'register_cron_events' ] );
-		add_action( 'wporg_translate_update_contributor_profile_badges', [ $this, 'update_contributor_profile_badges' ] );
-		add_action( 'wporg_translate_update_polyglots_stats', [ $this, 'update_polyglots_stats' ] );
+		add_filter( 'cron_schedules', array( $this, 'register_cron_schedules' ) );
+		add_action( 'init', array( $this, 'register_cron_events' ) );
+		add_action( 'wporg_translate_update_contributor_profile_badges', array( $this, 'update_contributor_profile_badges' ) );
+		add_action( 'wporg_translate_update_polyglots_stats', array( $this, 'update_polyglots_stats' ) );
 
 		// Toolbar.
 		add_action( 'admin_bar_menu', array( $this, 'add_profile_settings_to_admin_bar' ) );
@@ -77,10 +79,10 @@ class Plugin {
 		// Load the API endpoints.
 		add_action( 'rest_api_init', array( __NAMESPACE__ . '\REST_API\Base', 'load_endpoints' ) );
 
-		//Locales\Serbian_Latin::init();
+		// Locales\Serbian_Latin::init();
 
 		// Correct `WP_Locale` for variant locales in project lists.
-		add_filter( 'gp_translation_sets_sort', [ $this, 'filter_gp_translation_sets_sort' ] );
+		add_filter( 'gp_translation_sets_sort', array( $this, 'filter_gp_translation_sets_sort' ) );
 
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			$this->register_cli_commands();
@@ -94,7 +96,7 @@ class Plugin {
 	 * @param string $slug Slug of a theme.
 	 * @return array Filtered WP-CLI arguments.
 	 */
-	public function set_version_for_default_themes_in_development(  $args, $slug ) {
+	public function set_version_for_default_themes_in_development( $args, $slug ) {
 		if ( 'twentytwentyone' !== $slug || ! empty( $args['version'] ) ) {
 			return $args;
 		}
@@ -164,12 +166,17 @@ class Plugin {
 			return;
 		}
 
-		$user_ids = $wpdb->get_col( $wpdb->prepare( "
+		$user_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"
 			SELECT user_id
 			FROM {$wpdb->user_translations_count}
 			WHERE accepted > 0 AND date_modified > %s
 			GROUP BY user_id
-		", gmdate( 'Y-m-d H:i:s', $last_sync ) ) );
+		",
+				gmdate( 'Y-m-d H:i:s', $last_sync )
+			)
+		);
 
 		if ( ! $user_ids ) {
 			update_option( 'wporg_translate_last_badges_sync', $now );
@@ -229,7 +236,7 @@ class Plugin {
 			// New translation being added.
 
 			$translation_set = GP::$translation_set->get( $args['translation_set_id'] );
-			$project = GP::$project->get( $translation_set->project_id );
+			$project         = GP::$project->get( $translation_set->project_id );
 
 			// If the current user can approve / write to the project, skip.
 			if (
@@ -255,7 +262,7 @@ class Plugin {
 			if ( $existing_rejected_translations ) {
 				$locale = GP_Locales::by_slug( $translation_set->locale );
 
-				$translations = [];
+				$translations = array();
 				foreach ( range( 0, GP::$translation->get_static( 'number_of_plural_translations' ) - 1 ) as $i ) {
 					if ( isset( $args[ "translation_$i" ] ) ) {
 						$translations[] = $args[ "translation_$i" ];
@@ -268,7 +275,6 @@ class Plugin {
 					}
 				}
 			}
-
 		}
 
 		return $args;
@@ -288,7 +294,7 @@ class Plugin {
 		}
 
 		$translation_set = GP::$translation_set->get( $translation->translation_set_id );
-		$project = GP::$project->get( $translation_set->project_id );
+		$project         = GP::$project->get( $translation_set->project_id );
 
 		// If the current user can approve / write to the project, skip. Probably not needed due to the `waiting` check above.
 		if (
@@ -328,14 +334,14 @@ class Plugin {
 	 */
 	function allow_searching_for_no_author_translations( $clauses, $set, $filters ) {
 		$user_login = gp_array_get( $filters, 'user_login' );
-	
+
 		if ( '0' === $user_login ) {
 			$clauses['where'] .= ( $clauses['where'] ? ' AND' : '' ) . ' t.user_id = 0';
 		} elseif ( 'anonymous' === $user_login ) {
 			// 'Anonymous' user exists, but has no translations.
 			$clauses['where'] = preg_replace( '/(user_id\s*=\s*\d+)/', 'user_id = 0', $clauses['where'] );
 		}
-	
+
 		return $clauses;
 	}
 
@@ -350,10 +356,10 @@ class Plugin {
 	 */
 	public function add_consistency_tool_link( $more_links, $project, $locale, $translation_set, $translation ) {
 		$consistency_tool_url = add_query_arg(
-			[
+			array(
 				'search' => urlencode( $translation->singular ),
 				'set'    => urlencode( $locale->slug . '/' . $translation_set->slug ),
-			],
+			),
 			home_url( '/consistency' )
 		);
 
@@ -396,12 +402,14 @@ class Plugin {
 		$logout_node = $wp_admin_bar->get_node( 'logout' );
 		$wp_admin_bar->remove_node( 'logout' );
 
-		$wp_admin_bar->add_node( [
-			'parent' => 'user-actions',
-			'id'     => 'gp-profile-settings',
-			'title'  => 'Translate Settings',
-			'href'   => gp_url( '/settings' ),
-		] );
+		$wp_admin_bar->add_node(
+			array(
+				'parent' => 'user-actions',
+				'id'     => 'gp-profile-settings',
+				'title'  => 'Translate Settings',
+				'href'   => gp_url( '/settings' ),
+			)
+		);
 
 		if ( $logout_node ) {
 			$wp_admin_bar->add_node( $logout_node ); // Ensures that logout is the last action.
@@ -418,10 +426,10 @@ class Plugin {
 			return;
 		}
 
-		$menu = [
-			'id' => 'log-in',
+		$menu = array(
+			'id'   => 'log-in',
 			'href' => wp_login_url( gp_url_current() ),
-		];
+		);
 		$wp_admin_bar->add_menu( $menu );
 	}
 
@@ -487,14 +495,14 @@ class Plugin {
 	 */
 	public function bump_assets_versions() {
 		$scripts = wp_scripts();
-		foreach ( [ 'gp-common', 'gp-editor', 'gp-glossary', 'gp-translations-page', 'gp-mass-create-sets-page' ] as $handle ) {
+		foreach ( array( 'gp-common', 'gp-editor', 'gp-glossary', 'gp-translations-page', 'gp-mass-create-sets-page' ) as $handle ) {
 			if ( isset( $scripts->registered[ $handle ] ) ) {
 				$scripts->registered[ $handle ]->ver = $scripts->registered[ $handle ]->ver . '-1';
 			}
 		}
 
 		$styles = wp_styles();
-		foreach ( [ 'gp-base' ] as $handle ) {
+		foreach ( array( 'gp-base' ) as $handle ) {
 			if ( isset( $styles->registered[ $handle ] ) ) {
 				$styles->registered[ $handle ]->ver = $styles->registered[ $handle ]->ver . '-1';
 			}
@@ -544,23 +552,29 @@ class Plugin {
 	 */
 	public function natural_sort_projects( $sub_projects, $parent_id ) {
 		if ( in_array( $parent_id, array( 1, 13, 58 ) ) ) { // 1 = WordPress, 13 = BuddyPress, 58 = bbPress
-			usort( $sub_projects, function( $a, $b ) {
-				return - strcasecmp( $a->name, $b->name );
-			} );
+			usort(
+				$sub_projects,
+				function( $a, $b ) {
+					return - strcasecmp( $a->name, $b->name );
+				}
+			);
 		}
 
 		if ( in_array( $parent_id, array( 17, 523 ) ) ) { // 17 = Plugins, 523 = Themes
-			usort( $sub_projects, function( $a, $b ) {
-				return strcasecmp( $a->name, $b->name );
-			} );
+			usort(
+				$sub_projects,
+				function( $a, $b ) {
+					return strcasecmp( $a->name, $b->name );
+				}
+			);
 		}
 
 		// Attach wp-themes meta keys
 		if ( 523 == $parent_id ) {
 			foreach ( $sub_projects as $project ) {
 				$project->non_db_field_names = array_merge( $project->non_db_field_names, array( 'version', 'screenshot' ) );
-				$project->version = gp_get_meta( 'wp-themes', $project->id, 'version' );
-				$project->screenshot = esc_url( gp_get_meta( 'wp-themes', $project->id, 'screenshot' ) );
+				$project->version            = gp_get_meta( 'wp-themes', $project->id, 'version' );
+				$project->screenshot         = esc_url( gp_get_meta( 'wp-themes', $project->id, 'screenshot' ) );
 			}
 		}
 
@@ -577,7 +591,7 @@ class Plugin {
 	function localize_links( $content, $wp_locale ) {
 		global $wpdb;
 
-		static $subdomains = [];
+		static $subdomains = array();
 		if ( ! isset( $subdomains[ $wp_locale ] ) ) {
 			$subdomains[ $wp_locale ] = $wpdb->get_var( $wpdb->prepare( 'SELECT subdomain FROM wporg_locales WHERE locale = %s LIMIT 1', $wp_locale ) );
 		}
@@ -645,5 +659,17 @@ class Plugin {
 
 		$reasons = isset( $locale_reasons[ $locale ] ) ? $locale_reasons[ $locale ] : array();
 		return array_merge( $default_reasons, $reasons );
+	}
+
+	public function log_translation_source( $translation ) {
+		global $wpdb;
+		$translation_source = 'frontend'; // just a placeholder for now.
+		$result             = $wpdb->insert(
+			'translate_meta',
+			array(
+				'meta_key'   => $translation_id,
+				'meta_value' => $translation_source,
+			)
+		);
 	}
 }

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -299,7 +299,7 @@ class Plugin {
 	 * @return void
 	 */
 	public function log_translation_source( GP_Translation $translation ) {
-		$source = $source_meta = '';
+		$source = '';
 		if ( $translation && 'GP_Route_Translation' === GP::$current_route->class_name ) {
 			if ( 'import_translations_post' === GP::$current_route->last_method_called ) {
 				$this->imported_translation_ids[] = $translation->id;

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -301,10 +301,12 @@ class Plugin {
 			$gp_external_translations = get_user_option( 'gp_external_translations', get_current_user_id() );
 			if ( $gp_external_translations['last_translation_source'] && $translation->id ) {
 				$source = $gp_external_translations['last_translation_source'];
+				unset( $gp_external_translations['last_translation_source'] );
+				update_user_option( get_current_user_id(), 'gp_external_translations', $gp_external_translations );
+			} else {
+				$source = 'frontend';
 			}
 		}
-		unset( $gp_external_translations['last_translation_source'] );
-		update_user_option( get_current_user_id(), 'gp_external_translations', $gp_external_translations );
 
 		gp_update_meta( 0, $translation->id, $source, 'gp_option' );
 	}

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -297,8 +297,9 @@ class Plugin {
 		$source = '';
 		if ( 'GP_Route_Translation' === GP::$current_route->class_name ) {
 			if ( 'import_translations_post' === GP::$current_route->last_method_called ) {
-				$source                           = 'import';
+				$http_referer                     = stripslashes( $_POST['_wp_http_referer'] );
 				$this->imported_translation_ids[] = $translation->id;
+				$source                           = preg_match( '/^\.\.\/\?sort/', $http_referer ) ? 'import_from_playground' : 'import_from_frontend';
 				return;
 			}
 			if ( 'translations_post' === GP::$current_route->last_method_called ) {

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -328,13 +328,13 @@ class Plugin {
 		global $wpdb;
 		$source = $this->imported_source;
 
-		$sql = 'INSERT INTO ' . $wpdb->gp_meta . ' (meta_key, meta_value) VALUES ';
+		$sql = 'INSERT INTO ' . $wpdb->gp_meta . ' (object_type, object_id, meta_key, meta_value) VALUES ';
 		$sql_vars = array();
 		$sql_values = array_map(
-			function( $value ) use ( $source, $sql_vars ) {
-				$sql_vars[] = $value;
+			function( $translation_id ) use ( $source, $sql_vars ) {
+				$sql_vars[] = $translation_id;
 				$sql_vars[] = $source;
-				return '( %d, %s )';
+				return '( "translation", %d, "source", %s )';
 			},
 			$this->imported_translation_ids
 		);

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -294,7 +294,13 @@ class Plugin {
 	 * @return void
 	 */
 	public function log_translation_source( GP_Translation $translation ) {
-		$source = '';
+		static $already_logged = array();
+		$key                   = ! $translation->translation_0 ? null : $translation->translation_0;
+		if ( isset( $already_logged[ $key ] ) ) {
+			return;
+		}
+		$already_logged[ $key ] = true;
+		$source                 = '';
 		if ( $translation && 'GP_Route_Translation' === GP::$current_route->class_name ) {
 			if ( 'import_translations_post' === GP::$current_route->last_method_called ) {
 				$this->imported_translation_ids[] = $translation->id;

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -300,7 +300,7 @@ class Plugin {
 	 */
 	public function log_translation_source( GP_Translation $translation ) {
 		$source = '';
-		if ( 'GP_Route_Translation' === GP::$current_route->class_name ) {
+		if ( $translation && 'GP_Route_Translation' === GP::$current_route->class_name ) {
 			if ( 'import_translations_post' === GP::$current_route->last_method_called ) {
 				$this->imported_translation_ids[] = $translation->id;
 

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/js/editor.js
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/js/editor.js
@@ -344,7 +344,6 @@
 				.on( 'click', 'button.panel-header-actions__cancel', $gp.editor.hooks.cancel )
 				.on( 'click', 'button.translation-actions__copy', $gp.editor.hooks.copy )
 				.on( 'click', 'button.translation-actions__insert-tab', $gp.editor.hooks.tab )
-				.on( 'click', 'button.translation-actions__save', saveExternalSuggestions )
 				.on( 'click', 'button.translation-actions__save', $gp.editor.hooks.ok )
 				.on( 'click', 'button.translation-actions__help', openHelpModal )
 				.on( 'click', 'button.translation-actions__ltr', switchTextDirection )
@@ -352,8 +351,6 @@
 				.on( 'focus', 'textarea', textareaAutosize )
 				.on( 'click', 'summary', toggleDetails )
 				.on( 'click', 'button.button-menu__toggle', toggleLinkMenu )
-				.on( 'click', '.translation-suggestion.with-tooltip.openai', addSuggestion )
-				.on( 'click', '.translation-suggestion.with-tooltip.deepl', addSuggestion )
 				.on( 'click', '.sidebar-tabs li', changeRightTab );
 		}
 	})( $gp.editor.install_hooks );

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/js/editor.js
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/js/editor.js
@@ -71,24 +71,13 @@
 	}
 
 
-	// Convert object to query params.
-	function convertObjectToQueryParam( object ) {
-		const params = new URLSearchParams();
-
-		Object.entries(object).forEach(([key, value]) => {
-		params.append(key, value);
-		});
-
-		return params.toString();
-	}
-
 	//Prefilter ajax requests to add translation_source to the request.
 	$.ajaxPrefilter( function ( options ) {
 		let data = Object.fromEntries( new URLSearchParams( options.data ) );
 
 		if ( 'POST' === options.type && $gp_editor_options.url === options.url ) {
-			data.translation_source = 'frontend';
-			options.data = convertObjectToQueryParam( data );
+			options.data += '&translation_source=frontend';
+
 		}
 	});
 

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/js/editor.js
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/js/editor.js
@@ -120,6 +120,71 @@
 		});
 	}
 
+	// Override save function in GlotPress.
+	$gp.editor.save = function(button) {
+		
+		var editor, textareaName,
+					data = [],
+					translations,
+					source = 'frontend';
+
+				if ( ! $gp.editor.current ) {
+					return;
+				}
+
+				editor = $gp.editor.current;
+				button.prop( 'disabled', true );
+				$gp.notices.notice( 'Saving&hellip;' );
+
+				if ( $openAITranslationsUsed[ editor.original_id ] ) {
+					source = 'openai';
+					$openAITranslationsUsed.splice( [ editor.original_id ] );
+				} 
+				if( $deeplTranslationsUsed[ editor.original_id ] ) {
+					source = 'deepl';
+					$deeplTranslationsUsed.splice( [ editor.original_id ] );
+				}
+
+				data = {
+					original_id: editor.original_id,
+					_gp_route_nonce: button.data( 'nonce' ),
+					translation_source: source,
+				};
+
+				textareaName = 'translation[' + editor.original_id + '][]';
+				translations = $( 'textarea[name="' + textareaName + '"]', editor ).map( function() {
+					return this.value;
+				} ).get();
+
+				data[ textareaName ] = translations;
+
+				$.ajax( {
+					type: 'POST',
+					url: $gp_editor_options.url,
+					data: data,
+					dataType: 'json',
+					success: function( response ) {
+						var original_id;
+
+						button.prop( 'disabled', false );
+						$gp.notices.success( 'Saved!' );
+
+						for ( original_id in response ) {
+							$gp.editor.replace_current( response[ original_id ] );
+						}
+
+						if ( $gp.editor.current.hasClass( 'no-warnings' ) ) {
+							$gp.editor.next();
+						}
+					},
+					error: function( xhr, msg ) {
+						button.prop( 'disabled', false );
+						msg = xhr.responseText ? 'Error: ' + xhr.responseText : 'Error saving the translation!';
+						$gp.notices.error( msg );
+					},
+				} );
+	}
+
 	// Override functions to adopt custom markup.
 	$gp.editor.copy = function() {
 		var $activeTextarea = $gp.editor.current.find( '.textareas.active textarea' );

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/js/editor.js
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/js/editor.js
@@ -2,8 +2,6 @@
 ( function( $ ){
 	var $html = $( 'html' );
 	var $document = $( document );
-	var $openAITranslationsUsed = [];
-	var $deeplTranslationsUsed = [];
 
 	function checkStorage() {
 		var test = 'test',
@@ -72,53 +70,6 @@
 		autosize( $textarea );
 	}
 
-	/**
-	 * Adds the suggestion to the translation in an array, and removes the previous suggestions, so
-	 * we only store the last one in the database, using the saveExternalSuggestions() function.
-	 *
-	 * @return {void}
-	 */
-	function addSuggestion() {
-		var $row = $( this );
-		if ( ! $row ) {
-			return;
-		}
-		var $originalId = $row.closest( 'tr' ).attr( 'id' ).substring( 7 );
-		var $CSSclass = $row.attr( 'class' );
-		if ( $CSSclass.indexOf( 'openai' ) > -1 ) {
-			$openAITranslationsUsed[ $originalId ] = $row.find( '.translation-suggestion__translation' ).text();
-			delete $deeplTranslationsUsed[ $originalId ];
-		} else if ( $CSSclass.indexOf( 'deepl' ) > -1 ) {
-			$deeplTranslationsUsed[ $originalId ] = $row.find( '.translation-suggestion__translation' ).text();
-			delete $openAITranslationsUsed[ $originalId ];
-		}
-	}
-
-	/**
-	 * Saves the number of external suggestions used and used without modification.
-	 *
-	 * @return {void}
-	 **/
-	function saveExternalSuggestions() {
-		var $button = $( this );
-		var $row = $button.closest( 'tr.editor' );
-		var $originalId = $row.attr( 'id' ).substring( 7 );
-		if ( ! $openAITranslationsUsed[$originalId] && ! $deeplTranslationsUsed[$originalId] ) {
-			return;
-		}
-		var $translation = $row.find( 'textarea' ).val();
-		var $data = {
-			nonce: wporgEditorSettings.nonce,
-			translation: $translation,
-			openAITranslationsUsed: $openAITranslationsUsed[$originalId],
-			deeplTranslationsUsed: $deeplTranslationsUsed[$originalId]
-		};
-		$.ajax({
-			url: '/-save-external-suggestions',
-			type: 'POST',
-			data: $data,
-		});
-	}
 
 	// Convert object to query params.
 	function convertObjectToQueryParam( object ) {
@@ -137,14 +88,6 @@
 
 		if ( 'POST' === options.type && $gp_editor_options.url === options.url ) {
 			data.translation_source = 'frontend';
-			if ( $openAITranslationsUsed[ data.original_id ] ) {
-				data.translation_source = 'openai';
-				$openAITranslationsUsed.splice( [ data.original_id ] );
-			} 
-			if ( $deeplTranslationsUsed[ data.original_id ] ) {
-				data.translation_source = 'deepl';
-				$deeplTranslationsUsed.splice( [ data.original_id ] );
-			}
 			options.data = convertObjectToQueryParam( data );
 		}
 	});

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/routes/class-translation-memory.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/routes/class-translation-memory.php
@@ -530,8 +530,6 @@ class Translation_Memory extends GP_Route {
 	 */
 	private function update_one_external_translation( string $translation, string $suggestion, string $external_translations_used, string $external_same_translations_used, string $external_translation_source ) {
 		$is_the_same_translation = $translation == $suggestion;
-		unset( $gp_external_translations['last_translation_source'] );
-
 		$gp_external_translations = get_user_option( 'gp_external_translations' );
 		$translations_used        = gp_array_get( $gp_external_translations, $external_translations_used, 0 );
 		$same_translations_used   = gp_array_get( $gp_external_translations, $external_same_translations_used, 0 );

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/routes/class-translation-memory.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/routes/class-translation-memory.php
@@ -501,8 +501,7 @@ class Translation_Memory extends GP_Route {
 				$_POST['translation'],
 				$_POST['openAITranslationsUsed'],
 				'openai_translations_used',
-				'openai_same_translations_used',
-				'openai',
+				'openai_same_translations_used'
 			);
 		}
 		if ( isset( $_POST['deeplTranslationsUsed'] ) ) {
@@ -510,8 +509,7 @@ class Translation_Memory extends GP_Route {
 				$_POST['translation'],
 				$_POST['deeplTranslationsUsed'],
 				'deepl_translations_used',
-				'deepl_same_translations_used',
-				'deepl',
+				'deepl_same_translations_used'
 			);
 		}
 		wp_send_json_success();
@@ -524,32 +522,26 @@ class Translation_Memory extends GP_Route {
 	 * @param string $suggestion                      The suggestion.
 	 * @param string $external_translations_used      The external translations used.
 	 * @param string $external_same_translations_used The external same translations used.
-	 * @param string $external_translation_source     The external translation source.
 	 *
 	 * @return void
 	 */
-	private function update_one_external_translation( string $translation, string $suggestion, string $external_translations_used, string $external_same_translations_used, string $external_translation_source ) {
-		$is_the_same_translation = $translation == $suggestion;
+	private function update_one_external_translation( string $translation, string $suggestion, string $external_translations_used, string $external_same_translations_used ) {
+		$is_the_same_translation  = $translation == $suggestion;
 		$gp_external_translations = get_user_option( 'gp_external_translations' );
 		$translations_used        = gp_array_get( $gp_external_translations, $external_translations_used, 0 );
 		$same_translations_used   = gp_array_get( $gp_external_translations, $external_same_translations_used, 0 );
-
 		if ( ! is_int( $translations_used ) || $translations_used < 0 ) {
 			$translations_used = 0;
 		}
-		$current_translation_used                                = $translations_used++;
-		$gp_external_translations[ $external_translations_used ] = $translations_used++;
+		$translations_used++;
+		$gp_external_translations[ $external_translations_used ] = $translations_used;
 		if ( $is_the_same_translation ) {
 			if ( ! is_int( $same_translations_used ) || $same_translations_used < 0 ) {
 				$same_translations_used = 0;
 			}
-			$current_same_translations_used                               = $same_translations_used++;
+			$same_translations_used++;
 			$gp_external_translations[ $external_same_translations_used ] = $same_translations_used;
 		}
-		if ( $gp_external_translations[ $external_translations_used ] > $current_translation_used || $gp_external_translations[ $external_same_translations_used ] > $current_same_translations_used ) {
-			$gp_external_translations['last_translation_source'] = $external_translation_source;
-		}
-
 		update_user_option( get_current_user_id(), 'gp_external_translations', $gp_external_translations );
 	}
 }

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/routes/class-translation-memory.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/routes/class-translation-memory.php
@@ -501,7 +501,8 @@ class Translation_Memory extends GP_Route {
 				$_POST['translation'],
 				$_POST['openAITranslationsUsed'],
 				'openai_translations_used',
-				'openai_same_translations_used'
+				'openai_same_translations_used',
+				'openai',
 			);
 		}
 		if ( isset( $_POST['deeplTranslationsUsed'] ) ) {
@@ -509,7 +510,8 @@ class Translation_Memory extends GP_Route {
 				$_POST['translation'],
 				$_POST['deeplTranslationsUsed'],
 				'deepl_translations_used',
-				'deepl_same_translations_used'
+				'deepl_same_translations_used',
+				'deepl',
 			);
 		}
 		wp_send_json_success();
@@ -522,26 +524,34 @@ class Translation_Memory extends GP_Route {
 	 * @param string $suggestion                      The suggestion.
 	 * @param string $external_translations_used      The external translations used.
 	 * @param string $external_same_translations_used The external same translations used.
+	 * @param string $external_translation_source     The external translation source.
 	 *
 	 * @return void
 	 */
-	private function update_one_external_translation( string $translation, string $suggestion, string $external_translations_used, string $external_same_translations_used ) {
-		$is_the_same_translation  = $translation == $suggestion;
+	private function update_one_external_translation( string $translation, string $suggestion, string $external_translations_used, string $external_same_translations_used, string $external_translation_source ) {
+		$is_the_same_translation = $translation == $suggestion;
+		unset( $gp_external_translations['last_translation_source'] );
+
 		$gp_external_translations = get_user_option( 'gp_external_translations' );
 		$translations_used        = gp_array_get( $gp_external_translations, $external_translations_used, 0 );
 		$same_translations_used   = gp_array_get( $gp_external_translations, $external_same_translations_used, 0 );
+
 		if ( ! is_int( $translations_used ) || $translations_used < 0 ) {
 			$translations_used = 0;
 		}
-		$translations_used++;
-		$gp_external_translations[ $external_translations_used ] = $translations_used;
+		$current_translation_used                                = $translations_used++;
+		$gp_external_translations[ $external_translations_used ] = $translations_used++;
 		if ( $is_the_same_translation ) {
 			if ( ! is_int( $same_translations_used ) || $same_translations_used < 0 ) {
 				$same_translations_used = 0;
 			}
-			$same_translations_used++;
+			$current_same_translations_used                               = $same_translations_used++;
 			$gp_external_translations[ $external_same_translations_used ] = $same_translations_used;
 		}
+		if ( $gp_external_translations[ $external_translations_used ] > $current_translation_used || $gp_external_translations[ $external_same_translations_used ] > $current_same_translations_used ) {
+			$gp_external_translations['last_translation_source'] = $external_translation_source;
+		}
+
 		update_user_option( get_current_user_id(), 'gp_external_translations', $gp_external_translations );
 	}
 }

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/js/translation-suggestions.js
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/js/translation-suggestions.js
@@ -486,18 +486,18 @@
 		return params.toString();
 	}
 
-	// Prefilter ajax requests to add translation_source to the request.
+	// Prefilter ajax requests to add translation_assist to the request.
 	$.ajaxPrefilter( function ( options ) {
 		let data = Object.fromEntries( new URLSearchParams( options.data ) );
 
-		if ( 'POST' === options.type && $gp_editor_options.url === options.url && ! data.translation_source ) {
+		if ( 'POST' === options.type && $gp_editor_options.url === options.url && ! data.translation_assist ) {
 
 			if ( $openAITranslationsUsed[ data.original_id ] ) {
-				data.translation_source = 'openai';
+				data.translation_assist = 'openai';
 				$openAITranslationsUsed.splice( [ data.original_id ] );
 			} 
 			if ( $deeplTranslationsUsed[ data.original_id ] ) {
-				data.translation_source = 'deepl';
+				data.translation_assist = 'deepl';
 				$deeplTranslationsUsed.splice( [ data.original_id ] );
 			}
 			options.data = convertObjectToQueryParam( data );

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/js/translation-suggestions.js
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/js/translation-suggestions.js
@@ -475,34 +475,6 @@
 		};
 	})( $gp.editor.install_hooks );
 
-	// Convert object to query params.
-	function convertObjectToQueryParam( object ) {
-		const params = new URLSearchParams();
-
-		Object.entries(object).forEach(([key, value]) => {
-		params.append(key, value);
-		});
-
-		return params.toString();
-	}
-
-	// Prefilter ajax requests to add translation_assist to the request.
-	$.ajaxPrefilter( function ( options ) {
-		let data = Object.fromEntries( new URLSearchParams( options.data ) );
-
-		if ( 'POST' === options.type && $gp_editor_options.url === options.url && ! data.translation_assist ) {
-
-			if ( $openAITranslationsUsed[ data.original_id ] ) {
-				data.translation_assist = 'openai';
-				$openAITranslationsUsed.splice( [ data.original_id ] );
-			} 
-			if ( $deeplTranslationsUsed[ data.original_id ] ) {
-				data.translation_assist = 'deepl';
-				$deeplTranslationsUsed.splice( [ data.original_id ] );
-			}
-			options.data = convertObjectToQueryParam( data );
-		}
-	});
 	/**
 	 * Adds the suggestion to the translation in an array, and removes the previous suggestions, so
 	 * we only store the last one in the database, using the saveExternalSuggestions() function.

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/js/translation-suggestions.js
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/js/translation-suggestions.js
@@ -24,6 +24,18 @@
 	 */
 	var DeeplTMSuggestionRequested = [];
 
+	/** 
+	* Stores the OpenAI translations used.
+	* @type {array}
+	*/
+   var $openAITranslationsUsed = [];
+
+   /**
+	* Stores the DeepL translations used.
+	* @type {array}
+	* */
+   var $deeplTranslationsUsed = [];
+
 	/**
 	 * Stores (caches) the "Other Languages" suggestions that has already been queried,
 	 * to avoid making the query another time. The key is the originalId.
@@ -453,11 +465,93 @@
 			original();
 
 			$( $gp.editor.table )
-				.on( 'click', '.translation-suggestion', copySuggestion );
+				.on( 'click', '.translation-suggestion', copySuggestion )
+				.on( 'click', 'button.translation-actions__save', saveExternalSuggestions )
+				.on( 'click', '.translation-suggestion.with-tooltip.openai', addSuggestion )
+				.on( 'click', '.translation-suggestion.with-tooltip.deepl', addSuggestion );
 			$( document ).ready( function() {
 				getSuggestionsForTheFirstRow();
 			});
 		};
 	})( $gp.editor.install_hooks );
+
+	// Convert object to query params.
+	function convertObjectToQueryParam( object ) {
+		const params = new URLSearchParams();
+
+		Object.entries(object).forEach(([key, value]) => {
+		params.append(key, value);
+		});
+
+		return params.toString();
+	}
+
+	// Prefilter ajax requests to add translation_source to the request.
+	$.ajaxPrefilter( function ( options ) {
+		let data = Object.fromEntries( new URLSearchParams( options.data ) );
+
+		if ( 'POST' === options.type && $gp_editor_options.url === options.url && ! data.translation_source ) {
+
+			if ( $openAITranslationsUsed[ data.original_id ] ) {
+				data.translation_source = 'openai';
+				$openAITranslationsUsed.splice( [ data.original_id ] );
+			} 
+			if ( $deeplTranslationsUsed[ data.original_id ] ) {
+				data.translation_source = 'deepl';
+				$deeplTranslationsUsed.splice( [ data.original_id ] );
+			}
+			options.data = convertObjectToQueryParam( data );
+		}
+	});
+	/**
+	 * Adds the suggestion to the translation in an array, and removes the previous suggestions, so
+	 * we only store the last one in the database, using the saveExternalSuggestions() function.
+	 *
+	 * @return {void}
+	 */
+	function addSuggestion() {
+		var $row = $( this );
+		if ( ! $row ) {
+			return;
+		}
+		var $originalId = $row.closest( 'tr' ).attr( 'id' ).substring( 7 );
+		var $CSSclass = $row.attr( 'class' );
+		if ( $CSSclass.indexOf( 'openai' ) > -1 ) {
+			$openAITranslationsUsed[ $originalId ] = $row.find( '.translation-suggestion__translation' ).text();
+			delete $deeplTranslationsUsed[ $originalId ];
+		} else if ( $CSSclass.indexOf( 'deepl' ) > -1 ) {
+			$deeplTranslationsUsed[ $originalId ] = $row.find( '.translation-suggestion__translation' ).text();
+			delete $openAITranslationsUsed[ $originalId ];
+		}
+	}
+
+	/**
+	 * Saves the number of external suggestions used and used without modification.
+	 *
+	 * @return {void}
+	 **/
+	function saveExternalSuggestions() {
+
+		var $button = $( this );
+		var $row = $button.closest( 'tr.editor' );
+		var $originalId = $row.attr( 'id' ).substring( 7 );
+		if ( ! $openAITranslationsUsed[$originalId] && ! $deeplTranslationsUsed[$originalId] ) {
+			return;
+		}
+
+		var $translation = $row.find( 'textarea' ).val();
+		var $data = {
+			nonce: wporgEditorSettings.nonce,
+			translation: $translation,
+			openAITranslationsUsed: $openAITranslationsUsed[$originalId],
+			deeplTranslationsUsed: $deeplTranslationsUsed[$originalId]
+		};
+
+		$.ajax({
+			url: '/-save-external-suggestions',
+			type: 'POST',
+			data: $data,
+		});
+	}
 
 })( jQuery );


### PR DESCRIPTION
In this PR we focus on logging translation sources which we have categorized into 3 namely;
**Frontend** - Translations that are submitted by clicking the `Save` button on the translations page on translate.wordpress.org
![Screenshot 2023-06-30 at 22 34 44](https://github.com/WordPress/wordpress.org/assets/2834132/110ed238-9f4d-4fbf-91f9-1faa14ad6d51)

**Import** - Translations imported via the Import Translations page
![Screenshot 2023-06-30 at 22 35 21](https://github.com/WordPress/wordpress.org/assets/2834132/6db3ec38-3959-4933-bf02-caf18580b8cc)

**Playground**: Translations sent to translate.wordpress.org via the Playground( Translate Live)
![Screenshot 2023-06-30 at 22 39 01](https://github.com/WordPress/wordpress.org/assets/2834132/771ccb88-ff48-4c39-98c4-ee36a5308cdf)

These sources are stored in the `translate_meta` table.

We also decide to store `source_meta` to know if the translations were assisted and we have now defined these assistance as the following;
- openai
- deepl
- translation_memory
- openai_modified
- deepl_modified
- translation_memory_modified


