### PR TITLE
Trac: Add information link to workflow keywords

### DIFF
--- a/wordpress.org/public_html/style/trac/wp-trac.js
+++ b/wordpress.org/public_html/style/trac/wp-trac.js
@@ -1180,9 +1180,12 @@ var wpTrac, coreKeywordList, gardenerKeywordList, reservedTerms, coreFocusesList
 					// If the owner field exists, then we're on /newticket. Remove it.
 					$('#field-owner').parents('tr').hide();
 
-					html = '<div><label id="keyword-label" for="keyword-add" style="width:' + labelWidth + 'px">Workflow Keywords:</label>';
-					html += '<select id="keyword-add"><option value=""> - Add - </option></select>';
-					html += '<button type="button" id="edit-keywords" aria-label="Manual keyword" aria-expanded="false">Manual</button></div>';
+					html = '<div>'
+						html += '<label id="keyword-label" for="keyword-add" style="width:' + labelWidth + 'px">Workflow Keywords:</label>';
+						html += '<select id="keyword-add"><option value=""> - Add - </option></select>';
+						html += '<button type="button" id="edit-keywords" aria-label="Manual keyword" aria-expanded="false">Manual</button>';
+						html += ' <a href="https://make.wordpress.org/core/handbook/contribute/trac/keywords/" title="Keywords documentation">ℹ</a>';
+					html += '</div>';
 					html += '<div id="keyword-bin"></div>';
 					container.prepend( html );
 					elements.bin = $('#keyword-bin');


### PR DESCRIPTION
Meta trac: https://meta.trac.wordpress.org/ticket/8027

Add link to keywords documentation to tract "Workflow Keywords" section: https://make.wordpress.org/core/handbook/contribute/trac/keywords/

Uses `U+2139 INFORMATION SOURCE` for a brief link text.

## Before

<img width="1056" height="178" alt="before" src="https://github.com/user-attachments/assets/611a731d-d7b5-409a-8359-5f9754b5561b" />


## After

<img width="856" height="148" alt="Screenshot 2025-08-28 at 11 29 05" src="https://github.com/user-attachments/assets/49869fcd-c26f-41ef-9be7-3f1959996db1" />

## After hover
And the title on hover (the cursor is missing in the screenshot):

<img width="1056" height="178" alt="Screenshot 2025-08-28 at 11 30 11" src="https://github.com/user-attachments/assets/38ade5f6-8415-4a56-bbdc-eda97f5b4a3d" />
