### PR TITLE
Remove extra fields from pending-profile page.

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/functions-restapi.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/functions-restapi.php
@@ -175,7 +175,7 @@ function wporg_login_rest_resend_confirmation_email( $request ) {
 	$account = $request['account'];
 
 	$success_message = sprintf(
-		__( 'Please check your email %s for a confirmation link to set your password.', 'wporg' ),
+		__( 'A confirmation email has been resent.', 'wporg' ),
 		'<code>' . esc_html( $account ) . '</code>'
 	);
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/functions-restapi.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/functions-restapi.php
@@ -174,10 +174,7 @@ function wporg_login_rest_email_in_use( $request ) {
 function wporg_login_rest_resend_confirmation_email( $request ) {
 	$account = $request['account'];
 
-	$success_message = sprintf(
-		__( 'A confirmation email has been resent.', 'wporg' ),
-		'<code>' . esc_html( $account ) . '</code>'
-	);
+	$success_message = __( 'A confirmation email has been resent.', 'wporg' );
 
 	$pending_user = wporg_get_pending_user( $request['account'] );
 	if ( ! $pending_user || $pending_user['created'] || ! $pending_user['user_activation_key'] ) {

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/js/registration.js
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/js/registration.js
@@ -43,20 +43,24 @@
 
 				e.preventDefault();
 
-				$this.closest( 'div.message' ).next('div.message.info').remove();
-
 				$.post(
 					wporg_registration.rest_url + '/resend-confirmation-email',
 					{
 						account: account,
 					},
 					function( datas ) {
-						$this.closest( 'div.message' ).after(
-							'<div class="message info"><p><span>' + datas + '</span></p></div>'
-						);
+						const content = `<div class="message info"><p><span>${ datas }</span></p></div>`;
+						const $message = $this.closest( 'div.message' );
+					
+						// On the pending-create page, we offer to resend the email.
+						// In that case, the resend button exists within the message div, so we replace it.
+						if ( $message.length) {
+							$message.replaceWith( content );
+						} else {
+							$this.before( content );
+						}
 					}
 				);
-
 			});
 
 			$loginForm.on( 'click', '.change-email', function( e ) {
@@ -64,6 +68,7 @@
 
 				$(this).remove();
 				$loginForm.find( '.login-email' ).removeClass( 'hidden' ).find( 'input' ).addClass( 'error' );
+				$loginForm.find( '.login-submit' ).removeClass( 'hidden' );
 			});
 
 			// Apply the input validation after initial blur, to avoid showing as invalid during initial edits.

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/pending-profile.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/pending-profile.php
@@ -63,61 +63,45 @@ $email_change_available = empty( $pending_user['meta']['changed_email'] );
 get_header();
 ?>
 <form name="registerform" id="registerform" action="" method="post">
+	<?php
+	if ( $pending_user['cleared'] ) {
+		printf(
+			'<h2>' . __( 'Confirm your email address', 'wporg' ) . '</h2>' .
+			/* translators: %s Email address */
+			'<p>' . __( 'Please check your email %s for a confirmation link to set your password.', 'wporg' ) . '</p>' .
+			'<p>' . '<a href="#" class="resend" data-account="%s">' . __( 'Resend confirmation email.', 'wporg' ) . '</a></p>' .
+			( $email_change_available ? '<a href="#" class="change-email">' . __( 'Incorrect email? Update email address.', 'wporg' ) . '</a>' : '' ),
+			'<code>' . esc_html( $pending_user['user_email'] ) . '</code>',
+			esc_attr( $pending_user['user_email'] )
+		);
+	} else {
+		printf(
+			'<h2>' . __( 'Your account is pending approval', 'wporg' ) . '</h2>' .
+			/* translators: %s Email address */
+			'<p>' . __( 'You will receive an email at %s to set your password when approved.', 'wporg' ) . '</p>' .
+			'<p>' . __( 'Please contact %s for more details.', 'wporg' ) . '</p>' .
+			( $email_change_available ? '<a href="#" class="change-email">' . __( 'Incorrect email? Update email address.', 'wporg' ) . '</a>' : '' ),
+			'<code>' . esc_html( $pending_user['user_email'] ) . '</code>',
+			'<a href="mailto:' . $sso::SUPPORT_EMAIL . '">' . $sso::SUPPORT_EMAIL . '</a>'
+		);
+	}
 
-	<div class="message info">
-		<p><?php
-		if ( $pending_user['cleared'] ) {
-			printf(
-				/* translators: %s Email address */
-				__( 'Please check your email %s for a confirmation link to set your password.', 'wporg' ) .
-				'<br><br>' . '<a href="#" class="resend" data-account="%s">' . __( 'Resend confirmation email.', 'wporg' ) . '</a>' .
-				( $email_change_available ? '<br>' . '<a href="#" class="change-email">' . __( 'Incorrect email? Update email address.', 'wporg' ) . '</a>' : '' ),
-				'<code>' . esc_html( $pending_user['user_email'] ) . '</code>',
-				esc_attr( $pending_user['user_email'] )
-			);
-		} else {
-			printf(
-				/* translators: %s Email address */
-				__( 'Your account is pending approval. You will receive an email at %s to set your password when approved.', 'wporg' ) . 
-				'<br>' . __( 'Please contact %s for more details.', 'wporg' ) .
-				( $email_change_available ? '<br><br>' . '<a href="#" class="change-email">' . __( 'Incorrect email? Update email address.', 'wporg' ) . '</a>' : '' ),
-				'<code>' . esc_html( $pending_user['user_email'] ) . '</code>',
-				'<a href="mailto:' . $sso::SUPPORT_EMAIL . '">' . $sso::SUPPORT_EMAIL . '</a>'
-			);
-		}
-
-		if ( 'local' === wp_get_environment_type() && ! empty( $_COOKIE['emailed_url'] ) ) {
-			printf(
-				'<br><br><strong>Local Development</strong>: The URL emailed to you is: <a href="%1$s">%1$s</a>.',
-				wp_unslash( $_COOKIE['emailed_url'] )
-			);
-		}
-		?></p>
-	</div>
-
-	<p class="intro">
-		<?php _e( 'Complete your WordPress.org Profile information.', 'wporg' ); ?>
-	</p>
-
-	<p class="login-login">
-		<label for="user_login"><?php _e( 'Username', 'wporg' ); ?></label>
-		<input type="text" disabled="disabled" class=" disabled" value="<?php echo esc_attr( $profile_user ); ?>" size="20" />
-	</p>
+	if ( 'local' === wp_get_environment_type() && ! empty( $_COOKIE['emailed_url'] ) ) {
+		printf(
+			'<br><br><strong>Local Development</strong>: The URL emailed to you is: <a href="%1$s">%1$s</a>.',
+			wp_unslash( $_COOKIE['emailed_url'] )
+		);
+	}
+	?>
 
 	<p class="login-email hidden">
 		<label for="user_email"><?php _e( 'Email', 'wporg' ); ?></label>
 		<input type="text" name="user_email" value="<?php echo esc_attr( $pending_user['user_email'] ); ?>" size="20" maxlength="100" />
 	</p>
 
-	<?php
-		$fields = &$pending_user['meta'];
-		include __DIR__ . '/partials/register-profilefields.php';
-	?>
-
-	<p class="login-submit">
+	<p class="login-submit hidden">
 		<input type="submit" name="wp-submit" id="wp-submit" class="button button-primary" value="<?php esc_attr_e( 'Save Profile Information', 'wporg' ); ?>" />
 	</p>
-
 </form>
 
 <p id="nav">

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/stylesheets/login.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/stylesheets/login.css
@@ -129,7 +129,7 @@ body.route-pending-create {
  */
 
 body {
-	color: #555d66;
+	color: #1e1e1e;
 	font-size: 14px;
 }
 
@@ -140,14 +140,15 @@ body {
 }
 
 a {
-	color: #555d66 !important;
+	color: #3858e9; !important;
 	text-decoration: underline !important;
 	font-weight: normal;
 	outline: 0;
 }
 
 a:hover, a:active {
-	text-decoration: underline;
+	color: #3858e9; !important;
+	text-decoration: none !important;
 }
 
 h2 {
@@ -172,6 +173,15 @@ strong {
 	text-align: center;
 }
 
+code {
+	color: #1e1e1e;
+	background-color: #f6f6f6;
+	border-radius: 2px;
+	line-height: 1.67;
+	padding: 3px !important;
+	font-weight: 600;
+}
+
 .wp-core-ui .button-primary {
 	-webkit-box-shadow: none;
 	box-shadow: none;
@@ -191,6 +201,7 @@ strong {
 	position: relative;
 	-webkit-box-shadow: 0 1px 2px rgba(0, 0, 0, .2);
 	box-shadow: 0 1px 2px rgba(0, 0, 0, .2);
+	text-wrap: pretty;
 }
 
 #login h1 {
@@ -391,6 +402,7 @@ body.route-linkexpired #login .message {
 	padding-left: 24px;
 	padding-right: 24px;
 	margin-right: -24px;
+	background: #fbfbfb;
 }
 
 body.route-register #login .message p,
@@ -447,8 +459,8 @@ body.rtl.route-register .message.error .avatar {
 }
 
 body.route-pending-profile #login .message.info {
-	margin-top: -24px;
-	width: 350px;
+	width: calc(100% + 48px);
+	box-shadow: none;
 }
 
 body.route-pending-profile #login .message.info,
@@ -463,6 +475,20 @@ body.route-pending-create input.disabled {
 	border: none;
 	box-shadow: unset;
 	margin-bottom: 0;
+}
+
+body.route-pending-profile #login  {
+	width: 450px;
+}
+
+body.route-pending-profile h2  {
+	margin-bottom: 16px;
+	font-size: 18px;
+	font-weight: 600;
+}
+
+body.route-pending-profile p {
+	margin-bottom: 16px;
 }
 
 form p.checkbox.error {


### PR DESCRIPTION
This PR removes extra field data when a profile is pending.

# Why?
When the profile is pending, users are waiting for someone to approve. Once approved, an email is sent to the user that opens `pending-create` which includes the profiles fields, along with a field to set the password.

We therefore don't need to show users these profiles field when the account is pending or the users needs to confirm their email. It distracts from the next step.

There are some incidental changes:
- Style: Updated links to use same color as wp.org.
- Style: Expand the box a bit to make copy more legible
- Content: Add headings to states
- Spacing changes.

## Current

| State | Image |
|--------|--------|
| Pending | <img width="427" alt="Screenshot 2024-10-16 at 10 59 08 AM" src="https://github.com/user-attachments/assets/f4f44474-3197-4955-822e-b8970098043c"> |


## This PR
| State | Image |
|--------|--------|
| Pending Approval | <img width="524" alt="Screenshot 2024-10-16 at 10 40 41 AM" src="https://github.com/user-attachments/assets/72014200-d2a8-4499-be3e-58e03b8eb193"> |
| Email confirmation | <img width="525" alt="Screenshot 2024-10-16 at 10 40 14 AM" src="https://github.com/user-attachments/assets/9931967b-cf95-49a6-8ce5-071cd2b782a8"> |
| Resend confirmation | <img width="547" alt="Screenshot 2024-10-16 at 10 40 21 AM" src="https://github.com/user-attachments/assets/aaee58ea-23d3-4102-9090-db8507876e3c"> | 
| Resend confirmation on create | <img width="361" alt="Screenshot 2024-10-16 at 10 55 43 AM" src="https://github.com/user-attachments/assets/f5b4116a-8c71-477e-89db-170da22b83c6"> | 
| Resend confirmation on create confirmation | <img width="356" alt="Screenshot 2024-10-16 at 10 55 52 AM" src="https://github.com/user-attachments/assets/fb5b0116-cc80-4cd2-aad8-f5d2d2603ae8"> | 
| Updating email | <img width="588" alt="Screenshot 2024-10-16 at 11 03 37 AM" src="https://github.com/user-attachments/assets/d62ca930-a991-4d75-9914-1b0f1da80378"> | 






