### PR TITLE
Allow some URL for the events in the robots.txt

### DIFF
--- a/wordpress.org/public_html/wp-content/mu-plugins/pub/wporg-robots.php
+++ b/wordpress.org/public_html/wp-content/mu-plugins/pub/wporg-robots.php
@@ -18,7 +18,10 @@ function wporg_robots_txt( $robots ) {
 		           "Allow: /locale/$\n" .
 		           "Allow: /locale/*/glossary/$\n" .
 		           "Allow: /locale/*/stats/plugins/$\n" .
-		           "Allow: /locale/*/stats/themes/$\n";
+		           "Allow: /locale/*/stats/themes/$\n" .
+		           "Allow: /events/rss\n" .
+		           "Allow: /events/feed\n" .
+		           "Allow: /events/*/*\n";
 
 	} elseif ( 'wordpress.org' === $blog_details->domain ) {
 		// WordPress.org/search/ should not be indexed.


### PR DESCRIPTION
The https://translate.wordpress.org/robots.txt file is blocking some URL for the events, as you can see at https://github.com/WordPress/wporg-gp-translation-events/issues/356. This functionality blocks the posibility to correctly share the individual events in the social networks.

This PR enables 3 patterns in the robots.txt for https://translate.wordpress.org/ (https://translate.wordpress.org/robots.txt):
- `/events/rss` for the RSS feed.
- `/events/feed` for the RSS feed.
- `/events/*/*` for 3-level URLs like https://translate.wordpress.org/events/2024/wordpress-translation-week-2024-online/

Fixes https://github.com/WordPress/wporg-gp-translation-events/issues/356