### PR TITLE
Support Forums: Allow rosetta configuration of local nav menu items

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/functions.php
@@ -17,10 +17,22 @@ require_once get_theme_root( 'wporg-parent-2021' ) . '/wporg-parent-2021/inc/ros
 add_filter( 'bbp_show_lead_topic', '__return_true' );
 
 /**
+ * Get the local navigation menu object if it exists.
+ */
+function get_local_nav_menu_object() {
+	$local_nav_menu_locations = get_nav_menu_locations();
+	$local_nav_menu_object = isset( $local_nav_menu_locations['local-navigation'] )
+		? wp_get_nav_menu_object( $local_nav_menu_locations['local-navigation'] )
+		: false;
+
+	return $local_nav_menu_object;
+}
+
+/**
  * Register a local nav menu for non-English forums, if it doesn't already exist.
  */
 function register_local_nav_menu() {
-	if ( substr( get_locale(), 0, 2 ) === 'en' || wp_get_nav_menu_object( 'local-navigation' ) ) {
+	if ( substr( get_locale(), 0, 2 ) === 'en' || get_local_nav_menu_object() ) {
 		return;
 	}
 
@@ -54,7 +66,7 @@ function add_site_navigation_menus( $menus ) {
 			),
 		);
 	} else {
-		$local_nav_menu_object = wp_get_nav_menu_object( 'local-navigation' );
+		$local_nav_menu_object = get_local_nav_menu_object();
 		$menu_items_fallback = array(
 			'forums' => array(
 				 array(

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/functions.php
@@ -24,7 +24,7 @@ function add_site_navigation_menus( $menus ) {
 		return;
 	}
 
-	if ( get_locale() === 'en_US' ) {
+	if ( substr( get_locale(), 0, 2 ) === 'en' ) {
 		return array(
 			'forums' => array(
 				array(

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/functions.php
@@ -20,22 +20,61 @@ add_filter( 'bbp_show_lead_topic', '__return_true' );
  * Provide a list of local navigation menus.
  */
 function add_site_navigation_menus( $menus ) {
-	return array(
-		'forums' => array(
-			array(
-				'label' => __( 'Welcome to Support', 'wporg-forums' ),
-				'url' => '/welcome/',
+	if ( is_admin() ) {
+		return;
+	}
+
+	if ( get_locale() === 'en_US' ) {
+		return array(
+			'forums' => array(
+				array(
+					'label' => __( 'Welcome to Support', 'wporg-forums' ),
+					'url' => '/welcome/',
+				),
+				array(
+					'label' => __( 'Guidelines', 'wporg-forums' ),
+					'url' => '/guidelines/',
+				),
+				array(
+					'label' => __( 'Get Involved', 'wporg-forums' ),
+					'url' => 'https://make.wordpress.org/support/handbook/contributing-to-the-wordpress-forums/',
+				)
 			),
-			array(
-				'label' => __( 'Guidelines', 'wporg-forums' ),
-				'url' => '/guidelines/',
+		);
+	} else {
+		$menu_object = wp_get_nav_menu_object( 'navigation' );
+		$menu_items_fallback = array(
+			'forums' => array(
+				 array(
+					'label' => __( 'Get Involved', 'wporg-forums' ),
+					'url' => 'https://make.wordpress.org/support/handbook/contributing-to-the-wordpress-forums/',
+				)
 			),
-			array(
-				'label' => __( 'Get Involved', 'wporg-forums' ),
-				'url' => 'https://make.wordpress.org/support/handbook/contributing-to-the-wordpress-forums/',
+		);
+
+		if ( ! $menu_object ) {
+			return $menu_items_fallback;
+		}
+
+		$menu_items = wp_get_nav_menu_items( $menu_object->term_id );
+
+		if ( ! $menu_items || empty( $menu_items ) ) {
+			return $menu_items_fallback;
+		}
+
+		return array(
+			'forums' => array_map(
+				function( $menu_item ) {
+					return array(
+						'label' => esc_html( $menu_item->title ),
+						'url' => esc_url( $menu_item->url )
+					);
+				},
+				// Limit local nav items to 3
+				array_slice( $menu_items, 0, 3 )
 			)
-		),
-	);
+		);
+	}
 }
 add_filter( 'wporg_block_navigation_menus', '\add_site_navigation_menus' );
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/functions.php
@@ -17,6 +17,18 @@ require_once get_theme_root( 'wporg-parent-2021' ) . '/wporg-parent-2021/inc/ros
 add_filter( 'bbp_show_lead_topic', '__return_true' );
 
 /**
+ * Register a local nav menu for non-English forums, if it doesn't already exist.
+ */
+function register_local_nav_menu() {
+	if ( substr( get_locale(), 0, 2 ) === 'en' || wp_get_nav_menu_object( 'local-navigation' ) ) {
+		return;
+	}
+
+	register_nav_menu( 'local-navigation', __( 'Local Navigation', 'wporg-forums' ) );
+}
+add_action( 'after_setup_theme', 'register_local_nav_menu' );
+
+/**
  * Provide a list of local navigation menus.
  */
 function add_site_navigation_menus( $menus ) {
@@ -42,7 +54,7 @@ function add_site_navigation_menus( $menus ) {
 			),
 		);
 	} else {
-		$menu_object = wp_get_nav_menu_object( 'navigation' );
+		$local_nav_menu_object = wp_get_nav_menu_object( 'local-navigation' );
 		$menu_items_fallback = array(
 			'forums' => array(
 				 array(
@@ -52,11 +64,11 @@ function add_site_navigation_menus( $menus ) {
 			),
 		);
 
-		if ( ! $menu_object ) {
+		if ( ! $local_nav_menu_object ) {
 			return $menu_items_fallback;
 		}
 
-		$menu_items = wp_get_nav_menu_items( $menu_object->term_id );
+		$menu_items = wp_get_nav_menu_items( $local_nav_menu_object->term_id );
 
 		if ( ! $menu_items || empty( $menu_items ) ) {
 			return $menu_items_fallback;


### PR DESCRIPTION
Allows rosetta support sites to configure a `navigation` menu with items to replace the `en_US` items.

If a menu is not found with that name, the fallback is a menu with only the Get Involved link.

Fixes #236 

### Screenshots

| Admin menu | With configured menu (es_ES) | Without configured menu (de_DE) |
|-|-|-|
| ![Screenshot 2024-04-15 at 12 15 42 PM](https://github.com/WordPress/wordpress.org/assets/1017872/4cf82d2a-ad04-40ff-a196-7ee9889d509c) | ![Screenshot 2024-04-15 at 12 17 41 PM](https://github.com/WordPress/wordpress.org/assets/1017872/f128e713-1e9b-472c-8f1c-a0ee4de6a1c9) | ![Screenshot 2024-04-15 at 12 40 46 PM](https://github.com/WordPress/wordpress.org/assets/1017872/b65b338f-8c35-4882-b0dd-f79d7b2c8b85) |
