### PR TITLE
Remove duplicated readme/plugin fields

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
@@ -266,8 +266,16 @@ class Import {
 			$plugin->post_title = strip_tags( $headers->Name );
 		}
 
-		$plugin->post_content = trim( $content ) ?: $plugin->post_content;
-		$plugin->post_excerpt = trim( $readme->short_description ) ?: $headers->Description ?: $plugin->post_excerpt;
+		if ( $readme->short_description ) {
+			$plugin->post_excerpt = $readme->short_description;
+		} elseif ( $headers->Description ) {
+			// Trim to match legacy readme length...
+			$plugin->post_excerpt = $readme->trim_length( wp_strip_all_tags( $headers->Description ), 'short_description' );
+		}
+
+		if ( $content ) {
+			$plugin->post_content = $content;
+		}
 
 		/*
 		 * Bump last updated if:

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
@@ -256,21 +256,18 @@ class Import {
 			$content = "<!--section=description-->\n{$headers->Description}";
 		}
 
-		// Use the Readme name, as long as it's not the plugin slug.
-		if (
-			$readme->name &&
-			$readme->name !== $plugin->post_name
-		) {
-			$plugin->post_title = $readme->name;
-		} elseif ( $headers->Name ) {
+		// Use the Plugin name by default, falling back to the readme name (if availble) only in the event of a missing header.
+		if ( $headers->Name ) {
 			$plugin->post_title = strip_tags( $headers->Name );
+		} elseif ( $readme->name ) {
+			$plugin->post_title = $readme->name;
 		}
 
-		if ( $readme->short_description ) {
-			$plugin->post_excerpt = $readme->short_description;
-		} elseif ( $headers->Description ) {
+		if ( $headers->Description ) {
 			// Trim to match legacy readme length...
 			$plugin->post_excerpt = $readme->trim_length( wp_strip_all_tags( $headers->Description ), 'short_description' );
+		} elseif ( $readme->short_description ) {
+			$plugin->post_excerpt = $readme->short_description;
 		}
 
 		if ( $content ) {

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/readme/class-parser.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/readme/class-parser.php
@@ -243,8 +243,7 @@ class Parser {
 		if ( $this->parse_possible_header( $line, true /* only valid headers */ ) ) {
 			array_unshift( $contents, $line );
 
-			$this->warnings['invalid_plugin_name_header'] = true;
-			$this->name                                   = false;
+			$this->name = false;
 		}
 
 		// Strip Github style header\n==== underlines.
@@ -254,8 +253,6 @@ class Parser {
 
 		// Handle readme's which do `=== Plugin Name ===\nMy SuperAwesomePlugin Name\n...`
 		if ( 'plugin name' == strtolower( $this->name ) ) {
-			$this->warnings['invalid_plugin_name_header'] = true;
-
 			$this->name = false;
 			$line       = $this->get_first_nonwhitespace( $contents );
 

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/readme/class-parser.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/readme/class-parser.php
@@ -545,14 +545,14 @@ class Parser {
 	}
 
 	/**
-	 * @access protected
+	 * Trim a string to a specific length, ensuring that it ends on a full sentence.
 	 *
 	 * @param string $desc
 	 * @param int    $length
 	 * @param string $type   The type of the length, 'char' or 'words'.
 	 * @return string
 	 */
-	protected function trim_length( $desc, $length = 150, $type = 'char' ) {
+	public function trim_length( $desc, $length = 150, $type = 'char' ) {
 		if ( is_string( $length ) ) {
 			$length = $this->maximum_field_lengths[ $length ] ?? $length;
 		}

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/readme/class-parser.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/readme/class-parser.php
@@ -471,22 +471,16 @@ class Parser {
 		$this->upgrade_notice = array_map( array( $this, 'parse_markdown' ), $this->upgrade_notice );
 		$this->faq            = array_map( array( $this, 'parse_markdown' ), $this->faq );
 
-		// Use the first line of the description for the short description if not provided.
-		if ( ! $this->short_description && ! empty( $this->sections['description'] ) ) {
-			$this->short_description = array_filter( explode( "\n", $this->sections['description'] ) )[0];
-			$this->warnings['no_short_description_present'] = true;
-		}
-
 		// Sanitize and trim the short_description to match requirements.
-		$this->short_description = $this->sanitize_text( $this->short_description );
-		$this->short_description = $this->parse_markdown( $this->short_description );
-		$this->short_description = wp_strip_all_tags( $this->short_description );
-		$short_description       = $this->trim_length( $this->short_description, 'short_description' );
-		if ( $short_description !== $this->short_description ) {
-			if ( empty( $this->warnings['no_short_description_present'] ) ) {
+		if ( $this->short_description ) {
+			$this->short_description = $this->sanitize_text( $this->short_description );
+			$this->short_description = $this->parse_markdown( $this->short_description );
+			$this->short_description = wp_strip_all_tags( $this->short_description );
+			$short_description       = $this->trim_length( $this->short_description, 'short_description' );
+			if ( $short_description !== $this->short_description ) {
 				$this->warnings['trimmed_short_description'] = true;
+				$this->short_description                     = $short_description;
 			}
-			$this->short_description = $short_description;
 		}
 
 		if ( isset( $this->sections['screenshots'] ) ) {

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/readme/class-validator.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/readme/class-validator.php
@@ -101,15 +101,8 @@ class Validator {
 		// it could bypass the protections above in validate_url().
 		$readme = new Parser( 'data:text/plain,' . urlencode( $readme ) );
 
-		// Fatal errors.
-		if ( isset( $readme->warnings['invalid_plugin_name_header'] ) ) {
-			$errors['invalid_plugin_name_header'] = $readme->warnings['invalid_plugin_name_header'];
-		} elseif ( empty( $readme->name ) ) {
-			$errors['invalid_plugin_name_header'] = true;
-		}
-
 		if (
-			empty( $errors['invalid_plugin_name_header'] ) &&
+			$readme->name &&
 			( $trademark_check = Trademarks::check( $readme->name, wp_get_current_user() ) )
 		) {
 			$errors['trademarked_name'] = [
@@ -234,13 +227,6 @@ class Validator {
 		}
 
 		switch( $error_code ) {
-			case 'invalid_plugin_name_header':
-				return sprintf(
-					/* translators: 1: 'Plugin Name' section title, 2: 'Plugin Name' */
-					__( 'We cannot find a plugin name in your readme. Plugin names look like: %1$s. Please change %2$s to reflect the actual name of your plugin.', 'wporg-plugins' ),
-					'<code>=== Plugin Name ===</code>',
-					'<code>Plugin Name</code>'
-				);
 			case 'requires_header_ignored':
 				$latest_wordpress_version = defined( 'WP_CORE_STABLE_BRANCH' ) ? WP_CORE_STABLE_BRANCH : '6.5';
 

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/readme/class-validator.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/readme/class-validator.php
@@ -187,10 +187,7 @@ class Validator {
 			$notes['requires_php_header_missing'] = true;
 		}
 
-		if ( isset( $readme->warnings['no_short_description_present'] ) ) {
-			$notes['no_short_description_present'] = $readme->warnings['no_short_description_present'];
-
-		} elseif ( isset( $readme->warnings['trimmed_short_description'] ) ) {
+		if ( isset( $readme->warnings['trimmed_short_description'] ) ) {
 			$warnings['trimmed_short_description'] = $readme->warnings['trimmed_short_description'];
 		}
 
@@ -340,12 +337,6 @@ class Validator {
 					/* translators: %s: list of tags with low usage. */
 					__( 'The following tags are not widely used: %s', 'wporg-plugins' ),
 					'<code>' . implode( '</code>, <code>', array_map( 'esc_html', $data ) ) . '</code>'
-				);
-			case 'no_short_description_present':
-				return sprintf(
-					/* translators: %s: section title */
-					__( 'The %s section is missing. An excerpt was generated from your main plugin description.', 'wporg-plugins' ),
-					'<code>Short Description</code>'
 				);
 			case 'trimmed_short_description':
 				return sprintf(

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/readme/readme.txt
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/readme/readme.txt
@@ -1,4 +1,3 @@
-=== Plugin Name ===
 Contributors: (this should be a list of wordpress.org userid's)
 Donate link: https://example.com/
 Tags: tag1, tag2
@@ -9,14 +8,9 @@ Requires PHP: 7.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-Here is a short description of the plugin.  This should be no more than 150 characters.  No markup here.
-
 == Description ==
 
-This is the long description.  No limit, and you can use Markdown (as well as in the following sections).
-
-For backwards compatibility, if this section is missing, the full length of the short description will be used, and
-Markdown parsed.
+This is the description. No limit, and you can use Markdown (as well as in the following sections).
 
 A few notes about the sections above:
 


### PR DESCRIPTION
This PR removes the `Plugin Name` and `Short Description` fields from readme's, and instead uses the Plugin headers.

This is an exploration of what the changes would look like.

Trac Ticket: https://meta.trac.wordpress.org/ticket/6106