### PR TITLE
Reorder the preference for the "Other locales" tab

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/routes/class-other-languages.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/routes/class-other-languages.php
@@ -9,6 +9,21 @@ use const WordPressdotorg\GlotPress\TranslationSuggestions\PLUGIN_DIR;
 
 class Other_Languages extends GP_Route {
 
+	/**
+	 * Indicates the related locales for each locale, so we will put them in the top list
+	 * of "Other locales".
+	 *
+	 * This array should be sync with
+	 * https://github.com/GlotPress/gp-translation-helpers/blob/main/helpers/helper-other-locales.php
+	 *
+	 * @since 0.0.1
+	 * @var array
+	 */
+	public array $related_locales = array(
+		'gl' => array( 'es', 'pt', 'pt-ao', 'pt-br', 'ca', 'it', 'fr', 'ro' ),
+		'es' => array( 'gl', 'ca', 'pt', 'pt-ao', 'pt-br', 'it', 'fr', 'ro' ),
+	);
+
 	public function get_suggestions( $project_path, $locale_slug, $translation_set_slug ) {
 		$original_id = gp_get( 'original' );
 		$nonce       = gp_get( 'nonce' );
@@ -38,7 +53,7 @@ class Other_Languages extends GP_Route {
 
 		$suggestions = $this->query( $original, $translation_set );
 
-		wp_send_json_success( gp_tmpl_get_output( 'other-languages-suggestions', [ 'suggestions' => $suggestions ], PLUGIN_DIR . '/templates/' ) );
+		wp_send_json_success( gp_tmpl_get_output( 'other-languages-suggestions', array( 'suggestions' => $suggestions ), PLUGIN_DIR . '/templates/' ) );
 	}
 
 	protected function query( $original, $set_to_exclude ) {
@@ -77,6 +92,28 @@ ORDER BY
 			ARRAY_A
 		);
 
-		return $results;
+		$results_with_preference = array();
+
+		// Put the variants in the top list.
+		foreach ( $results as $key => $result ) {
+			if ( explode( '-', $result['locale'] )[0] === explode( '-', $set_to_exclude->locale )[0] ) {
+				$results_with_preference[] = $result;
+				unset( $results[ $key ] );
+			}
+		}
+
+		if ( ! empty( $this->related_locales[ $set_to_exclude->locale ] ) ) {
+			foreach ( $this->related_locales[ $set_to_exclude->locale ] as $locale ) {
+				foreach ( $results as $key => $result ) {
+					if ( $result['locale'] == $locale ) {
+						$results_with_preference[] = $result;
+						unset( $results[ $key ] );
+						continue 2;
+					}
+				}
+			}
+		}
+
+		return array_merge( $results_with_preference, $results );
 	}
 }


### PR DESCRIPTION
## Problem

In the "[Improving Translation Suggestions [Other Languages]](https://make.wordpress.org/polyglots/2023/05/31/improving-translation-suggestions-other-languages/)" P2 we proposed to add an improvement to put in the top place the translations from languages related with the current translation. This PR is related with https://github.com/GlotPress/gp-translation-helpers/pull/184, because both add the same information in different places: this one in the bottom of the translation and the other one in the right sidebar. 
<!--
Please describe what is the status/problem before the PR.
-->

## Solution

This PR adds:
- an array with the related languages for each locale. This should be improved, with new locales, in the future. In this PR I have only added related languages for Galician and Spanish. You need to use the `slug` property from each `GP_Locale` from [GlotPress](https://github.com/GlotPress/GlotPress/blob/develop/locales/locales.php) or from the [DotOrg environment](https://github.com/WordPress/wordpress.org/blob/trunk/wordpress.org/public_html/wp-content/mu-plugins/pub/locales/locales.php).
- a reorder method, to use the previous array to put this related locales just after the language variants.

**Some examples from [translate.w.org](https://translate.wordpress.org/)**

Translation to Spanish (Spain) with Spanish variants and related locales. [Link](https://translate.wordpress.org/projects/wp/dev/es/default/?filters%5Boriginal_id%5D=6929622&filters%5Bstatus%5D=either&filters%5Btranslation_id%5D=59173494).

![image](https://github.com/WordPress/wordpress.org/assets/1667814/84de732c-31d5-4baa-a685-df984dac3848)

Translation to Spanish (Colombia) with Spanish variants but without related locales. [Link](https://translate.wordpress.org/projects/wp/dev/es-co/default/?filters%5Bstatus%5D=either&filters%5Boriginal_id%5D=6929622&filters%5Btranslation_id%5D=59601111).

![image](https://github.com/WordPress/wordpress.org/assets/1667814/a9d98ff3-f885-4bd1-9b17-d648633c2a8a)

Translation to Spanish (Spain) with relate locales but without Spanish variants, because these variants doesn't have any translations for this original string. [Link](https://translate.wordpress.org/projects/apps/ios/dev/es/default/?filters%5Bstatus%5D=either&filters%5Boriginal_id%5D=16114703&filters%5Btranslation_id%5D=106976241).

![image](https://github.com/WordPress/wordpress.org/assets/1667814/ea3ad93d-e278-4002-beee-55a024e63f5a)

Translation to Italian without variants or related languages. [Link](https://translate.wordpress.org/projects/apps/ios/dev/it/default/?filters%5Boriginal_id%5D=16114703&filters%5Bstatus%5D=either&filters%5Btranslation_id%5D=106977633). 

![image](https://github.com/WordPress/wordpress.org/assets/1667814/9a2ad445-8164-4b09-8fdd-e53beca59d7f)

Translation to Dutch with variants (Dutch formal and Dutch (Belgium)). [Link](https://translate.wordpress.org/projects/wp/dev/nl/default/?filters%5Boriginal_id%5D=6929622&filters%5Bstatus%5D=either&filters%5Btranslation_id%5D=59173446). 

![image](https://github.com/WordPress/wordpress.org/assets/1667814/72249271-8fdf-41b5-aff1-e6583eff37ce)

<!--
Please describe how this PR improves the situation.
-->

<!--
## Testing instructions

Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

