### PR TITLE
Translate: Add translation errors for translate.w.org

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-custom-errors/wporg-gp-custom-errors.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-custom-errors/wporg-gp-custom-errors.php
@@ -127,7 +127,7 @@ class WPorg_GP_Custom_Translation_Errors {
 	 * @param GP_Locale   $locale      The locale.
 	 * @return string|true The error message or true if no error.
 	 */
-	public function error_unexepected_slug( $original, $translation, $gp_original, $locale ) {
+	public function error_unexpected_slug( $original, $translation, $gp_original, $locale ) {
 		if ( ! $this->is_core_project( $gp_original ) ) {
 			return true;
 		}

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-custom-errors/wporg-gp-custom-errors.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-custom-errors/wporg-gp-custom-errors.php
@@ -38,8 +38,6 @@ class WPorg_GP_Custom_Translation_Errors {
 	 * @return bool
 	 */
 	public function is_core_project( GP_Original $gp_original ): bool {
-		// todo: change it.
-		return true;
 		$project = GP::$project->get( $gp_original->project_id );
 
 		if ( self::WORPRESS_CORE_PROJECT_ID == $project->parent_project_id ) {

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-custom-errors/wporg-gp-custom-errors.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-custom-errors/wporg-gp-custom-errors.php
@@ -155,6 +155,39 @@ class WPorg_GP_Custom_Translation_Errors {
 			sanitize_title( $translation )
 		);
 	}
+
+	/**
+	 * Adds an error for unexpected date formats.
+	 *
+	 * @param string      $original    The original string.
+	 * @param string      $translation The translated string.
+	 * @param GP_Original $gp_original The GP_original object.
+	 * @param GP_Locale   $locale      The locale.
+	 * @return string|true The error message or true if no error.
+	 */
+	public function error_timezone_date_format( $original, $translation, $gp_original, $locale ) {
+		if ( ! $this->is_core_project( $gp_original ) ) {
+			return true;
+		}
+		if ( is_null( $gp_original->context ) ) {
+			return true;
+		}
+		if ( ! str_contains( $gp_original->context, 'timezone date format' ) ) {
+			return true;
+		}
+
+		$date_time = DateTime::createFromFormat( $translation, gmdate( $translation ) );
+		if ( $date_time ) {
+			return true;
+		}
+
+		$spaces_present = $translation !== trim( $translation );
+		if ( $spaces_present ) {
+			return esc_html__( 'The translation has empty spaces, new lines or another similar elements.', 'glotpress' );
+		}
+
+		return esc_html__( 'Must be a valid timezone date format.', 'glotpress' );
+	}
 }
 
 /**

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-custom-errors/wporg-gp-custom-errors.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-custom-errors/wporg-gp-custom-errors.php
@@ -39,6 +39,7 @@ class WPorg_GP_Custom_Translation_Errors {
 	 */
 	public function is_core_project( GP_Original $gp_original ): bool {
 		$project = GP::$project->get( $gp_original->project_id );
+		$project = GP::$project->get( $project->parent_project_id );
 
 		if ( self::WORPRESS_CORE_PROJECT_ID == $project->parent_project_id ) {
 			return true;

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-custom-errors/wporg-gp-custom-errors.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-custom-errors/wporg-gp-custom-errors.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Plugin name: GlotPress: Custom Translation Errors
+ * Description: Provides custom translation errors.
+ * Version:     1.0
+ * Author:      WordPress.org
+ * Author URI:  http://wordpress.org/
+ * License:     GPLv2 or later
+ */
+class WPorg_GP_Custom_Translation_Errors {
+	/**
+	 * The parent WordPress core project ID.
+	 *
+	 * @var int
+	 */
+	const WORPRESS_CORE_PROJECT_ID = 1;
+
+	/**
+	 * Registers all methods starting with error_ with GlotPress.
+	 */
+	public function __construct() {
+		$errors = array_filter(
+			get_class_methods( get_class( $this ) ),
+			function ( $key ) {
+				return gp_startswith( $key, 'error_' );
+			}
+		);
+
+		foreach ( $errors as $error ) {
+			GP::$translation_errors->add( str_replace( 'error_', '', $error ), array( $this, $error ) );
+		}
+	}
+
+	/**
+	 * Checks if the project is a WordPress core project.
+	 *
+	 * @param GP_Original $gp_original The GP_original object.
+	 * @return bool
+	 */
+	public function is_core_project( GP_Original $gp_original ): bool {
+		// todo: change it.
+		return true;
+		$project = GP::$project->get( $gp_original->project_id );
+
+		if ( self::WORPRESS_CORE_PROJECT_ID == $project->parent_project_id ) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	/**
+	 * Adds an error for unexpected timezone strings.
+	 *
+	 * Must be either a valid integer offset (-12 to 14) or a valid timezone string (America/New_York)
+	 *
+	 * @param string      $original    The original string.
+	 * @param string      $translation The translated string.
+	 * @param GP_Original $gp_original The GP_original object.
+	 * @param GP_Locale   $locale      The locale.
+	 * @return string|true The error message or true if no error.
+	 */
+	public function error_unexpected_timezone( $original, $translation, $gp_original, $locale ) {
+		if ( ! $this->is_core_project( $gp_original ) ) {
+			return true;
+		}
+		if ( is_null( $gp_original->context ) ) {
+			return true;
+		}
+		if ( ! str_contains( $gp_original->context, 'default GMT offset or timezone string' ) ) {
+			return true;
+		}
+		$spaces_present = $translation !== trim( $translation );
+		// Must be either a valid offset (-12 to 14).
+		if ( is_numeric( $translation ) && floor( $translation ) == $translation && ! $spaces_present && $translation >= -12 && $translation <= 14 ) {
+			// Countries with half-hour offsets or similar need to use a timezone string.
+			return true;
+		}
+		// Or a valid timezone string (America/New_York).
+		if ( in_array( $translation, timezone_identifiers_list() ) ) {
+			return true;
+		}
+		if ( $spaces_present ) {
+			return esc_html__( 'The translation has empty spaces, new lines or another similar elements.', 'glotpress' );
+		}
+
+		return esc_html__( 'Must be either a valid integer offset (-12 to 14) or a valid timezone string (America/New_York).', 'glotpress' );
+	}
+
+	/**
+	 * Adds an error for unexpected start of week number.
+	 *
+	 * It should be 0, 1 or 6.
+	 *
+	 * @param string      $original    The original string.
+	 * @param string      $translation The translated string.
+	 * @param GP_Original $gp_original The GP_original object.
+	 * @param GP_Locale   $locale      The locale.
+	 * @return string|true The error message or true if no error.
+	 */
+	public function error_unexpected_start_of_week_number( $original, $translation, $gp_original, $locale ) {
+		if ( ! $this->is_core_project( $gp_original ) ) {
+			return true;
+		}
+		if ( is_null( $gp_original->context ) ) {
+			return true;
+		}
+		if ( ! str_contains( $gp_original->context, 'start of week' ) ) {
+			return true;
+		}
+		$spaces_present = $translation !== trim( $translation );
+		if ( is_numeric( $translation ) && ! $spaces_present && ( $translation == 0 || $translation == 1 || $translation == 6 ) ) {
+			return true;
+		}
+		if ( $spaces_present ) {
+			return esc_html__( 'The translation has empty spaces, new lines or another similar elements.', 'glotpress' );
+		}
+
+		return esc_html__( 'Must be one of the following integers: 0, 1, or 6.', 'glotpress' );
+	}
+
+	/**
+	 * Adds an error for unexpected slug format.
+	 *
+	 * @param string      $original    The original string.
+	 * @param string      $translation The translated string.
+	 * @param GP_Original $gp_original The GP_original object.
+	 * @param GP_Locale   $locale      The locale.
+	 * @return string|true The error message or true if no error.
+	 */
+	public function error_unexepected_slug( $original, $translation, $gp_original, $locale ) {
+		if ( ! $this->is_core_project( $gp_original ) ) {
+			return true;
+		}
+		if ( is_null( $gp_original->context ) ) {
+			return true;
+		}
+		if ( ! (
+			str_contains( $gp_original->context, 'Default post slug' ) ||
+			str_contains( $gp_original->context, 'sample permalink structure' )
+		) ) {
+			return true;
+		}
+		$spaces_present = $translation !== trim( $translation );
+		if ( $translation == sanitize_title( $translation ) ) {
+			return true;
+		}
+
+		if ( $spaces_present ) {
+			return esc_html__( 'The translation has empty spaces, new lines or another similar elements.', 'glotpress' );
+		}
+
+		return sprintf(
+		/* translators: %1$s: The slug made with the translation suggested. */
+			esc_html__( 'Must be a slug, like %1$s.', 'glotpress' ),
+			sanitize_title( $translation )
+		);
+	}
+}
+
+/**
+ * Returns the instance of the WPorg_GP_Custom_Translation_Errors class.
+ *
+ * @return WPorg_GP_Custom_Translation_Errors
+ */
+function wporg_gp_custom_translation_errors() {
+	 global $wporg_gp_custom_translation_errors;
+
+	if ( ! isset( $wporg_gp_custom_translation_errors ) ) {
+		$wporg_gp_custom_translation_errors = new WPorg_GP_Custom_Translation_Errors();
+	}
+
+	return $wporg_gp_custom_translation_errors;
+}
+
+add_action( 'plugins_loaded', 'wporg_gp_custom_translation_errors' );

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-custom-errors/wporg-gp-custom-errors.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-custom-errors/wporg-gp-custom-errors.php
@@ -65,7 +65,7 @@ class WPorg_GP_Custom_Translation_Errors {
 		if ( is_null( $gp_original->context ) ) {
 			return true;
 		}
-		if ( ! str_contains( $gp_original->context, 'default GMT offset or timezone string' ) ) {
+		if ( strpos( $gp_original->context, 'default GMT offset or timezone string' ) === false ) {
 			return true;
 		}
 		$spaces_present = $translation !== trim( $translation );
@@ -103,7 +103,7 @@ class WPorg_GP_Custom_Translation_Errors {
 		if ( is_null( $gp_original->context ) ) {
 			return true;
 		}
-		if ( ! str_contains( $gp_original->context, 'start of week' ) ) {
+		if ( strpos( $gp_original->context, 'start of week' ) === false ) {
 			return true;
 		}
 		$spaces_present = $translation !== trim( $translation );
@@ -133,10 +133,10 @@ class WPorg_GP_Custom_Translation_Errors {
 		if ( is_null( $gp_original->context ) ) {
 			return true;
 		}
-		if ( ! (
-			str_contains( $gp_original->context, 'Default post slug' ) ||
-			str_contains( $gp_original->context, 'sample permalink structure' )
-		) ) {
+		if (
+			strpos( $gp_original->context, 'Default post slug' ) === false &&
+			strpos( $gp_original->context, 'sample permalink structure' ) === false
+		) {
 			return true;
 		}
 		$spaces_present = $translation !== trim( $translation );


### PR DESCRIPTION
## Problem
<!--
Please, describe what is the status/problem before the PR.
-->

We have some situations where we don't check some translations or if we check it, we return a warning, that can be dismissed by the translator, so the translators can add incorrect, and sometimes, dangerous translations. We address this problem at the GlotPress core, in [this PR](https://github.com/GlotPress/GlotPress/pull/1644), but some checks are very specific to the WordPress core, so it doesn't make sense to add them in the GlotPress core, so we add them only for [translate.wordpress.org](https://translate.wordpress.org/).

## Solution
<!--
Please, describe how this PR improves the situation.
-->

This PR adds a new plugin, who depends on the new classes added in [this PR](https://github.com/GlotPress/GlotPress/pull/1644), that adds some new error checks for the WordPress core:
- **Adds an error for unexpected timezone strings**. Must be either a valid offset (-12 to 14) or a valid timezone string (America/New_York).
- **Adds an error for unexpected start of week number**. Default start of the week. 0 = Sunday, 1 = Monday, 6 = Saturday. Be advised that the translation core comments says that this value only should be 0 or 1 (Sunday or Monday), but we have some countries who start the week on Saturday (6). More information [here](https://www.timeanddate.com/calendar/days/first-day-of-the-week.html). It looks like [Maldives starts on Friday](https://en.wikipedia.org/wiki/Week), but currently we don't support any language for this island.
- **Adds an error for unexpected slug format**.
- **Adds an error for unexpected timezone date format**. Date and time format for exact current time, mainly about timezones, see https://www.php.net/manual/datetime.format.php


In the future, this approach will do to add a new error a trivial action, because the developer will only need to add a new method with the checks.

**Important**: to release the first version of this plugin, we need to deploy before [this PR](https://github.com/GlotPress/GlotPress/pull/1644). 

## To-do
<!--
Please, describe the other undone tasks or items on the to-do list for this PR,
only if it is applicable.
-->
- [ ] Add more error checks for the WordPress core.

## Testing Instructions
<!-- 
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
Please, include step-by-step instructions on how to test this PR:
1. Open a original string in a project.
2. Add the translation.
3. etc. 
-->
Before start testing, switch GlotPress to [this branch](https://github.com/GlotPress/GlotPress/pull/1644) in your testing environment. 

The new plugin needs to be activated through code while testing. If you are using some mu-plugin to force the load of this plugin, please, increase the priority of this mu-plugin (with a low number in the `add_action( 'plugins_loaded',);` function, because this new plugin uses the same hook and you could have problems with this.


### Testing "Adds an error for unexpected timezone strings"

1. Look for a string with this context in the core: "default GMT offset or timezone string". [Here](https://translate.wordpress.org/projects/wp/dev/admin/art-xemoji/default/?filters%5Boriginal_id%5D=40444) you have one string. 
2. Try to add an incorrect number (-13 or 15), a random text (e.g. "asdf"), or an incorrect timezone (Europa/Madrid, the good one is Europe/Madrid) to see the error.
3. Try to add a correct number (-5, 0 or 5, a number between -12 and 14) or a timezone (e.g., Europe/Madrid) to get the translation suggestion added.

![image](https://github.com/WordPress/wordpress.org/assets/1667814/b2dde303-af7f-4274-a74c-a2e5f522b65c)

### Testing "Adds an error for unexpected start of week number"

1. Look for a string with this context in the core: "start of week". [Here](https://translate.wordpress.org/projects/wp/dev/admin/art-xemoji/default/?filters%5Boriginal_id%5D=40445) you have one string. 
2. Try to add an incorrect number (3), or a random text (e.g. "asdf")  to see the error.
3. Try to add a correct number (0, 1, 6) to get the translation suggestion added.

![image](https://github.com/WordPress/wordpress.org/assets/1667814/cc76f28b-2d77-470a-8bf2-4b6d69fa2565)

### Testing "Adds an error for unexpected slug format"

1. Look for a string with this context in the core: "Default post slug" or "sample permalink structure". [Here](https://translate.wordpress.org/projects/wp/dev/admin/art-xemoji/default/?filters%5Boriginal_id%5D=1405) and [here](https://translate.wordpress.org/projects/wp/dev/admin/art-xemoji/default/?filters%5Boriginal_id%5D=26155) you have two strings. 
2. Try to add an incorrect slug ("incorrect  slug") to see the error.
3. Try to add a correct slug ("ola-mundo") to get the translation suggestion added.

![image](https://github.com/WordPress/wordpress.org/assets/1667814/2194d92b-5c9b-4655-88d7-9caa63a349f9)

### Testing "Adds an error for unexpected timezone date format"

Currently, we have these translations:
- Y-m-d H:i:s -> 2023-06-29 18:04:46 -> 73 languages like English (Australia), Japanese, Polish, Portuguese.
- d-m-Y H:i:s -> 29-06-2023 18:05:10 -> 24 languages like Arabic, a few Spanish variants, Hindi, Dutch.
- d.m.Y H:i:s -> 29.06.2023 18:05:24 -> 6 languages like Bulgarian, Norwegian, Russian.
- d/m/Y H:i:s -> 29/06/2023 18:09:32 -> 3 languages like Catalan, Spanish (Chile), Portuguese (Brazil).
- j. n. Y G:i:s -> 29. 6. 2023 18:09:50 -> Czech.
- j.n.Y G:i:s -> 29.6.2023 18:10:09 -> German and its variants.
- j.m.Y G:i:s -> 29.06.2023 18:10:28 -> Lower Sorbian and Upper Sorbian.
- j F Y H:i -> 29 June 2023 18:10 -> English (UK).
- d.m.Y h:i -> 29.06.2023 06:22 -> Estonian.
- A-m-d H:i:s -> PM-06-29 18:23:23 -> Friulian (This translation is incorrect, because it throws an error).

1. Look for a string with this context in the core: "timezone date format". [Here](https://translate.wordpress.org/projects/wp/dev/admin/art-xemoji/default/?filters%5Boriginal_id%5D=216367) you have one string. 
2. Try to add an incorrect date format ("A-m-d H:i:s") to see the error.
3. Try to add a correct format ("J.m.Y G:i:s") to get the translation suggestion added.

![image](https://github.com/WordPress/wordpress.org/assets/1667814/757a8b46-3d05-49fb-96a8-6ae095f13d98)
