### PR TITLE
Switch parameters in `groups_is_user_member`

### DIFF
--- a/profiles.wordpress.org/public_html/wp-content/plugins/wporg-profiles-association-handler/wporg-profiles-association-handler.php
+++ b/profiles.wordpress.org/public_html/wp-content/plugins/wporg-profiles-association-handler/wporg-profiles-association-handler.php
@@ -254,7 +254,7 @@ if ( ! class_exists( 'WPOrg_Profiles_Association_Handler' ) ) {
 						$users_altered++;
 					}
 				} elseif ( 'remove' == $command ) {
-					if ( groups_is_user_member( $group_id, $user_id ) ) {
+					if ( groups_is_user_member( $user_id, $group_id ) ) {
 						groups_leave_group( $group_id, $user_id );
 						$users_altered++;
 					}


### PR DESCRIPTION
Per: https://www.buddyboss.com/resources/reference/functions/groups_is_user_member/ the function expects parameters in a different order, which stops any badges from being removed.