### PR TITLE
Gives devmuhib announce permissions in training channel

### DIFF
--- a/common/includes/slack/announce/config.php
+++ b/common/includes/slack/announce/config.php
@@ -536,6 +536,7 @@ function get_whitelist() {
 			'colorful tones', // @colorful-tones on Slack
 			'courane01', // @Courtney on Slack
 			'courtneypk',
+			'devmuhib', // @Muhibul Haque on Slack
 			'digitalchild',
 			'eboxnet',
 			'fikekomala',


### PR DESCRIPTION
This PR addresses ticket https://meta.trac.wordpress.org/ticket/7847

Grant [Muhibul Haque](https://profiles.wordpress.org/devmuhib/) Slack /here access for #training 