### PR TITLE
Wporg-SEO: Add canonical redirects for sanitized characters and case-changes

### DIFF
--- a/wordpress.org/public_html/wp-content/mu-plugins/pub/wporg-redirects.php
+++ b/wordpress.org/public_html/wp-content/mu-plugins/pub/wporg-redirects.php
@@ -10,11 +10,6 @@ if ( 1 === get_current_blog_id() && is_multisite() && 'wordpress.org' === get_bl
 			wp_safe_redirect( '/news/feed/' . ( 'feed' !== get_query_var('feed') ? get_query_var('feed') : '' ), 301 );
 			exit;
 
-		// temp fix for /B;ocks, rm later
-		} elseif ( 0 === strpos( $_SERVER['REQUEST_URI'], '/Blocks' ) ) {
-			wp_safe_redirect( '/blocks/', 301 );
-		   	exit;
-
 		// WordPress.org does not have a specific site search, only the global WordPress.org search
 		} elseif ( ! empty( $_GET['s'] ) && false === strpos( $_SERVER['REQUEST_URI'], '/search/' ) ) {
 			wp_safe_redirect( '/search/' . urlencode( wp_unslash( $_GET['s'] ) ) . '/', 301 );

--- a/wordpress.org/public_html/wp-content/mu-plugins/pub/wporg-seo/canonical-redirects.php
+++ b/wordpress.org/public_html/wp-content/mu-plugins/pub/wporg-seo/canonical-redirects.php
@@ -1,2 +1,0 @@
-<?php
-namespace WordPressdotorg\SEO\Redirects;

--- a/wordpress.org/public_html/wp-content/mu-plugins/pub/wporg-seo/redirects.php
+++ b/wordpress.org/public_html/wp-content/mu-plugins/pub/wporg-seo/redirects.php
@@ -1,5 +1,6 @@
 <?php
 namespace WordPressdotorg\SEO\Redirects;
+use function WordPressdotorg\SEO\Canonical\get_canonical_url;
 
 /**
  * Custom Canonical redirect for Facebook and Twitter referrers.
@@ -23,3 +24,31 @@ function facebook_twitter_referers() {
 	}
 }
 add_action( 'template_redirect', __NAMESPACE__ . '\facebook_twitter_referers', 9 ); // Before redirect_canonical();
+
+/**
+ * Redirect pages to the canonical case sensitive URL.
+ *
+ * Eg. https://wordpress.org/Blocks
+ */
+function case_sensitivity_canonical_urls() {
+	// Only run on pages with canonical enabled.
+	if ( ! has_action( 'template_redirect', 'redirect_canonical' ) ) {
+		return;
+	}
+
+	if ( ! preg_match( '/[A-Z]/', $_SERVER['REQUEST_URI'] ) ) {
+		return;
+	}
+
+	$requested_url = set_url_scheme( 'https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] );
+	$canonical_url = get_canonical_url();
+
+	if (
+		$requested_url !== $canonical_url &&
+		0 === strcasecmp( $requested_url, $canonical_url )
+	) {
+		wp_safe_redirect( $canonical_url, 301 );
+		exit;
+	}
+}
+add_action( 'template_redirect', __NAMESPACE__ . '\case_sensitivity_canonical_urls' );

--- a/wordpress.org/public_html/wp-content/mu-plugins/pub/wporg-seo/redirects.php
+++ b/wordpress.org/public_html/wp-content/mu-plugins/pub/wporg-seo/redirects.php
@@ -52,3 +52,53 @@ function case_sensitivity_canonical_urls() {
 	}
 }
 add_action( 'template_redirect', __NAMESPACE__ . '\case_sensitivity_canonical_urls' );
+
+/**
+ * Redirect pages to the canonical URL when the query parameter contained a data point that was sanitized to -.
+ *
+ * Eg. https://wordpress.org/download/releases/6.3/ or https://wordpress.org/documentation/wordpress-version/version-6.3/
+ */
+function sanitized_url_param_canonical_urls() {
+	global $wp_query;
+	// Only run on pages with canonical enabled.
+	if ( ! has_action( 'template_redirect', 'redirect_canonical' ) ) {
+		return;
+	}
+
+	if ( ! preg_match( '/[^a-z0-9]/i', $_SERVER['REQUEST_URI'] ) ) {
+		return;
+	}
+
+	$requested_url = set_url_scheme( 'https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] );
+	$canonical_url = get_canonical_url();
+
+	foreach ( [ 'name', 'pagename' ] as $qv_field ) {
+		if ( ! isset( $wp_query->query[ $qv_field ] ) ) {
+			continue;
+		}
+
+		$sanitized  = $wp_query->query_vars[ $qv_field ];
+		$raw        = $wp_query->query[ $qv_field ];
+		if ( 'pagename' === $qv_field ) {
+			$raw = basename( $raw );
+		}
+
+		if (
+			$sanitized === $raw ||
+			sanitize_title_for_query( $raw ) != $sanitized
+		) {
+			continue;
+		}
+
+		$canonical_with_raw = str_replace( $sanitized, $raw, $canonical_url );
+
+		if (
+			$canonical_with_raw !== $canonical_url &&
+			0 === strcasecmp( $requested_url, $canonical_with_raw )
+		) {
+			wp_safe_redirect( $canonical_url, 301 );
+			exit;
+		}
+	}
+}
+add_action( 'template_redirect', __NAMESPACE__ . '\sanitized_url_param_canonical_urls' );

--- a/wordpress.org/public_html/wp-content/mu-plugins/pub/wporg-seo/wporg-seo.php
+++ b/wordpress.org/public_html/wp-content/mu-plugins/pub/wporg-seo/wporg-seo.php
@@ -9,4 +9,3 @@ include __DIR__ . '/redirects.php';
 include __DIR__ . '/canonical.php';
 include __DIR__ . '/archive-rel-next-prev.php';
 // include __DIR__ . '/hreflang.php';
-// include __DIR__ . '/canonical-redirects.php';


### PR DESCRIPTION
This:
 - Redirects urls such as `https://wordpress.org/Blocks/` to `https://wordpress.org/blocks/` (only if the page can be found..)
 - Redirects urls such as `https://wordpress.org/download/releases/6.3/` to `https://wordpress.org/download/releases/6-3/`

NOTE: In the case of `6.3` above, we may actually want to (long-term) alter WordPress's slugification to allow version identifiers like that on WordPress.org.

This has only been lightly tested.