### PR TITLE
Fix: Adjusted input box padding of Core Trac

### DIFF
--- a/wordpress.org/public_html/style/trac/wp-trac.css
+++ b/wordpress.org/public_html/style/trac/wp-trac.css
@@ -730,6 +730,7 @@ input[type=text], input.textwidget, textarea {
 	-webkit-border-radius: 3px;
 	border-radius: 3px;
 	font-size: 13px;
+	padding: 0 6px;
 }
 input[name="description"] {
 	width: 100%;


### PR DESCRIPTION
Trac Ticket: Core-63105

## Changes:

- Set padding to 0 6px for input boxes.

## Screenshot

<img width="396" alt="Screenshot 2025-03-14 at 9 12 45 PM" src="https://github.com/user-attachments/assets/e517ded5-fc4b-4b5c-8061-43fc06e179ec" />


