### PR TITLE
Add announce privs for test team reps

### DIFF
--- a/common/includes/slack/announce/config.php
+++ b/common/includes/slack/announce/config.php
@@ -278,6 +278,7 @@ function get_whitelist() {
 			'tweetythierry', // @Thierry Muller on Slack
 		) ),
 		'core-test' => array_merge( get_committers(), array(
+			'ankit-k-gupta', // @Ankit K Gupta on Slack
 			'Boniu91', // @Piotrek Boniu on Slack
 			'francina',
 			'hellofromTonya', // @hellofromtonya on Slack
@@ -285,6 +286,7 @@ function get_whitelist() {
 			'justinahinon',
 			'monikarao',
 			'ryan', // @boren on Slack
+			'webtechpooja', // @Pooja Derashri on Slack
 		) ),
 		'core-themes' => array_merge( get_committers(), array(
 			'anlino', // @andersnoren on Slack


### PR DESCRIPTION
Adds `/here` privilege to Test team's new reps for the 2023-2024 term (see https://make.wordpress.org/test/2023/10/16/introducing-test-team-reps-for-2023-2024/).
