### PR TITLE
Bump the minimum recommended version of PHP to 8.3

### DIFF
--- a/wordpress.org/public_html/wp-content/mu-plugins/pub/servehappy-config.php
+++ b/wordpress.org/public_html/wp-content/mu-plugins/pub/servehappy-config.php
@@ -16,11 +16,11 @@ define( 'RECOMMENDED_PHP', '7.4' );
 define( 'MINIMUM_PHP', '7.2.24' );
 
 // The lowest branch of PHP which is actively supported.
-define( 'SUPPORTED_PHP', '7.4' );
+define( 'SUPPORTED_PHP', '8.3' );
 
 // The lowest branch of PHP which is receiving security updates.
-define( 'SECURE_PHP', '7.4' );
+define( 'SECURE_PHP', '8.1' );
 
 // The lowest branch of PHP which is still considered acceptable in WordPress.
 // Sites with a version lower than this will see the ServeHappy dashboard widget urging them to update.
-define( 'ACCEPTABLE_PHP', '7.4' );
+define( 'ACCEPTABLE_PHP', '8.1' );

--- a/wordpress.org/public_html/wp-content/mu-plugins/pub/servehappy-config.php
+++ b/wordpress.org/public_html/wp-content/mu-plugins/pub/servehappy-config.php
@@ -10,7 +10,7 @@ namespace WordPressdotorg\API\Serve_Happy;
  */
 
 // The latest branch of PHP which WordPress.org recommends.
-define( 'RECOMMENDED_PHP', '7.4' );
+define( 'RECOMMENDED_PHP', '8.3' );
 
 // The oldest branch of PHP which WordPress core still works with.
 define( 'MINIMUM_PHP', '7.2.24' );


### PR DESCRIPTION
Bumpity bump.

* `SUPPORTED_PHP` gets bumped to 8.3 because that's the oldest version actively supported by the PHP project
* `SECURE_PHP` and `ACCEPTABLE_PHP` get bumped to 8.1 because that's the oldest version receiving security updates from the PHP project
* `RECOMMENDED_PHP` gets bumped to 8.3 because that's the highest version that's fully supported by the latest version of WordPress

## Depends on

* https://make.wordpress.org/core/2025/07/07/proposal-remove-the-beta-support-label-from-php-8-3-for-wordpress-6-8/

## Refs

* https://meta.trac.wordpress.org/ticket/6612
* https://www.php.net/supported-versions

## Core PR

* https://github.com/WordPress/wordpress-develop/pull/9206
