### PR TITLE
Slack: Grant announce privilege to mikachan for #core

### DIFF
--- a/common/includes/slack/announce/config.php
+++ b/common/includes/slack/announce/config.php
@@ -126,6 +126,7 @@ function get_whitelist() {
 			'marybaum',
 			'meaganhanes',
 			'metalandcoffee',
+			'mikachan',
 			'monikarao',
 			'mukesh27',
 			'nicolefurlan',


### PR DESCRIPTION
[mikachan](https://profiles.wordpress.org/mikachan/) is a new [Core Team rep](https://make.wordpress.org/updates/team-reps/) for 2024, and will need `/here` privileges for facilitating weekly dev chats, etc.