### PR TITLE
Plugins: Add sorting

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/src/blocks/filter-bar/render.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/src/blocks/filter-bar/render.php
@@ -10,14 +10,10 @@ if ( isset( $wp_query ) && ( ! empty( $wp_query->query_vars['browse'] ) && 'favo
 $filter_blocks = <<<FILTERS
 	<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"className":"wporg-query-filters","layout":{"type":"flex","flexWrap":"nowrap"}} -->
 	<div class="wp-block-group wporg-query-filters">
-		<!-- wp:wporg/query-filter {"key":"business_model","multiple":false} /-->
 		<!-- wp:wporg/query-filter {"key":"sort","multiple":false} /-->
 	</div>
 	<!-- /wp:group -->
 	FILTERS;
-
-// Temporarily disable the filters.
-$filter_blocks = '';
 
 $search_placeholder = esc_attr__( 'Search plugins', 'wporg-plugins' );
 $search_button      = esc_attr__( 'Search plugins', 'wporg-plugins' );

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/src/blocks/search-page/render.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/src/blocks/search-page/render.php
@@ -5,6 +5,11 @@ echo do_blocks( <<<BLOCKS
 	<!-- wp:wporg/filter-bar /-->
 	<!-- wp:wporg/category-navigation /-->
 	<!-- wp:query-title {"type":"search","fontFamily":"inter","className":"section-heading"} /-->
+	<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"className":"wporg-query-filters","layout":{"type":"flex","flexWrap":"nowrap"}} -->
+	<div class="wp-block-group wporg-query-filters">
+		<!-- wp:wporg/query-filter {"key":"sort","multiple":false} /-->
+	</div>
+	<!-- /wp:group -->
 	<!-- wp:query {"tagName":"div","className":"plugin-cards"} -->
 	<div class="wp-block-query plugin-cards">
 			<!-- wp:post-template {"className":"is-style-cards-grid","layout":{"type":"grid","minimumColumnWidth":"48%"}} -->


### PR DESCRIPTION
This is effectively a cutdown version of #202 but specific for sort with the new plugin directory theme.

This enables a sorting dropdown on archives & search.

ZERO effort has been put into styling and getting the dropdowns in the correct locations on either search or archives.

It's worth noting that custom sorting is already enabled for non-search archives, just not exposed with a dropdown, for example, `tags/performance/?orderby=rating`

Sorting for search is arguably useless, as when you sort you immediately loose relevancy order in the results, and you end up with the same top-20 plugins showing up in every search in the first few places.

This requires a change to Jetpack Search on WordPress.com to allow us to sort by some fields, D148116, notably this is required for the `ratings`, `num_ratings`, `tested`, and `active_installs` sorts. If you're an Automattician with a WordPress.com sandbox, you can test using the diff D148116 w/ `JETPACK__SANDBOX_DOMAIN`.

Trac: https://meta.trac.wordpress.org/ticket/2753