### PR TITLE
Adjust 6.4 credits to avoid an extra noteworthy contributor on the last line

### DIFF
--- a/api.wordpress.org/public_html/core/credits/wp-64.php
+++ b/api.wordpress.org/public_html/core/credits/wp-64.php
@@ -91,7 +91,6 @@ class WP_64_Credits extends WP_Credits {
 					'James Roberts'       => 'James Roberts',
 					'nalininonstopnewsuk' => 'Nalini Thakor',
 					'codente'             => 'Jamie VanRaalte',
-					'sabernhardt'         => 'Stephen Bernhardt',
 					'CoachBirgit'         => 'Birgit Olzem',
 					'annebovelett'        => 'Anne-Mieke Bovelett',
 					'huzaifaalmesbah'     => 'Huzaifa Al Mesbah',


### PR DESCRIPTION
Removes me from the 'contributing-developers' section to make the total evenly divisible by four. However, I should still be in the list of text links further down.

**Before:** each row can have up to four names (and images) until the last row.

![final two rows: one row with four images and names, the last row with one name and image](https://github.com/WordPress/wordpress.org/assets/17100257/0e1a2d4b-ab9e-4d39-a3b1-4d86ed2af440)