### PR TITLE
Fix: missing closing </p> tag

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/loggedout.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/loggedout.php
@@ -26,7 +26,7 @@ get_header();
 			esc_url( $redirect_to ),
 			esc_html( $hostname )
 		);
-		echo '<p>';
+		echo '</p>';
 	}
 ?>
 


### PR DESCRIPTION
It was during [this commit @ line 29](https://github.com/WordPress/wordpress.org/commit/5a573d2a6a4c8fdb48e22787226618e6308d8ce1), and [changeset #12241](https://meta.trac.wordpress.org/browser/sites/trunk/wordpress.org/public_html/wp-content/themes/pub/wporg-login/loggedout.php?rev=12241), this opening paragraph tag `<p>` was mistakenly left unclosed due to a typo.