### PR TITLE
Update support forum ratings component

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-ratings-compat.php
+++ b/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-ratings-compat.php
@@ -221,56 +221,11 @@ class Ratings_Compat {
 				'<span>' . number_format_i18n( $this->reviews_count ) . '</span>'
 			);
 		?></div>
-		<?php
-			foreach ( array( 5, 4, 3, 2, 1 ) as $rating ) {
-				$ratings_count = isset( $this->ratings_counts[ $rating ] ) ? $this->ratings_counts[ $rating ] : 0;
-				$ratings_count_total = isset( $this->ratings_counts ) ? array_sum( $this->ratings_counts) : 0;
-				$stars_title = sprintf(
-					/* translators: %s: number of stars */
-					_n(
-						'Click to see reviews that provided a rating of %d star',
-						'Click to see reviews that provided a rating of %d stars',
-						$rating,
-						'wporg-forums'
-					),
-					$rating
-				);
-				/* translators: %d: number of stars */
-				$stars_text = sprintf(
-					/* translators: %d: number of stars */
-					_n( '%d star', '%d stars', $rating, 'wporg-forums' ),
-					$rating
-				);
-				$width = 0;
-				if ( $ratings_count && $ratings_count_total ) {
-					$width = 100 * ( $ratings_count / $ratings_count_total );
-				}
-				?>
-				<div class="counter-container">
-				<a href="<?php echo esc_url( sprintf( home_url( '/%s/%s/reviews/?filter=%s' ), $this->compat, $this->slug, $rating ) ); ?>"
-					title="<?php echo esc_attr( $stars_title ); ?>">
-					<span class="counter-label" style="float:left;margin-right:5px;min-width:58px;"><?php echo esc_html( $stars_text ); ?></span>
-					<span class="counter-back" style="height:17px;width:100px;background-color:#ececec;float:left;">
-						<span class="counter-bar" style="width:<?php echo esc_attr( $width ); ?>px;height:17px;background-color:#ffc733;float:left;"></span>
-					</span>
-				</a>
-				<span class="counter-count" style="margin-left:5px;"><?php echo esc_html( number_format_i18n( $ratings_count ) ); ?></span>
-				</div>
-				<?php
-			}
-		?>
+		<?php echo do_blocks( '<!-- wp:wporg/ratings-bars /-->' ); ?>
 	</div>
 	<div class="col-5">
 		<div style="font-weight:bold;"><?php _e( 'Average Rating', 'wporg-forums' ); ?></div>
-		<?php
-			echo \WPORG_Ratings::get_dashicons_stars( $this->avg_rating );
-			printf(
-				/* translators: 1: number of stars in rating, 2: total number of stars (5) */
-				__( '%1$s out of %2$s stars', 'wporg-forums' ),
-				round( isset( $this->avg_rating ) ? $this->avg_rating : 0, 1 ),
-				'<span>5</span>'
-			);
-		?>
+			<?php echo do_blocks( '<!-- wp:wporg/ratings-stars /-->' ); ?>
 		<div class="reviews-submit-link">
 		<?php
 			if ( is_user_logged_in() ) {

--- a/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-ratings-compat.php
+++ b/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-ratings-compat.php
@@ -225,7 +225,7 @@ class Ratings_Compat {
 	</div>
 	<div class="col-5">
 		<div style="font-weight:bold;"><?php _e( 'Average Rating', 'wporg-forums' ); ?></div>
-			<?php echo do_blocks( '<!-- wp:wporg/ratings-stars /-->' ); ?>
+		<?php echo do_blocks( '<!-- wp:wporg/ratings-stars /-->' ); ?>
 		<div class="reviews-submit-link">
 		<?php
 			if ( is_user_logged_in() ) {

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress.php
@@ -4,13 +4,12 @@
  *
  * @package WPBBP
  */
-
+global $wp_query;
 get_header(); ?>
 
 <main id="main" class="wp-block-group alignfull site-main is-layout-constrained wp-block-group-is-layout-constrained" role="main">
 
 		<div class="wp-block-group alignwide is-layout-flow wp-block-group-is-layout-flow">
-
 		<div class="entry-content">
 			<?php while ( have_posts() ) : the_post(); ?>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress.php
@@ -4,6 +4,7 @@
  *
  * @package WPBBP
  */
+
 get_header(); ?>
 
 <main id="main" class="wp-block-group alignfull site-main is-layout-constrained wp-block-group-is-layout-constrained" role="main">

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress.php
@@ -9,6 +9,7 @@ get_header(); ?>
 <main id="main" class="wp-block-group alignfull site-main is-layout-constrained wp-block-group-is-layout-constrained" role="main">
 
 		<div class="wp-block-group alignwide is-layout-flow wp-block-group-is-layout-flow">
+
 		<div class="entry-content">
 			<?php while ( have_posts() ) : the_post(); ?>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress.php
@@ -4,7 +4,6 @@
  *
  * @package WPBBP
  */
-global $wp_query;
 get_header(); ?>
 
 <main id="main" class="wp-block-group alignfull site-main is-layout-constrained wp-block-group-is-layout-constrained" role="main">

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/functions.php
@@ -9,6 +9,7 @@
  * Include locale specific styles.
  */
 require_once get_theme_root( 'wporg-parent-2021' ) . '/wporg-parent-2021/inc/rosetta-styles.php';
+require_once( __DIR__ . '/inc/block-config.php' );
 
 /**
  * Use the ‘Lead Topic’ uses the single topic part
@@ -1557,50 +1558,3 @@ function bb_is_intl_forum() {
  * Include the Strings for the supporg/update-php page.
  */
 include_once __DIR__ . '/helphub-update-php-strings.php';
-
-
-/**
- * Update ratings blocks with real rating data.
- *
- * @param array $data    Rating data.
- * @param int   $post_id Current post.
- *
- * @return array
- */
-function wporg_set_rating_data( $data, $post_id ) {
-	$post = wporg_support_get_compat_object();
-
-	if ( class_exists( '\WPORG_Ratings' ) ) {
-		$rating  = \WPORG_Ratings::get_avg_rating( $post->type, $post->post_name ) ?: 0;
-		$ratings = \WPORG_Ratings::get_rating_counts( $post->type, $post->post_name ) ?: array();
-	}
-
-	/**
-	 * Why do we multiply the average rating by 20?
-	 * The themes API does it this way, and the rating plugin was built to fit that. 
-	 * Instead of redoing everything, multiplying here keeps things simple and works well.
-	 *
-	 * @see theme-directory/class-themes-api.php for more info.
-	 */
-	$adjusted_rating = $rating * 20;
-
-	return array(
-		'rating' => $adjusted_rating,
-		'ratingsCount' => array_sum( $ratings ),
-		'ratings' => $ratings,
-		'supportUrl' => esc_url( sprintf( home_url( '/%s/%s/reviews/' ), $post->type, $post->post_name ) )
-	);
-}
-
-add_filter( 'wporg_ratings_data', 'wporg_set_rating_data', 10, 2 );
-
-function wporg_render_block_context( $context, $parsed_block, $parent_block ) {
-
-	if ( in_array( $parsed_block['blockName'], [ 'wporg/ratings-stars', 'wporg/ratings-bars'  ] ) ) {
-		$context = array_merge( $context, [ 'postId' => wporg_support_get_compat_object()->ID ] );
-	}
-
-	return $context;
-}
-
-add_filter( 'render_block_context', 'wporg_render_block_context', 10, 3	 );

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/functions.php
@@ -1557,3 +1557,50 @@ function bb_is_intl_forum() {
  * Include the Strings for the supporg/update-php page.
  */
 include_once __DIR__ . '/helphub-update-php-strings.php';
+
+
+/**
+ * Update ratings blocks with real rating data.
+ *
+ * @param array $data    Rating data.
+ * @param int   $post_id Current post.
+ *
+ * @return array
+ */
+function wporg_set_rating_data( $data, $post_id ) {
+	$post = wporg_support_get_compat_object();
+
+	if ( class_exists( '\WPORG_Ratings' ) ) {
+		$rating  = \WPORG_Ratings::get_avg_rating( $post->type, $post->post_name ) ?: 0;
+		$ratings = \WPORG_Ratings::get_rating_counts( $post->type, $post->post_name ) ?: array();
+	}
+
+	/**
+	 * Why do we multiply the average rating by 20?
+	 * The themes API does it this way, and the rating plugin was built to fit that. 
+	 * Instead of redoing everything, multiplying here keeps things simple and works well.
+	 *
+	 * @see theme-directory/class-themes-api.php for more info.
+	 */
+	$adjusted_rating = $rating * 20;
+
+	return array(
+		'rating' => $adjusted_rating,
+		'ratingsCount' => array_sum( $ratings ),
+		'ratings' => $ratings,
+		'supportUrl' => esc_url( sprintf( home_url( '/%s/%s/reviews/' ), $post->type, $post->post_name ) )
+	);
+}
+
+add_filter( 'wporg_ratings_data', 'wporg_set_rating_data', 10, 2 );
+
+function wporg_render_block_context( $context, $parsed_block, $parent_block ) {
+
+	if ( in_array( $parsed_block['blockName'], [ 'wporg/ratings-stars', 'wporg/ratings-bars'  ] ) ) {
+		$context = array_merge( $context, [ 'postId' => wporg_support_get_compat_object()->ID ] );
+	}
+
+	return $context;
+}
+
+add_filter( 'render_block_context', 'wporg_render_block_context', 10, 3	 );

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/inc/block-config.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/inc/block-config.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Set up configuration for dynamic blocks.
+ */
+
+/**
+ * Actions and filters.
+ */
+add_filter( 'render_block_context', 'wporg_render_block_context', 10, 3	);
+add_filter( 'wporg_ratings_data', 'wporg_set_rating_data', 10, 2 );
+
+/**
+ * Update ratings blocks with real rating data.
+ *
+ * @param array $data    Rating data.
+ * @param int   $post_id Current post.
+ *
+ * @return array
+ */
+function wporg_set_rating_data( $data, $post_id ) {
+	$post = wporg_support_get_compat_object();
+
+	if ( class_exists( '\WPORG_Ratings' ) ) {
+		$rating  = \WPORG_Ratings::get_avg_rating( $post->type, $post->post_name ) ?: 0;
+		$ratings = \WPORG_Ratings::get_rating_counts( $post->type, $post->post_name ) ?: array();
+	}
+
+	/**
+	 * Why do we multiply the average rating by 20?
+	 * The themes API does it this way, and the rating plugin was built to fit that. 
+	 * Instead of redoing everything, multiplying here keeps things simple and works well.
+	 *
+	 * @see theme-directory/class-themes-api.php for more info.
+	 */
+	$adjusted_rating = $rating * 20;
+
+	return array(
+		'rating' => $adjusted_rating,
+		'ratingsCount' => array_sum( $ratings ),
+		'ratings' => $ratings,
+		'supportUrl' => esc_url( sprintf( home_url( '/%s/%s/reviews/' ), $post->type, $post->post_name ) )
+	);
+}
+
+/**
+ * Modifies the block context to include a `postId` for specific blocks.
+ * 
+ * The `wporg/ratings-stars` and `wporg/ratings-bars` require a postId. Due to context, it's unavailable.
+ * 
+ * @param array      $context      The current block context.
+ * @param array      $parsed_block The block being rendered.
+ * @param WP_Block|null $parent_block Optional. The parent block, if any.
+ *
+ * @return array The modified block context.
+ */
+function wporg_render_block_context( $context, $parsed_block, $parent_block ) {
+    if ( isset( $parsed_block['blockName'] ) && 
+         in_array( $parsed_block['blockName'], [ 'wporg/ratings-stars', 'wporg/ratings-bars' ], true ) ) {
+
+        $compat_object = wporg_support_get_compat_object();
+
+        if ( $compat_object ) {
+            $context = array_merge( $context, [ 'postId' => $compat_object->ID ] );
+        }
+    }
+
+    return $context;
+}

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/package-lock.json
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/package-lock.json
@@ -8,9 +8,6 @@
 			"name": "wporg-support",
 			"version": "1.0.0",
 			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"postcss-scss": "~4.0.9"
-			},
 			"devDependencies": {
 				"@lodder/grunt-postcss": "~3.1.1",
 				"@wordpress/browserslist-config": "~5.33.0",
@@ -2308,6 +2305,7 @@
 			"version": "3.3.7",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
 			"integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -2613,7 +2611,8 @@
 		"node_modules/picocolors": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+			"dev": true
 		},
 		"node_modules/picomatch": {
 			"version": "2.3.1",
@@ -2640,6 +2639,7 @@
 			"version": "8.4.33",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
 			"integrity": "sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -2695,6 +2695,7 @@
 			"version": "4.0.9",
 			"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.9.tgz",
 			"integrity": "sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -3254,6 +3255,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
 			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/sass/site/_bbpress.scss
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/sass/site/_bbpress.scss
@@ -1344,8 +1344,8 @@ div.bbp-breadcrumb {
 	.review-ratings {
 
 		@extend .clear;
-		margin-bottom: ms(0);
-		padding-bottom: 10px;
+		margin-bottom: var(--wp--preset--spacing--20);
+		padding-bottom: var(--wp--preset--spacing--20);
 		border-bottom: 1px solid var(--wp--custom--color--border);
 		display: flex;
 		flex-direction: row-reverse;
@@ -1354,7 +1354,6 @@ div.bbp-breadcrumb {
 			font-size: ms(-2);
 			margin: 0;
 			min-width: 40%;
-			border-top: 1px solid var(--wp--custom--color--border);
 			flex-shrink: 0;
 
 			.reviews-total-count {

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/style-rtl.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/style-rtl.css
@@ -3557,8 +3557,8 @@ div.bbp-breadcrumb .bbp-breadcrumb-sep {
 # Plugin / Theme specific support pages
 --------------------------------------------------------------*/
 .bbp-view .review-ratings {
-	margin-bottom: 1rem;
-	padding-bottom: 10px;
+	margin-bottom: var(--wp--preset--spacing--20);
+	padding-bottom: var(--wp--preset--spacing--20);
 	border-bottom: 1px solid var(--wp--custom--color--border);
 	display: flex;
 	flex-direction: row-reverse;
@@ -3567,7 +3567,6 @@ div.bbp-breadcrumb .bbp-breadcrumb-sep {
 	font-size: 0.8rem;
 	margin: 0;
 	min-width: 40%;
-	border-top: 1px solid var(--wp--custom--color--border);
 	flex-shrink: 0;
 }
 .bbp-view .review-ratings .col-3 .reviews-total-count {

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/style.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/style.css
@@ -3557,8 +3557,8 @@ div.bbp-breadcrumb .bbp-breadcrumb-sep {
 # Plugin / Theme specific support pages
 --------------------------------------------------------------*/
 .bbp-view .review-ratings {
-	margin-bottom: 1rem;
-	padding-bottom: 10px;
+	margin-bottom: var(--wp--preset--spacing--20);
+	padding-bottom: var(--wp--preset--spacing--20);
 	border-bottom: 1px solid var(--wp--custom--color--border);
 	display: flex;
 	flex-direction: row-reverse;
@@ -3567,7 +3567,6 @@ div.bbp-breadcrumb .bbp-breadcrumb-sep {
 	font-size: 0.8rem;
 	margin: 0;
 	min-width: 40%;
-	border-top: 1px solid var(--wp--custom--color--border);
 	flex-shrink: 0;
 }
 .bbp-view .review-ratings .col-3 .reviews-total-count {


### PR DESCRIPTION
This PR updates the support forum reviews stars & bars to use the shared component.

Related: https://github.com/WordPress/wporg-mu-plugins/pull/633, https://github.com/WordPress/wordpress.org/pull/380

## Important

The forums display more precise rating numbers, while the new components round ratings to the nearest 0.5. Since we already use the new components in multiple places, if we want to keep the current precision, we should do it everywhere at once in the new components.

## Considerations
The `ratings-stars` and `ratings-bars` components [expect](https://github.com/WordPress/wporg-mu-plugins/blob/trunk/mu-plugins/blocks/ratings-stars/render.php#L3) the context to contain `postId`. However, based on how bbPress works and how it's been modified, the `postId` is not set. 

As a result, I've made use of the `render_block_context` block to set it. we still don't use that in `wporg_set_rating_data`, as we need to call `wporg_support_get_compat_object` to get all the relevant data. It feels a bit silly, but feels better than the alternative. The alternative would be to change the blocks to not return if the post_id is not set. That feels less predictable.

I've also done some minor styling updates.

## Screenshots

| Before | After |
|--------|--------|
| <img width="1102" alt="Screenshot 2024-10-25 at 12 08 11 PM" src="https://github.com/user-attachments/assets/8fa92f21-a7c6-48eb-8e46-5c8e84d42f8c"> | <img width="1241" alt="Screenshot 2024-10-25 at 11 52 50 AM" src="https://github.com/user-attachments/assets/674e9933-e79a-49d5-bfd6-e022820a7ac8"> |
| <img width="1104" alt="Screenshot 2024-10-25 at 11 49 34 AM" src="https://github.com/user-attachments/assets/5c8e75b1-9c09-45d4-8a32-497ba81e477e"> | <img width="1244" alt="Screenshot 2024-10-25 at 11 53 09 AM" src="https://github.com/user-attachments/assets/04d1ec01-b388-4716-a275-49eaa370cf78">  | 








