### PR TITLE
Navigation: Add "Log in" link to local nav

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/inc/block-config.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/inc/block-config.php
@@ -74,6 +74,15 @@ function add_site_navigation_menus( $menus ) {
 		)
 	);
 
+	if ( ! is_user_logged_in() ) {
+		global $wp;
+		$redirect_url = home_url( $wp->request );
+		$items['plugins'][] = array(
+			'label' => __( 'Log in', 'wporg-plugins' ),
+			'url' => wp_login_url( $redirect_url ),
+		);
+	}
+
 	/*
 	// Not usually in the menu, but we need to show these somehow.
 	if ( is_tax( 'plugin_section', 'adopt-me' ) ) {


### PR DESCRIPTION
This updates the Plugin Directory to include the "Log in" link in the local navigation across the site. The link only appears when you're logged out, once logged in, you can manage your account/login status in the admin bar.

I've already deactivated the "Logged Out Admin Bar" plugin on this site, so it won't show until you log in (and then it will show on all sites, see https://github.com/WordPress/wporg-mu-plugins/commit/3b39f5f1d1134b266e68ac966744a584d464279b).

See https://github.com/WordPress/wporg-mu-plugins/issues/647

(See also https://github.com/WordPress/wporg-theme-directory/pull/156 for the same change on the Theme Directory)

### Screenshots

| Logged out | Logged in |
|--------|-------|
| ![Screen Shot 2024-09-10 at 11 48 19](https://github.com/user-attachments/assets/c481720e-85df-4942-9c1a-089045b5b1e5) | ![Screen Shot 2024-09-10 at 11 49 17](https://github.com/user-attachments/assets/2f2bb3f6-34cb-411f-ad74-1006010c542e) |

### How to test the changes in this Pull Request:

1. Be logged out
2. There should be a "log in" link
3. Clicking it and signing in should redirect you back to the page you were just on
4. The "log in" link should not appear
5. You should see the admin bar

cc @WordPress/meta-design 