### PR TITLE
Update template-tags.php to set ID for Advanced Options heading

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/inc/template-tags.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/inc/template-tags.php
@@ -290,7 +290,7 @@ function the_plugin_advanced_zone() {
 
 	echo '<hr>';
 
-	echo '<h2>' . esc_html__( 'Advanced Options', 'wporg-plugins' ) . '</h2>';
+	echo '<h2 id = "plugin-advanced-options">' . esc_html__( 'Advanced Options', 'wporg-plugins' ) . '</h2>';
 
 	echo '<p>' . esc_html__( 'This section is intended for advanced users and developers only. They are presented here for testing and educational purposes.', 'wporg-plugins' ) . '</p>';
 


### PR DESCRIPTION
Set ID for Advanced Options H2 heading. This is useful for plugin developers who want to make it easier to direct users to previous versions of a plugin.

Without this, Downloads History was the most convenient ID to anchor.

https://meta.trac.wordpress.org/ticket/7844