### PR TITLE
Log locale slug as suggestion source when suggestions from other languages are used

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/js/translation-suggestions.js
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/js/translation-suggestions.js
@@ -478,9 +478,13 @@
 		if ( ! $row ) {
 			return;
 		}
-		externalSuggestion.suggestion_source = $row.data( 'suggestion-source' ) == 'translation' ? 'tm' : $row.data( 'suggestion-source' );
-		externalSuggestion.translation = $row.find( '.translation-suggestion__translation' ).text();
-
+		if ( $row.data( 'suggestion-locale' ) ) {
+			externalSuggestion.suggestion_source = $row.data( 'suggestion-locale' );
+			externalSuggestion.translation = $row.find( '.translation-suggestion__translation-raw' ).text();
+		} else {
+			externalSuggestion.suggestion_source = $row.data( 'suggestion-source' );
+			externalSuggestion.translation = $row.find( '.translation-suggestion__translation' ).text();
+		}
 	}
 
 	//Prefilter ajax requests to add external translations used to the request.

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/js/translation-suggestions.js
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/js/translation-suggestions.js
@@ -489,7 +489,7 @@
 
 	//Prefilter ajax requests to add external translations used to the request.
 	$.ajaxPrefilter( function ( options ) {
-		if ( ! externalSuggestion.suggestion_source || ! externalSuggestion.translation ) {
+		if ( ! externalSuggestion || ! externalSuggestion.suggestion_source || ! externalSuggestion.translation ) {
 			return;
 		}
 		if ( 'POST' === options.type && $gp_editor_options.url === options.url ) {

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/js/translation-suggestions.js
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/js/translation-suggestions.js
@@ -489,9 +489,7 @@
 
 	//Prefilter ajax requests to add external translations used to the request.
 	$.ajaxPrefilter( function ( options ) {
-		const isSuggestionUsed = Object.keys( externalSuggestion ).length  > 0 ? true : false;
-
-		if ( ! externalSuggestion || ! isSuggestionUsed ) {
+		if ( ! externalSuggestion.suggestion_source || ! externalSuggestion.translation ) {
 			return;
 		}
 		if ( 'POST' === options.type && $gp_editor_options.url === options.url ) {

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/templates/other-languages-suggestions.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/templates/other-languages-suggestions.php
@@ -6,7 +6,7 @@ if ( empty( $suggestions ) ) {
 	echo '<ul class="suggestions-list">';
 	foreach ( $suggestions as $suggestion ) {
 		echo '<li>';
-		echo '<div class="translation-suggestion with-tooltip" tabindex="0" role="button" data-suggestion-source="' . esc_html( strtolower( $suggestion['locale'] ) ) . '" aria-pressed="false" aria-label="Copy translation">';
+		echo '<div class="translation-suggestion with-tooltip" tabindex="0" role="button" data-suggestion-locale="' . esc_html( strtolower( $suggestion['locale'] ) ) . '" aria-pressed="false" aria-label="Copy translation">';
 
 			echo '<span class="translation-suggestion__translation">';
 				echo esc_translation( $suggestion['translation'] );

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/templates/other-languages-suggestions.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/templates/other-languages-suggestions.php
@@ -6,7 +6,7 @@ if ( empty( $suggestions ) ) {
 	echo '<ul class="suggestions-list">';
 	foreach ( $suggestions as $suggestion ) {
 		echo '<li>';
-		echo '<div class="translation-suggestion with-tooltip" tabindex="0" role="button" aria-pressed="false" aria-label="Copy translation">';
+		echo '<div class="translation-suggestion with-tooltip" tabindex="0" role="button" data-suggestion-source="' . esc_html( strtolower( $suggestion['locale'] ) ) . '" aria-pressed="false" aria-label="Copy translation">';
 
 			echo '<span class="translation-suggestion__translation">';
 				echo esc_translation( $suggestion['translation'] );

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/templates/translation-memory-suggestions.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/templates/translation-memory-suggestions.php
@@ -4,8 +4,10 @@ if ( empty( $suggestions ) ) {
 } else {
 	echo '<ul class="suggestions-list">';
 	foreach ( $suggestions as $suggestion ) {
+		$suggestion_type = ( 'translation' === strtolower( $type ) ) ? 'tm' : $type;
+
 		echo '<li>';
-		echo '<div class="translation-suggestion with-tooltip ' . esc_html( strtolower( $type ) ) . '" tabindex="0" data-suggestion-source="' . esc_html( strtolower( $type ) ) . '" role="button" aria-pressed="false" aria-label="Copy translation">';
+		echo '<div class="translation-suggestion with-tooltip ' . esc_html( strtolower( $type ) ) . '" tabindex="0" data-suggestion-source="' . esc_html( strtolower( $suggestion_type ) ) . '" role="button" aria-pressed="false" aria-label="Copy translation">';
 			echo '<span class="' . esc_html( strtolower( $type ) ) . '-suggestion__score">';
 		if ( 'Translation' == $type ) {
 			echo number_format( 100 * $suggestion['similarity_score'] ) . '%';


### PR DESCRIPTION
When suggestions from other languages are clicked, the system logs them as `undefined` or `undefined_modified` if they are modified. 
![Screenshot 2023-07-24 at 12 26 39](https://github.com/WordPress/wordpress.org/assets/2834132/59951758-ab76-483f-8301-8c4d246e05da)

We fix this by logging the suggestion source as the slug of the locale e.g `es`, `de`, etc. When they are modified it's logged as `es_modified`, `de_modified`