### PR TITLE
Plugins: Pass the current plugin through to locale suggestions API

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/patterns/nav.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/patterns/nav.php
@@ -30,7 +30,7 @@
 <?php
 	$lang_suggest_endpoint = rest_url( '/plugins/v2/locale-banner' );
 	if ( is_singular( 'plugin' ) ) {
-		$lang_suggest_endpoint = add_query_arg( 'currentPlugin', get_queried_object()->post_name, $lang_suggest_endpoint );
+		$lang_suggest_endpoint = add_query_arg( 'plugin_slug', get_queried_object()->post_name, $lang_suggest_endpoint );
 	}
 ?>
 <!-- wp:wporg/language-suggest {"align":"full","endpoint":"<?php echo esc_attr( $lang_suggest_endpoint ); ?>"} -->


### PR DESCRIPTION
In [this slack thread](https://wordpress.slack.com/archives/C04U953K77A/p1714467181419539) it was pointed out that the single plugin locale suggestions weren't working with the new theme. It would always show the generic plugin directory string. It looks like the parameter name was incorrect, it should be `plugin_slug`.

For example, the following two commands should return different text.

```
curl 'https://wordpress.org/plugins/wp-json/plugins/v2/locale-banner?plugin_slug=jetpack' -H 'Accept-Language: en-US,en;q=0.8,es-ES;q=0.5'

curl 'https://wordpress.org/plugins/wp-json/plugins/v2/locale-banner' -H 'Accept-Language: en-US,en;q=0.8,es-ES;q=0.5'
```

This PR just updates the URL for the `wporg/language-suggest` block to use the right query string name.

To test:

- Have your browser set to accept multiple languages (or be in a non-English country)
- View a single plugin
- It should have a distinct message from the homepage banner
