### PR TITLE
Add `php-compatibility` focus to trac-select shortcode

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/trac-notifications/trac-components.php
+++ b/wordpress.org/public_html/wp-content/plugins/trac-notifications/trac-components.php
@@ -656,7 +656,7 @@ jQuery( function( $ ) {
 		}
 		echo '<option value="" selected="selected">' . $default . '</option>';
 		if ( in_array( 'focus', $topics ) ) {
-			$focuses = array( 'accessibility', 'administration', 'coding-standards', 'css', 'docs', 'javascript', 'multisite', 'performance', 'privacy', 'rest-api', 'rtl', 'template', 'ui' );
+			$focuses = array( 'accessibility', 'administration', 'coding-standards', 'css', 'docs', 'javascript', 'multisite', 'performance', 'php-compatibility', 'privacy', 'rest-api', 'rtl', 'template', 'ui' );
 			foreach ( $focuses as $focus ) {
 				echo '<option value="focus/' . esc_attr( rawurlencode( $focus ) ) . '">' . $focus . ( $both ? ' (focus)' : '' ) . '</option>';
 			}


### PR DESCRIPTION
Adds `php-compatibility` to the shortcode, which in turn makes this option available in the "Tickets by Focus" dropdown on the [Trac reports page](https://make.wordpress.org/core/reports/). Allows ticket reports with this focus to be more conveniently accessed.

> <img width="376" alt="SCR-20240509-jmyd" src="https://github.com/WordPress/wordpress.org/assets/824344/1a4cbf8a-a9b2-4b43-b10e-ae61494315ea">

Also see https://meta.trac.wordpress.org/ticket/7169, where this keyword was introduced.
