### PR TITLE
Change "MySQL Version" heading on wp.org

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-main/page-about-stats.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-main/page-about-stats.php
@@ -47,7 +47,7 @@ the_post();
 						<div id="php_versions" class="wporg-stats-chart loading"></div>
 					</section>
 					<section>
-						<h2><?php esc_html_e( 'MySQL Version', 'wporg' ); ?> <a class="swap-table dashicons dashicons-editor-table" title="<?php esc_attr_e( 'View as Table', 'wporg' ); ?>" aria-hidden="true"></a></h2>
+						<h2><?php esc_html_e( 'Database Version', 'wporg' ); ?> <a class="swap-table dashicons dashicons-editor-table" title="<?php esc_attr_e( 'View as Table', 'wporg' ); ?>" aria-hidden="true"></a></h2>
 						<div id="mysql_versions" class="wporg-stats-chart loading"></div>
 					</section>
 					<section>


### PR DESCRIPTION
This data includes databases other than MySQL and potentially could include more non-MySQL databases in the future. I have therefore changed it to "Database Version" here.

Trac ticket: [#7106](https://meta.trac.wordpress.org/ticket/7106)