### PR TITLE
WordPress.tv: make the main heading on video pages an h1

### DIFF
--- a/wordpress.tv/public_html/wp-content/themes/wptv2/archive.php
+++ b/wordpress.tv/public_html/wp-content/themes/wptv2/archive.php
@@ -13,7 +13,7 @@ get_header();
 global $wp_query, $post, $wptv;
 ?>
 <div class="wptv-hero">
-	<h2 class="page-title"><?php
+	<h1 class="page-title"><?php
 		if ( is_category() ) :
 			printf( __( '&#8216;%s&#8217; Videos', 'wptv' ), single_cat_title( '', false ) );
 
@@ -45,7 +45,7 @@ global $wp_query, $post, $wptv;
 
 		endif;
 	?>
-	</h2>
+	</h1>
 </div>
 <div class="container">
 	<div class="primary-content">

--- a/wordpress.tv/public_html/wp-content/themes/wptv2/category-wordcamptv.php
+++ b/wordpress.tv/public_html/wp-content/themes/wptv2/category-wordcamptv.php
@@ -19,7 +19,7 @@ global $wptv;
 <div class="wptv-hero group">
 	<div class="container">
 
-		<h2 class="page-title"><?php single_term_title(); ?></h2>
+		<h1 class="page-title"><?php single_term_title(); ?></h1>
 		<div class="desc"><?php echo category_description(); ?></div>
 
 		<?php if ( $featured->have_posts() ) : $featured->the_post(); ?>

--- a/wordpress.tv/public_html/wp-content/themes/wptv2/category.php
+++ b/wordpress.tv/public_html/wp-content/themes/wptv2/category.php
@@ -21,7 +21,7 @@ if ( get_query_var( 'paged' ) < 2 && $wp_query->found_posts > 6 ) : ?>
 <div class="wptv-hero group">
 	<div class="container">
 
-		<h2 class="page-title"><?php single_term_title(); ?></h2>
+		<h1 class="page-title"><?php single_term_title(); ?></h1>
 		<div class="desc"><?php echo category_description(); ?></div>
 
 		<?php if ( have_posts() ) : the_post(); ?>

--- a/wordpress.tv/public_html/wp-content/themes/wptv2/front-page.php
+++ b/wordpress.tv/public_html/wp-content/themes/wptv2/front-page.php
@@ -23,18 +23,18 @@ get_header(); ?>
 		<?php while ( $featured->have_posts() ) : $featured->the_post(); ?>
 		<div class="main-video">
 			<?php $wptv->the_video(); ?>
-			<h3>
+			<h2>
 				<a href="<?php the_permalink(); ?>" rel="bookmark" class="video-title"><?php the_title(); ?></a>
 				<?php $wptv->the_event( '<strong class="video-event">', '</strong>' ); ?>
-			</h3>
+			</h2>
 		</div><!-- .main-video -->
 		<?php endwhile; // $featured->have_posts ?>
 
 		<div class="secondary-videos">
-			<h3>
+			<h2>
 				<?php esc_html_e( 'WordCampTV', 'wptv' ); ?>
 				<a href="<?php echo home_url( '/category/wordcamptv/' ); ?>" class="view-more"><?php _e( 'More &rarr;', 'wptv' ); ?></a>
-			</h3>
+			</h2>
 			<ul>
 				<?php
 					$featured = new WP_Query( array( // WordCampTV Featured
@@ -79,7 +79,7 @@ get_header(); ?>
 		<?php
 			if ( have_posts() ) :
 		?>
-		<h3><?php esc_html_e( 'Latest Videos', 'wptv' ); ?></h3>
+		<h2><?php esc_html_e( 'Latest Videos', 'wptv' ); ?></h2>
 		<ul class="video-list four-col">
 
 			<?php while ( have_posts() ) : the_post(); ?>
@@ -108,7 +108,7 @@ get_header(); ?>
 
 			if ( $popular->have_posts() ) :
 		?>
-		<h3><?php esc_html_e( 'Popular Videos', 'wptv' ); ?></h3>
+		<h2><?php esc_html_e( 'Popular Videos', 'wptv' ); ?></h2>
 		<ul class="video-list four-col">
 
 			<?php while ( $popular->have_posts() ) : $popular->the_post(); ?>

--- a/wordpress.tv/public_html/wp-content/themes/wptv2/header.php
+++ b/wordpress.tv/public_html/wp-content/themes/wptv2/header.php
@@ -38,12 +38,10 @@ global $wptv;
 	<div id="header">
 		<div class="sleeve">
 
-			<?php if ( is_home() ) { ?> 
-			<h1><a class="homelogo" rel="home" href="<?php echo $wptv->home_url( '/' ); ?>"><img src="<?php echo get_template_directory_uri(); ?>/i/wptv-2x.png" alt="<?php echo esc_attr( get_bloginfo( 'name' ) ); ?>" height="40" width="210" /></a></h1>
-			<?php } else { ?>
-			<a class="homelogo" rel="home" href="<?php echo $wptv->home_url( '/' ); ?>"><img src="<?php echo get_template_directory_uri(); ?>/i/wptv-2x.png" alt="<?php echo esc_attr( get_bloginfo( 'name' ) ); ?>" height="40" width="210" /></a><
-			<?php } ?>
-			
+			<?php if ( is_front_page() ) { echo '<h1>'; } ?>
+			<a class="homelogo" rel="home" href="<?php echo $wptv->home_url( '/' ); ?>"><img src="<?php echo get_template_directory_uri(); ?>/i/wptv-2x.png" alt="<?php echo esc_attr( get_bloginfo( 'name' ) ); ?>" height="40" width="210" /></a></h1>
+			<?php if ( is_front_page() ) { echo '</h1>'; } ?>
+
 			<form id="searchform" name="searchform" method="get" action="<?php echo $wptv->home_url( '/' ); ?>">
 				<label for="searchbox" class="screen-reader-text"><?php esc_attr_e( 'Search WordPress.tv', 'wptv' ); ?></label>
 				<input type="search" placeholder="<?php esc_attr_e( 'Search WordPress.tv', 'wptv' ); ?>" id="searchbox" name="s" value="<?php the_search_query(); ?>"  />

--- a/wordpress.tv/public_html/wp-content/themes/wptv2/header.php
+++ b/wordpress.tv/public_html/wp-content/themes/wptv2/header.php
@@ -38,8 +38,12 @@ global $wptv;
 	<div id="header">
 		<div class="sleeve">
 
-			<h1><a rel="home" href="<?php echo $wptv->home_url( '/' ); ?>"><img src="<?php echo get_template_directory_uri(); ?>/i/wptv-2x.png" alt="<?php echo esc_attr( get_bloginfo( 'name' ) ); ?>" height="40" width="210" /></a></h1>
-
+			<?php if ( is_home() ) { ?> 
+			<h1><a class="homelogo" rel="home" href="<?php echo $wptv->home_url( '/' ); ?>"><img src="<?php echo get_template_directory_uri(); ?>/i/wptv-2x.png" alt="<?php echo esc_attr( get_bloginfo( 'name' ) ); ?>" height="40" width="210" /></a></h1>
+			<?php } else { ?>
+			<a class="homelogo" rel="home" href="<?php echo $wptv->home_url( '/' ); ?>"><img src="<?php echo get_template_directory_uri(); ?>/i/wptv-2x.png" alt="<?php echo esc_attr( get_bloginfo( 'name' ) ); ?>" height="40" width="210" /></a><
+			<?php } ?>
+			
 			<form id="searchform" name="searchform" method="get" action="<?php echo $wptv->home_url( '/' ); ?>">
 				<label for="searchbox" class="screen-reader-text"><?php esc_attr_e( 'Search WordPress.tv', 'wptv' ); ?></label>
 				<input type="search" placeholder="<?php esc_attr_e( 'Search WordPress.tv', 'wptv' ); ?>" id="searchbox" name="s" value="<?php the_search_query(); ?>"  />

--- a/wordpress.tv/public_html/wp-content/themes/wptv2/index.php
+++ b/wordpress.tv/public_html/wp-content/themes/wptv2/index.php
@@ -16,7 +16,7 @@ if ( have_posts() ) :
 ?>
 
 	<div class="wptv-hero">
-		<h2 class="page-title"><?php esc_html_e( 'Archives', 'wptv' ); ?></h2>
+		<h1 class="page-title"><?php esc_html_e( 'Archives', 'wptv' ); ?></h1>
 	</div>
 	<div class="container">
 		<div class="primary-content">
@@ -32,7 +32,7 @@ if ( have_posts() ) :
 					<div class="video-description">
 						<div class="video-info">
 
-							<h5><?php esc_html_e( 'Published', 'wptv' ); ?></h5>
+							<h2 class="video-meta-heading"><?php esc_html_e( 'Published', 'wptv' ); ?></h2>
 							<p class="video-date"><?php the_date(); ?></p>
 
 							<?php if ( $post->post_excerpt ) : ?>
@@ -40,10 +40,10 @@ if ( have_posts() ) :
 							<?php
 								endif;
 
-								$wptv->the_terms( 'event',    '<h5>Event</h5><p class="video-event">',       '<br /> ', '</p>' );
-								$wptv->the_terms( 'speakers', '<h5>Speakers</h5><p class="video-speakers">', '<br /> ', '</p>' );
-								$wptv->the_terms( 'post_tag', '<h5>Tags</h5><p class="video-tags">',         '<br /> ', '</p>' );
-								$wptv->the_terms( 'language', '<h5>Language</h5><p class="video-lang">',     '<br /> ', '</p>' );
+								$wptv->the_terms( 'event',    '<h2 class="video-meta-heading">Event</h2><p class="video-event">',       '<br /> ', '</p>' );
+								$wptv->the_terms( 'speakers', '<h2 class="video-meta-heading">Speakers</h2><p class="video-speakers">', '<br /> ', '</p>' );
+								$wptv->the_terms( 'post_tag', '<h2 class="video-meta-heading">Tags</h2><p class="video-tags">',         '<br /> ', '</p>' );
+								$wptv->the_terms( 'language', '<h2 class="video-meta-heading">Language</h2><p class="video-lang">',     '<br /> ', '</p>' );
 							?>
 						</div><!-- .video-info -->
 					</div>

--- a/wordpress.tv/public_html/wp-content/themes/wptv2/page.php
+++ b/wordpress.tv/public_html/wp-content/themes/wptv2/page.php
@@ -6,9 +6,9 @@ get_header();
 the_post();
 ?>
 <div class="wptv-hero">
-	<h2 class="page-title">
+	<h1 class="page-title">
 		<?php the_title(); ?>
-	</h2>
+	</h1>
 </div>
 
 <div class="container">

--- a/wordpress.tv/public_html/wp-content/themes/wptv2/single.php
+++ b/wordpress.tv/public_html/wp-content/themes/wptv2/single.php
@@ -15,7 +15,7 @@ the_post();
 	<div class="container">
 
 		<?php get_template_part( 'breadcrumbs' ); ?>
-		<h2 class="video-title"><?php the_title(); ?></h2>
+		<h1 class="video-title"><?php the_title(); ?></h1>
 
 		<div class="the-video">
 			<?php $wptv->the_video(); ?>

--- a/wordpress.tv/public_html/wp-content/themes/wptv2/style.css
+++ b/wordpress.tv/public_html/wp-content/themes/wptv2/style.css
@@ -1929,7 +1929,7 @@ h4 {
 	margin: 20px 0 10px;
 }
 
-h5 {
+h5, .video-meta-heading {
 	font-size: 12px;
 	font-weight: bold;
 	text-transform: uppercase;

--- a/wordpress.tv/public_html/wp-content/themes/wptv2/style.css
+++ b/wordpress.tv/public_html/wp-content/themes/wptv2/style.css
@@ -237,7 +237,7 @@ div.success p {
 	display: table;
 }
 
-#header h1 {
+#header .homelogo {
 	padding-top: 8px;
 }
 
@@ -2519,7 +2519,7 @@ h3#comments {
 		padding: 0 20px;
 	}
 
-	#header h1 {
+	#header .homelogo {
 		float: left;
 	}
 

--- a/wordpress.tv/public_html/wp-content/themes/wptv2/taxonomy-event.php
+++ b/wordpress.tv/public_html/wp-content/themes/wptv2/taxonomy-event.php
@@ -19,16 +19,16 @@ if ( get_query_var( 'paged' ) < 2 && $wp_query->found_posts > 6 ) : ?>
 	<div class="container">
 
 		<?php get_template_part( 'breadcrumbs' ); ?>
-		<h2 class="page-title"><?php single_term_title(); ?></h2>
+		<h1 class="page-title"><?php single_term_title(); ?></h1>
 
 		<?php if ( have_posts() ) : the_post(); ?>
 
 			<div class="main-video">
 				<?php $wptv->the_video(); ?>
-				<h3>
+				<h2>
 					<a href="<?php the_permalink(); ?>" rel="bookmark" class="video-title"><?php the_title(); ?></a>
 					<?php $wptv->the_event( '<strong class="video-event">', '</strong>' ); ?>
-				</h3>
+				</h2>
 			</div><!-- .main-video -->
 
 		<?php endif; ?>


### PR DESCRIPTION
Currently, the logo on WordPress TV pages is always an `h1`, and on single video pages, the video title is an `h2`. This is wrong, both from an SEO and accessibility perspective. 

This pull adjusts the heading structure to be more logical across the theme.