### PR TITLE
Accessibility: Improve text contrast on dark background

### DIFF
--- a/wordpress.tv/public_html/wp-content/themes/wptv2/style.css
+++ b/wordpress.tv/public_html/wp-content/themes/wptv2/style.css
@@ -2041,7 +2041,7 @@ h5 {
 }
 
 .wptv-hero .main-video .video-event a {
-	color: #8e8e8e;
+	color: #d0d0d0;
 	font-size: 14px;
 	font-weight: normal;
 }


### PR DESCRIPTION
This PR updates the text color from #8e8e8e to #d0d0d0 on main video sections with a #2f2f2f background to meet WCAG AA accessibility standards. The previous color combination had insufficient contrast for normal-sized text, which could hinder readability for users with visual impairments.

New contrast ratio is ~8.68:1, exceeding the required minimum of 4.5:1 for normal text.

Changes:
- Updated text color in .wptv-hero .main-video .video-event a 
- Verified contrast using WebAIM Contrast Checker

This improves overall accessibility and user experience.

Trac: https://meta.trac.wordpress.org/ticket/8000