### PR TITLE
Patterns API: Fix endpoint tests

### DIFF
--- a/api.wordpress.org/public_html/patterns/1.0/tests/test-index.php
+++ b/api.wordpress.org/public_html/patterns/1.0/tests/test-index.php
@@ -81,12 +81,12 @@ class Test_Patterns extends TestCase {
 	 * @group e2e
 	 */
 	public function test_browse_all_patterns() : void {
-		$response = send_request( '/patterns/1.0/?per_page=100' );
+		$response = send_request( '/patterns/1.0/?per_page=20' );
 		$this->assertResponseHasPattern( $response );
 
-		// When all locales and keywords are included, there should be at least 100 patterns.
+		// When all locales and keywords are included, there should be at least 20 patterns.
 		$patterns = json_decode( $response->body );
-		$this->assertSame( 100, count( $patterns ) );
+		$this->assertSame( 20, count( $patterns ) );
 
 		/*
 		 * The exact number of unique categories will vary based on which cohort of pattens happen to be returned,
@@ -108,7 +108,7 @@ class Test_Patterns extends TestCase {
 		 * This can't include a `pattern-keyword` param because of the workaround in
 		 * `WordPressdotorg\Pattern_Directory\Pattern_Post_Type\register_rest_fields()`.
 		 */
-		$response = send_request( '/patterns/1.0/?pattern-categories=' . $button_term_id . '&locale=en_US' );
+		$response = send_request( '/patterns/1.0/?per_page=20&pattern-categories=' . $button_term_id . '&locale=en_US' );
 		$this->assertResponseHasPattern( $response );
 
 		$patterns   = json_decode( $response->body );

--- a/api.wordpress.org/public_html/patterns/1.0/tests/test-index.php
+++ b/api.wordpress.org/public_html/patterns/1.0/tests/test-index.php
@@ -9,7 +9,7 @@ use Requests_Response;
  */
 class Test_Patterns extends TestCase {
 	/**
-	 * Asserts that an HTTP response is valid and contains a pattern.
+	 * Asserts that an HTTP response is valid and contains items matching the pattern format.
 	 *
 	 * @param Requests_Response $response
 	 */
@@ -19,10 +19,12 @@ class Test_Patterns extends TestCase {
 		$patterns = json_decode( $response->body );
 		$this->assertIsArray( $patterns );
 		$this->assertGreaterThan( 0, count( $patterns ) );
-		$this->assertIsString( $patterns[0]->title->rendered );
-		$this->assertIsInt( $patterns[0]->meta->wpop_viewport_width );
-		$this->assertIsArray( $patterns[0]->category_slugs );
-		$this->assertIsArray( $patterns[0]->keyword_slugs );
+		foreach ( $patterns as $pattern ) {
+			$this->assertIsString( $pattern->title->rendered );
+			$this->assertIsInt( $pattern->meta->wpop_viewport_width );
+			$this->assertIsArray( $pattern->category_slugs );
+			$this->assertIsArray( $pattern->keyword_slugs );
+		}
 	}
 
 	/**

--- a/api.wordpress.org/public_html/patterns/1.0/tests/test-index.php
+++ b/api.wordpress.org/public_html/patterns/1.0/tests/test-index.php
@@ -253,7 +253,7 @@ class Test_Patterns extends TestCase {
 
 			// The Core keyword (11) is hardcoded in `test_search_patterns()`, so don't need to specify it here.
 			"only match Core posts" => array(
-				'search_term'       => 'two buttons', // Post ID 727.
+				'search_term'       => 'Two images with text and buttons', // Post ID 727.
 				'locale'            => 'en_US',
 				'match_expected'    => false,
 				'expected_post_ids' => false,

--- a/api.wordpress.org/public_html/patterns/1.0/tests/test-index.php
+++ b/api.wordpress.org/public_html/patterns/1.0/tests/test-index.php
@@ -290,7 +290,7 @@ class Test_Patterns extends TestCase {
 	 * @group e2e
 	 */
 	public function test_search_title_match_boosted_above_description_match() : void {
-		$search_term = 'image';
+		$search_term = 'heading';
 		$locale      = 'en_US';
 
 		$response = send_request( "/patterns/1.0/?search=$search_term&pattern-keywords=11&locale=$locale" );
@@ -307,8 +307,8 @@ class Test_Patterns extends TestCase {
 
 		usort( $expectedPatterns, function( $a, $b ) use ( $search_term ) {
 			$adjustment       = 0;
-			$found_in_title_a = false === stripos( $search_term, $a->title->rendered );
-			$found_in_title_b = false === stripos( $search_term, $b->title->rendered );
+			$found_in_title_a = false !== stripos( $search_term, $a->title->rendered );
+			$found_in_title_b = false !== stripos( $search_term, $b->title->rendered );
 
 			if ( $found_in_title_a && ! $found_in_title_b ) {
 				$adjustment = -1;

--- a/api.wordpress.org/public_html/patterns/1.0/tests/test-index.php
+++ b/api.wordpress.org/public_html/patterns/1.0/tests/test-index.php
@@ -340,7 +340,9 @@ class Test_Patterns extends TestCase {
 
 		$this->assertAllPatternsMatchSearchTerm( $patterns, $search_term );
 
-		$this->markTestIncomplete(); // todo the following code works, but `WordPressdotorg\Pattern_Directory\Search\modify_es_query_args` isn't boosting the primary locale yet
+		// The following test works, but `WordPressdotorg\Pattern_Directory\Search\modify_es_query_args` isn't boosting the primary locale yet.
+		// See https://github.com/WordPress/pattern-directory/issues/347
+		$this->markTestIncomplete();
 
 		$actualOrder = array_column( array_column( $patterns, 'meta' ), 'wpop_locale'  );
 

--- a/api.wordpress.org/public_html/patterns/1.0/tests/test-index.php
+++ b/api.wordpress.org/public_html/patterns/1.0/tests/test-index.php
@@ -87,13 +87,6 @@ class Test_Patterns extends TestCase {
 		// When all locales and keywords are included, there should be at least 20 patterns.
 		$patterns = json_decode( $response->body );
 		$this->assertSame( 20, count( $patterns ) );
-
-		/*
-		 * The exact number of unique categories will vary based on which cohort of pattens happen to be returned,
-		 * but `3` seems like a safe minimum in practice.
-		 */
-		$term_slugs = $this->get_term_slugs( $patterns );
-		$this->assertGreaterThan( 3, count( $term_slugs ) );
 	}
 
 	/**


### PR DESCRIPTION
We recently had an issue causing errors on client WP sites because the Patterns API returned malformed category data — see https://github.com/WordPress/pattern-directory/pull/711. If these tests were working and easy to run, it would have been caught earlier.

These tests function as e2e tests running against production data, checking that the output behaves as expected. This PR fixes the tests by updating the test cases to better match the real content, and to check the expected type of all patterns in a response.

Note: I'll also add a schema test to the pattern directory plugin, which could run as part of the CI, and catch this before it even merged.

**To test**

Requires a sandbox (I think?)

1. Get composer on your sandbox if you don't have it already (I just downloaded the `composer.phar` to my home directory, there are also brew instructions in the dotorg repo at `/wordpress/api/README.md`)
2. Install deps: `composer install`
3. Run the tests: `composer run test -- --group patterns`
4. The tests take about a minute, but all should pass except for one incomplete

The events tests are also failing, but that can be fixed in another PR.
