### PR TITLE
Plugin Directory: Use a rounded number for the plugins count

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/patterns/front-page-header.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/patterns/front-page-header.php
@@ -5,6 +5,18 @@
  * Inserter: no
  */
 
+$count = wp_count_posts( 'plugin' )->publish;
+$count = floor( $count / 1000 ) * 1000;
+$description = sprintf(
+	/* Translators: Total number of plugins, rounded to thousands (ex, 12,000). */
+	_n(
+		'Extend your WordPress experience! Browse over %s free plugin.',
+		'Extend your WordPress experience! Browse over %s free plugins.',
+		$count,
+		'wporg-themes'
+	),
+	number_format_i18n( $count )
+);
 ?>
 
 <!-- wp:pattern {"slug":"wporg-plugins-2024/front-page-nav"} /-->
@@ -20,16 +32,7 @@
 		<!-- /wp:heading -->
 
 		<!-- wp:paragraph {"style":{"typography":{"lineHeight":"2.3"}},"textColor":"white"} -->
-		<p class="has-white-color has-text-color" style="line-height:2.3">
-		<?php
-			$plugin_count = wp_count_posts( 'plugin' )->publish;
-			printf(
-				/* Translators: Total number of plugins. */
-				esc_html( _n( 'Extend your WordPress experience! Browse %s free plugin.', 'Extend your WordPress experience! Browse %s free plugins.', $plugin_count, 'wporg-plugins' ) ),
-				esc_html( number_format_i18n( $plugin_count ) )
-			);
-			?>
-		</p>
+		<p class="has-white-color has-text-color" style="line-height:2.3"><?php echo esc_html( $description ); ?></p>
 		<!-- /wp:paragraph -->
 	</div>
 	<!-- /wp:group -->


### PR DESCRIPTION
See https://github.com/WordPress/wporg-theme-directory/issues/68#issuecomment-2115897450. The Theme Directory uses a rounded number ("Over 12,000 free themes to customize your WordPress site"), which is an easier number to read. This PR updates the plugin directory header to round down to the nearest thousand, and adds "over" — which will give us the tagline:

> Extend your WordPress experience! Browse over 59,000 free plugins.

![Screen Shot 2024-05-17 at 14 45 05](https://github.com/WordPress/wordpress.org/assets/541093/1171b66e-d449-4425-89ad-b163d0966075)
