### PR TITLE
Fix: Make 'See all reviews' link fully visible for better localization

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/inc/block-bindings.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/inc/block-bindings.php
@@ -43,7 +43,7 @@ function get_meta_block_value( $args, $block ) {
 			return sprintf(
 				'<a href="%s">%s</a>',
 				esc_url( 'https://wordpress.org/support/plugin/' . $plugin_post->post_name . '/reviews/' ),
-				__( 'See all<span class="screen-reader-text"> reviews</span>', 'wporg-themes' )
+				__( 'See all reviews', 'wporg-themes' )
 			);
 		case 'submit-review-link':
 			return sprintf(


### PR DESCRIPTION
**Fix localization of "See all reviews" link by removing hidden screen-reader text**

Hello all,

This pull  request addresses the issue described here:
[https://github.com/WordPress/wordpress.org/issues/481](https://github.com/WordPress/wordpress.org/issues/481)

**What I changed :**
I replaced the original translation string:

```php
__( 'See all<span class="screen-reader-text"> reviews</span>', 'wporg-themes' )
```

with:

```php
__( 'See all reviews', 'wporg-themes' )
```

**Why this change is necessary :**
This improves localization and  accessibility.
In French for example,  the previous string would result in something like:

> "Voir tous les"

Which is incomplete and incorrect, because "reviews" was hidden using the `screen-reader-text` class.
After this change, the sentence becomes:

> "Voir tous les avis"

Which is grammatically correct and understandable for all users.

**Note:**
I'm not sure whether you would also recommend adding `flex-wrap: wrap` on the parent container to prevent layout issues on smaller screens. Let me know if you'd like me to add that as well.

Thanks in advance !
