### PR TITLE
Add a 2FA nag on login for users who should have 2FA but don't.

### DIFF
--- a/common/includes/wporg-sso/wp-plugin.php
+++ b/common/includes/wporg-sso/wp-plugin.php
@@ -1,4 +1,6 @@
 <?php
+use function WordPressdotorg\Two_Factor\{ user_should_2fa, user_requires_2fa };
+
 /**
  * WordPress-specific WPORG SSO: redirects all WP login and registration screens to our SSO ones.
  *
@@ -26,6 +28,7 @@ if ( class_exists( 'WPOrg_SSO' ) && ! class_exists( 'WP_WPOrg_SSO' ) ) {
 
 			// Primarily for logged in users.
 			'updated-tos'     => '/updated-policies',
+			'2fa'             => '/2fa',
 			'logout'          => '/logout',
 
 			// Primarily for logged out users.
@@ -93,6 +96,9 @@ if ( class_exists( 'WPOrg_SSO' ) && ! class_exists( 'WP_WPOrg_SSO' ) ) {
 
 					// Updated TOS interceptor.
 					add_filter( 'send_auth_cookies', [ $this, 'maybe_block_auth_cookies' ], 100, 5 );
+
+					// Maybe nag about 2FA
+					add_filter( 'login_redirect', [ $this, 'maybe_redirect_to_enable_2fa' ], 1000, 3 );
 				}
 			}
 		}
@@ -798,6 +804,26 @@ if ( class_exists( 'WPOrg_SSO' ) && ! class_exists( 'WP_WPOrg_SSO' ) ) {
 					'redirect_to',
 					urlencode( $redirect ),
 					home_url( '/updated-policies' )
+				);
+			}
+
+			return $redirect;
+		}
+
+		/**
+		 * Redirects the user to a "please enable 2fa" page.
+		 */
+		public function maybe_redirect_to_enable_2fa( $redirect, $orig_redirect, $user ) {
+			if (
+				! str_contains( $redirect, '/2fa' ) &&
+				! is_wp_error( $user ) &&
+				user_should_2fa( $user ) &&
+				! Two_Factor_Core::is_user_using_two_factor( $user->ID )
+			) {
+				$redirect = add_query_arg(
+					'redirect_to',
+					urlencode( $redirect ),
+					home_url( '/2fa' )
 				);
 			}
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/2fa.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/2fa.php
@@ -19,19 +19,27 @@ get_header();
 
 <p>&nbsp;</p>
 
-<p><?php _e( 'WordPress.org now requires that your account be protected by Two-Factor Authentication.', 'wporg' ); ?></p>
+<?php
+if ( $requires_2fa ) {
+	echo '<p>' . __( 'WordPress.org now requires that your account be protected by Two-Factor Authentication.', 'wporg' ) . '</p>';
+} else {
+	echo '<p>' . __( "WordPress.org supports Two-Factor Authentication and you'll soon be required to set it up on your account.", 'wporg' ) . '</p>';
+}
 
 <p>&nbsp;</p>
 
-<p><?php _e( 'Users who are Plugin or Theme Authors, or who have elevated access to any of our Sites &amp; Tools are required to setup Two-Factor Authentication.', 'wporg' ); ?></p>
+<p><?php printf( __( 'For more information on Two-Factor Authentication, <a href="%s">please read our documentation</a>.', 'wporg' ), 'https://developer.wordpress.org/advanced-administration/security/mfa/' ); ?></p>
 
 <p>&nbsp;</p>
+
 
 <a href="<?php echo esc_url( get_edit_account_url() ); ?>"><button class="button-primary"><?php _e( "OK, I'll setup 2FA now.", 'wporg' ); ?></button></a>
 
-<p class="center">
-	<a href="<?php echo esc_url( $redirect_to ); ?>" style="font-style: italic;"><?php _e( "I'll do it later", 'wporg' ); ?></a>
-</p>
+<?php if ( ! $requires_2fa ) { ?>
+	<p class="center">
+		<a href="<?php echo esc_url( $redirect_to ); ?>" style="font-style: italic;"><?php _e( "I'll do it later", 'wporg' ); ?></a>
+	</p>
+<?php } ?>
 
 <p id="nav">
 	<a href="<?php echo wporg_login_wordpress_url(); ?>"><?php _e( 'WordPress.org', 'wporg' ); ?></a>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/2fa.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/2fa.php
@@ -28,7 +28,7 @@ if ( $requires_2fa ) {
 
 <p>&nbsp;</p>
 
-<p><?php printf( __( 'For more information on Two-Factor Authentication, <a href="%s">please read our documentation</a>.', 'wporg' ), 'https://developer.wordpress.org/advanced-administration/security/mfa/' ); ?></p>
+<p><?php printf( __( 'For more information on Two-Factor Authentication, <a href="%s">please read our documentation</a>.', 'wporg' ), 'https://make.wordpress.org/meta/handbook/tutorials-guides/configuring-two-factor-authentication/' ); ?></p>
 
 <p>&nbsp;</p>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/2fa.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/2fa.php
@@ -1,0 +1,40 @@
+<?php
+use function WordPressdotorg\Two_Factor\{ user_requires_2fa, user_should_2fa, get_edit_account_url };
+/**
+ * The 2FA notification screen.
+ *
+ * @package wporg-login
+ */
+
+$sso          = WPOrg_SSO::get_instance();
+$user         = wp_get_current_user();
+$requires_2fa = user_requires_2fa( $user );
+$should_2fa   = user_should_2fa( $user );
+$redirect_to  = wp_validate_redirect( wp_unslash( $_REQUEST['redirect_to'] ?? '' ), wporg_login_wordpress_url() );
+
+get_header();
+?>
+
+<h2 class="center"><?php _e( 'Two-Factor Authentication', 'wporg' ); ?></h2>
+
+<p>&nbsp;</p>
+
+<p><?php _e( 'WordPress.org now requires that your account be protected by Two-Factor Authentication.', 'wporg' ); ?></p>
+
+<p>&nbsp;</p>
+
+<p><?php _e( 'Users who are Plugin or Theme Authors, or who have elevated access to any of our Sites &amp; Tools are required to setup Two-Factor Authentication.', 'wporg' ); ?></p>
+
+<p>&nbsp;</p>
+
+<a href="<?php echo esc_url( get_edit_account_url() ); ?>"><button class="button-primary"><?php _e( "OK, I'll setup 2FA now.", 'wporg' ); ?></button></a>
+
+<p class="center">
+	<a href="<?php echo esc_url( $redirect_to ); ?>" style="font-style: italic;"><?php _e( "I'll do it later", 'wporg' ); ?></a>
+</p>
+
+<p id="nav">
+	<a href="<?php echo wporg_login_wordpress_url(); ?>"><?php _e( 'WordPress.org', 'wporg' ); ?></a>
+</p>
+
+<?php get_footer(); ?>


### PR DESCRIPTION
In conjunction with https://github.com/WordPress/wporg-two-factor/pull/288 this adds a nag upon login that the user should really setup 2FA.

I imagine instead of landing on the final account screen that's shown in the below video, it'd land on the wizard from https://github.com/WordPress/wporg-two-factor/pull/286 being triggered immediately.

https://github.com/user-attachments/assets/545668db-4bed-4d75-b479-ef0056352ea5

