### PR TITLE
Update name for Plugins Team

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-upload.php
@@ -35,7 +35,7 @@ class Upload {
 				$plugin->review_email = Upload_Handler::find_review_email( $plugin );
 
 				if ( $plugin->review_email && 'closed' !== $plugin->review_email->status ) {
-					$plugin->status = __( "Being Reviewed &#8212; We've got your email. This plugin is currently waiting on action from our review team.", 'wporg-plugins' );
+					$plugin->status = __( "Being Reviewed &#8212; We've got your email. This plugin is currently waiting on action from our plugins team.", 'wporg-plugins' );
 				}
 			} elseif ( 'approved' === $plugin->post_status ) {
 				$plugin->status = __( 'Approved &#8212; Please check your email for instructions on uploading your plugin.', 'wporg-plugins' );
@@ -235,7 +235,7 @@ class Upload {
 					</p>
 
 					<p>
-						<?php _e( 'Please review the Plugin Check results for your plugin, and fix any significant problems. This will help streamline the preview process and reduce delays by ensuring your plugin already meets the required standards when the plugin review team examines it.', 'wporg-plugins' ); ?>
+						<?php _e( 'Please review the Plugin Check results for your plugin, and fix any significant problems. This will help streamline the preview process and reduce delays by ensuring your plugin already meets the required standards when the Plugins Team examines it.', 'wporg-plugins' ); ?>
 					</p>
 
 					<ul>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/build/blocks/front-page/render.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/build/blocks/front-page/render.php
@@ -139,7 +139,7 @@ echo do_blocks( '<!-- wp:template-part {"slug":"grid-controls"} /-->' );
 		'title' => __( 'Stay up-to-date', 'wporg-plugins' ),
 		'text'  => sprintf(
 			/* translators: URL to make/plugins site. */
-			__( 'Plugin development is constantly changing with each new WordPress release. Keep up with the latest changes by following the <a href="%s">Plugin Review Team&#8217;s blog</a>.', 'wporg-plugins' ),
+			__( 'Plugin development is constantly changing with each new WordPress release. Keep up with the latest changes by following the <a href="%s">Plugins Team&#8217;s blog</a>.', 'wporg-plugins' ),
 			esc_url( 'https://make.wordpress.org/plugins/' )
 		),
 	), $widget_args );

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/inc/template-tags.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/inc/template-tags.php
@@ -746,7 +746,7 @@ function the_author_notice( $post = null ) {
 		printf(
 			'<div class="notice notice-alt notice-%s">%s</div>',
 			esc_attr( $notice['type'] ),
-			'<p><strong>' . __( 'A note from the Plugin Review team, visible only to the plugin author &amp; committers.', 'wporg-plugins' ) . '</strong></p>' .
+			'<p><strong>' . __( 'A note from the Plugins Team, visible only to the plugin author &amp; committers.', 'wporg-plugins' ) . '</strong></p>' .
 			wp_kses_post( $notice['html'] ) // Should have wrapping <p> tags.
 		);
 	}

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/js/build/blocks/front-page/render.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/js/build/blocks/front-page/render.php
@@ -139,7 +139,7 @@ echo do_blocks( '<!-- wp:wporg/filter-bar /--><!-- wp:wporg/category-navigation 
 		'title' => __( 'Stay Up-to-Date', 'wporg-plugins' ),
 		'text'  => sprintf(
 			/* translators: URL to make/plugins site. */
-			__( 'Plugin development is constantly changing with each new WordPress release. Keep up with the latest changes by following the <a href="%s">Plugin Review Team&#8217;s blog</a>.', 'wporg-plugins' ),
+			__( 'Plugin development is constantly changing with each new WordPress release. Keep up with the latest changes by following the <a href="%s">Plugins Team&#8217;s blog</a>.', 'wporg-plugins' ),
 			esc_url( 'https://make.wordpress.org/plugins/' )
 		),
 	), $widget_args );

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/patterns/page-add.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/patterns/page-add.php
@@ -69,7 +69,7 @@ do_blocks( '<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom"
 				<li><?php printf( __( 'The plugin accepts unsanitized data: <a href="%s">Learn about Sanitizing Data</a>', 'wporg-plugins' ), 'https://developer.wordpress.org/apis/security/sanitizing/' ); ?></li>
 				<li><?php printf( __( 'The plugin processes form data without a nonce: <a href="%s">Learn about Nonces</a>', 'wporg-plugins' ), 'https://developer.wordpress.org/apis/security/nonces/' ); ?></li>
 			</ul>
-			<p><?php _e( 'If the code in your plugin falls into one of the above categories, <strong>your plugin will not be approved</strong>. The plugin review team will refer you back to these Handbook pages, adding further delay to the review process.', 'wporg-plugins' ); ?></p>
+			<p><?php _e( 'If the code in your plugin falls into one of the above categories, <strong>your plugin will not be approved</strong>. The Plugins Team will refer you back to these Handbook pages, adding further delay to the review process.', 'wporg-plugins' ); ?></p>
 
 			<h3><?php esc_html_e( 'What will my plugin URL be?', 'wporg-plugins' ); ?></h3>
 			<p><?php echo wp_kses_post( __( 'Your plugin&#8217;s URL will be populated based on the value of <code>Plugin Name</code> in your main plugin file (the one with the plugin headers). If you set yours as <code>Plugin Name: Boaty McBoatface</code> then your URL will be <code>https://wordpress.org/plugins/boaty-mcboatface</code> and your slug will be <code>boaty-mcboatface</code> for example. If there is an existing plugin with your name, then you will be <code>boaty-mcboatface-2</code> and so on. It behaves exactly like WordPress post names.', 'wporg-plugins' ) ); ?></p>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/src/blocks/front-page/render.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/src/blocks/front-page/render.php
@@ -139,7 +139,7 @@ echo do_blocks( '<!-- wp:template-part {"slug":"grid-controls"} /-->' );
 		'title' => __( 'Stay up-to-date', 'wporg-plugins' ),
 		'text'  => sprintf(
 			/* translators: URL to make/plugins site. */
-			__( 'Plugin development is constantly changing with each new WordPress release. Keep up with the latest changes by following the <a href="%s">Plugin Review Team&#8217;s blog</a>.', 'wporg-plugins' ),
+			__( 'Plugin development is constantly changing with each new WordPress release. Keep up with the latest changes by following the <a href="%s">Plugins Team&#8217;s blog</a>.', 'wporg-plugins' ),
 			esc_url( 'https://make.wordpress.org/plugins/' )
 		),
 	), $widget_args );


### PR DESCRIPTION
We have updated the name to Plugins Team and we want to update in wordpress.org site. [More information](https://make.wordpress.org/plugins/2025/07/12/team-name-change-to-plugins-team/)