### PR TITLE
Add svn password language.

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-plugin-approved.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-plugin-approved.php
@@ -15,7 +15,7 @@ class Plugin_Approved extends Markdown_Base {
 	}
 
 	function markdown() {
-		/* translators: 1: plugin name, 2: plugin author's username, 3: plugin slug */
+		/* translators: 1: plugin name, 2: plugin author's username, 3: plugin slug, 4: link to plugin authors profile */
 		$email_text = __(
 'Congratulations, the plugin hosting request for %1$s has been approved.
 
@@ -64,7 +64,6 @@ If you have issues or questions, please reply to this email and let us know.
 
 Enjoy!', 'wporg-plugins' );
 
-		/* translators: 1: plugin name, 2: plugin author's username, 3: plugin slug, 4: link to plugin authors profile */
 		return sprintf(
 			$email_text,
 			$this->plugin->post_title,

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-plugin-approved.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-plugin-approved.php
@@ -3,7 +3,7 @@ namespace WordPressdotorg\Plugin_Directory\Email;
 
 use WordPressdotorg\Plugin_Directory\Tools;
 
-class Plugin_Approved extends Base {
+class Plugin_Approved extends Markdown_Base {
 	protected $required_args = [];
 
 	function subject() {
@@ -14,7 +14,7 @@ class Plugin_Approved extends Base {
 		);
 	}
 
-	function body() {
+	function markdown() {
 		/* translators: 1: plugin name, 2: plugin author's username, 3: plugin slug */
 		$email_text = __(
 'Congratulations, the plugin hosting request for %1$s has been approved.
@@ -29,35 +29,35 @@ Once your account access has been activated, you may upload your code using a SV
 To answer some common questions:
 
 * You must use SVN to upload your code -- we are unable to do that for you
-* Your SVN username is %2$s and is case sensitive.
-* Generate your SVN password in your <a href="https://profiles.wordpress.org/%2$s/profile/edit/group/3/?screen=svn-password">WordPress.org profile</a>.
+* Your SVN username is `%2$s` and is case sensitive.
+* Generate your SVN password in your [WordPress.org profile](https://profiles.wordpress.org/%2$s/profile/edit/group/3/?screen=svn-password).
 * SVN will not accept your email address as a username
 * Due to the size of the directory, it may take 72 hours before all search results are properly updated
 
 To help you get started, here are some links:
 
-Using Subversion with the WordPress Plugin Directory:
+Using Subversion with the WordPress Plugin Directory:<br>
 https://developer.wordpress.org/plugins/wordpress-org/how-to-use-subversion/
 
-Generating your SVN Password:
+Generating your SVN Password:<br>
 https://make.wordpress.org/meta/handbook/tutorials-guides/svn-access/
 
-FAQ about the WordPress Plugin Directory:
+FAQ about the WordPress Plugin Directory:<br>
 https://developer.wordpress.org/plugins/wordpress-org/plugin-developer-faq/
 
-WordPress Plugin Directory readme.txt standard:
+WordPress Plugin Directory readme.txt standard:<br>
 https://wordpress.org/plugins/developers/#readme
 
-A readme.txt validator:
+A readme.txt validator:<br>
 https://wordpress.org/plugins/developers/readme-validator/
 
-Plugin Assets (header images, etc):
+Plugin Assets (header images, etc):<br>
 https://developer.wordpress.org/plugins/wordpress-org/plugin-assets/
 
-WordPress Plugin Directory Guidelines:
+WordPress Plugin Directory Guidelines:<br>
 https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/
 
-Block Specific Plugin Guidelines:
+Block Specific Plugin Guidelines:<br>
 https://developer.wordpress.org/plugins/wordpress-org/block-specific-plugin-guidelines/
 
 If you have issues or questions, please reply to this email and let us know.

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-plugin-approved.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-plugin-approved.php
@@ -30,7 +30,7 @@ To answer some common questions:
 
 * You must use SVN to upload your code -- we are unable to do that for you
 * Your SVN username is `%2$s` and is case sensitive.
-* Generate your SVN password in your [WordPress.org profile](%4$s).
+* You can <strong>set up your SVN credentials</strong> (if you haven\'t already) in the "Account & Security" section of your [WordPress.org profile](%4$s).
 * SVN will not accept your email address as a username
 * Due to the size of the directory, it may take 72 hours before all search results are properly updated
 

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-plugin-approved.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-plugin-approved.php
@@ -30,7 +30,7 @@ To answer some common questions:
 
 * You must use SVN to upload your code -- we are unable to do that for you
 * Your SVN username is `%2$s` and is case sensitive.
-* Generate your SVN password in your [WordPress.org profile](https://profiles.wordpress.org/%4$s/profile/edit/group/3/?screen=svn-password).
+* Generate your SVN password in your [WordPress.org profile](%4$s).
 * SVN will not accept your email address as a username
 * Due to the size of the directory, it may take 72 hours before all search results are properly updated
 
@@ -64,12 +64,13 @@ If you have issues or questions, please reply to this email and let us know.
 
 Enjoy!', 'wporg-plugins' );
 
+		/* translators: 1: plugin name, 2: plugin author's username, 3: plugin slug, 4: link to plugin authors profile */
 		return sprintf(
 			$email_text,
 			$this->plugin->post_title,
 			$this->user->user_login,
 			$this->plugin->post_name,
-			$this->user->user_nicename
+			"https://profiles.wordpress.org/{$this->user->user_nicename}/profile/edit/group/3/?screen=svn-password"
 		);
 	}
 }

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-plugin-approved.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-plugin-approved.php
@@ -30,7 +30,7 @@ To answer some common questions:
 
 * You must use SVN to upload your code -- we are unable to do that for you
 * Your SVN username is `%2$s` and is case sensitive.
-* Generate your SVN password in your [WordPress.org profile](https://profiles.wordpress.org/%2$s/profile/edit/group/3/?screen=svn-password).
+* Generate your SVN password in your [WordPress.org profile](https://profiles.wordpress.org/%4$s/profile/edit/group/3/?screen=svn-password).
 * SVN will not accept your email address as a username
 * Due to the size of the directory, it may take 72 hours before all search results are properly updated
 
@@ -68,7 +68,8 @@ Enjoy!', 'wporg-plugins' );
 			$email_text,
 			$this->plugin->post_title,
 			$this->user->user_login,
-			$this->plugin->post_name
+			$this->plugin->post_name,
+			$this->user->user_nicename
 		);
 	}
 }

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-plugin-approved.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-plugin-approved.php
@@ -29,8 +29,8 @@ Once your account access has been activated, you may upload your code using a SV
 To answer some common questions:
 
 * You must use SVN to upload your code -- we are unable to do that for you
-* Your SVN username is %2$s and your password is the same as you use to log in to WordPress.org
-* Your username is case sensitive
+* Your SVN username is %2$s and is case sensitive.
+* Generate your SVN password in your <a href="https://profiles.wordpress.org/%2$s/profile/edit/group/3/?screen=svn-password">WordPress.org profile</a>.
 * SVN will not accept your email address as a username
 * Due to the size of the directory, it may take 72 hours before all search results are properly updated
 
@@ -38,6 +38,9 @@ To help you get started, here are some links:
 
 Using Subversion with the WordPress Plugin Directory:
 https://developer.wordpress.org/plugins/wordpress-org/how-to-use-subversion/
+
+Generating your SVN Password:
+https://make.wordpress.org/meta/handbook/tutorials-guides/svn-access/
 
 FAQ about the WordPress Plugin Directory:
 https://developer.wordpress.org/plugins/wordpress-org/plugin-developer-faq/


### PR DESCRIPTION
The approved plugin email should be updated to direct users to use svn passwords. This updates the approval email to use markdown to allow words to be linked. This has some minor effects on the layout, indenting lists.


| Before | After |
|--------|--------|
| <img width="1005" alt="Screenshot 2024-09-04 at 2 12 08 PM" src="https://github.com/user-attachments/assets/69c48202-bdad-468c-aad6-2cdb1210ae2d"> | <img width="1008" alt="Screenshot 2024-09-04 at 2 13 32 PM" src="https://github.com/user-attachments/assets/9185e62a-65b0-4388-a508-6757e58179a7"> | 


