### PR TITLE
Translate: Add site tour items

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -95,6 +95,47 @@ class Plugin {
 		// Correct `WP_Locale` for variant locales in project lists.
 		add_filter( 'gp_translation_sets_sort', [ $this, 'filter_gp_translation_sets_sort' ] );
 
+		// Add site tour items
+		add_filter( 'gp_tour', function(){
+			return array(
+				'ui-intro' => [
+					[
+						'title' => 'UI Introduction Tour',
+						'color' => '#3939c7',
+					],
+					[
+						'selector' => '.source-string__singular',
+						'html' => 'This is the original string, pay attention to underlined words: they are in the glossary of your locale and if the context fits you must use the translation suggested by the glossary',
+						'popover-position' => 'left'
+					], 
+					[
+						'selector' => '.source-details__references',
+						'html' => 'This is the comments, context and references area: it can contain very useful information such as placheholders meaning, context of the string, a link to the code that could contain more comments about the use of that string.',
+					],
+					[
+						'selector' => '.translation-wrapper .textareas',
+						'html' => 'This is the area where you can suggest your translation. Good grammar helps! Also, always pay attention to context and the Glossary entries that may apply.',
+					],
+					[
+						'selector' => '.translation-actions',
+						'html' => 'This is the buttons area where you can find the very helpful “Help” button!',
+				   ],
+					[
+						'selector' => '.suggestions-wrapper',
+						'html' => 'This is the Translations memory and Other languages area, remember Translation Memory could be a very useful help, but it all depends on the context. Context is all!',
+					],
+					[
+						'selector' => '.sidebar-tabs',
+						'html' => 'This is the meta information area, Discussion and History can give more context information about the string, Make sure you always check these as well, if available.',
+					],
+					[
+						'selector' => '.translation-actions__primary',
+						'html' => 'When you\'re happy with your translation click on the “Suggest” button',
+					],
+				],
+			);
+		}, 10 );
+
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			$this->register_cli_commands();
 		}

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -97,49 +97,50 @@ class Plugin {
 
 		// Add site tour items
 		if ( isset( $_GET['site_tour'] ) && 'test' == $_GET['site_tour'] ) {
-			gp_enqueue_style( 'gp-jquery-webui-popover' );
-			gp_enqueue_scripts( array( 'gp-tour' ) );
-
-			add_filter( 'gp_tour', function(){
-				return array(
-					'ui-intro' => [
-						[
-							'title' => 'UI Introduction Tour',
-							'color' => '#3939c7',
+			add_filter(
+				'gp_tour',
+				function() {
+					return array(
+						'ui-intro' => [
+							[
+								'title' => 'UI Introduction Tour',
+								'color' => '#3939c7',
+							],
+							[
+								'selector'         => '.source-string__singular',
+								'html'             => 'This is the original string, pay attention to underlined words: they are in the glossary of your locale and if the context fits you must use the translation suggested by the glossary',
+								'popover-position' => 'left',
+							],
+							[
+								'selector' => '.source-details__references',
+								'html'     => 'This is the comments, context and references area: it can contain very useful information such as placheholders meaning, context of the string, a link to the code that could contain more comments about the use of that string.',
+							],
+							[
+								'selector' => '.translation-wrapper .textareas',
+								'html'     => 'This is the area where you can suggest your translation. Good grammar helps! Also, always pay attention to context and the Glossary entries that may apply.',
+							],
+							[
+								'selector' => '.translation-actions',
+								'html'     => 'This is the buttons area where you can find the very helpful “Help” button!',
+							],
+							[
+								'selector' => '.suggestions-wrapper',
+								'html'     => 'This is the Translations memory and Other languages area, remember Translation Memory could be a very useful help, but it all depends on the context. Context is all!',
+							],
+							[
+								'selector' => '.sidebar-tabs',
+								'html'     => 'This is the meta information area, Discussion and History can give more context information about the string, Make sure you always check these as well, if available.',
+							],
+							[
+								'selector' => '.translation-actions__primary',
+								'html'     => 'When you\'re happy with your translation click on the “Suggest” button',
+							],
 						],
-						[
-							'selector' => '.source-string__singular',
-							'html' => 'This is the original string, pay attention to underlined words: they are in the glossary of your locale and if the context fits you must use the translation suggested by the glossary',
-							'popover-position' => 'left'
-						], 
-						[
-							'selector' => '.source-details__references',
-							'html' => 'This is the comments, context and references area: it can contain very useful information such as placheholders meaning, context of the string, a link to the code that could contain more comments about the use of that string.',
-						],
-						[
-							'selector' => '.translation-wrapper .textareas',
-							'html' => 'This is the area where you can suggest your translation. Good grammar helps! Also, always pay attention to context and the Glossary entries that may apply.',
-						],
-						[
-							'selector' => '.translation-actions',
-							'html' => 'This is the buttons area where you can find the very helpful “Help” button!',
-					],
-						[
-							'selector' => '.suggestions-wrapper',
-							'html' => 'This is the Translations memory and Other languages area, remember Translation Memory could be a very useful help, but it all depends on the context. Context is all!',
-						],
-						[
-							'selector' => '.sidebar-tabs',
-							'html' => 'This is the meta information area, Discussion and History can give more context information about the string, Make sure you always check these as well, if available.',
-						],
-						[
-							'selector' => '.translation-actions__primary',
-							'html' => 'When you\'re happy with your translation click on the “Suggest” button',
-						],
-					],
-				);
-			}, 10 );
-	}
+					);
+				},
+				10
+			);
+		}
 
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			$this->register_cli_commands();

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -96,45 +96,47 @@ class Plugin {
 		add_filter( 'gp_translation_sets_sort', [ $this, 'filter_gp_translation_sets_sort' ] );
 
 		// Add site tour items
-		add_filter( 'gp_tour', function(){
-			return array(
-				'ui-intro' => [
-					[
-						'title' => 'UI Introduction Tour',
-						'color' => '#3939c7',
+		if ( isset( $_GET['site_tour'] ) && 'test' == $_GET['site_tour'] ) {
+			add_filter( 'gp_tour', function(){
+				return array(
+					'ui-intro' => [
+						[
+							'title' => 'UI Introduction Tour',
+							'color' => '#3939c7',
+						],
+						[
+							'selector' => '.source-string__singular',
+							'html' => 'This is the original string, pay attention to underlined words: they are in the glossary of your locale and if the context fits you must use the translation suggested by the glossary',
+							'popover-position' => 'left'
+						], 
+						[
+							'selector' => '.source-details__references',
+							'html' => 'This is the comments, context and references area: it can contain very useful information such as placheholders meaning, context of the string, a link to the code that could contain more comments about the use of that string.',
+						],
+						[
+							'selector' => '.translation-wrapper .textareas',
+							'html' => 'This is the area where you can suggest your translation. Good grammar helps! Also, always pay attention to context and the Glossary entries that may apply.',
+						],
+						[
+							'selector' => '.translation-actions',
+							'html' => 'This is the buttons area where you can find the very helpful “Help” button!',
 					],
-					[
-						'selector' => '.source-string__singular',
-						'html' => 'This is the original string, pay attention to underlined words: they are in the glossary of your locale and if the context fits you must use the translation suggested by the glossary',
-						'popover-position' => 'left'
-					], 
-					[
-						'selector' => '.source-details__references',
-						'html' => 'This is the comments, context and references area: it can contain very useful information such as placheholders meaning, context of the string, a link to the code that could contain more comments about the use of that string.',
+						[
+							'selector' => '.suggestions-wrapper',
+							'html' => 'This is the Translations memory and Other languages area, remember Translation Memory could be a very useful help, but it all depends on the context. Context is all!',
+						],
+						[
+							'selector' => '.sidebar-tabs',
+							'html' => 'This is the meta information area, Discussion and History can give more context information about the string, Make sure you always check these as well, if available.',
+						],
+						[
+							'selector' => '.translation-actions__primary',
+							'html' => 'When you\'re happy with your translation click on the “Suggest” button',
+						],
 					],
-					[
-						'selector' => '.translation-wrapper .textareas',
-						'html' => 'This is the area where you can suggest your translation. Good grammar helps! Also, always pay attention to context and the Glossary entries that may apply.',
-					],
-					[
-						'selector' => '.translation-actions',
-						'html' => 'This is the buttons area where you can find the very helpful “Help” button!',
-				   ],
-					[
-						'selector' => '.suggestions-wrapper',
-						'html' => 'This is the Translations memory and Other languages area, remember Translation Memory could be a very useful help, but it all depends on the context. Context is all!',
-					],
-					[
-						'selector' => '.sidebar-tabs',
-						'html' => 'This is the meta information area, Discussion and History can give more context information about the string, Make sure you always check these as well, if available.',
-					],
-					[
-						'selector' => '.translation-actions__primary',
-						'html' => 'When you\'re happy with your translation click on the “Suggest” button',
-					],
-				],
-			);
-		}, 10 );
+				);
+			}, 10 );
+	}
 
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			$this->register_cli_commands();

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -97,6 +97,9 @@ class Plugin {
 
 		// Add site tour items
 		if ( isset( $_GET['site_tour'] ) && 'test' == $_GET['site_tour'] ) {
+			gp_enqueue_style( 'gp-jquery-webui-popover' );
+			gp_enqueue_scripts( array( 'gp-jquery-webui-popover', 'gp-tour' ) );
+
 			add_filter( 'gp_tour', function(){
 				return array(
 					'ui-intro' => [

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -98,7 +98,7 @@ class Plugin {
 		// Add site tour items
 		if ( isset( $_GET['site_tour'] ) && 'test' == $_GET['site_tour'] ) {
 			gp_enqueue_style( 'gp-jquery-webui-popover' );
-			gp_enqueue_scripts( array( 'gp-jquery-webui-popover', 'gp-tour' ) );
+			gp_enqueue_scripts( array( 'gp-tour' ) );
 
 			add_filter( 'gp_tour', function(){
 				return array(

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/header.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/header.php
@@ -2,6 +2,9 @@
 
 echo do_blocks( '<!-- wp:wporg/global-header /-->' );
 
+gp_enqueue_style( 'gp-jquery-webui-popover' );
+gp_enqueue_scripts( array( 'gp-tour' ) );
+
 ?>
 <script type="text/javascript">document.body.className = document.body.className.replace('no-js','js');</script>
 

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/style.css
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/style.css
@@ -429,6 +429,8 @@ body.wporg-make #headline h2 a:before {
 	--gp-color-status-old-subtle: #cdc5e1;
 	--gp-color-status-waiting-subtle: #ffe399;
 	--gp-color-status-rejected-subtle: #eb9090;
+
+	--gp-color-tour: #d54e21;
 }
 
 .locale-sub-projects .stats,
@@ -3209,6 +3211,16 @@ ul.sidebar-tabs {
 	width: 6rem;
 	background: #0073aa;
 	margin-right: 10px !important;
+}
+
+/* GlotPress Tour Overrides */
+a.tour-button {
+	text-shadow: none;
+	padding-top: 0;
+	text-decoration: none;
+}
+.pulse-wrapper {
+	margin: 0;
 }
 
 @media screen and (max-width: 530px), (min-width: 1024px) and (max-width: 1450px) {


### PR DESCRIPTION
Add tour items for translate.wordpress.org, which is loaded only if the correct GET parameter is appended to the page url.

This PR adds a site tour to translate.wordpress.org by adding this filter below;

To test this PR;
- In GlotPress,  switch to the `site-tour` branch and run `git pull` to pull latest updates.
- Then append this GET parameter  `site_tour=test` to the end of your url for example,  to view the site tour on the Events Manager project; https://translate.wordpress.org/projects/wp-plugins/events-manager/dev/art-xemoji/default/?filters%5Bstatus%5D=untranslated&site_tour=test