### PR TITLE
Add a "Live Preview" link for theme reviewers

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
@@ -1107,6 +1107,7 @@ WordPress.org - https://wordpress.org/themes/{$this->theme_slug}/
 
 SVN - https://themes.svn.wordpress.org/{$this->theme_slug}/{$this->theme->display( 'Version' )}
 ZIP - https://wordpress.org/themes/download/{$this->theme_slug}.{$this->theme->display( 'Version' )}.zip?nostats=1
+Live preview – https://playground.wordpress.net/#{%22preferredVersions%22:{%22php%22:%227.4%22,%22wp%22:%22latest%22},%22steps%22:[{%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22},{%22step%22:%22defineWpConfigConsts%22,%22consts%22:{%22WP_DEBUG%22:true}},{%22step%22:%22installPlugin%22,%22pluginZipFile%22:{%22resource%22:%22wordpress.org/plugins%22,%22slug%22:%22theme-check%22},%22options%22:{%22activate%22:true}},{%22step%22:%22installTheme%22,%22themeZipFile%22:{%22resource%22:%22url%22,%22url%22:%22https://wordpress.org/themes/download/{$this->theme_slug}.{$this->theme->display( 'Version' )}.zip?nostats=1%22}}]}
 {$this->trac_ticket->parent_link}
 {$this->trac_ticket->diff_line}
 History:

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
@@ -1107,7 +1107,7 @@ WordPress.org - https://wordpress.org/themes/{$this->theme_slug}/
 
 SVN - https://themes.svn.wordpress.org/{$this->theme_slug}/{$this->theme->display( 'Version' )}
 ZIP - https://wordpress.org/themes/download/{$this->theme_slug}.{$this->theme->display( 'Version' )}.zip?nostats=1
-Live preview – https://playground.wordpress.net/#{%22preferredVersions%22:{%22php%22:%227.4%22,%22wp%22:%22latest%22},%22steps%22:[{%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22},{%22step%22:%22defineWpConfigConsts%22,%22consts%22:{%22WP_DEBUG%22:true}},{%22step%22:%22installPlugin%22,%22pluginZipFile%22:{%22resource%22:%22wordpress.org/plugins%22,%22slug%22:%22theme-check%22},%22options%22:{%22activate%22:true}},{%22step%22:%22installTheme%22,%22themeZipFile%22:{%22resource%22:%22url%22,%22url%22:%22https://wordpress.org/themes/download/{$this->theme_slug}.{$this->theme->display( 'Version' )}.zip?nostats=1%22}}]}
+Live preview – https://playground.wordpress.net/#{%22preferredVersions%22:{%22php%22:%227.4%22,%22wp%22:%22latest%22},%22steps%22:[{%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22},{%22step%22:%22defineWpConfigConsts%22,%22consts%22:{%22WP_DEBUG%22:true}},{%22step%22:%22installPlugin%22,%22pluginZipFile%22:{%22resource%22:%22wordpress.org/plugins%22,%22slug%22:%22theme-check%22},%22options%22:{%22activate%22:true}},{%22step%22:%22installTheme%22,%22themeZipFile%22:{%22resource%22:%22url%22,%22url%22:%22https://downloads.wordpress.org/theme/{$this->theme_slug}.{$this->theme->display( 'Version' )}.zip?nostats=1%22}}]}
 {$this->trac_ticket->parent_link}
 {$this->trac_ticket->diff_line}
 History:


### PR DESCRIPTION
Adds a "Live preview" link to the automated trac ticket comment that gets posted when a new theme version is submitted for a review. See an [example of the automated comment](https://themes.trac.wordpress.org/ticket/158677).

The link leads to a [WordPress Playground](https://w.org/playground) instance set up with:

* The version of the theme listed in the comment
* Imported [theme unit test data](https://github.com/WordPress/theme-test-data)
* The Theme Check plugin installed and activated
* `WP_DEBUG` enabled

## Caveats

### Zip URL

The zip file URL used in the comment follows this pattern:

```
https://wordpress.org/themes/download/gutenify-shoppe.1.0.0.zip?nostats=1
```

However, I used the following URL for this PR:

```
https://downloads.wordpress.org/theme/gutenify-shoppe.1.0.0.zip?nostats=1
```

Why?

1. The former URL redirects to the latter, even for themes that are not live yet
2. Playground uses `fetch()` and can only interact with URLs that provide appropriate `Access-Control-*` headers. Only the latter URL does that.

### Missing images in the theme unit test data

The theme unit test data references images from a wordpress.com site that doesn't provide the `Access-Control-*` headers and thus can't be downloaded. A fix would involve updating the following XML file to load images from `raw.githubusercontent.com`: https://raw.githubusercontent.com/WordPress/theme-test-data/master/themeunittestdata.wordpress.xml 

This is outside of scope for this PR and can be addressed separately if needed.

## Testing instructions

I am not sure how to test this PR 😆 Any suggestions @dd32 @acosmin?

## Implementation

The following Blueprint is used to achieve this setup ([preview in the Blueprints builder](https://playground.wordpress.net/builder/builder.html#{%22preferredVersions%22:{%22php%22:%227.4%22,%22wp%22:%22latest%22},%22steps%22:[{%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22},{%22step%22:%22defineWpConfigConsts%22,%22consts%22:{%22WP_DEBUG%22:true}},{%22step%22:%22importFile%22,%22file%22:{%22resource%22:%22url%22,%22url%22:%22https://raw.githubusercontent.com/WordPress/theme-test-data/master/themeunittestdata.wordpress.xml%22,%22caption%22:%22Downloading%20theme%20testing%20content%22},%22progress%22:{%22caption%22:%22Installing%20theme%20testing%20content%22}},{%22step%22:%22installPlugin%22,%22pluginZipFile%22:{%22resource%22:%22wordpress.org/plugins%22,%22slug%22:%22theme-check%22},%22options%22:{%22activate%22:true}},{%22step%22:%22installTheme%22,%22themeZipFile%22:{%22resource%22:%22url%22,%22url%22:%22https://downloads.wordpress.org/theme/pendant.1.0.15.zip%22,%22caption%22:%22Downloading%20the%20theme%22}}]})):

```json
{
  "preferredVersions": {
    "php": "7.4",
    "wp": "latest"
  },
  "steps": [
    {
      "step": "login",
      "username": "admin",
      "password": "password"
    },
    {
      "step": "defineWpConfigConsts",
      "consts": {
        "WP_DEBUG": true
      }
    },
    {
      "step": "importFile",
      "file": {
        "resource": "url",
        "url": "https://raw.githubusercontent.com/WordPress/theme-test-data/master/themeunittestdata.wordpress.xml",
        "caption": "Downloading theme testing content"
      },
      "progress": {
        "caption": "Installing theme testing content"
      }
    },
    {
      "step": "installPlugin",
      "pluginZipFile": {
        "resource": "wordpress.org/plugins",
        "slug": "theme-check"
      },
      "options": {
        "activate": true
      }
    },
    {
      "step": "installTheme",
      "themeZipFile": {
        "resource": "url",
        "url": "https://downloads.wordpress.org/theme/pendant.1.0.15.zip",
        "caption": "Downloading the theme"
      }
    }
  ]
}
```

Trac ticket: https://meta.trac.wordpress.org/ticket/7382

