### PR TITLE
Fix singular/plural form for Persian language on WP Site

### DIFF
--- a/wordpress.org/public_html/wp-content/mu-plugins/pub/locales/locales.php
+++ b/wordpress.org/public_html/wp-content/mu-plugins/pub/locales/locales.php
@@ -1031,8 +1031,8 @@ class GP_Locales {
 		$fa->lang_code_iso_639_2 = 'fas';
 		$fa->wp_locale = 'fa_IR';
 		$fa->slug = 'fa';
-		$fa->nplurals = 1;
-		$fa->plural_expression = '0';
+		$fa->nplurals = 2;
+		$fa->plural_expression = 'n > 1';
 		$fa->text_direction = 'rtl';
 		$fa->google_code = 'fa';
 		$fa->facebook_locale = 'fa_IR';
@@ -1046,8 +1046,8 @@ class GP_Locales {
 		$fa_af->country_code = 'af';
 		$fa_af->wp_locale = 'fa_AF';
 		$fa_af->slug = 'fa-af';
-		$fa_af->nplurals = 1;
-		$fa_af->plural_expression = '0';
+		$fa_af->nplurals = 2;
+		$fa_af->plural_expression = 'n > 1';
 		$fa_af->text_direction = 'rtl';
 		$fa_af->google_code = 'fa';
 		$fa_af->alphabet = 'persian';


### PR DESCRIPTION
Hi,
Currently the form of singular and plural for Persian language on translate.wordpress.org site is not correct, Previously we fixed this on GlotPress but it seems WP site missed this fix https://meta.trac.wordpress.org/browser/sites/trunk/wordpress.org/public_html/wp-content/mu-plugins/pub/locales/locales.php?rev=12939#L1027 https://github.com/GlotPress/GlotPress/pull/1012
Correct form for Persian languages:
$fa->nplurals = 2;
$fa->plural_expression = 'n > 1';

$fa_af->nplurals = 2;
$fa_af->plural_expression = 'n > 1';

The ticket is:
https://meta.trac.wordpress.org/ticket/7583