### PR TITLE
Remove extra AJAX call and replace with AJAX prefilter

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/class-plugin.php
@@ -195,26 +195,24 @@ class Plugin {
 	 * @param object $translation Created translation.
 	 */
 	public function update_external_translations( $translation ) {
-		if ( 'GP_Route_Translation' === GP::$current_route->class_name ) {
-			if ( 'translations_post' === GP::$current_route->last_method_called ) {
-				if ( isset( $_POST['openAITranslationsUsed'] ) ) {
-					Translation_Memory::update_one_external_translation(
-						$translation->translation_0,
-						$_POST['openAITranslationsUsed'],
-						'openai_translations_used',
-						'openai_same_translations_used',
-						'openai',
-					);
-				}
-				if ( isset( $_POST['deeplTranslationsUsed'] ) ) {
-					Translation_Memory::update_one_external_translation(
-						$translation->translation_0,
-						$_POST['deeplTranslationsUsed'],
-						'deepl_translations_used',
-						'deepl_same_translations_used',
-						'deepl',
-					);
-				}
+		if ( 'GP_Route_Translation' === GP::$current_route->class_name && 'translations_post' === GP::$current_route->last_method_called ) {
+			if ( isset( $_POST['openAITranslationsUsed'] ) && $translation ) {
+				Translation_Memory::update_one_external_translation(
+					$translation->translation_0,
+					$_POST['openAITranslationsUsed'],
+					'openai_translations_used',
+					'openai_same_translations_used',
+					'openai',
+				);
+			}
+			if ( isset( $_POST['deeplTranslationsUsed'] ) && $translation ) {
+				Translation_Memory::update_one_external_translation(
+					$translation->translation_0,
+					$_POST['deeplTranslationsUsed'],
+					'deepl_translations_used',
+					'deepl_same_translations_used',
+					'deepl',
+				);
 			}
 		}
 	}

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/class-plugin.php
@@ -196,7 +196,7 @@ class Plugin {
 	 */
 	public function update_external_translations( $translation ) {
 		if ( 'GP_Route_Translation' === GP::$current_route->class_name && 'translations_post' === GP::$current_route->last_method_called ) {
-			if ( isset( $_POST['openAITranslationsUsed'] ) && $translation ) {
+			if ( isset( $_POST['openAITranslationsUsed'] ) && 'openai' == $_POST['openAITranslationsUsed'] && $translation ) {
 				Translation_Memory::update_one_external_translation(
 					$translation->translation_0,
 					$_POST['openAITranslationsUsed'],
@@ -205,7 +205,7 @@ class Plugin {
 					'openai',
 				);
 			}
-			if ( isset( $_POST['deeplTranslationsUsed'] ) && $translation ) {
+			if ( isset( $_POST['deeplTranslationsUsed'] ) && 'deepl' == $_POST['deeplTranslationsUsed'] && $translation ) {
 				Translation_Memory::update_one_external_translation(
 					$translation->translation_0,
 					$_POST['deeplTranslationsUsed'],

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/class-plugin.php
@@ -204,7 +204,6 @@ class Plugin {
 				$_POST['openAITranslationsUsed'],
 				'openai_translations_used',
 				'openai_same_translations_used',
-				'openai',
 			);
 		}
 		if ( isset( $_POST['deeplTranslationsUsed'] ) && 'deepl' == $_POST['deeplTranslationsUsed'] ) {
@@ -213,7 +212,6 @@ class Plugin {
 				$_POST['deeplTranslationsUsed'],
 				'deepl_translations_used',
 				'deepl_same_translations_used',
-				'deepl',
 			);
 		}
 	}

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/class-plugin.php
@@ -195,25 +195,26 @@ class Plugin {
 	 * @param object $translation Created translation.
 	 */
 	public function update_external_translations( $translation ) {
-		if ( 'GP_Route_Translation' === GP::$current_route->class_name && 'translations_post' === GP::$current_route->last_method_called ) {
-			if ( isset( $_POST['openAITranslationsUsed'] ) && 'openai' == $_POST['openAITranslationsUsed'] && $translation ) {
-				Translation_Memory::update_one_external_translation(
-					$translation->translation_0,
-					$_POST['openAITranslationsUsed'],
-					'openai_translations_used',
-					'openai_same_translations_used',
-					'openai',
-				);
-			}
-			if ( isset( $_POST['deeplTranslationsUsed'] ) && 'deepl' == $_POST['deeplTranslationsUsed'] && $translation ) {
-				Translation_Memory::update_one_external_translation(
-					$translation->translation_0,
-					$_POST['deeplTranslationsUsed'],
-					'deepl_translations_used',
-					'deepl_same_translations_used',
-					'deepl',
-				);
-			}
+		if ( 'GP_Route_Translation' !== GP::$current_route->class_name || 'translations_post' !== GP::$current_route->last_method_called || ! $translation ) {
+			return;
+		}
+		if ( isset( $_POST['openAITranslationsUsed'] ) && 'openai' == $_POST['openAITranslationsUsed'] ) {
+			Translation_Memory::update_one_external_translation(
+				$translation->translation_0,
+				$_POST['openAITranslationsUsed'],
+				'openai_translations_used',
+				'openai_same_translations_used',
+				'openai',
+			);
+		}
+		if ( isset( $_POST['deeplTranslationsUsed'] ) && 'deepl' == $_POST['deeplTranslationsUsed'] ) {
+			Translation_Memory::update_one_external_translation(
+				$translation->translation_0,
+				$_POST['deeplTranslationsUsed'],
+				'deepl_translations_used',
+				'deepl_same_translations_used',
+				'deepl',
+			);
 		}
 	}
 }

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/routes/class-translation-memory.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/routes/class-translation-memory.php
@@ -482,40 +482,6 @@ class Translation_Memory extends GP_Route {
 	}
 
 	/**
-	 * Updates the external translations used by each user.
-	 *
-	 * @return void
-	 */
-	public function update_external_translations() {
-		if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( $_POST['nonce'], 'wporg-editor-settings' ) ) {
-			wp_send_json_error( array( 'message' => esc_html__( 'Invalid nonce.', 'glotpress' ) ), 403 );
-		}
-		if ( ! isset( $_POST['translation'] ) ) {
-			wp_send_json_error( array( 'message' => esc_html__( 'Translation parameter is not present.', 'glotpress' ) ), 400 );
-		}
-		if ( ! isset( $_POST['openAITranslationsUsed'] ) && ! isset( $_POST['deeplTranslationsUsed'] ) ) {
-			wp_send_json_error( array( 'message' => esc_html__( 'Translation suggested parameter is not present.', 'glotpress' ) ), 400 );
-		}
-		if ( isset( $_POST['openAITranslationsUsed'] ) ) {
-			$this->update_one_external_translation(
-				$_POST['translation'],
-				$_POST['openAITranslationsUsed'],
-				'openai_translations_used',
-				'openai_same_translations_used'
-			);
-		}
-		if ( isset( $_POST['deeplTranslationsUsed'] ) ) {
-			$this->update_one_external_translation(
-				$_POST['translation'],
-				$_POST['deeplTranslationsUsed'],
-				'deepl_translations_used',
-				'deepl_same_translations_used'
-			);
-		}
-		wp_send_json_success();
-	}
-
-	/**
 	 * Updates an external translation used by each user.
 	 *
 	 * @param string $translation                     The translation.
@@ -525,7 +491,7 @@ class Translation_Memory extends GP_Route {
 	 *
 	 * @return void
 	 */
-	private function update_one_external_translation( string $translation, string $suggestion, string $external_translations_used, string $external_same_translations_used ) {
+	public static function update_one_external_translation( string $translation, string $suggestion, string $external_translations_used, string $external_same_translations_used ) {
 		$is_the_same_translation  = $translation == $suggestion;
 		$gp_external_translations = get_user_option( 'gp_external_translations' );
 		$translations_used        = gp_array_get( $gp_external_translations, $external_translations_used, 0 );

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/js/translation-suggestions.js
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/js/translation-suggestions.js
@@ -509,8 +509,6 @@
 
 	//Prefilter ajax requests to add external translations used to the request.
 	$.ajaxPrefilter( function ( options ) {
-		
-
 		let data = Object.fromEntries( new URLSearchParams( options.data ) );
 		let originalId = data.original_id;
 		if ( ! $openAITranslationsUsed[originalId] && ! $deeplTranslationsUsed[originalId] ) {

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/js/translation-suggestions.js
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/js/translation-suggestions.js
@@ -496,28 +496,18 @@
 		}
 	}
 
-	// Convert object to query params.
-	function convertObjectToQueryParam( object ) {
-		const params = new URLSearchParams();
-
-		Object.entries(object).forEach(([key, value]) => {
-		params.append(key, value);
-		});
-
-		return params.toString();
-	}
-
 	//Prefilter ajax requests to add external translations used to the request.
 	$.ajaxPrefilter( function ( options ) {
 		let data = Object.fromEntries( new URLSearchParams( options.data ) );
 		let originalId = data.original_id;
-		if ( ! $openAITranslationsUsed[originalId] && ! $deeplTranslationsUsed[originalId] ) {
+
+		const isExternalTranslationUsed = $openAITranslationsUsed[originalId] || $deeplTranslationsUsed[originalId];
+		if ( ! isExternalTranslationUsed ) {
 			return;
 		}
 		if ( 'POST' === options.type && $gp_editor_options.url === options.url ) {
-			data.openAITranslationsUsed = $openAITranslationsUsed[originalId];
-			data.deeplTranslationsUsed =  $deeplTranslationsUsed[originalId];
-			options.data = convertObjectToQueryParam( data );
+				options.data += ( $openAITranslationsUsed[originalId] ) ? '&openAITranslationsUsed=' + $openAITranslationsUsed[originalId] : '';
+				options.data += ( $openAITranslationsUsed[originalId] ) ? '&deeplTranslationsUsed=' + $deeplTranslationsUsed[originalId] : '';
 		}
 	});
 })( jQuery );


### PR DESCRIPTION
In this PR we remove the extra AJAX call that saves the external translations used and replace that with AJAX prefilter which modifies the payload to include external translations used.