### PR TITLE
Improve message from WordCamps for login/create account.

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/functions.php
@@ -474,19 +474,25 @@ function wporg_login_wporg_is_starpress( $redirect_to = '' ) {
 	}
 
 	if ( str_contains( $from, 'buddypress.org' ) ) {
-		$message .= '<strong>' . __( 'BuddyPress is part of WordPress.org', 'wporg' ) . '</strong><br>';
+		$message .= '<strong>' . __( 'BuddyPress is part of WordPress.org', 'wporg' ) . '</strong>';
 		$message .= __( 'Log in to your WordPress.org account to contribute to BuddyPress, or get help in the support forums.', 'wporg' );
 	
 	} elseif ( str_contains( $from, 'bbpress.org' ) ) {
-		$message .= '<strong>' . __( 'bbPress is part of WordPress.org', 'wporg' ) . '</strong><br>';
+		$message .= '<strong>' . __( 'bbPress is part of WordPress.org', 'wporg' ) . '</strong>';
 		$message .= __( 'Log in to your WordPress.org account to contribute to bbPress, or get help in the support forums.', 'wporg' );
 	
-	} elseif ( str_contains( $from, 'wordcamp.org' ) ) {
-		$message .= '<strong>' . __( 'WordCamp is part of WordPress.org', 'wporg' ) . '</strong><br>';
-		$message .= __( 'Log in to your WordPress.org account to contribute to WordCamps and meetups around the globe.', 'wporg' );
+	} elseif ( str_contains( $from, 'wordcamp.org' ) || str_contains( $from, 'events.wordpress.org' ) ) {
+
+		if ( !empty( $_REQUEST['wcname'] ) ) {
+			$message .= '<strong>' . sprintf( __( 'Register for %s', 'wporg' ), esc_html( $_REQUEST['wcname'] ) ) . '</strong>';
+			$message .=  __( 'Log in to your WordPress.org account. If you don\'t have one, you can <a href="/register">create an account</a>.', 'wporg' );
+		} else {
+			$message .= '<strong>' . __( 'WordCamp is part of WordPress.org', 'wporg' ) . '</strong>';
+			$message .= __( 'Log in to your WordPress.org account to contribute to WordCamps and meetups around the globe.', 'wporg' );
+		}
 	
 	} elseif ( str_contains( $from, 'learn.wordpress.org' ) ) {
-		$message .= '<strong>' . __( 'Access all of Learn WordPress', 'wporg' ) . '</strong><br>';
+		$message .= '<strong>' . __( 'Access all of Learn WordPress', 'wporg' ) . '</strong>';
 		$message .= __( 'Log in to your WordPress.org account to take or continue a course and track your progress.', 'wporg' );
 
 	} else {

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/functions.php
@@ -483,7 +483,7 @@ function wporg_login_wporg_is_starpress( $redirect_to = '' ) {
 	
 	} elseif ( str_contains( $from, 'wordcamp.org' ) || str_contains( $from, 'events.wordpress.org' ) ) {
 
-		if ( !empty( $_REQUEST['wcname'] ) ) {
+		if ( ! empty( $_REQUEST['wcname'] ) ) {
 			$message .= '<strong>' . sprintf( __( 'Register for %s', 'wporg' ), esc_html( $_REQUEST['wcname'] ) ) . '</strong>';
 			$message .=  __( 'Log in to your WordPress.org account. If you don\'t have one, you can <a href="/register">create an account</a>.', 'wporg' );
 		} else {

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/stylesheets/login.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/stylesheets/login.css
@@ -241,7 +241,6 @@ p.intro, #login .message {
 p.intro strong {
 	display: block;
 	margin-bottom: 8px;
-	text-align: center;
 }
 
 #login .message + #login_error {

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/stylesheets/login.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/stylesheets/login.css
@@ -238,6 +238,12 @@ p.intro, #login .message {
 	text-wrap: pretty;
 }
 
+p.intro strong {
+	display: block;
+	margin-bottom: 8px;
+	text-align: center;
+}
+
 #login .message + #login_error {
 	margin-top: 0 !important;
 	border-top: 1px solid #f5f5f5;


### PR DESCRIPTION
This PR depends on https://github.com/WordPress/wordcamp.org/pull/1399 and adds some custom message for users who arrive from WordCamps to login/create account.


## Screenshot
<img width="462" alt="Screenshot 2024-10-18 at 2 59 45 PM" src="https://github.com/user-attachments/assets/80c67465-718d-4960-9ee7-0a7772851898">
