### PR TITLE
Translate: Fix initialization error in logging translation source

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -24,7 +24,7 @@ class Plugin {
 	/**
 	 * @var string The source of translations that have been imported.
 	 */
-	private string $imported_source;
+	private string $imported_source = '';
 
 	/**
 	 * Returns always the same instance of this plugin.


### PR DESCRIPTION
When an import is done and we try to log the source, we get the error below;

`E_ERROR: Uncaught Error: Typed property WordPressdotorg\GlotPress\Customizations\Plugin::$imported_source must not be accessed before initialization in /home/wporg/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php:364`

In this PR we set the variable to an empty string to initalize it before it's used.