### PR TITLE
Requirements page: Bump recommended versions of MySQL and MariaDB

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-main/page-about-requirements.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-main/page-about-requirements.php
@@ -51,7 +51,7 @@ the_post();
 						<li>
 							<?php
 							/* translators: 1: URL to MySQL; 2: MySQL Version; 3: URL to MariaDB; 4: MariaDB Version */
-							printf( wp_kses_post( __( '<a href="%1$s">MySQL</a> version %2$s or greater <em>OR</em> <a href="%3$s">MariaDB</a> version %4$s or greater.', 'wporg' ) ), 'https://www.mysql.com/', '5.7', 'https://mariadb.org/', '10.3' );
+							printf( wp_kses_post( __( '<a href="%1$s">MySQL</a> version %2$s or greater <em>OR</em> <a href="%3$s">MariaDB</a> version %4$s or greater.', 'wporg' ) ), 'https://www.mysql.com/', '8.0', 'https://mariadb.org/', '10.4' );
 							?>
 						</li>
 						<li>
@@ -82,7 +82,7 @@ the_post();
 							/* translators: 1: PHP Version including; 2: MySQL Version */
 							wp_kses_post( __( 'Note: If you are in a legacy environment where you only have older PHP or MySQL versions, WordPress also works with PHP %1$s+ and MySQL %2$s+, but these versions have reached official End Of Life and as such <strong>may expose your site to security vulnerabilities</strong>.', 'wporg' ) ),
 							MINIMUM_PHP,
-							'5.0'
+							'5.5.5'
 						);
 						?>
 					</p>
@@ -104,7 +104,7 @@ the_post();
 							<li>
 								<?php
 								/* translators: 1: MySQL version; 2: MariaDB Version */
-								printf( esc_html__( 'MySQL %1$s or greater OR MariaDB %2$s or greater', 'wporg' ), '5.7', '10.3' );
+								printf( esc_html__( 'MySQL %1$s or greater OR MariaDB %2$s or greater', 'wporg' ), '8.0', '10.4' );
 								?>
 							</li>
 							<li><?php esc_html_e( 'Nginx or Apache with mod_rewrite module', 'wporg' ); ?></li>


### PR DESCRIPTION
Ticket: https://meta.trac.wordpress.org/ticket/7236

It is planned to update the Rosetta site to the new version in the following issue, and the new version is already enabled in some locales.

https://github.com/WordPress/wporg-main-2022/issues/266

My understanding is that if the new version is enabled, the Requirements page will load the following pattern:

https://github.com/WordPress/wporg-main-2022/blob/trunk/source/wp-content/themes/wporg-main-2022/patterns/about-requirements.php

The recommended version of this **pattern** is output via a shortcode and has been updated by the PRs below.

- https://github.com/WordPress/wporg-main-2022/pull/396
- https://github.com/WordPress/wporg-main-2022/pull/273
- https://github.com/WordPress/wporg-main-2022/pull/364

However, if a Rosetta site is not yet a new version, the page **template** below is loaded.

https://github.com/WordPress/wordpress.org/blob/trunk/wordpress.org/public_html/wp-content/themes/pub/wporg-main/page-about-requirements.php

Therefore, it is necessary to update the recommended version of MySQL/MariaDB even in locales where the new version has not yet been applied.

Below is [the current Requirements page for the Japanese locale](https://ja.wordpress.org/about/requirements/), which is not yet a new version.

![ja wordpress org_about_requirements](https://github.com/WordPress/wordpress.org/assets/54422211/ea1f97fa-5483-4855-9d8a-c33e69efdf34)
