### PR TITLE
Plugin Directory: Move spacing to parent element for search bar

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/patterns/full-width-search.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/patterns/full-width-search.php
@@ -8,12 +8,8 @@
 
 ?>
 
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}}}} -->
-	<div class="wp-block-group alignfull" style="margin-top:var(--wp--preset--spacing--20);margin-bottom:var(--wp--preset--spacing--20)">
-	<!-- wp:group {"tagName":"div","style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}}} -->
-		<div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
-			<!-- wp:search {"label":"<?php esc_attr_e( 'Search plugins', 'wporg' ); ?>","showLabel":false,"placeholder":"<?php esc_attr_e( 'Search plugins', 'wporg' ); ?>","width":232,"widthUnit":"px","buttonText":"<?php esc_attr_e( 'Search plugins', 'wporg' ); ?>","buttonPosition":"button-inside","buttonUseIcon":true} /-->
-		</div>
-	<!-- /wp:group -->
-	</div>
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"},"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}}} -->
+<div class="wp-block-group alignfull" style="margin-top:var(--wp--preset--spacing--20);margin-bottom:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
+	<!-- wp:search {"label":"<?php esc_attr_e( 'Search plugins', 'wporg' ); ?>","showLabel":false,"placeholder":"<?php esc_attr_e( 'Search plugins', 'wporg' ); ?>","width":232,"widthUnit":"px","buttonText":"<?php esc_attr_e( 'Search plugins', 'wporg' ); ?>","buttonPosition":"button-inside","buttonUseIcon":true} /-->
+</div>
 <!-- /wp:group -->

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/templates/single-plugin.html
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/templates/single-plugin.html
@@ -1,8 +1,8 @@
 <!-- wp:template-part {"slug":"header","tagName":"div","className":"has-display-contents"} /-->
 
-<!-- wp:pattern {"slug":"wporg-plugins-2024/full-width-search"} /-->
 <!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group" style="padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)">
+	<!-- wp:pattern {"slug":"wporg-plugins-2024/full-width-search"} /-->
 	<!-- wp:wporg/single-plugin /-->
 </main>
 <!-- /wp:group -->


### PR DESCRIPTION
This is an alternate solution to #327 — rather than creating a duplicate container for the search bar, the left/right spacing can be added to the `alignfull` element directly. This adds back the expected left/right spacing now that nested alignfull elements have negative margins.

There were other changes in [the commit](https://github.com/WordPress/wordpress.org/commit/a05e8bbb772f8446adc5d34a8f7baeb8b1ffb7fd) that I left alone, except for one— I moved the search bar back into the `main` tag. This does not change anything visually.