### PR TITLE
Theme Previews: Style card: Add support for themes that don't set colors in theme.json

### DIFF
--- a/wp-themes.com/public_html/wp-content/plugins/style-variations/inc/global-style-page.php
+++ b/wp-themes.com/public_html/wp-content/plugins/style-variations/inc/global-style-page.php
@@ -3,16 +3,18 @@
 namespace WordPressdotorg\Theme_Preview\Style_Variations\Global_Style_Page;
 
 /**
- * Uses custom page if query string is present to display style variation cards.
+ * Bypass the template loader to show the "card view" when query string is present.
+ *
+ * @param string $template The path of the template to include.
+ *
+ * @return string Updated template path.
  */
-function redirect_to_style_page() {
+function inject_style_card_view( $template ) {
 	if ( ! isset( $_GET['card_view'] ) ) {
-		return;
+		return $template;
 	}
 
-	include dirname( __DIR__ ) . '/views/card.php';
-	exit;
-
+	return dirname( __DIR__ ) . '/views/card.php';
 }
 
-add_action( 'template_redirect', __NAMESPACE__ . '\redirect_to_style_page' );
+add_action( 'template_include', __NAMESPACE__ . '\inject_style_card_view', 100 );

--- a/wp-themes.com/public_html/wp-content/plugins/style-variations/views/card.php
+++ b/wp-themes.com/public_html/wp-content/plugins/style-variations/views/card.php
@@ -9,6 +9,24 @@ namespace WordPressdotorg\Theme_Preview\Style_Variations;
 $global_settings = wp_get_global_settings();
 $palette         = $global_settings['color']['palette'];
 
+$global_styles = wp_get_global_styles();
+$has_set_background = isset( $global_styles['color'], $global_styles['color']['background'] );
+
+$classes = 'wporg-global-style-container';
+
+// If the background is not set via theme.json's color.background setting, the background might be set on
+// a wrapper element in the template. This will try to find the first child element of the template with
+// a background color, and pull out those classes to use on the global style container.
+// For example, it should add `has-first-background-color`, or  `has-custom-main-gradiant-gradient-background`.
+if ( ! $has_set_background ) {
+	$template_html = get_the_block_template_html();
+
+	$tags = new \WP_HTML_Tag_Processor( $template_html );
+	if ( $tags->next_tag( [ 'class_name' => 'has-background' ] ) ) {
+		$classes .= ' ' . $tags->get_attribute( 'class' );
+	}
+}
+
 ?><!DOCTYPE html>
 <html <?php language_attributes(); ?>>
 <head>
@@ -63,7 +81,8 @@ $palette         = $global_settings['color']['palette'];
 </head>
 
 <body <?php body_class(); ?>>
-<div class="wporg-global-style-container">
+
+<div class="<?php echo esc_attr( $classes ); ?>">
 	<div>
 		<div><h1 id="wporg-global-style-heading">Aa</h1></div>
 		<div id="wporg-global-style-circles"></div>
@@ -95,8 +114,11 @@ $palette         = $global_settings['color']['palette'];
 	var h1TextColor = rgba2hex( window.getComputedStyle( h1Element ).color ).toLowerCase();
 	var bodyColor = rgba2hex( window.getComputedStyle( document.body ).backgroundColor ).toLowerCase();
 
+	// If no background is set on this element, it's still a valid value (#0000).
+	var divColor = rgba2hex( window.getComputedStyle( document.querySelector( '.wporg-global-style-container' ) ).backgroundColor ).toLowerCase();
+
 	// Remove the already used colors
-	var colors = palette.theme.filter( entry => ! [ h1TextColor, bodyColor ].includes( entry.color.toLowerCase() ) );
+	var colors = palette.theme.filter( entry => ! [ h1TextColor, bodyColor, divColor ].includes( entry.color.toLowerCase() ) );
 	
 	// Create circles for the first 2 colors.
 	colors.slice( 0, 2 ).forEach( entry => {


### PR DESCRIPTION
See https://github.com/WordPress/wporg-theme-directory/issues/154 — Some block themes set the page background color not by setting the `styles.color.background` property, but instead by adding a top-level wrapper block. When done this way, the background is not picked up by the style variation card view. This PR attempts to pull out any relevant classes from the first wrapper element it sees, and applies those to the style card container.

I think these themes are technically doing it wrong— the colors and other base styles should be set in theme.json, not as settings on blocks— but providing this workaround will at least display slightly better. It's not perfect though, you can see in the screenshots below that the font color for Danva is still incorrect (which leads to the all-black image). This is, again, because the text color is set on each individual element, not the body tag. The fonts are also not correct, same reason.

**Screenshots**

| | Before | After |
|---|---|---|
| TT4 default | ![before-theme-twentytwentyfour-default](https://github.com/user-attachments/assets/21a714b1-954a-4937-ad44-d469def2c094) | ![theme-twentytwentyfour-default](https://github.com/user-attachments/assets/8a8e67ba-3c40-4c19-8f27-992ef0f21148) |
| TT4 blue | ![before-theme-twentytwentyfour-blue](https://github.com/user-attachments/assets/dacfab99-5835-4f3c-a9af-bc6df84ab6d8) | ![theme-twentytwentyfour-blue](https://github.com/user-attachments/assets/7e84429f-0219-4103-ab95-53de90d57f51) |
| Creativium default | ![before-theme-creativium-default](https://github.com/user-attachments/assets/556e558e-4d88-4510-b1c1-a482e37d5ceb) | ![theme-creativium-default](https://github.com/user-attachments/assets/6827a3d2-1f3c-41c2-a974-30ae10f08fcf) |
| Creativium amethyst | ![before-theme-creativium-amethyst](https://github.com/user-attachments/assets/d05d254f-595b-4b14-adf8-84afaed220b2) | ![theme-creativium-amethyst](https://github.com/user-attachments/assets/5046c186-9c19-48ac-8aa4-8dda930ad162) |
| Danva default | ![before-theme-danva-default](https://github.com/user-attachments/assets/8f3bfc25-24d9-417c-bf30-5d6518c1dec9) | ![theme-danva-default](https://github.com/user-attachments/assets/13df3d7f-b18a-4e97-b681-6aa8e0bd5ad7) |
| Danva blue | ![before-theme-danva-blue](https://github.com/user-attachments/assets/09751650-65d3-4626-8368-8a59a1aad76c) | ![theme-danva-blue](https://github.com/user-attachments/assets/16ed7e6f-71e7-435c-a6e1-ba6cca3d1bb0) |

To test:

- Apply the patch to a sandbox, and use your sandbox for wp-themes.com
- Check out a few themes with issues to `themes-preview/wp-content/themes/` on your sandbox
    Try with different themes than I did, for example [Topwork](https://wordpress.org/themes/topwork/) or [hardlight](https://wordpress.org/themes/hardlight/)
- View the card preview with a URL like https://wp-themes.com/[THEME]/?style_variation=[VARIATION]&card_view