### PR TITLE
fixed WordPress.tv mobile version grid design responsive issue

### DIFF
--- a/wordpress.tv/public_html/wp-content/themes/wptv2/style.css
+++ b/wordpress.tv/public_html/wp-content/themes/wptv2/style.css
@@ -2712,4 +2712,17 @@ h3#comments {
 	.entry .contact-form textarea {
 		width: 98%;
 	}
+
+	.wptv-hero .secondary-videos li {
+		max-width: initial;
+	}
+
+	.wptv-hero .secondary-videos li a {
+		display: block;
+	}
+
+	.wptv-hero .secondary-videos .video-thumbnail img {
+		width: 100%;
+		height: auto;
+	}
 }


### PR DESCRIPTION
Trac ticket: [#7079](https://meta.trac.wordpress.org/ticket/7079)

### Issue
In mobile version grid section width is not proper. It looks like too little grid. It should be full width.

### Fixed
added some css to max-width:400px to fix the issue in mobile. Tested in Browser and all okay.