### PR TITLE
Add the new 'sustainability' focus to the `trac-select` shortcode.

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/trac-notifications/trac-components.php
+++ b/wordpress.org/public_html/wp-content/plugins/trac-notifications/trac-components.php
@@ -656,7 +656,7 @@ jQuery( function( $ ) {
 		}
 		echo '<option value="" selected="selected">' . $default . '</option>';
 		if ( in_array( 'focus', $topics ) ) {
-			$focuses = array( 'accessibility', 'administration', 'coding-standards', 'css', 'docs', 'javascript', 'multisite', 'performance', 'privacy', 'rest-api', 'rtl', 'template', 'ui' );
+			$focuses = array( 'accessibility', 'administration', 'coding-standards', 'css', 'docs', 'javascript', 'multisite', 'performance', 'privacy', 'rest-api', 'rtl', 'sustainability', 'template', 'ui' );
 			foreach ( $focuses as $focus ) {
 				echo '<option value="focus/' . esc_attr( rawurlencode( $focus ) ) . '">' . $focus . ( $both ? ' (focus)' : '' ) . '</option>';
 			}


### PR DESCRIPTION
This adds the 'sustainability' focus to the dropdown selector on the main "Tickets" page to make finding these tickets easier. The sustainability focusa is relatively new and when we added it, we forgot to add it here to the dropdown.

![image](https://github.com/WordPress/wordpress.org/assets/2676022/81091e9d-0a2f-466a-8843-a2a64e93cdf3)
