### PR TITLE
Log the translation suggestion usage

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -67,6 +67,7 @@ class Plugin {
 		add_action( 'gp_translation_created', array( $this, 'auto_reject_replaced_suggestions' ) );
 		add_action( 'gp_translation_created', array( $this, 'log_translation_source' ) );
 		add_action( 'gp_translation_saved', array( $this, 'log_translation_source' ) );
+		add_action( 'gp_translations_imported', array( $this, 'log_imported_translations' ) );
 
 		add_filter( 'gp_for_translation_clauses', array( $this, 'allow_searching_for_no_author_translations' ), 10, 3 );
 
@@ -384,6 +385,24 @@ class Plugin {
 		$sql       .= implode( ', ', $sql_values );
 		$wpdb->query( $wpdb->prepare( $sql, $sql_vars ) );
 
+	}
+
+	/**
+	 * Logs imported translations.
+	 *
+	 * @return void
+	 */
+	public function log_imported_translations() {
+		global $wpdb;
+		foreach ( $this->imported_translation_ids as $translation_id ) {
+			$result = $wpdb->insert(
+				'translate_meta',
+				array(
+					'meta_key'   => $translation_id,
+					'meta_value' => 'import',
+				)
+			);
+		}
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -401,15 +401,17 @@ class Plugin {
 		$source = $this->imported_source;
 
 		$sql = 'INSERT INTO ' . $wpdb->gp_meta . ' (meta_key, meta_value) VALUES ';
-
+		$sql_vars = array();
 		$sql_values = array_map(
-			function( $value ) use ( $source ) {
-				return "($value, '$source')";
+			function( $value ) use ( $source, $sql_vars ) {
+				$sql_vars[] = $value;
+				$sql_vars[] = $source;
+				return '( %d, %s )';
 			},
 			$this->imported_translation_ids
 		);
 		$sql       .= implode( ', ', $sql_values );
-		$wpdb->query( $sql );
+		$wpdb->query( $wpdb->prepare( $sql, $sql_vars ) );
 
 	}
 

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -66,14 +66,12 @@ class Plugin {
 		add_filter( 'gp_translation_prepare_for_save', array( $this, 'auto_reject_already_rejected' ), 10, 2 );
 		add_action( 'gp_translation_created', array( $this, 'auto_reject_replaced_suggestions' ) );
 		add_action( 'gp_translation_created', array( $this, 'log_translation_source' ) );
-		add_action( 'gp_translation_saved', array( $this, 'log_translation_source' ) );
 
 		add_filter( 'gp_for_translation_clauses', array( $this, 'allow_searching_for_no_author_translations' ), 10, 3 );
 
 		add_filter( 'gp_custom_reasons', array( $this, 'get_custom_reasons' ), 10, 2 );
 
 		// Cron.
-<<<<<<< HEAD
 		add_filter( 'cron_schedules', [ $this, 'register_cron_schedules' ] );
 		add_action( 'init', [ $this, 'register_cron_events' ] );
 		add_action( 'wporg_translate_update_contributor_profile_badges', [ $this, 'update_contributor_profile_badges' ] );
@@ -81,12 +79,6 @@ class Plugin {
 		add_action( 'gp_translation_created', array( $this, 'log_translation_source' ) );
 		add_action( 'gp_translation_saved', array( $this, 'log_translation_source' ) );
 		add_action( 'gp_translations_imported', array( $this, 'log_imported_translations' ) );
-=======
-		add_filter( 'cron_schedules', array( $this, 'register_cron_schedules' ) );
-		add_action( 'init', array( $this, 'register_cron_events' ) );
-		add_action( 'wporg_translate_update_contributor_profile_badges', array( $this, 'update_contributor_profile_badges' ) );
-		add_action( 'wporg_translate_update_polyglots_stats', array( $this, 'update_polyglots_stats' ) );
->>>>>>> 8a7dfc8af (Save source in database when a translation is created or saved)
 
 		// Toolbar.
 		add_action( 'admin_bar_menu', array( $this, 'add_profile_settings_to_admin_bar' ) );
@@ -773,20 +765,5 @@ class Plugin {
 		$reasons = isset( $locale_reasons[ $locale ] ) ? $locale_reasons[ $locale ] : array();
 		return array_merge( $default_reasons, $reasons );
 	}
-<<<<<<< HEAD
-}
-=======
 
-	public function log_translation_source( $translation ) {
-		global $wpdb;
-		$translation_source = 'frontend'; // just a placeholder for now.
-		$result             = $wpdb->insert(
-			'translate_meta',
-			array(
-				'meta_key'   => $translation_id,
-				'meta_value' => $translation_source,
-			)
-		);
-	}
 }
->>>>>>> 8a7dfc8af (Save source in database when a translation is created or saved)

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -344,7 +344,7 @@ class Plugin {
 			$suggestion_used .= '_modified';
 		}
 		if ( $suggestion_used ) {
-			gp_update_meta( $translation->id, 'suggestionused', $suggestion_used, 'translation' );
+			gp_update_meta( $translation->id, 'suggestion-used', $suggestion_used, 'translation' );
 		}
 
 	}

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -330,20 +330,12 @@ class Plugin {
 					if ( isset( $_POST['openAITranslationsUsed'] ) ) {
 						$suggestion_source     = 'openai';
 						$suggested_translation = sanitize_text_field( $_POST['openAITranslationsUsed'] );
-<<<<<<< HEAD
 						$this->save_translation_suggestion_source( $translation, $suggested_translation, $suggestion_source );
-=======
-						$this->update_translation_source_meta( $translation, $suggested_translation, $suggestion_source );
->>>>>>> 6f4fd59a6 (Log source meta (openai or deepl))
 					}
 					if ( isset( $_POST['deeplTranslationsUsed'] ) ) {
 						$suggestion_source     = 'deepl';
 						$suggested_translation = sanitize_text_field( $_POST['deeplTranslationsUsed'] );
-<<<<<<< HEAD
 						$this->save_translation_suggestion_source( $translation, $suggested_translation, $suggestion_source );
-=======
-						$this->update_translation_source_meta( $translation, $suggested_translation, $suggestion_source );
->>>>>>> 6f4fd59a6 (Log source meta (openai or deepl))
 					}
 				}
 			}
@@ -354,11 +346,7 @@ class Plugin {
 	}
 
 	/**
-<<<<<<< HEAD
 	 * Save the source of a translation suggestion.
-=======
-	 * Updates translation source meta.
->>>>>>> 6f4fd59a6 (Log source meta (openai or deepl))
 	 *
 	 * @param object $translation Translation object.
 	 * @param string $suggested_translation Suggested translation string.
@@ -366,7 +354,6 @@ class Plugin {
 	 *
 	 * @return void
 	 */
-<<<<<<< HEAD
 	private function save_translation_suggestion_source( $translation, $suggested_translation, $suggestion_source ) {
 		$suggestion_used = $suggestion_source;
 		if ( $translation->translation_0 !== $suggested_translation ) {
@@ -374,18 +361,6 @@ class Plugin {
 		}
 		if ( $suggestion_used ) {
 			gp_update_meta( $translation->id, 'suggestion-used', $suggestion_used, 'translation' );
-=======
-	private function update_translation_source_meta( $translation, $suggested_translation, $suggestion_source ) {
-		$source_meta  = '';
-		$_translation = $translation->translation_0;
-		if ( $_translation === $suggested_translation ) {
-			$source_meta = $suggestion_source;
-		} else {
-			$source_meta = $suggestion_source . '_modified';
-		}
-		if ( $source_meta ) {
-			gp_update_meta( $translation->id, 'source_meta', $source_meta, 'translation' );
->>>>>>> 6f4fd59a6 (Log source meta (openai or deepl))
 		}
 
 	}

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -392,28 +392,6 @@ class Plugin {
 	}
 
 	/**
-	 * Logs imported translations.
-	 *
-	 * @return void
-	 */
-	public function log_imported_translations() {
-		global $wpdb;
-		$source = $this->imported_source;
-
-		$sql = 'INSERT INTO ' . $wpdb->gp_meta . ' (meta_key, meta_value) VALUES ';
-
-		$sql_values = array_map(
-			function( $value ) use ( $source ) {
-				return "($value, '$source')";
-			},
-			$this->imported_translation_ids
-		);
-		$sql       .= implode( ', ', $sql_values );
-		$wpdb->query( $sql );
-
-	}
-
-	/**
 	 * Auto-Rejects a translators submissions when the translator submits a replacement suggestion.
 	 *
 	 * @see https://github.com/GlotPress/GlotPress-WP/issues/889

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -316,14 +316,9 @@ class Plugin {
 			if ( 'translations_post' === GP::$current_route->last_method_called ) {
 				if ( isset( $_POST['translation_source'] ) && 'frontend' == $_POST['translation_source'] ) {
 					$source = 'frontend';
-					if ( isset( $_POST['openAITranslationsUsed'] ) ) {
-						$suggestion_source     = 'openai';
-						$suggested_translation = sanitize_text_field( $_POST['openAITranslationsUsed'] );
-						$this->save_translation_suggestion_source( $translation, $suggested_translation, $suggestion_source );
-					}
-					if ( isset( $_POST['deeplTranslationsUsed'] ) ) {
-						$suggestion_source     = 'deepl';
-						$suggested_translation = sanitize_text_field( $_POST['deeplTranslationsUsed'] );
+					if ( isset( $_POST['externalTranslationSource'] ) ) {
+						$suggestion_source     = sanitize_text_field( $_POST['externalTranslationSource'] );
+						$suggested_translation = sanitize_text_field( $_POST['externalTranslationUsed'] );
 						$this->save_translation_suggestion_source( $translation, $suggested_translation, $suggestion_source );
 					}
 				}

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -67,7 +67,6 @@ class Plugin {
 		add_action( 'gp_translation_created', array( $this, 'auto_reject_replaced_suggestions' ) );
 		add_action( 'gp_translation_created', array( $this, 'log_translation_source' ) );
 		add_action( 'gp_translation_saved', array( $this, 'log_translation_source' ) );
-		add_action( 'gp_translations_imported', array( $this, 'log_translation_source' ) );
 
 		add_filter( 'gp_for_translation_clauses', array( $this, 'allow_searching_for_no_author_translations' ), 10, 3 );
 

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -330,12 +330,20 @@ class Plugin {
 					if ( isset( $_POST['openAITranslationsUsed'] ) ) {
 						$suggestion_source     = 'openai';
 						$suggested_translation = sanitize_text_field( $_POST['openAITranslationsUsed'] );
+<<<<<<< HEAD
 						$this->save_translation_suggestion_source( $translation, $suggested_translation, $suggestion_source );
+=======
+						$this->update_translation_source_meta( $translation, $suggested_translation, $suggestion_source );
+>>>>>>> 6f4fd59a6 (Log source meta (openai or deepl))
 					}
 					if ( isset( $_POST['deeplTranslationsUsed'] ) ) {
 						$suggestion_source     = 'deepl';
 						$suggested_translation = sanitize_text_field( $_POST['deeplTranslationsUsed'] );
+<<<<<<< HEAD
 						$this->save_translation_suggestion_source( $translation, $suggested_translation, $suggestion_source );
+=======
+						$this->update_translation_source_meta( $translation, $suggested_translation, $suggestion_source );
+>>>>>>> 6f4fd59a6 (Log source meta (openai or deepl))
 					}
 				}
 			}
@@ -346,7 +354,11 @@ class Plugin {
 	}
 
 	/**
+<<<<<<< HEAD
 	 * Save the source of a translation suggestion.
+=======
+	 * Updates translation source meta.
+>>>>>>> 6f4fd59a6 (Log source meta (openai or deepl))
 	 *
 	 * @param object $translation Translation object.
 	 * @param string $suggested_translation Suggested translation string.
@@ -354,6 +366,7 @@ class Plugin {
 	 *
 	 * @return void
 	 */
+<<<<<<< HEAD
 	private function save_translation_suggestion_source( $translation, $suggested_translation, $suggestion_source ) {
 		$suggestion_used = $suggestion_source;
 		if ( $translation->translation_0 !== $suggested_translation ) {
@@ -361,6 +374,18 @@ class Plugin {
 		}
 		if ( $suggestion_used ) {
 			gp_update_meta( $translation->id, 'suggestion-used', $suggestion_used, 'translation' );
+=======
+	private function update_translation_source_meta( $translation, $suggested_translation, $suggestion_source ) {
+		$source_meta  = '';
+		$_translation = $translation->translation_0;
+		if ( $_translation === $suggested_translation ) {
+			$source_meta = $suggestion_source;
+		} else {
+			$source_meta = $suggestion_source . '_modified';
+		}
+		if ( $source_meta ) {
+			gp_update_meta( $translation->id, 'source_meta', $source_meta, 'translation' );
+>>>>>>> 6f4fd59a6 (Log source meta (openai or deepl))
 		}
 
 	}

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -344,7 +344,7 @@ class Plugin {
 			$suggestion_used .= '_modified';
 		}
 		if ( $suggestion_used ) {
-			gp_update_meta( $translation->id, 'suggestion-used', $suggestion_used, 'translation' );
+			gp_update_meta( $translation->id, 'suggestion_used', $suggestion_used, 'translation' );
 		}
 
 	}

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -344,7 +344,7 @@ class Plugin {
 			$suggestion_used .= '_modified';
 		}
 		if ( $suggestion_used ) {
-			gp_update_meta( $translation->id, 'suggestion-used', $suggestion_used, 'translation' );
+			gp_update_meta( $translation->id, 'suggestionused', $suggestion_used, 'translation' );
 		}
 
 	}

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -67,6 +67,7 @@ class Plugin {
 		add_action( 'gp_translation_created', array( $this, 'auto_reject_replaced_suggestions' ) );
 		add_action( 'gp_translation_created', array( $this, 'log_translation_source' ) );
 		add_action( 'gp_translation_saved', array( $this, 'log_translation_source' ) );
+		add_action( 'gp_translations_imported', array( $this, 'log_translation_source' ) );
 
 		add_filter( 'gp_for_translation_clauses', array( $this, 'allow_searching_for_no_author_translations' ), 10, 3 );
 

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -66,6 +66,7 @@ class Plugin {
 		add_filter( 'gp_translation_prepare_for_save', array( $this, 'auto_reject_already_rejected' ), 10, 2 );
 		add_action( 'gp_translation_created', array( $this, 'auto_reject_replaced_suggestions' ) );
 		add_action( 'gp_translation_created', array( $this, 'log_translation_source' ) );
+		add_action( 'gp_translation_saved', array( $this, 'log_translation_source' ) );
 
 		add_filter( 'gp_for_translation_clauses', array( $this, 'allow_searching_for_no_author_translations' ), 10, 3 );
 

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -400,18 +400,16 @@ class Plugin {
 		global $wpdb;
 		$source = $this->imported_source;
 
-		$sql = 'INSERT INTO ' . $wpdb->gp_meta . ' (object_type, object_id, meta_key, meta_value) VALUES ';
-		$sql_vars = array();
+		$sql = 'INSERT INTO ' . $wpdb->gp_meta . ' (meta_key, meta_value) VALUES ';
+
 		$sql_values = array_map(
-			function( $translation_id ) use ( $source, $sql_vars ) {
-				$sql_vars[] = $translation_id;
-				$sql_vars[] = $source;
-				return '( "translation", %d, "source", %s )';
+			function( $value ) use ( $source ) {
+				return "($value, '$source')";
 			},
 			$this->imported_translation_ids
 		);
 		$sql       .= implode( ', ', $sql_values );
-		$wpdb->query( $wpdb->prepare( $sql, $sql_vars ) );
+		$wpdb->query( $sql );
 
 	}
 

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -25,10 +25,6 @@ class Plugin {
 	 * @var string The source of translations that have been imported.
 	 */
 	private string $imported_source;
-<<<<<<< HEAD
-=======
-
->>>>>>> 23d0f9a17 (Generate sql statement and insert in database.)
 
 	/**
 	 * Returns always the same instance of this plugin.
@@ -69,9 +65,6 @@ class Plugin {
 
 		add_filter( 'gp_translation_prepare_for_save', array( $this, 'auto_reject_already_rejected' ), 10, 2 );
 		add_action( 'gp_translation_created', array( $this, 'auto_reject_replaced_suggestions' ) );
-		add_action( 'gp_translation_created', array( $this, 'log_translation_source' ) );
-		add_action( 'gp_translation_saved', array( $this, 'log_translation_source' ) );
-		add_action( 'gp_translations_imported', array( $this, 'log_imported_translations' ) );
 
 		add_filter( 'gp_for_translation_clauses', array( $this, 'allow_searching_for_no_author_translations' ), 10, 3 );
 
@@ -97,10 +90,10 @@ class Plugin {
 		// Load the API endpoints.
 		add_action( 'rest_api_init', array( __NAMESPACE__ . '\REST_API\Base', 'load_endpoints' ) );
 
-		// Locales\Serbian_Latin::init();
+		//Locales\Serbian_Latin::init();
 
 		// Correct `WP_Locale` for variant locales in project lists.
-		add_filter( 'gp_translation_sets_sort', array( $this, 'filter_gp_translation_sets_sort' ) );
+		add_filter( 'gp_translation_sets_sort', [ $this, 'filter_gp_translation_sets_sort' ] );
 
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			$this->register_cli_commands();
@@ -114,7 +107,7 @@ class Plugin {
 	 * @param string $slug Slug of a theme.
 	 * @return array Filtered WP-CLI arguments.
 	 */
-	public function set_version_for_default_themes_in_development( $args, $slug ) {
+	public function set_version_for_default_themes_in_development(  $args, $slug ) {
 		if ( 'twentytwentyone' !== $slug || ! empty( $args['version'] ) ) {
 			return $args;
 		}
@@ -184,17 +177,12 @@ class Plugin {
 			return;
 		}
 
-		$user_ids = $wpdb->get_col(
-			$wpdb->prepare(
-				"
+		$user_ids = $wpdb->get_col( $wpdb->prepare( "
 			SELECT user_id
 			FROM {$wpdb->user_translations_count}
 			WHERE accepted > 0 AND date_modified > %s
 			GROUP BY user_id
-		",
-				gmdate( 'Y-m-d H:i:s', $last_sync )
-			)
-		);
+		", gmdate( 'Y-m-d H:i:s', $last_sync ) ) );
 
 		if ( ! $user_ids ) {
 			update_option( 'wporg_translate_last_badges_sync', $now );
@@ -254,7 +242,7 @@ class Plugin {
 			// New translation being added.
 
 			$translation_set = GP::$translation_set->get( $args['translation_set_id'] );
-			$project         = GP::$project->get( $translation_set->project_id );
+			$project = GP::$project->get( $translation_set->project_id );
 
 			// If the current user can approve / write to the project, skip.
 			if (
@@ -280,7 +268,7 @@ class Plugin {
 			if ( $existing_rejected_translations ) {
 				$locale = GP_Locales::by_slug( $translation_set->locale );
 
-				$translations = array();
+				$translations = [];
 				foreach ( range( 0, GP::$translation->get_static( 'number_of_plural_translations' ) - 1 ) as $i ) {
 					if ( isset( $args[ "translation_$i" ] ) ) {
 						$translations[] = $args[ "translation_$i" ];
@@ -293,6 +281,7 @@ class Plugin {
 					}
 				}
 			}
+
 		}
 
 		return $args;
@@ -405,7 +394,7 @@ class Plugin {
 		}
 
 		$translation_set = GP::$translation_set->get( $translation->translation_set_id );
-		$project         = GP::$project->get( $translation_set->project_id );
+		$project = GP::$project->get( $translation_set->project_id );
 
 		// If the current user can approve / write to the project, skip. Probably not needed due to the `waiting` check above.
 		if (
@@ -445,14 +434,14 @@ class Plugin {
 	 */
 	function allow_searching_for_no_author_translations( $clauses, $set, $filters ) {
 		$user_login = gp_array_get( $filters, 'user_login' );
-
+	
 		if ( '0' === $user_login ) {
 			$clauses['where'] .= ( $clauses['where'] ? ' AND' : '' ) . ' t.user_id = 0';
 		} elseif ( 'anonymous' === $user_login ) {
 			// 'Anonymous' user exists, but has no translations.
 			$clauses['where'] = preg_replace( '/(user_id\s*=\s*\d+)/', 'user_id = 0', $clauses['where'] );
 		}
-
+	
 		return $clauses;
 	}
 
@@ -467,10 +456,10 @@ class Plugin {
 	 */
 	public function add_consistency_tool_link( $more_links, $project, $locale, $translation_set, $translation ) {
 		$consistency_tool_url = add_query_arg(
-			array(
+			[
 				'search' => urlencode( $translation->singular ),
 				'set'    => urlencode( $locale->slug . '/' . $translation_set->slug ),
-			),
+			],
 			home_url( '/consistency' )
 		);
 
@@ -513,14 +502,12 @@ class Plugin {
 		$logout_node = $wp_admin_bar->get_node( 'logout' );
 		$wp_admin_bar->remove_node( 'logout' );
 
-		$wp_admin_bar->add_node(
-			array(
-				'parent' => 'user-actions',
-				'id'     => 'gp-profile-settings',
-				'title'  => 'Translate Settings',
-				'href'   => gp_url( '/settings' ),
-			)
-		);
+		$wp_admin_bar->add_node( [
+			'parent' => 'user-actions',
+			'id'     => 'gp-profile-settings',
+			'title'  => 'Translate Settings',
+			'href'   => gp_url( '/settings' ),
+		] );
 
 		if ( $logout_node ) {
 			$wp_admin_bar->add_node( $logout_node ); // Ensures that logout is the last action.
@@ -537,10 +524,10 @@ class Plugin {
 			return;
 		}
 
-		$menu = array(
-			'id'   => 'log-in',
+		$menu = [
+			'id' => 'log-in',
 			'href' => wp_login_url( gp_url_current() ),
-		);
+		];
 		$wp_admin_bar->add_menu( $menu );
 	}
 
@@ -606,14 +593,14 @@ class Plugin {
 	 */
 	public function bump_assets_versions() {
 		$scripts = wp_scripts();
-		foreach ( array( 'gp-common', 'gp-editor', 'gp-glossary', 'gp-translations-page', 'gp-mass-create-sets-page' ) as $handle ) {
+		foreach ( [ 'gp-common', 'gp-editor', 'gp-glossary', 'gp-translations-page', 'gp-mass-create-sets-page' ] as $handle ) {
 			if ( isset( $scripts->registered[ $handle ] ) ) {
 				$scripts->registered[ $handle ]->ver = $scripts->registered[ $handle ]->ver . '-1';
 			}
 		}
 
 		$styles = wp_styles();
-		foreach ( array( 'gp-base' ) as $handle ) {
+		foreach ( [ 'gp-base' ] as $handle ) {
 			if ( isset( $styles->registered[ $handle ] ) ) {
 				$styles->registered[ $handle ]->ver = $styles->registered[ $handle ]->ver . '-1';
 			}
@@ -663,29 +650,23 @@ class Plugin {
 	 */
 	public function natural_sort_projects( $sub_projects, $parent_id ) {
 		if ( in_array( $parent_id, array( 1, 13, 58 ) ) ) { // 1 = WordPress, 13 = BuddyPress, 58 = bbPress
-			usort(
-				$sub_projects,
-				function( $a, $b ) {
-					return - strcasecmp( $a->name, $b->name );
-				}
-			);
+			usort( $sub_projects, function( $a, $b ) {
+				return - strcasecmp( $a->name, $b->name );
+			} );
 		}
 
 		if ( in_array( $parent_id, array( 17, 523 ) ) ) { // 17 = Plugins, 523 = Themes
-			usort(
-				$sub_projects,
-				function( $a, $b ) {
-					return strcasecmp( $a->name, $b->name );
-				}
-			);
+			usort( $sub_projects, function( $a, $b ) {
+				return strcasecmp( $a->name, $b->name );
+			} );
 		}
 
 		// Attach wp-themes meta keys
 		if ( 523 == $parent_id ) {
 			foreach ( $sub_projects as $project ) {
 				$project->non_db_field_names = array_merge( $project->non_db_field_names, array( 'version', 'screenshot' ) );
-				$project->version            = gp_get_meta( 'wp-themes', $project->id, 'version' );
-				$project->screenshot         = esc_url( gp_get_meta( 'wp-themes', $project->id, 'screenshot' ) );
+				$project->version = gp_get_meta( 'wp-themes', $project->id, 'version' );
+				$project->screenshot = esc_url( gp_get_meta( 'wp-themes', $project->id, 'screenshot' ) );
 			}
 		}
 
@@ -702,7 +683,7 @@ class Plugin {
 	function localize_links( $content, $wp_locale ) {
 		global $wpdb;
 
-		static $subdomains = array();
+		static $subdomains = [];
 		if ( ! isset( $subdomains[ $wp_locale ] ) ) {
 			$subdomains[ $wp_locale ] = $wpdb->get_var( $wpdb->prepare( 'SELECT subdomain FROM wporg_locales WHERE locale = %s LIMIT 1', $wp_locale ) );
 		}
@@ -771,5 +752,4 @@ class Plugin {
 		$reasons = isset( $locale_reasons[ $locale ] ) ? $locale_reasons[ $locale ] : array();
 		return array_merge( $default_reasons, $reasons );
 	}
-
 }

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -65,12 +65,15 @@ class Plugin {
 
 		add_filter( 'gp_translation_prepare_for_save', array( $this, 'auto_reject_already_rejected' ), 10, 2 );
 		add_action( 'gp_translation_created', array( $this, 'auto_reject_replaced_suggestions' ) );
+		add_action( 'gp_translation_created', array( $this, 'log_translation_source' ) );
+		add_action( 'gp_translation_saved', array( $this, 'log_translation_source' ) );
 
 		add_filter( 'gp_for_translation_clauses', array( $this, 'allow_searching_for_no_author_translations' ), 10, 3 );
 
 		add_filter( 'gp_custom_reasons', array( $this, 'get_custom_reasons' ), 10, 2 );
 
 		// Cron.
+<<<<<<< HEAD
 		add_filter( 'cron_schedules', [ $this, 'register_cron_schedules' ] );
 		add_action( 'init', [ $this, 'register_cron_events' ] );
 		add_action( 'wporg_translate_update_contributor_profile_badges', [ $this, 'update_contributor_profile_badges' ] );
@@ -78,6 +81,12 @@ class Plugin {
 		add_action( 'gp_translation_created', array( $this, 'log_translation_source' ) );
 		add_action( 'gp_translation_saved', array( $this, 'log_translation_source' ) );
 		add_action( 'gp_translations_imported', array( $this, 'log_imported_translations' ) );
+=======
+		add_filter( 'cron_schedules', array( $this, 'register_cron_schedules' ) );
+		add_action( 'init', array( $this, 'register_cron_events' ) );
+		add_action( 'wporg_translate_update_contributor_profile_badges', array( $this, 'update_contributor_profile_badges' ) );
+		add_action( 'wporg_translate_update_polyglots_stats', array( $this, 'update_polyglots_stats' ) );
+>>>>>>> 8a7dfc8af (Save source in database when a translation is created or saved)
 
 		// Toolbar.
 		add_action( 'admin_bar_menu', array( $this, 'add_profile_settings_to_admin_bar' ) );
@@ -90,10 +99,10 @@ class Plugin {
 		// Load the API endpoints.
 		add_action( 'rest_api_init', array( __NAMESPACE__ . '\REST_API\Base', 'load_endpoints' ) );
 
-		//Locales\Serbian_Latin::init();
+		// Locales\Serbian_Latin::init();
 
 		// Correct `WP_Locale` for variant locales in project lists.
-		add_filter( 'gp_translation_sets_sort', [ $this, 'filter_gp_translation_sets_sort' ] );
+		add_filter( 'gp_translation_sets_sort', array( $this, 'filter_gp_translation_sets_sort' ) );
 
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			$this->register_cli_commands();
@@ -107,7 +116,7 @@ class Plugin {
 	 * @param string $slug Slug of a theme.
 	 * @return array Filtered WP-CLI arguments.
 	 */
-	public function set_version_for_default_themes_in_development(  $args, $slug ) {
+	public function set_version_for_default_themes_in_development( $args, $slug ) {
 		if ( 'twentytwentyone' !== $slug || ! empty( $args['version'] ) ) {
 			return $args;
 		}
@@ -177,12 +186,17 @@ class Plugin {
 			return;
 		}
 
-		$user_ids = $wpdb->get_col( $wpdb->prepare( "
+		$user_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"
 			SELECT user_id
 			FROM {$wpdb->user_translations_count}
 			WHERE accepted > 0 AND date_modified > %s
 			GROUP BY user_id
-		", gmdate( 'Y-m-d H:i:s', $last_sync ) ) );
+		",
+				gmdate( 'Y-m-d H:i:s', $last_sync )
+			)
+		);
 
 		if ( ! $user_ids ) {
 			update_option( 'wporg_translate_last_badges_sync', $now );
@@ -242,7 +256,7 @@ class Plugin {
 			// New translation being added.
 
 			$translation_set = GP::$translation_set->get( $args['translation_set_id'] );
-			$project = GP::$project->get( $translation_set->project_id );
+			$project         = GP::$project->get( $translation_set->project_id );
 
 			// If the current user can approve / write to the project, skip.
 			if (
@@ -268,7 +282,7 @@ class Plugin {
 			if ( $existing_rejected_translations ) {
 				$locale = GP_Locales::by_slug( $translation_set->locale );
 
-				$translations = [];
+				$translations = array();
 				foreach ( range( 0, GP::$translation->get_static( 'number_of_plural_translations' ) - 1 ) as $i ) {
 					if ( isset( $args[ "translation_$i" ] ) ) {
 						$translations[] = $args[ "translation_$i" ];
@@ -281,7 +295,6 @@ class Plugin {
 					}
 				}
 			}
-
 		}
 
 		return $args;
@@ -394,7 +407,7 @@ class Plugin {
 		}
 
 		$translation_set = GP::$translation_set->get( $translation->translation_set_id );
-		$project = GP::$project->get( $translation_set->project_id );
+		$project         = GP::$project->get( $translation_set->project_id );
 
 		// If the current user can approve / write to the project, skip. Probably not needed due to the `waiting` check above.
 		if (
@@ -434,14 +447,14 @@ class Plugin {
 	 */
 	function allow_searching_for_no_author_translations( $clauses, $set, $filters ) {
 		$user_login = gp_array_get( $filters, 'user_login' );
-	
+
 		if ( '0' === $user_login ) {
 			$clauses['where'] .= ( $clauses['where'] ? ' AND' : '' ) . ' t.user_id = 0';
 		} elseif ( 'anonymous' === $user_login ) {
 			// 'Anonymous' user exists, but has no translations.
 			$clauses['where'] = preg_replace( '/(user_id\s*=\s*\d+)/', 'user_id = 0', $clauses['where'] );
 		}
-	
+
 		return $clauses;
 	}
 
@@ -456,10 +469,10 @@ class Plugin {
 	 */
 	public function add_consistency_tool_link( $more_links, $project, $locale, $translation_set, $translation ) {
 		$consistency_tool_url = add_query_arg(
-			[
+			array(
 				'search' => urlencode( $translation->singular ),
 				'set'    => urlencode( $locale->slug . '/' . $translation_set->slug ),
-			],
+			),
 			home_url( '/consistency' )
 		);
 
@@ -502,12 +515,14 @@ class Plugin {
 		$logout_node = $wp_admin_bar->get_node( 'logout' );
 		$wp_admin_bar->remove_node( 'logout' );
 
-		$wp_admin_bar->add_node( [
-			'parent' => 'user-actions',
-			'id'     => 'gp-profile-settings',
-			'title'  => 'Translate Settings',
-			'href'   => gp_url( '/settings' ),
-		] );
+		$wp_admin_bar->add_node(
+			array(
+				'parent' => 'user-actions',
+				'id'     => 'gp-profile-settings',
+				'title'  => 'Translate Settings',
+				'href'   => gp_url( '/settings' ),
+			)
+		);
 
 		if ( $logout_node ) {
 			$wp_admin_bar->add_node( $logout_node ); // Ensures that logout is the last action.
@@ -524,10 +539,10 @@ class Plugin {
 			return;
 		}
 
-		$menu = [
-			'id' => 'log-in',
+		$menu = array(
+			'id'   => 'log-in',
 			'href' => wp_login_url( gp_url_current() ),
-		];
+		);
 		$wp_admin_bar->add_menu( $menu );
 	}
 
@@ -593,14 +608,14 @@ class Plugin {
 	 */
 	public function bump_assets_versions() {
 		$scripts = wp_scripts();
-		foreach ( [ 'gp-common', 'gp-editor', 'gp-glossary', 'gp-translations-page', 'gp-mass-create-sets-page' ] as $handle ) {
+		foreach ( array( 'gp-common', 'gp-editor', 'gp-glossary', 'gp-translations-page', 'gp-mass-create-sets-page' ) as $handle ) {
 			if ( isset( $scripts->registered[ $handle ] ) ) {
 				$scripts->registered[ $handle ]->ver = $scripts->registered[ $handle ]->ver . '-1';
 			}
 		}
 
 		$styles = wp_styles();
-		foreach ( [ 'gp-base' ] as $handle ) {
+		foreach ( array( 'gp-base' ) as $handle ) {
 			if ( isset( $styles->registered[ $handle ] ) ) {
 				$styles->registered[ $handle ]->ver = $styles->registered[ $handle ]->ver . '-1';
 			}
@@ -650,23 +665,29 @@ class Plugin {
 	 */
 	public function natural_sort_projects( $sub_projects, $parent_id ) {
 		if ( in_array( $parent_id, array( 1, 13, 58 ) ) ) { // 1 = WordPress, 13 = BuddyPress, 58 = bbPress
-			usort( $sub_projects, function( $a, $b ) {
-				return - strcasecmp( $a->name, $b->name );
-			} );
+			usort(
+				$sub_projects,
+				function( $a, $b ) {
+					return - strcasecmp( $a->name, $b->name );
+				}
+			);
 		}
 
 		if ( in_array( $parent_id, array( 17, 523 ) ) ) { // 17 = Plugins, 523 = Themes
-			usort( $sub_projects, function( $a, $b ) {
-				return strcasecmp( $a->name, $b->name );
-			} );
+			usort(
+				$sub_projects,
+				function( $a, $b ) {
+					return strcasecmp( $a->name, $b->name );
+				}
+			);
 		}
 
 		// Attach wp-themes meta keys
 		if ( 523 == $parent_id ) {
 			foreach ( $sub_projects as $project ) {
 				$project->non_db_field_names = array_merge( $project->non_db_field_names, array( 'version', 'screenshot' ) );
-				$project->version = gp_get_meta( 'wp-themes', $project->id, 'version' );
-				$project->screenshot = esc_url( gp_get_meta( 'wp-themes', $project->id, 'screenshot' ) );
+				$project->version            = gp_get_meta( 'wp-themes', $project->id, 'version' );
+				$project->screenshot         = esc_url( gp_get_meta( 'wp-themes', $project->id, 'screenshot' ) );
 			}
 		}
 
@@ -683,7 +704,7 @@ class Plugin {
 	function localize_links( $content, $wp_locale ) {
 		global $wpdb;
 
-		static $subdomains = [];
+		static $subdomains = array();
 		if ( ! isset( $subdomains[ $wp_locale ] ) ) {
 			$subdomains[ $wp_locale ] = $wpdb->get_var( $wpdb->prepare( 'SELECT subdomain FROM wporg_locales WHERE locale = %s LIMIT 1', $wp_locale ) );
 		}
@@ -752,4 +773,20 @@ class Plugin {
 		$reasons = isset( $locale_reasons[ $locale ] ) ? $locale_reasons[ $locale ] : array();
 		return array_merge( $default_reasons, $reasons );
 	}
+<<<<<<< HEAD
 }
+=======
+
+	public function log_translation_source( $translation ) {
+		global $wpdb;
+		$translation_source = 'frontend'; // just a placeholder for now.
+		$result             = $wpdb->insert(
+			'translate_meta',
+			array(
+				'meta_key'   => $translation_id,
+				'meta_value' => $translation_source,
+			)
+		);
+	}
+}
+>>>>>>> 8a7dfc8af (Save source in database when a translation is created or saved)

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -400,13 +400,13 @@ class Plugin {
 		global $wpdb;
 		$source = $this->imported_source;
 
-		$sql = 'INSERT INTO ' . $wpdb->gp_meta . ' (meta_key, meta_value) VALUES ';
+		$sql = 'INSERT INTO ' . $wpdb->gp_meta . ' (object_type, object_id, meta_key, meta_value) VALUES ';
 		$sql_vars = array();
 		$sql_values = array_map(
-			function( $value ) use ( $source, $sql_vars ) {
-				$sql_vars[] = $value;
+			function( $translation_id ) use ( $source, $sql_vars ) {
+				$sql_vars[] = $translation_id;
 				$sql_vars[] = $source;
-				return '( %d, %s )';
+				return '( "translation", %d, "source", %s )';
 			},
 			$this->imported_translation_ids
 		);

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -25,6 +25,10 @@ class Plugin {
 	 * @var string The source of translations that have been imported.
 	 */
 	private string $imported_source;
+<<<<<<< HEAD
+=======
+
+>>>>>>> 23d0f9a17 (Generate sql statement and insert in database.)
 
 	/**
 	 * Returns always the same instance of this plugin.
@@ -394,15 +398,19 @@ class Plugin {
 	 */
 	public function log_imported_translations() {
 		global $wpdb;
-		foreach ( $this->imported_translation_ids as $translation_id ) {
-			$result = $wpdb->insert(
-				'translate_meta',
-				array(
-					'meta_key'   => $translation_id,
-					'meta_value' => 'import',
-				)
-			);
-		}
+		$source = $this->imported_source;
+
+		$sql = 'INSERT INTO ' . $wpdb->gp_meta . ' (meta_key, meta_value) VALUES ';
+
+		$sql_values = array_map(
+			function( $value ) use ( $source ) {
+				return "($value, '$source')";
+			},
+			$this->imported_translation_ids
+		);
+		$sql       .= implode( ', ', $sql_values );
+		$wpdb->query( $sql );
+
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/js/editor.js
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/js/editor.js
@@ -98,14 +98,6 @@
 
 		if ( 'POST' === options.type && $gp_editor_options.url === options.url ) {
 			data.translation_source = 'frontend';
-			if ( $openAITranslationsUsed[ data.original_id ] ) {
-				data.translation_source = 'openai';
-				$openAITranslationsUsed.splice( [ data.original_id ] );
-			} 
-			if ( $deeplTranslationsUsed[ data.original_id ] ) {
-				data.translation_source = 'deepl';
-				$deeplTranslationsUsed.splice( [ data.original_id ] );
-			}
 			options.data = convertObjectToQueryParam( data );
 		}
 	});

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/js/editor.js
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/js/editor.js
@@ -97,8 +97,8 @@
 		let data = Object.fromEntries( new URLSearchParams( options.data ) );
 
 		if ( 'POST' === options.type && $gp_editor_options.url === options.url ) {
-			data.translation_source = 'frontend';
-			options.data = convertObjectToQueryParam( data );
+			options.data += '&translation_source=frontend';
+
 		}
 	});
 

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/js/editor.js
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/js/editor.js
@@ -81,70 +81,34 @@
 		}
 	});
 
-	// Override save function in GlotPress.
-	$gp.editor.save = function(button) {
-		
-		var editor, textareaName,
-					data = [],
-					translations,
-					source = 'frontend';
+	// Convert object to query params.
+	function convertObjectToQueryParam( object ) {
+		const params = new URLSearchParams();
 
-				if ( ! $gp.editor.current ) {
-					return;
-				}
+		Object.entries(object).forEach(([key, value]) => {
+		params.append(key, value);
+		});
 
-				editor = $gp.editor.current;
-				button.prop( 'disabled', true );
-				$gp.notices.notice( 'Saving&hellip;' );
-
-				if ( $openAITranslationsUsed[ editor.original_id ] ) {
-					source = 'openai';
-					$openAITranslationsUsed.splice( [ editor.original_id ] );
-				} 
-				if( $deeplTranslationsUsed[ editor.original_id ] ) {
-					source = 'deepl';
-					$deeplTranslationsUsed.splice( [ editor.original_id ] );
-				}
-
-				data = {
-					original_id: editor.original_id,
-					_gp_route_nonce: button.data( 'nonce' ),
-					translation_source: source,
-				};
-
-				textareaName = 'translation[' + editor.original_id + '][]';
-				translations = $( 'textarea[name="' + textareaName + '"]', editor ).map( function() {
-					return this.value;
-				} ).get();
-
-				data[ textareaName ] = translations;
-
-				$.ajax( {
-					type: 'POST',
-					url: $gp_editor_options.url,
-					data: data,
-					dataType: 'json',
-					success: function( response ) {
-						var original_id;
-
-						button.prop( 'disabled', false );
-						$gp.notices.success( 'Saved!' );
-
-						for ( original_id in response ) {
-							$gp.editor.replace_current( response[ original_id ] );
-						}
-
-						if ( $gp.editor.current.hasClass( 'no-warnings' ) ) {
-							$gp.editor.next();
-						}
-					},
-					error: function( xhr, msg ) {
-						button.prop( 'disabled', false );
-						msg = xhr.responseText ? 'Error: ' + xhr.responseText : 'Error saving the translation!';
-						$gp.notices.error( msg );
-					},
-				} );
+		return params.toString();
 	}
+
+	//Prefilter ajax requests to add translation_source to the request.
+	$.ajaxPrefilter( function ( options ) {
+		let data = Object.fromEntries( new URLSearchParams( options.data ) );
+
+		if ( 'POST' === options.type && $gp_editor_options.url === options.url ) {
+			data.translation_source = 'frontend';
+			if ( $openAITranslationsUsed[ data.original_id ] ) {
+				data.translation_source = 'openai';
+				$openAITranslationsUsed.splice( [ data.original_id ] );
+			} 
+			if ( $deeplTranslationsUsed[ data.original_id ] ) {
+				data.translation_source = 'deepl';
+				$deeplTranslationsUsed.splice( [ data.original_id ] );
+			}
+			options.data = convertObjectToQueryParam( data );
+		}
+	});
 
 	// Override functions to adopt custom markup.
 	$gp.editor.copy = function() {

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/js/editor.js
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/js/editor.js
@@ -81,27 +81,6 @@
 		}
 	});
 
-	// Convert object to query params.
-	function convertObjectToQueryParam( object ) {
-		const params = new URLSearchParams();
-
-		Object.entries(object).forEach(([key, value]) => {
-		params.append(key, value);
-		});
-
-		return params.toString();
-	}
-
-	//Prefilter ajax requests to add translation_source to the request.
-	$.ajaxPrefilter( function ( options ) {
-		let data = Object.fromEntries( new URLSearchParams( options.data ) );
-
-		if ( 'POST' === options.type && $gp_editor_options.url === options.url ) {
-			options.data += '&translation_source=frontend';
-
-		}
-	});
-
 	// Override functions to adopt custom markup.
 	$gp.editor.copy = function() {
 		var $activeTextarea = $gp.editor.current.find( '.textareas.active textarea' );

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/class-plugin.php
@@ -195,26 +195,24 @@ class Plugin {
 	 * @param object $translation Created translation.
 	 */
 	public function update_external_translations( $translation ) {
-		if ( 'GP_Route_Translation' === GP::$current_route->class_name ) {
-			if ( 'translations_post' === GP::$current_route->last_method_called ) {
-				if ( isset( $_POST['openAITranslationsUsed'] ) ) {
-					Translation_Memory::update_one_external_translation(
-						$translation->translation_0,
-						$_POST['openAITranslationsUsed'],
-						'openai_translations_used',
-						'openai_same_translations_used',
-						'openai',
-					);
-				}
-				if ( isset( $_POST['deeplTranslationsUsed'] ) ) {
-					Translation_Memory::update_one_external_translation(
-						$translation->translation_0,
-						$_POST['deeplTranslationsUsed'],
-						'deepl_translations_used',
-						'deepl_same_translations_used',
-						'deepl',
-					);
-				}
+		if ( 'GP_Route_Translation' === GP::$current_route->class_name && 'translations_post' === GP::$current_route->last_method_called ) {
+			if ( isset( $_POST['openAITranslationsUsed'] ) && $translation ) {
+				Translation_Memory::update_one_external_translation(
+					$translation->translation_0,
+					$_POST['openAITranslationsUsed'],
+					'openai_translations_used',
+					'openai_same_translations_used',
+					'openai',
+				);
+			}
+			if ( isset( $_POST['deeplTranslationsUsed'] ) && $translation ) {
+				Translation_Memory::update_one_external_translation(
+					$translation->translation_0,
+					$_POST['deeplTranslationsUsed'],
+					'deepl_translations_used',
+					'deepl_same_translations_used',
+					'deepl',
+				);
 			}
 		}
 	}

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/class-plugin.php
@@ -196,7 +196,7 @@ class Plugin {
 	 */
 	public function update_external_translations( $translation ) {
 		if ( 'GP_Route_Translation' === GP::$current_route->class_name && 'translations_post' === GP::$current_route->last_method_called ) {
-			if ( isset( $_POST['openAITranslationsUsed'] ) && $translation ) {
+			if ( isset( $_POST['openAITranslationsUsed'] ) && 'openai' == $_POST['openAITranslationsUsed'] && $translation ) {
 				Translation_Memory::update_one_external_translation(
 					$translation->translation_0,
 					$_POST['openAITranslationsUsed'],
@@ -205,7 +205,7 @@ class Plugin {
 					'openai',
 				);
 			}
-			if ( isset( $_POST['deeplTranslationsUsed'] ) && $translation ) {
+			if ( isset( $_POST['deeplTranslationsUsed'] ) && 'deepl' == $_POST['deeplTranslationsUsed'] && $translation ) {
 				Translation_Memory::update_one_external_translation(
 					$translation->translation_0,
 					$_POST['deeplTranslationsUsed'],

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/class-plugin.php
@@ -204,7 +204,6 @@ class Plugin {
 				$_POST['openAITranslationsUsed'],
 				'openai_translations_used',
 				'openai_same_translations_used',
-				'openai',
 			);
 		}
 		if ( isset( $_POST['deeplTranslationsUsed'] ) && 'deepl' == $_POST['deeplTranslationsUsed'] ) {
@@ -213,7 +212,6 @@ class Plugin {
 				$_POST['deeplTranslationsUsed'],
 				'deepl_translations_used',
 				'deepl_same_translations_used',
-				'deepl',
 			);
 		}
 	}

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/class-plugin.php
@@ -195,25 +195,26 @@ class Plugin {
 	 * @param object $translation Created translation.
 	 */
 	public function update_external_translations( $translation ) {
-		if ( 'GP_Route_Translation' === GP::$current_route->class_name && 'translations_post' === GP::$current_route->last_method_called ) {
-			if ( isset( $_POST['openAITranslationsUsed'] ) && 'openai' == $_POST['openAITranslationsUsed'] && $translation ) {
-				Translation_Memory::update_one_external_translation(
-					$translation->translation_0,
-					$_POST['openAITranslationsUsed'],
-					'openai_translations_used',
-					'openai_same_translations_used',
-					'openai',
-				);
-			}
-			if ( isset( $_POST['deeplTranslationsUsed'] ) && 'deepl' == $_POST['deeplTranslationsUsed'] && $translation ) {
-				Translation_Memory::update_one_external_translation(
-					$translation->translation_0,
-					$_POST['deeplTranslationsUsed'],
-					'deepl_translations_used',
-					'deepl_same_translations_used',
-					'deepl',
-				);
-			}
+		if ( 'GP_Route_Translation' !== GP::$current_route->class_name || 'translations_post' !== GP::$current_route->last_method_called || ! $translation ) {
+			return;
+		}
+		if ( isset( $_POST['openAITranslationsUsed'] ) && 'openai' == $_POST['openAITranslationsUsed'] ) {
+			Translation_Memory::update_one_external_translation(
+				$translation->translation_0,
+				$_POST['openAITranslationsUsed'],
+				'openai_translations_used',
+				'openai_same_translations_used',
+				'openai',
+			);
+		}
+		if ( isset( $_POST['deeplTranslationsUsed'] ) && 'deepl' == $_POST['deeplTranslationsUsed'] ) {
+			Translation_Memory::update_one_external_translation(
+				$translation->translation_0,
+				$_POST['deeplTranslationsUsed'],
+				'deepl_translations_used',
+				'deepl_same_translations_used',
+				'deepl',
+			);
 		}
 	}
 }

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/class-plugin.php
@@ -56,7 +56,7 @@ class Plugin {
 		}
 
 		add_action( self::TM_UPDATE_EVENT, array( Translation_Memory_Client::class, 'update' ) );
-		add_action( 'gp_translation_created', array( $this, 'update_external_translations' ) );
+		add_action( 'gp_translation_created', array( Translation_Memory::class, 'update_external_translations' ) );
 	}
 
 	/**
@@ -187,32 +187,5 @@ class Plugin {
 			<p class="suggestions__loading-indicator">Loading <span aria-hidden="true" class="suggestions__loading-indicator__icon"><span></span><span></span><span></span></span></p>
 		</details>
 		<?php
-	}
-
-	/**
-	 * Update the number of external translations used.
-	 *
-	 * @param object $translation Created translation.
-	 */
-	public function update_external_translations( $translation ) {
-		if ( 'GP_Route_Translation' !== GP::$current_route->class_name || 'translations_post' !== GP::$current_route->last_method_called || ! $translation ) {
-			return;
-		}
-		if ( isset( $_POST['openAITranslationsUsed'] ) && 'openai' == $_POST['openAITranslationsUsed'] ) {
-			Translation_Memory::update_one_external_translation(
-				$translation->translation_0,
-				$_POST['openAITranslationsUsed'],
-				'openai_translations_used',
-				'openai_same_translations_used',
-			);
-		}
-		if ( isset( $_POST['deeplTranslationsUsed'] ) && 'deepl' == $_POST['deeplTranslationsUsed'] ) {
-			Translation_Memory::update_one_external_translation(
-				$translation->translation_0,
-				$_POST['deeplTranslationsUsed'],
-				'deepl_translations_used',
-				'deepl_same_translations_used',
-			);
-		}
 	}
 }

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/routes/class-translation-memory.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/routes/class-translation-memory.php
@@ -482,40 +482,6 @@ class Translation_Memory extends GP_Route {
 	}
 
 	/**
-	 * Updates the external translations used by each user.
-	 *
-	 * @return void
-	 */
-	public function update_external_translations() {
-		if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( $_POST['nonce'], 'wporg-editor-settings' ) ) {
-			wp_send_json_error( array( 'message' => esc_html__( 'Invalid nonce.', 'glotpress' ) ), 403 );
-		}
-		if ( ! isset( $_POST['translation'] ) ) {
-			wp_send_json_error( array( 'message' => esc_html__( 'Translation parameter is not present.', 'glotpress' ) ), 400 );
-		}
-		if ( ! isset( $_POST['openAITranslationsUsed'] ) && ! isset( $_POST['deeplTranslationsUsed'] ) ) {
-			wp_send_json_error( array( 'message' => esc_html__( 'Translation suggested parameter is not present.', 'glotpress' ) ), 400 );
-		}
-		if ( isset( $_POST['openAITranslationsUsed'] ) ) {
-			$this->update_one_external_translation(
-				$_POST['translation'],
-				$_POST['openAITranslationsUsed'],
-				'openai_translations_used',
-				'openai_same_translations_used'
-			);
-		}
-		if ( isset( $_POST['deeplTranslationsUsed'] ) ) {
-			$this->update_one_external_translation(
-				$_POST['translation'],
-				$_POST['deeplTranslationsUsed'],
-				'deepl_translations_used',
-				'deepl_same_translations_used'
-			);
-		}
-		wp_send_json_success();
-	}
-
-	/**
 	 * Updates an external translation used by each user.
 	 *
 	 * @param string $translation                     The translation.
@@ -525,7 +491,7 @@ class Translation_Memory extends GP_Route {
 	 *
 	 * @return void
 	 */
-	private function update_one_external_translation( string $translation, string $suggestion, string $external_translations_used, string $external_same_translations_used ) {
+	public static function update_one_external_translation( string $translation, string $suggestion, string $external_translations_used, string $external_same_translations_used ) {
 		$is_the_same_translation  = $translation == $suggestion;
 		$gp_external_translations = get_user_option( 'gp_external_translations' );
 		$translations_used        = gp_array_get( $gp_external_translations, $external_translations_used, 0 );

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/routes/class-translation-memory.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/routes/class-translation-memory.php
@@ -482,16 +482,36 @@ class Translation_Memory extends GP_Route {
 	}
 
 	/**
+	 * Update the number of external translations used.
+	 *
+	 * @preturn void
+	 */
+	public function update_external_translations( $translation ) {
+		$is_source_set    = isset( $_POST['externalTranslationSource'] ) && isset( $_POST['externalTranslationUsed'] );
+		$is_request_valid = 'GP_Route_Translation' === GP::$current_route->class_name && 'translations_post' === GP::$current_route->last_method_called;
+		if ( ! $is_request_valid || ! $is_source_set || ! $translation ) {
+			return;
+		}
+		self::update_one_external_translation(
+			$translation->translation_0,
+			sanitize_text_field( $_POST['externalTranslationSource'] ),
+			sanitize_text_field( $_POST['externalTranslationUsed'] ),
+		);
+	}
+
+	/**
 	 * Updates an external translation used by each user.
 	 *
 	 * @param string $translation                     The translation.
+	 * @param string $suggestion_source               The suggestion_source.
 	 * @param string $suggestion                      The suggestion.
-	 * @param string $external_translations_used      The external translations used.
-	 * @param string $external_same_translations_used The external same translations used.
 	 *
 	 * @return void
 	 */
-	public static function update_one_external_translation( string $translation, string $suggestion, string $external_translations_used, string $external_same_translations_used ) {
+	private static function update_one_external_translation( string $translation, string $suggestion_source, string $suggestion ) {
+		$external_translations_used      = $suggestion_source . '_translations_used';
+		$external_same_translations_used = $suggestion_source . '_same_translations_used';
+
 		$is_the_same_translation  = $translation == $suggestion;
 		$gp_external_translations = get_user_option( 'gp_external_translations' );
 		$translations_used        = gp_array_get( $gp_external_translations, $external_translations_used, 0 );

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/routes/class-translation-memory.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/routes/class-translation-memory.php
@@ -530,8 +530,6 @@ class Translation_Memory extends GP_Route {
 	 */
 	private function update_one_external_translation( string $translation, string $suggestion, string $external_translations_used, string $external_same_translations_used, string $external_translation_source ) {
 		$is_the_same_translation = $translation == $suggestion;
-		unset( $gp_external_translations['last_translation_source'] );
-
 		$gp_external_translations = get_user_option( 'gp_external_translations' );
 		$translations_used        = gp_array_get( $gp_external_translations, $external_translations_used, 0 );
 		$same_translations_used   = gp_array_get( $gp_external_translations, $external_same_translations_used, 0 );

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/routes/class-translation-memory.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/routes/class-translation-memory.php
@@ -501,8 +501,7 @@ class Translation_Memory extends GP_Route {
 				$_POST['translation'],
 				$_POST['openAITranslationsUsed'],
 				'openai_translations_used',
-				'openai_same_translations_used',
-				'openai',
+				'openai_same_translations_used'
 			);
 		}
 		if ( isset( $_POST['deeplTranslationsUsed'] ) ) {
@@ -510,8 +509,7 @@ class Translation_Memory extends GP_Route {
 				$_POST['translation'],
 				$_POST['deeplTranslationsUsed'],
 				'deepl_translations_used',
-				'deepl_same_translations_used',
-				'deepl',
+				'deepl_same_translations_used'
 			);
 		}
 		wp_send_json_success();
@@ -524,32 +522,26 @@ class Translation_Memory extends GP_Route {
 	 * @param string $suggestion                      The suggestion.
 	 * @param string $external_translations_used      The external translations used.
 	 * @param string $external_same_translations_used The external same translations used.
-	 * @param string $external_translation_source     The external translation source.
 	 *
 	 * @return void
 	 */
-	private function update_one_external_translation( string $translation, string $suggestion, string $external_translations_used, string $external_same_translations_used, string $external_translation_source ) {
-		$is_the_same_translation = $translation == $suggestion;
+	private function update_one_external_translation( string $translation, string $suggestion, string $external_translations_used, string $external_same_translations_used ) {
+		$is_the_same_translation  = $translation == $suggestion;
 		$gp_external_translations = get_user_option( 'gp_external_translations' );
 		$translations_used        = gp_array_get( $gp_external_translations, $external_translations_used, 0 );
 		$same_translations_used   = gp_array_get( $gp_external_translations, $external_same_translations_used, 0 );
-
 		if ( ! is_int( $translations_used ) || $translations_used < 0 ) {
 			$translations_used = 0;
 		}
-		$current_translation_used                                = $translations_used++;
-		$gp_external_translations[ $external_translations_used ] = $translations_used++;
+		$translations_used++;
+		$gp_external_translations[ $external_translations_used ] = $translations_used;
 		if ( $is_the_same_translation ) {
 			if ( ! is_int( $same_translations_used ) || $same_translations_used < 0 ) {
 				$same_translations_used = 0;
 			}
-			$current_same_translations_used                               = $same_translations_used++;
+			$same_translations_used++;
 			$gp_external_translations[ $external_same_translations_used ] = $same_translations_used;
 		}
-		if ( $gp_external_translations[ $external_translations_used ] > $current_translation_used || $gp_external_translations[ $external_same_translations_used ] > $current_same_translations_used ) {
-			$gp_external_translations['last_translation_source'] = $external_translation_source;
-		}
-
 		update_user_option( get_current_user_id(), 'gp_external_translations', $gp_external_translations );
 	}
 }

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/routes/class-translation-memory.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/routes/class-translation-memory.php
@@ -484,7 +484,7 @@ class Translation_Memory extends GP_Route {
 	/**
 	 * Update the number of external translations used.
 	 *
-	 * @preturn void
+	 * @return void
 	 */
 	public function update_external_translations( $translation ) {
 		$is_source_set    = isset( $_POST['externalTranslationSource'] ) && isset( $_POST['externalTranslationUsed'] );

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/routes/class-translation-memory.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/routes/class-translation-memory.php
@@ -501,7 +501,8 @@ class Translation_Memory extends GP_Route {
 				$_POST['translation'],
 				$_POST['openAITranslationsUsed'],
 				'openai_translations_used',
-				'openai_same_translations_used'
+				'openai_same_translations_used',
+				'openai',
 			);
 		}
 		if ( isset( $_POST['deeplTranslationsUsed'] ) ) {
@@ -509,7 +510,8 @@ class Translation_Memory extends GP_Route {
 				$_POST['translation'],
 				$_POST['deeplTranslationsUsed'],
 				'deepl_translations_used',
-				'deepl_same_translations_used'
+				'deepl_same_translations_used',
+				'deepl',
 			);
 		}
 		wp_send_json_success();
@@ -522,26 +524,34 @@ class Translation_Memory extends GP_Route {
 	 * @param string $suggestion                      The suggestion.
 	 * @param string $external_translations_used      The external translations used.
 	 * @param string $external_same_translations_used The external same translations used.
+	 * @param string $external_translation_source     The external translation source.
 	 *
 	 * @return void
 	 */
-	private function update_one_external_translation( string $translation, string $suggestion, string $external_translations_used, string $external_same_translations_used ) {
-		$is_the_same_translation  = $translation == $suggestion;
+	private function update_one_external_translation( string $translation, string $suggestion, string $external_translations_used, string $external_same_translations_used, string $external_translation_source ) {
+		$is_the_same_translation = $translation == $suggestion;
+		unset( $gp_external_translations['last_translation_source'] );
+
 		$gp_external_translations = get_user_option( 'gp_external_translations' );
 		$translations_used        = gp_array_get( $gp_external_translations, $external_translations_used, 0 );
 		$same_translations_used   = gp_array_get( $gp_external_translations, $external_same_translations_used, 0 );
+
 		if ( ! is_int( $translations_used ) || $translations_used < 0 ) {
 			$translations_used = 0;
 		}
-		$translations_used++;
-		$gp_external_translations[ $external_translations_used ] = $translations_used;
+		$current_translation_used                                = $translations_used++;
+		$gp_external_translations[ $external_translations_used ] = $translations_used++;
 		if ( $is_the_same_translation ) {
 			if ( ! is_int( $same_translations_used ) || $same_translations_used < 0 ) {
 				$same_translations_used = 0;
 			}
-			$same_translations_used++;
+			$current_same_translations_used                               = $same_translations_used++;
 			$gp_external_translations[ $external_same_translations_used ] = $same_translations_used;
 		}
+		if ( $gp_external_translations[ $external_translations_used ] > $current_translation_used || $gp_external_translations[ $external_same_translations_used ] > $current_same_translations_used ) {
+			$gp_external_translations['last_translation_source'] = $external_translation_source;
+		}
+
 		update_user_option( get_current_user_id(), 'gp_external_translations', $gp_external_translations );
 	}
 }

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/js/translation-suggestions.js
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/js/translation-suggestions.js
@@ -479,8 +479,7 @@
 		if ( ! $row ) {
 			return;
 		}
-		externalSuggestion.suggestion_source = $row.data( 'suggestion-source' );
-
+		externalSuggestion.suggestion_source = $row.data( 'suggestion-source' ) == 'translation' ? 'tm' : $row.data( 'suggestion-source' );
 		externalSuggestion.translation = $row.find( '.translation-suggestion__translation' ).text();
 
 	}

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/js/translation-suggestions.js
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/js/translation-suggestions.js
@@ -486,18 +486,18 @@
 		return params.toString();
 	}
 
-	// Prefilter ajax requests to add translation_source to the request.
+	// Prefilter ajax requests to add translation_assist to the request.
 	$.ajaxPrefilter( function ( options ) {
 		let data = Object.fromEntries( new URLSearchParams( options.data ) );
 
-		if ( 'POST' === options.type && $gp_editor_options.url === options.url && ! data.translation_source ) {
+		if ( 'POST' === options.type && $gp_editor_options.url === options.url && ! data.translation_assist ) {
 
 			if ( $openAITranslationsUsed[ data.original_id ] ) {
-				data.translation_source = 'openai';
+				data.translation_assist = 'openai';
 				$openAITranslationsUsed.splice( [ data.original_id ] );
 			} 
 			if ( $deeplTranslationsUsed[ data.original_id ] ) {
-				data.translation_source = 'deepl';
+				data.translation_assist = 'deepl';
 				$deeplTranslationsUsed.splice( [ data.original_id ] );
 			}
 			options.data = convertObjectToQueryParam( data );

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/js/translation-suggestions.js
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/js/translation-suggestions.js
@@ -509,8 +509,6 @@
 
 	//Prefilter ajax requests to add external translations used to the request.
 	$.ajaxPrefilter( function ( options ) {
-		
-
 		let data = Object.fromEntries( new URLSearchParams( options.data ) );
 		let originalId = data.original_id;
 		if ( ! $openAITranslationsUsed[originalId] && ! $deeplTranslationsUsed[originalId] ) {

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/js/translation-suggestions.js
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/js/translation-suggestions.js
@@ -475,34 +475,6 @@
 		};
 	})( $gp.editor.install_hooks );
 
-	// Convert object to query params.
-	function convertObjectToQueryParam( object ) {
-		const params = new URLSearchParams();
-
-		Object.entries(object).forEach(([key, value]) => {
-		params.append(key, value);
-		});
-
-		return params.toString();
-	}
-
-	// Prefilter ajax requests to add translation_assist to the request.
-	$.ajaxPrefilter( function ( options ) {
-		let data = Object.fromEntries( new URLSearchParams( options.data ) );
-
-		if ( 'POST' === options.type && $gp_editor_options.url === options.url && ! data.translation_assist ) {
-
-			if ( $openAITranslationsUsed[ data.original_id ] ) {
-				data.translation_assist = 'openai';
-				$openAITranslationsUsed.splice( [ data.original_id ] );
-			} 
-			if ( $deeplTranslationsUsed[ data.original_id ] ) {
-				data.translation_assist = 'deepl';
-				$deeplTranslationsUsed.splice( [ data.original_id ] );
-			}
-			options.data = convertObjectToQueryParam( data );
-		}
-	});
 	/**
 	 * Adds the suggestion to the translation in an array, and removes the previous suggestions, so
 	 * we only store the last one in the database, using the saveExternalSuggestions() function.

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/js/translation-suggestions.js
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/js/translation-suggestions.js
@@ -487,7 +487,6 @@
 
 	//Prefilter ajax requests to add external translations used to the request.
 	$.ajaxPrefilter( function ( options ) {
-		let data = Object.fromEntries( new URLSearchParams( options.data ) );
 		if ( ! externalSuggestion ) {
 			return;
 		}

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/js/translation-suggestions.js
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/js/translation-suggestions.js
@@ -496,28 +496,18 @@
 		}
 	}
 
-	// Convert object to query params.
-	function convertObjectToQueryParam( object ) {
-		const params = new URLSearchParams();
-
-		Object.entries(object).forEach(([key, value]) => {
-		params.append(key, value);
-		});
-
-		return params.toString();
-	}
-
 	//Prefilter ajax requests to add external translations used to the request.
 	$.ajaxPrefilter( function ( options ) {
 		let data = Object.fromEntries( new URLSearchParams( options.data ) );
 		let originalId = data.original_id;
-		if ( ! $openAITranslationsUsed[originalId] && ! $deeplTranslationsUsed[originalId] ) {
+
+		const isExternalTranslationUsed = $openAITranslationsUsed[originalId] || $deeplTranslationsUsed[originalId];
+		if ( ! isExternalTranslationUsed ) {
 			return;
 		}
 		if ( 'POST' === options.type && $gp_editor_options.url === options.url ) {
-			data.openAITranslationsUsed = $openAITranslationsUsed[originalId];
-			data.deeplTranslationsUsed =  $deeplTranslationsUsed[originalId];
-			options.data = convertObjectToQueryParam( data );
+				options.data += ( $openAITranslationsUsed[originalId] ) ? '&openAITranslationsUsed=' + $openAITranslationsUsed[originalId] : '';
+				options.data += ( $openAITranslationsUsed[originalId] ) ? '&deeplTranslationsUsed=' + $deeplTranslationsUsed[originalId] : '';
 		}
 	});
 })( jQuery );

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/js/translation-suggestions.js
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/js/translation-suggestions.js
@@ -460,8 +460,7 @@
 
 			$( $gp.editor.table )
 				.on( 'click', '.translation-suggestion', copySuggestion )
-				.on( 'click', '.translation-suggestion.with-tooltip.openai', addSuggestion )
-				.on( 'click', '.translation-suggestion.with-tooltip.deepl', addSuggestion );
+				.on( 'click', '.translation-suggestion', addSuggestion );
 			$( document ).ready( function() {
 				getSuggestionsForTheFirstRow();
 			});

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/js/translation-suggestions.js
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/js/translation-suggestions.js
@@ -485,12 +485,15 @@
 
 	//Prefilter ajax requests to add external translations used to the request.
 	$.ajaxPrefilter( function ( options ) {
-		if ( ! externalSuggestion ) {
+		const isSuggestionUsed = Object.keys( externalSuggestion ).length  > 0 ? true : false;
+
+		if ( ! externalSuggestion || ! isSuggestionUsed ) {
 			return;
 		}
 		if ( 'POST' === options.type && $gp_editor_options.url === options.url ) {
 				options.data += '&externalTranslationSource=' + externalSuggestion.suggestion_source;
 				options.data += '&externalTranslationUsed=' + externalSuggestion.translation;
+				externalSuggestion = {};
 		}
 	});
 })( jQuery );

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/templates/translation-memory-suggestions.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/templates/translation-memory-suggestions.php
@@ -5,7 +5,7 @@ if ( empty( $suggestions ) ) {
 	echo '<ul class="suggestions-list">';
 	foreach ( $suggestions as $suggestion ) {
 		echo '<li>';
-		echo '<div class="translation-suggestion with-tooltip ' . esc_html( strtolower( $type ) ) . '" tabindex="0" role="button" aria-pressed="false" aria-label="Copy translation">';
+		echo '<div class="translation-suggestion with-tooltip ' . esc_html( strtolower( $type ) ) . '" tabindex="0" data-suggestion-source="' . esc_html( strtolower( $type ) ) . '" role="button" aria-pressed="false" aria-label="Copy translation">';
 			echo '<span class="' . esc_html( strtolower( $type ) ) . '-suggestion__score">';
 		if ( 'Translation' == $type ) {
 			echo number_format( 100 * $suggestion['similarity_score'] ) . '%';


### PR DESCRIPTION
In this PR;
- we refactor the code that logs the usage of translation suggestions. We also removed the extra AJAX call in the `wporg-gp-translation-suggestions` plugin.
- We log translations whose source is translation memory. These are stored as `tm`.
- This improvements will allow easy logging of new external suggestions source that may be added in the future.

### How to test
- Go to the translations page of a any project and choose a string to translate.
1. If you enter a translation or paste a translation in the text area below, the source is logged as `frontend`
![Screenshot 2023-07-17 at 22 46 17](https://github.com/WordPress/wordpress.org/assets/2834132/b1783b42-336d-40f3-a1b5-b21423a064da)


2. If you click to copy a suggested translation e.g openai as shown below, two rows(one to log the translation source and the second to log the suggestions_used) are inserted in the `translate_meta` table, one that logs the translation source as `frontend` and the second that logs the `suggestion_used` as openai. 
This applies to clicking to copy translation suggestions from translation memory( `suggestion_used`is logged  as `tm`) and deepl ( `suggestion_used`is logged  as `deepl`).
![Screenshot 2023-07-17 at 22 46 36](https://github.com/WordPress/wordpress.org/assets/2834132/8949ea06-8909-4da9-860b-19464a2b7052)
