### PR TITLE
Forums: Navigation: Add "Log in" link to local nav

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/functions.php
@@ -54,56 +54,70 @@ function wporg_support_add_site_navigation_menus( $menus ) {
 	}
 
 	if ( substr( get_locale(), 0, 2 ) === 'en' ) {
-		return array(
-			'forums' => array(
-				array(
-					'label' => __( 'Welcome to Support', 'wporg-forums' ),
-					'url' => '/welcome/',
-				),
-				array(
-					'label' => __( 'Guidelines', 'wporg-forums' ),
-					'url' => '/guidelines/',
-				),
-				array(
-					'label' => __( 'Get Involved', 'wporg-forums' ),
-					'url' => 'https://make.wordpress.org/support/handbook/contributing-to-the-wordpress-forums/',
-				)
+		$menu = array(
+			array(
+				'label' => __( 'Welcome to Support', 'wporg-forums' ),
+				'url' => '/welcome/',
+			),
+			array(
+				'label' => __( 'Guidelines', 'wporg-forums' ),
+				'url' => '/guidelines/',
+			),
+			array(
+				'label' => __( 'Get involved', 'wporg-forums' ),
+				'url' => 'https://make.wordpress.org/support/handbook/contributing-to-the-wordpress-forums/',
 			),
 		);
 	} else {
 		$local_nav_menu_object = wporg_support_get_local_nav_menu_object();
-		$menu_items_fallback = array(
-			'forums' => array(
-				 array(
-					'label' => __( 'Get Involved', 'wporg-forums' ),
-					'url' => 'https://make.wordpress.org/support/handbook/contributing-to-the-wordpress-forums/',
-				)
+		$menu = array(
+			array(
+				'label' => __( 'Get involved', 'wporg-forums' ),
+				'url' => 'https://make.wordpress.org/support/handbook/contributing-to-the-wordpress-forums/',
 			),
 		);
 
+		if ( ! is_user_logged_in() ) {
+			global $wp;
+			$redirect_url = home_url( $wp->request );
+			$menu[] = array(
+				'label' => __( 'Log in', 'wporg-forums' ),
+				'url' => wp_login_url( $redirect_url ),
+			);
+		}
+
 		if ( ! $local_nav_menu_object ) {
-			return $menu_items_fallback;
+			return array( 'forums' => $menu );
 		}
 
 		$menu_items = wp_get_nav_menu_items( $local_nav_menu_object->term_id );
 
 		if ( ! $menu_items || empty( $menu_items ) ) {
-			return $menu_items_fallback;
+			return array( 'forums' => $menu );
 		}
 
-		return array(
-			'forums' => array_map(
-				function( $menu_item ) {
-					return array(
-						'label' => esc_html( $menu_item->title ),
-						'url' => esc_url( $menu_item->url )
-					);
-				},
-				// Limit local nav items to 3
-				array_slice( $menu_items, 0, 3 )
-			)
+		$menu = array_map(
+			function( $menu_item ) {
+				return array(
+					'label' => esc_html( $menu_item->title ),
+					'url' => esc_url( $menu_item->url )
+				);
+			},
+			// Limit local nav items to 3
+			array_slice( $menu_items, 0, 3 )
 		);
 	}
+
+	if ( ! is_user_logged_in() ) {
+		global $wp;
+		$redirect_url = home_url( $wp->request );
+		$menu[] = array(
+			'label' => __( 'Log in', 'wporg-forums' ),
+			'url' => wp_login_url( $redirect_url ),
+		);
+	}
+
+	return array( 'forums' => $menu );
 }
 add_filter( 'wporg_block_navigation_menus', 'wporg_support_add_site_navigation_menus' );
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/functions.php
@@ -83,6 +83,7 @@ function wporg_support_add_site_navigation_menus( $menus ) {
 			$menu[] = array(
 				'label' => __( 'Log in', 'wporg-forums' ),
 				'url' => wp_login_url( $redirect_url ),
+				'className' => 'has-separator',
 			);
 		}
 
@@ -114,6 +115,7 @@ function wporg_support_add_site_navigation_menus( $menus ) {
 		$menu[] = array(
 			'label' => __( 'Log in', 'wporg-forums' ),
 			'url' => wp_login_url( $redirect_url ),
+			'className' => 'has-separator',
 		);
 	}
 


### PR DESCRIPTION
This updates the Support Forums to include the "Log in" link in the local navigation across the site. The link only appears when you're logged out, once logged in, you can manage your account/login status in the admin bar. Once logged in, the "Log in" link disappears.

I've also changed the "Get Involved" text to "Get involved", to match the sentence case capitalization standard. I did not change "Welcome to Support", thinking "Support" is a proper noun - we can continue that discussion in #215.

See https://github.com/WordPress/wporg-mu-plugins/issues/647, fixes #227

### Screenshots

| | Logged out | Logged in |
|---|--------|-------|
| Main English site | ![anon-en-menu](https://github.com/user-attachments/assets/5ab2699e-0f04-4817-aedc-647301344a42) | ![user-en-menu](https://github.com/user-attachments/assets/1a8b7f77-089a-4cdd-ba6d-62b433c1aa04) |
| Rosetta site, custom menu | ![anon-custom-menu](https://github.com/user-attachments/assets/103cdd92-a59b-497c-96bb-15e61a59d33d) | ![user-custom-menu](https://github.com/user-attachments/assets/da28ee2f-ccdd-43f0-8ee6-2af2f936388c) |
| Rosetta site, no custom menu | ![anon-no-menu](https://github.com/user-attachments/assets/2c3711af-7717-4371-b7de-3f0a660b0616) | ![user-no-menu](https://github.com/user-attachments/assets/0c7fcfd5-4e80-4dd7-a328-a734a840c320) |

### How to test the changes in this Pull Request:

1. Be logged out
2. There should be a "log in" link
3. Clicking it and signing in should redirect you back to the page you were just on
4. The "log in" link should not appear
5. You should see the admin bar

cc @WordPress/meta-design 