### PR TITLE
wporg-support-2024: Include locale specific styles

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/functions.php
@@ -6,6 +6,11 @@
  */
 
 /**
+ * Include locale specific styles.
+ */
+require_once get_theme_root() . '/wporg-parent-2021/inc/rosetta-styles.php';
+
+/**
  * Use the ‘Lead Topic’ uses the single topic part
  * allowing styling the lead topic separately from the main reply loop.
  */


### PR DESCRIPTION
Include `wporg-parent-2021/inc/rosetta-styles.php` [in a similar manner to that theme](https://github.com/WordPress/wporg-parent-2021/blob/trunk/source/wp-content/themes/wporg-parent-2021/functions.php#L11), but in this case we need to navigate theme directories.

Fixes https://github.com/WordPress/wordpress.org/issues/240

## Testing
1. Visit https://ja.wordpress.org/support/?new-theme=1
2. Inspect a heading
3. `--wp--custom--heading--typography--text-wrap: unset` should be set (default is `balance`)