### PR TITLE
Theme Previews: Filter out duplicate style variations

### DIFF
--- a/wp-themes.com/public_html/wp-content/plugins/style-variations/inc/page-intercept.php
+++ b/wp-themes.com/public_html/wp-content/plugins/style-variations/inc/page-intercept.php
@@ -2,6 +2,8 @@
 
 namespace WordPressdotorg\Theme_Preview\Style_Variations\Page_Intercept;
 
+use function WordPressdotorg\Theme_Preview\Style_Variations\get_style_variations;
+
 /**
  * Return the name of the pattern from the $_GET request.
  *
@@ -29,7 +31,7 @@ function get_variation_from_query() {
 	/**
 	 * Retrieve all variations and match to make sure we have one with the same title.
 	 */
-	$variations = \WP_Theme_JSON_Resolver::get_style_variations();
+	$variations = get_style_variations();
 	if ( empty( $variations ) ) {
 		return false;
 	}
@@ -98,12 +100,12 @@ function filter_theme_json_user( $theme_json ) {
 /**
  * We need to call gutenberg's filter `theme_json_user` to make sure the styles are applied to the page.
  * This use to work for both the page and card but a core change stopped that.
- * 
+ *
  * See: https://core.trac.wordpress.org/ticket/56812
- * 
+ *
  * We now need to also call the core filter `wp_theme_json_data_user` to get the card preview to work.
  * Hopefully this code can be remove when we have a better component to use.
- * 
+ *
  * Ref: https://github.com/WordPress/gutenberg/issues/44886
 
  */

--- a/wp-themes.com/public_html/wp-content/plugins/style-variations/inc/styles-endpoint.php
+++ b/wp-themes.com/public_html/wp-content/plugins/style-variations/inc/styles-endpoint.php
@@ -2,8 +2,10 @@
 
 namespace WordPressdotorg\Theme_Preview\Style_Variations\API_Endpoint;
 
+use function WordPressdotorg\Theme_Preview\Style_Variations\get_style_variations;
+
 function endpoint_handler() {
-	$variations = \WP_Theme_JSON_Resolver::get_style_variations();
+	$variations = get_style_variations();
 	$theme_slug = get_option( 'stylesheet' );
 	$styles     = array();
 
@@ -25,7 +27,7 @@ function endpoint_handler() {
 		 */
 		foreach ( $variations as $variation ) {
 			$title = strtolower( $variation['title'] );
-			$link  = add_query_arg( 'style_variation', urlencode( $title ), $base );;
+			$link  = add_query_arg( 'style_variation', urlencode( $title ), $base );
 
 			$styles[] = array(
 				'title'        => $title,

--- a/wp-themes.com/public_html/wp-content/plugins/style-variations/style-variations.php
+++ b/wp-themes.com/public_html/wp-content/plugins/style-variations/style-variations.php
@@ -12,6 +12,47 @@ namespace WordPressdotorg\Theme_Preview\Style_Variations;
 
 defined( 'WPINC' ) || die();
 
+/**
+ * Get unique style variations.
+ *
+ * If there are multiple variations matching a title, use the longest. This is
+ * a rough way to check for full (combined) style variations, as opposed to
+ * color palettes or type sets.
+ *
+ * @return array Variation list, or empty array.
+ */
+function get_style_variations() {
+	$variations = array();
+	$all_variations = \WP_Theme_JSON_Resolver::get_style_variations();
+
+	foreach ( $all_variations as $variation ) {
+		// Safety check: variations must have a title and settings.
+		if ( ! isset( $variation['title'], $variation['settings'] ) ) {
+			continue;
+		}
+		$found_variations = wp_list_filter(
+			$variations,
+			array( 'title' => $variation['title'] )
+		);
+		if ( ! $found_variations ) {
+			$variations[] = $variation;
+		} else {
+			// Loop over the found variations, even though there should only
+			// ever be one, to keep track of the index value.
+			foreach ( $found_variations as $i => $found ) {
+				$found_settings = wp_json_encode( $found );
+				$new_settings = wp_json_encode( $variation );
+				if ( strlen( $new_settings ) > strlen( $found_settings ) ) {
+					// Replace the item in the variations list.
+					$variations[ $i ] = $variation;
+				}
+			}
+		}
+	}
+
+	return $variations;
+}
+
 require_once __DIR__ . '/inc/global-style-page.php';
 require_once __DIR__ . '/inc/page-intercept.php';
 require_once __DIR__ . '/inc/styles-endpoint.php';


### PR DESCRIPTION
If there are duplicate style variations, it's likely that one is a subset (color palette or type set) and one is combined. Find the one with more settings and use that.

For example in Twenty Twenty-Five, there are [color palette json files using names like Noon, Evening, etc](https://themes.trac.wordpress.org/browser/twentytwentyfive/1.0/styles?order=name#colors), typography sets that don't include colors, and combined sets using a color palette and a typography set. These combined styles use the same name as the color palettes. When `\WP_Theme_JSON_Resolver::get_style_variations();` runs, it fetches all the .json files, which includes the duplicates, but the name is assumed to be unique, which creates issues when picking which preview to display.

Fixes https://github.com/WordPress/wporg-theme-directory/issues/158.

Note: A possible follow-up improvement to the theme directory could be supporting the color palette and typography UI of the styles editor.

Style variations endpoint before; `evening`, `noon`, etc appear multiple times

<details>

```json
[
  {
    "title": "Default",
    "link": "https://wp-themes.com/twentytwentyfive",
    "preview_link": "https://wp-themes.com/twentytwentyfive?card_view"
  },
  {
    "title": "evening",
    "link": "https://wp-themes.com/twentytwentyfive?style_variation=evening",
    "preview_link": "https://wp-themes.com/twentytwentyfive?style_variation=evening&card_view"
  },
  {
    "title": "noon",
    "link": "https://wp-themes.com/twentytwentyfive?style_variation=noon",
    "preview_link": "https://wp-themes.com/twentytwentyfive?style_variation=noon&card_view"
  },
  {
    "title": "dusk",
    "link": "https://wp-themes.com/twentytwentyfive?style_variation=dusk",
    "preview_link": "https://wp-themes.com/twentytwentyfive?style_variation=dusk&card_view"
  },
  {
    "title": "afternoon",
    "link": "https://wp-themes.com/twentytwentyfive?style_variation=afternoon",
    "preview_link": "https://wp-themes.com/twentytwentyfive?style_variation=afternoon&card_view"
  },
  {
    "title": "twilight",
    "link": "https://wp-themes.com/twentytwentyfive?style_variation=twilight",
    "preview_link": "https://wp-themes.com/twentytwentyfive?style_variation=twilight&card_view"
  },
  {
    "title": "morning",
    "link": "https://wp-themes.com/twentytwentyfive?style_variation=morning",
    "preview_link": "https://wp-themes.com/twentytwentyfive?style_variation=morning&card_view"
  },
  {
    "title": "sunrise",
    "link": "https://wp-themes.com/twentytwentyfive?style_variation=sunrise",
    "preview_link": "https://wp-themes.com/twentytwentyfive?style_variation=sunrise&card_view"
  },
  {
    "title": "midnight",
    "link": "https://wp-themes.com/twentytwentyfive?style_variation=midnight",
    "preview_link": "https://wp-themes.com/twentytwentyfive?style_variation=midnight&card_view"
  },
  {
    "title": "evening",
    "link": "https://wp-themes.com/twentytwentyfive?style_variation=evening",
    "preview_link": "https://wp-themes.com/twentytwentyfive?style_variation=evening&card_view"
  },
  {
    "title": "noon",
    "link": "https://wp-themes.com/twentytwentyfive?style_variation=noon",
    "preview_link": "https://wp-themes.com/twentytwentyfive?style_variation=noon&card_view"
  },
  {
    "title": "dusk",
    "link": "https://wp-themes.com/twentytwentyfive?style_variation=dusk",
    "preview_link": "https://wp-themes.com/twentytwentyfive?style_variation=dusk&card_view"
  },
  {
    "title": "afternoon",
    "link": "https://wp-themes.com/twentytwentyfive?style_variation=afternoon",
    "preview_link": "https://wp-themes.com/twentytwentyfive?style_variation=afternoon&card_view"
  },
  {
    "title": "twilight",
    "link": "https://wp-themes.com/twentytwentyfive?style_variation=twilight",
    "preview_link": "https://wp-themes.com/twentytwentyfive?style_variation=twilight&card_view"
  },
  {
    "title": "morning",
    "link": "https://wp-themes.com/twentytwentyfive?style_variation=morning",
    "preview_link": "https://wp-themes.com/twentytwentyfive?style_variation=morning&card_view"
  },
  {
    "title": "sunrise",
    "link": "https://wp-themes.com/twentytwentyfive?style_variation=sunrise",
    "preview_link": "https://wp-themes.com/twentytwentyfive?style_variation=sunrise&card_view"
  },
  {
    "title": "midnight",
    "link": "https://wp-themes.com/twentytwentyfive?style_variation=midnight",
    "preview_link": "https://wp-themes.com/twentytwentyfive?style_variation=midnight&card_view"
  },
  {
    "title": "beiruti & literata",
    "link": "https://wp-themes.com/twentytwentyfive?style_variation=beiruti+%26+literata",
    "preview_link": "https://wp-themes.com/twentytwentyfive?style_variation=beiruti+%26+literata&card_view"
  },
  {
    "title": "vollkorn & fira code",
    "link": "https://wp-themes.com/twentytwentyfive?style_variation=vollkorn+%26+fira+code",
    "preview_link": "https://wp-themes.com/twentytwentyfive?style_variation=vollkorn+%26+fira+code&card_view"
  },
  {
    "title": "platypi & ysabeau office",
    "link": "https://wp-themes.com/twentytwentyfive?style_variation=platypi+%26+ysabeau+office",
    "preview_link": "https://wp-themes.com/twentytwentyfive?style_variation=platypi+%26+ysabeau+office&card_view"
  },
  {
    "title": "roboto slab & manrope",
    "link": "https://wp-themes.com/twentytwentyfive?style_variation=roboto+slab+%26+manrope",
    "preview_link": "https://wp-themes.com/twentytwentyfive?style_variation=roboto+slab+%26+manrope&card_view"
  },
  {
    "title": "literata & ysabeau office",
    "link": "https://wp-themes.com/twentytwentyfive?style_variation=literata+%26+ysabeau+office",
    "preview_link": "https://wp-themes.com/twentytwentyfive?style_variation=literata+%26+ysabeau+office&card_view"
  },
  {
    "title": "platypi & literata",
    "link": "https://wp-themes.com/twentytwentyfive?style_variation=platypi+%26+literata",
    "preview_link": "https://wp-themes.com/twentytwentyfive?style_variation=platypi+%26+literata&card_view"
  },
  {
    "title": "literata & fira sans",
    "link": "https://wp-themes.com/twentytwentyfive?style_variation=literata+%26+fira+sans",
    "preview_link": "https://wp-themes.com/twentytwentyfive?style_variation=literata+%26+fira+sans&card_view"
  }
]
```

</details>

Style variations endpoint after, only one entry each for `evening`, `noon`, etc

<details>

```json
[
  {
    "title": "Default",
    "link": "https://wp-themes.com/twentytwentyfive",
    "preview_link": "https://wp-themes.com/twentytwentyfive?card_view"
  },
  {
    "title": "evening",
    "link": "https://wp-themes.com/twentytwentyfive?style_variation=evening",
    "preview_link": "https://wp-themes.com/twentytwentyfive?style_variation=evening&card_view"
  },
  {
    "title": "noon",
    "link": "https://wp-themes.com/twentytwentyfive?style_variation=noon",
    "preview_link": "https://wp-themes.com/twentytwentyfive?style_variation=noon&card_view"
  },
  {
    "title": "dusk",
    "link": "https://wp-themes.com/twentytwentyfive?style_variation=dusk",
    "preview_link": "https://wp-themes.com/twentytwentyfive?style_variation=dusk&card_view"
  },
  {
    "title": "afternoon",
    "link": "https://wp-themes.com/twentytwentyfive?style_variation=afternoon",
    "preview_link": "https://wp-themes.com/twentytwentyfive?style_variation=afternoon&card_view"
  },
  {
    "title": "twilight",
    "link": "https://wp-themes.com/twentytwentyfive?style_variation=twilight",
    "preview_link": "https://wp-themes.com/twentytwentyfive?style_variation=twilight&card_view"
  },
  {
    "title": "morning",
    "link": "https://wp-themes.com/twentytwentyfive?style_variation=morning",
    "preview_link": "https://wp-themes.com/twentytwentyfive?style_variation=morning&card_view"
  },
  {
    "title": "sunrise",
    "link": "https://wp-themes.com/twentytwentyfive?style_variation=sunrise",
    "preview_link": "https://wp-themes.com/twentytwentyfive?style_variation=sunrise&card_view"
  },
  {
    "title": "midnight",
    "link": "https://wp-themes.com/twentytwentyfive?style_variation=midnight",
    "preview_link": "https://wp-themes.com/twentytwentyfive?style_variation=midnight&card_view"
  },
  {
    "title": "beiruti & literata",
    "link": "https://wp-themes.com/twentytwentyfive?style_variation=beiruti+%26+literata",
    "preview_link": "https://wp-themes.com/twentytwentyfive?style_variation=beiruti+%26+literata&card_view"
  },
  {
    "title": "vollkorn & fira code",
    "link": "https://wp-themes.com/twentytwentyfive?style_variation=vollkorn+%26+fira+code",
    "preview_link": "https://wp-themes.com/twentytwentyfive?style_variation=vollkorn+%26+fira+code&card_view"
  },
  {
    "title": "platypi & ysabeau office",
    "link": "https://wp-themes.com/twentytwentyfive?style_variation=platypi+%26+ysabeau+office",
    "preview_link": "https://wp-themes.com/twentytwentyfive?style_variation=platypi+%26+ysabeau+office&card_view"
  },
  {
    "title": "roboto slab & manrope",
    "link": "https://wp-themes.com/twentytwentyfive?style_variation=roboto+slab+%26+manrope",
    "preview_link": "https://wp-themes.com/twentytwentyfive?style_variation=roboto+slab+%26+manrope&card_view"
  },
  {
    "title": "literata & ysabeau office",
    "link": "https://wp-themes.com/twentytwentyfive?style_variation=literata+%26+ysabeau+office",
    "preview_link": "https://wp-themes.com/twentytwentyfive?style_variation=literata+%26+ysabeau+office&card_view"
  },
  {
    "title": "platypi & literata",
    "link": "https://wp-themes.com/twentytwentyfive?style_variation=platypi+%26+literata",
    "preview_link": "https://wp-themes.com/twentytwentyfive?style_variation=platypi+%26+literata&card_view"
  },
  {
    "title": "literata & fira sans",
    "link": "https://wp-themes.com/twentytwentyfive?style_variation=literata+%26+fira+sans",
    "preview_link": "https://wp-themes.com/twentytwentyfive?style_variation=literata+%26+fira+sans&card_view"
  }
]
```

</details>
