### PR TITLE
fix Color Contrast Issue on Five for the Future Page of WordPress.org

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-patterns/css/settings/_colors.scss
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-patterns/css/settings/_colors.scss
@@ -4,6 +4,7 @@
 $color__wp-blue: #0073aa;
 $color__green: #c7e8ca;
 $color__wporg-blue: #1e8cbe;
+$color__wporg-steel-blue: #1a7eab;
 $color__wporg-purple: #826eb4;
 
 // Base grays.

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-patterns/css/utilities/_colors.scss
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-patterns/css/utilities/_colors.scss
@@ -3,7 +3,7 @@
 }
 
 .has-wporg-blue-background-color {
-	background-color: $color__wporg-blue;
+	background-color: $color__wporg-steel-blue;
 }
 
 .has-wporg-purple-color {


### PR DESCRIPTION
With background color: #1e8cbe andforeground color: #ffffff, The block Element has insufficient color contrast of 3.78. and Expected contrast ratio of 4.5.
since color:#fff (white) is fine but background color #1e8cbe is causing issue,
Using background color: #1a7eab with original foreground color: #ffffff , contrast ratio 4.5 has meet.

Trac ticket: https://meta.trac.wordpress.org/ticket/7690