### PR TITLE
Improve discoverability of Plugin Previews

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/inc/template-tags.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/inc/template-tags.php
@@ -590,12 +590,12 @@ function the_plugin_self_toggle_preview_button() {
 		return;
 	}
 
-	echo '<h4>' . esc_html__( 'Toggle Live Preview', 'wporg-plugins' ) . '</h4>';
+	echo '<h4 id="live-preview">' . esc_html__( 'Toggle Live Preview', 'wporg-plugins' ) . '</h4>';
 	$preview_status = get_post_meta( $post->ID, '_public_preview', true ) ? 'enabled' : 'disabled';
 	if ( 'enabled' === $preview_status ) {
-		echo '<p>' . esc_html__( 'The Live Preview link to Playground is currently enabled. Use the toggle button to disable it.', 'wporg-plugins' ) . '</p>';
+		echo '<p>' . wp_kses( sprintf( __( 'The <a href="%s">Live Preview link to Playground</a> is currently enabled. Use the toggle button to disable it.', 'wporg-plugins' ), 'https://developer.wordpress.org/plugins/wordpress-org/previews-and-blueprints/' ), array( 'a' => array( 'href' => array() ) ) ) . '</p>';
 	} else {
-		echo '<p>' . esc_html__( 'The Live Preview link to Playground is currently disabled. Use the toggle button to enable it.', 'wporg-plugins' ) . '</p>';
+		echo '<p>' . wp_kses( sprintf( __( 'The <a href="%s">Live Preview link to Playground</a> is currently disabled. Use the toggle button to enable it.', 'wporg-plugins' ), 'https://developer.wordpress.org/plugins/wordpress-org/previews-and-blueprints/#committing-a-blueprint-to-subversion' ), array( 'a' => array( 'href' => array() ) ) ) . '</p>';
 	}
 
 	$blueprints = get_post_meta( $post->ID, 'assets_blueprints', true );

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/template-parts/plugin-single.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/template-parts/plugin-single.php
@@ -76,7 +76,7 @@ $plugin_title = $is_closed ? $post->post_name : get_the_title();
 						esc_attr( add_query_arg( array( 'preview' => 1 ), get_the_permalink() ) ),
 						esc_html__( 'Test Preview', 'wporg-plugins' ) . ' <span class="dashicons dashicons-hidden" title="' . esc_attr__( 'Only visible to you', 'wporg-plugins' ) . '"></span>'
 					);
-				} else {
+				} else ( current_user_can( 'plugin_admin_edit', $post ) ) {
 					$buttons .= sprintf(
 						'<!-- wp:button {"className":"is-small is-style-outline plugin-preview download-button"} -->
 						<div class="wp-block-button is-small is-style-outline plugin-preview download-button"><a class="wp-block-button__link wp-element-button" href="%1$s">%2$s</a></div>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/template-parts/plugin-single.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/template-parts/plugin-single.php
@@ -74,7 +74,15 @@ $plugin_title = $is_closed ? $post->post_name : get_the_title();
 						<div class="wp-block-button is-small is-style-outline plugin-preview download-button"><a class="wp-block-button__link wp-element-button" href="%1$s">%2$s</a></div>
 						<!-- /wp:button -->',
 						esc_attr( add_query_arg( array( 'preview' => 1 ), get_the_permalink() ) ),
-						esc_html__( 'Test Preview', 'wporg-plugins' )
+						esc_html__( 'Test Preview', 'wporg-plugins' ) . ' <span class="dashicons dashicons-hidden" title="' . esc_attr__( 'Only visible to you', 'wporg-plugins' ) . '"></span>'
+					);
+				} else {
+					$buttons .= sprintf(
+						'<!-- wp:button {"className":"is-small is-style-outline plugin-preview download-button"} -->
+						<div class="wp-block-button is-small is-style-outline plugin-preview download-button"><a class="wp-block-button__link wp-element-button" href="%1$s">%2$s</a></div>
+						<!-- /wp:button -->',
+						esc_attr( get_the_permalink() . 'advanced/#live-preview' ),
+						esc_html__( 'Preview Not Available', 'wporg-plugins' ) . ' <span class="dashicons dashicons-hidden" title="' . esc_attr__( 'Only visible to you', 'wporg-plugins' ) . '"></span>'
 					);
 				}
 				echo do_blocks( $buttons ); // phpcs:ignore -- Output escaped while building string.

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/template-parts/plugin-single.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/template-parts/plugin-single.php
@@ -76,7 +76,7 @@ $plugin_title = $is_closed ? $post->post_name : get_the_title();
 						esc_attr( add_query_arg( array( 'preview' => 1 ), get_the_permalink() ) ),
 						esc_html__( 'Test Preview', 'wporg-plugins' ) . ' <span class="dashicons dashicons-hidden" title="' . esc_attr__( 'Only visible to you', 'wporg-plugins' ) . '"></span>'
 					);
-				} else ( current_user_can( 'plugin_admin_edit', $post ) ) {
+				} elseif ( current_user_can( 'plugin_admin_edit', $post ) ) {
 					$buttons .= sprintf(
 						'<!-- wp:button {"className":"is-small is-style-outline plugin-preview download-button"} -->
 						<div class="wp-block-button is-small is-style-outline plugin-preview download-button"><a class="wp-block-button__link wp-element-button" href="%1$s">%2$s</a></div>


### PR DESCRIPTION
This modifies a few bits in the plugin directory to make it easier to discover plugin previews and how they work:

### Add a "Preview Not Available"
To indicate that there could be a preview button. The eye indicates that this is only visible to the plugin admin.

Before:
![Screenshot 2024-09-03 at 10 48 37](https://github.com/user-attachments/assets/ec9fd7be-ef24-4494-9dbe-3cf84cb626f4)

After:
![Screenshot 2024-09-03 at 12 11 42](https://github.com/user-attachments/assets/aba90f75-e0b5-4683-99d8-9f89e9c19946)

### Link the documentation on the advanced page
Before:
![Screenshot 2024-09-03 at 10 11 26](https://github.com/user-attachments/assets/c7407ea2-2073-473b-8815-6be0003d1537)

After:
![Screenshot 2024-09-03 at 11 27 23](https://github.com/user-attachments/assets/f3ca19d1-c58f-45ed-9f98-0d90de5b8a1b)


### Add an eye to the "Test Preview"
Indicate that the "Test Preview" doesn't mean the preview is enabled:
Before:
![Screenshot 2024-09-03 at 10 41 15](https://github.com/user-attachments/assets/2dc2e9bc-9f37-4b31-94f8-fc101b39738e)

After:
![Screenshot 2024-09-03 at 11 30 04](https://github.com/user-attachments/assets/1254b162-e5f5-4d12-be24-fd2db029f371)

