### PR TITLE
Fix Search Input Box and Search Button Misalignment

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/style.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/style.css
@@ -1133,8 +1133,10 @@ article.handbook .entry-meta {
 }
 
 .o2-post #searchform #searchsubmit {
-	height: 33.5px;
-	padding-bottom: .6em;
+	padding-block: var(--wp--custom--form--padding--block);
+    padding-inline: var(--wp--custom--form--padding--inline);
+    font-size: var(--wp--custom--form--typography--font-size);
+    line-height: var(--wp--custom--form--typography--line-height);
 }
 
 article.post .entry-meta {

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe/style.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe/style.css
@@ -597,8 +597,10 @@ input[type="submit"]:hover {
 	margin-bottom: 5em;
 }
 .o2-post #searchform #searchsubmit {
-	height: 33.5px;
-	padding-bottom: .6em;
+	padding-block: var(--wp--custom--form--padding--block);
+    padding-inline: var(--wp--custom--form--padding--inline);
+    font-size: var(--wp--custom--form--typography--font-size);
+    line-height: var(--wp--custom--form--typography--line-height);
 }
 
 pre, code {

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe/style.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe/style.css
@@ -597,10 +597,8 @@ input[type="submit"]:hover {
 	margin-bottom: 5em;
 }
 .o2-post #searchform #searchsubmit {
-	padding-block: var(--wp--custom--form--padding--block);
-    padding-inline: var(--wp--custom--form--padding--inline);
-    font-size: var(--wp--custom--form--typography--font-size);
-    line-height: var(--wp--custom--form--typography--line-height);
+	height: 33.5px;
+	padding-bottom: .6em;
 }
 
 pre, code {


### PR DESCRIPTION
Meta Trac: https://meta.trac.wordpress.org/ticket/8059

Fixes the height misalignment between the search input box and the search button on the WordPress Meta site.

Here, I have attached a screenshot after resolving the issue.

<img width="1198" height="872" alt="image" src="https://github.com/user-attachments/assets/cb7dab2f-7f4e-4eab-bfc0-ab7f183529cd" />
