### PR TITLE
Fix: Support Link padding inconsistency

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/client/components/plugin/style.scss
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/client/components/plugin/style.scss
@@ -284,7 +284,7 @@
 
 		a {
 			display: inline-block;
-			padding: 0.64rem 0 0.64rem 1.25rem;
+			padding: 0.64rem 0 0.64rem 0;
 			font-size: var(--wp--preset--font-size--normal);
 		}
 


### PR DESCRIPTION
Meta Trac: [Meta-7944](https://meta.trac.wordpress.org/ticket/7944)

This pull request fixes the inconsistent padding issue on the support link on the plugin page. 