### PR TITLE
Fix: Accessibility issue on Polyglots Team locale page

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/wp-i18n-teams/css/i18n-teams.css
+++ b/wordpress.org/public_html/wp-content/plugins/wp-i18n-teams/css/i18n-teams.css
@@ -130,7 +130,6 @@ td.no-right-border {
 	font-size: 14px;
 	font-size: 1.4rem;
 	line-height: 1.5;
-	color: white;
 	text-decoration: none;
 }
 @media only screen and (max-width: 600px) {


### PR DESCRIPTION
I have reported this issue where the download link in the Team's local page is not visible due to the white text and light gray background color combination. The reported track is below:

Trac: https://meta.trac.wordpress.org/ticket/7986

![jO6ucQr](https://github.com/user-attachments/assets/86346bf1-d572-4551-8c4b-0bcdf969eb4e)

This happens on all Team's locale page

![VkU5EkU](https://github.com/user-attachments/assets/ebf2d17e-1f65-4b44-a7aa-0e87ef8c52bd)


### What I changed

My patch removes the `color: white;` property on the `#locale-header ul li.download-button a`, which you can find in i18n-teams.css file.

### Result

![8hBUVLT](https://github.com/user-attachments/assets/3fd709dc-5a6c-4b3a-8a9b-b355bc3864e1)
