### PR TITLE
Adding devmuhib to meta-learn announce

### DIFF
--- a/common/includes/slack/announce/config.php
+++ b/common/includes/slack/announce/config.php
@@ -410,6 +410,7 @@ function get_whitelist() {
 		'meta-learn' => array(
 			'coreymckrill',
 			'courane01', // @Courtney on Slack
+			'devmuhib', // @Muhibul Haque on Slack
 			'digitalchild', // @Jamie Madden on Slack
 			'psykro', // @Jonathan on Slack
 			'tellyworth',


### PR DESCRIPTION
This PR addresses ticket https://meta.trac.wordpress.org/ticket/7547

Grant [Muhibul Haque](https://profiles.wordpress.org/devmuhib/) Slack /here access for #meta-learn