### PR TITLE
WordPress.tv: Show hero video thumbnail images at full width on narrow screens

### DIFF
--- a/wordpress.tv/public_html/wp-content/themes/wptv2/style.css
+++ b/wordpress.tv/public_html/wp-content/themes/wptv2/style.css
@@ -2076,12 +2076,11 @@ h5 {
 .wptv-hero .secondary-videos li {
 	font-size: 13px;
 	margin: 0 auto 23px;
-	max-width: 130px;
 }
 
 .wptv-hero .secondary-videos .video-thumbnail img {
-	width: 130px;
-	height: 75px;
+	width: 100%;
+	height: auto;
 }
 
 .wptv-hero .secondary-videos a:hover img {
@@ -2511,6 +2510,11 @@ h3#comments {
 	.wptv-hero .secondary-videos .video-thumbnail {
 		left: 0;
 		position: absolute;
+	}
+
+	.wptv-hero .secondary-videos .video-thumbnail img {
+		width: 130px;
+		height: 75px;
 	}
 }
 


### PR DESCRIPTION
- Removes `max-width` from the list item.
- Sets the thumbnail image to 100% width and auto height to start (without a media query).
- Moves the image's exact dimensions inside the `min-width: 415px` media query.

https://meta.trac.wordpress.org/ticket/6244