### PR TITLE
Fix pull request section width issue of Core Trac

### DIFF
--- a/wordpress.org/public_html/style/trac/wp-trac.css
+++ b/wordpress.org/public_html/style/trac/wp-trac.css
@@ -2507,7 +2507,7 @@ a.mention.me {
 	padding-left: 0;
 }
 #github-prs ul.pull-requests li div:last-of-type {
-	white-space: nowrap;
+	white-space: normal;
 	padding-right: 0;
 }
 #github-prs ul.pull-requests li > div:first-of-type > a:first-of-type {


### PR DESCRIPTION
Meta Trac ticket: <!-- insert a link to the WordPress Trac ticket here --> https://meta.trac.wordpress.org/ticket/7919

This PR fixes the width issue in the Pull Request section when no pull requests are attached.

Before Fix:
![image](https://github.com/user-attachments/assets/387b059a-bb11-40b9-9571-bce5bebddad8)

After Fix:
![image](https://github.com/user-attachments/assets/2f1c1087-fa5e-472c-8029-6b3c6e9b8f31)
