### PR TITLE
Fix GlotPress warnings (on local installs)

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/class-plugin.php
@@ -543,7 +543,7 @@ class Plugin {
 	 * and script loader.
 	 */
 	public function show_admin_bar() {
-		add_action( 'gp_head', 'wp_admin_bar_header' );
+		add_action( 'gp_head', 'wp_enqueue_admin_bar_header_styles' );
 		add_action( 'gp_head', '_admin_bar_bump_cb' );
 
 		gp_enqueue_script( 'admin-bar' );

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/header.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/header.php
@@ -22,10 +22,12 @@ gp_enqueue_scripts( array( 'gp-tour' ) );
 			<nav id="site-navigation" class="navigation-main clear" role="navigation">
 				<button type="button" class="menu-toggle dashicons dashicons-arrow-down-alt2"></button>
 				<?php
-				wp_nav_menu( [
-					'theme_location' => 'wporg_header_subsite_nav',
-					'fallback_cb' => false,
-				] );
+				wp_nav_menu(
+					array(
+						'theme_location' => 'wporg_header_subsite_nav',
+						'fallback_cb'    => false,
+					)
+				);
 				?>
 			</nav>
 		<?php endif; ?>

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-routes/inc/routes/class-index.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-routes/inc/routes/class-index.php
@@ -19,10 +19,7 @@ class Index extends GP_Route {
 	public function get_locales() {
 		$existing_locales = Plugin::get_existing_locales();
 
-		$locales = array();
-		foreach ( $existing_locales as $locale ) {
-			$locales[] = GP_Locales::by_slug( $locale );
-		}
+		$locales = array_filter( array_map( array( 'GP_Locales', 'by_slug' ), Plugin::get_existing_locales() ) );
 		usort( $locales, array( $this, '_sort_english_name_callback' ) );
 		unset( $existing_locales );
 
@@ -33,6 +30,6 @@ class Index extends GP_Route {
 	}
 
 	private function _sort_english_name_callback( $a, $b ) {
-		return $a->english_name > $b->english_name;
+		return $a->english_name <=> $b->english_name;
 	}
 }


### PR DESCRIPTION
We have a few warnings that are fixed here:
- Loading of a not fully populated locale list
- Deprecated hooks
- PHP 8 sorting operation