### PR TITLE
Grant Slack announce to Triage Leads in 6.6

### DIFF
--- a/common/includes/slack/announce/config.php
+++ b/common/includes/slack/announce/config.php
@@ -108,9 +108,11 @@ function get_whitelist() {
 			'cbringmann', // @Chloé Bringmann on Slack
 			'chaion07',
 			'chanthaboune',
+			'colorful-tones',
 			'costdev',
 			'danieltj',
 			'desrosj',
+			'fabiankaegy',
 			'francina',
 			'hellofromTonya', // @hellofromtonya on Slack
 			'ironprogrammer',


### PR DESCRIPTION
Meta ticket: https://meta.trac.wordpress.org/ticket/7579.