### PR TITLE
Adding the user fellyph to playground channel

### DIFF
--- a/common/includes/slack/announce/config.php
+++ b/common/includes/slack/announce/config.php
@@ -466,6 +466,7 @@ function get_whitelist() {
 			'bph',
 			'berislav.grgicak',
 			'bpayton',
+			'fellyph',
 			'zieladam',
 		),
 		'polyglots' => array(


### PR DESCRIPTION
## Motivation

Recently, I have joined the #playground team, and I'm responsible for conducting the bi-weekly meetings. For that, I will need permission to create reminders with `@here` for the channel when the meetup is about to start. 