### PR TITLE
Theme Directory: upgrade blueprint

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-repo-package.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-repo-package.php
@@ -16,11 +16,21 @@ class WPORG_Themes_Repo_Package {
 	public $wp_post;
 
 	/**
+	 * Holds the Version string for this instance of the class.
+	 *
+	 * NOTE: This may not be the latest version of the theme.
+	 *
+	 * @var string
+	 */
+	public $version = '';
+
+	/**
 	 * Construct a new Package for the given post ID or object.
 	 *
 	 * @param WP_Post|int|slug $wp_post The Post object, Post ID, or theme slug of the package.
+	 * @param string|bool $version Optional. The version string, or false for latest version.
 	 */
-	public function __construct( $wp_post = 0 ) {
+	public function __construct( $wp_post = 0, $version = false ) {
 		global $post;
 		if ( ! $wp_post ) {
 			return;
@@ -52,6 +62,13 @@ class WPORG_Themes_Repo_Package {
 				$this->wp_post = $theme[0];
 			}
 		}
+
+		$this->version = $version;
+		if ( $this->wp_post ) {
+			if ( ! $version || 'latest' === $version || 'latest-stable' === $version ) {
+				$this->version = $this->latest_version();
+			}
+		}
 	}
 
 	/**
@@ -60,16 +77,15 @@ class WPORG_Themes_Repo_Package {
 	 * @return string
 	 */
 	public function screenshot_url() {
-		$screen  = 'screenshot.png';
-		$version = $this->latest_version();
+		$screen = 'screenshot.png';
 
-		if ( ! empty( $this->wp_post->_screenshot[ $version ] ) ) {
-			$screen = $this->wp_post->_screenshot[ $version ];
+		if ( ! empty( $this->wp_post->_screenshot[ $this->version ] ) ) {
+			$screen = $this->wp_post->_screenshot[ $this->version ];
 		}
 
 		return sprintf( 'https://i0.wp.com/themes.svn.wordpress.org/%1$s/%2$s/%3$s',
 			$this->wp_post->post_name,
-			$version,
+			$this->version,
 			$screen
 		);
 	}
@@ -108,7 +124,8 @@ class WPORG_Themes_Repo_Package {
 	 * @param string $version Optional.
 	 * @return string
 	 */
-	public function download_url( $version = 'latest-stable' ) {
+	public function download_url( $version = false ) {
+		$version = $version ?: $this->version;
 		if ( 'latest-stable' === $version ) {
 			$version = $this->latest_version();
 		}
@@ -136,20 +153,19 @@ class WPORG_Themes_Repo_Package {
 	 * @return int|string
 	 */
 	public function __get( $name ) {
-		$version = $this->latest_version();
 		switch ( $name ) {
 			case 'version' :
 				return $version;
 			case 'theme-url' :
-				return $this->wp_post->_theme_url[ $version ] ?? '';
+				return $this->wp_post->_theme_url[ $this->version ] ?? '';
 			case 'author-url' :
-				return $this->wp_post->_author_url[ $version ] ?? '';
+				return $this->wp_post->_author_url[ $this->version ] ?? '';
 			case 'ticket' :
-				return $this->wp_post->_ticket_id[ $version ] ?? '';
+				return $this->wp_post->_ticket_id[ $this->version ] ?? '';
 			case 'requires':
-				return $this->wp_post->_requires[ $version ] ?? '';
+				return $this->wp_post->_requires[ $this->version ] ?? '';
 			case 'requires-php':
-				return $this->wp_post->_requires_php[ $version ] ?? '';
+				return $this->wp_post->_requires_php[ $this->version ] ?? '';
 			default:
 				return $this->wp_post->$name;
 		}

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
@@ -1159,91 +1159,21 @@ class WPORG_Themes_Upload {
 		// ZIP location
 		$theme_zip_link = "https://downloads.wordpress.org/theme/{$this->theme_slug}.{$this->theme->display( 'Version' )}.zip?nostats=1";
 
-		// Build the Live Preview Blueprint & URL.
-		 $blueprint_parent_step = '';
-		 if (
-			$this->theme->parent() &&
-			in_array( 'buddypress', $this->theme->get( 'Tags' ) )
-		) {
-			$blueprint_parent_step = <<<BLUEPRINT_PARENT_BP
-			{
-				"step": "installPlugin",
-				"pluginZipFile": {
-					"resource": "wordpress.org/plugins",
-					"slug": "buddypress"
-				},
-				"options": {
-					"activate": true
-				}
-			},
-			BLUEPRINT_PARENT_BP;
-		} elseif ( $this->theme->parent() ) {
-			$blueprint_parent_step = <<<BLUEPRINT_PARENT_THEME
-			{
-				"step": "installTheme",
-				"themeZipFile": {
-					"resource": "wordpress.org/themes",
-					"slug": "{$this->theme->get_template()}"
-				}
-			},
-			BLUEPRINT_PARENT_THEME;
-		}
-
-		// NOTE: The username + password included below are only used for the local in-browser environment, and are not a secret.
-		$blueprint = <<<BLUEPRINT
-		{
-			"preferredVersions": {
-				"php": "7.4",
-				"wp": "latest"
-			},
-			"steps": [
-				{
-					"step": "login",
-					"username": "admin",
-					"password": "password"
-				},
-				{
-					"step": "defineWpConfigConsts",
-					"consts": {
-						"WP_DEBUG": true
-					}
-				},
-				{
-					"step": "importFile",
-					"file": {
-						"resource": "url",
-						"url": "https://raw.githubusercontent.com/WordPress/theme-test-data/master/themeunittestdata.wordpress.xml",
-						"caption": "Downloading theme testing content"
-					},
-					"progress": {
-						"caption": "Installing theme testing content"
-					}
-				},
-				{
-					"step": "installPlugin",
-					"pluginZipFile": {
-						"resource": "wordpress.org/plugins",
-						"slug": "theme-check"
-					},
-					"options": {
-						"activate": true
-					}
-				},
-				{$blueprint_parent_step}
-				{
-					"step": "installTheme",
-					"themeZipFile": {
-						"resource": "url",
-						"url": "{$theme_zip_link}",
-						"caption": "Downloading the theme"
-					}
-				}
-			]
-		}
-		BLUEPRINT;
-
-		// NOTE: The json_encode( json_decode() ) is to remove the whitespaces used above for readability.
-		$live_preview_link = 'https://playground.wordpress.net/#' . json_encode( json_decode( $blueprint ) );
+		$live_preview_link = add_query_arg(
+			'blueprint-url',
+			urlencode(
+				add_query_arg(
+					[
+						'preview_id' => $this->theme_post->ID,
+						'debug' => 'true',
+						'theme_previewer' => 'false',
+						'install_theme_testdata' => 'true',
+					],
+					rest_url( 'themes/v1/preview-blueprint/' . $this->theme_slug . '/' . $this->theme->display( 'Version' ) )
+				)
+			),
+			'https://playground.wordpress.net/'
+		);
 
 		// Hacky way to prevent a problem with xml-rpc.
 		$this->trac_ticket->description = <<<TICKET

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
@@ -1161,17 +1161,7 @@ class WPORG_Themes_Upload {
 
 		$live_preview_link = add_query_arg(
 			'blueprint-url',
-			urlencode(
-				add_query_arg(
-					[
-						'preview_id' => $this->theme_post->ID,
-						'debug' => 'true',
-						'theme_previewer' => 'false',
-						'install_theme_testdata' => 'true',
-					],
-					rest_url( 'themes/v1/preview-blueprint/' . $this->theme_slug . '/' . $this->theme->display( 'Version' ) )
-				)
-			),
+			urlencode( rest_url( 'themes/v1/review-blueprint/' . $this->theme_post->ID . '-' . $this->theme_slug . '/' . $this->theme->display( 'Version' ) ) ),
 			'https://playground.wordpress.net/'
 		);
 

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/rest-api/class-theme-preview.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/rest-api/class-theme-preview.php
@@ -57,8 +57,8 @@ class Theme_Preview {
 				),
 			),
 			'permission_callback' => function( $request ) {
-				$theme_data    = wporg_themes_theme_information( $request['slug'] ?? '' );
-				$theme_package = new WPORG_Themes_Repo_Package( $theme_data->slug ?? '', $request['version'] ?? false );
+				$theme_data    = wporg_themes_theme_information( $request['slug'] );
+				$theme_package = new WPORG_Themes_Repo_Package( $theme_data->slug );
 
 				if ( ! empty( $theme_data->error ) || ! $theme_package->post_author ) {
 					return false;

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/rest-api/class-theme-preview.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/rest-api/class-theme-preview.php
@@ -7,18 +7,69 @@ use WPORG_Themes_Repo_Package;
 class Theme_Preview {
 
 	function __construct() {
-		register_rest_route( 'themes/v1', 'preview-blueprint/(?<slug>[^/]+)', array(
+		register_rest_route( 'themes/v1', 'preview-blueprint/(?<slug>[^/]+)(/(?<version>[^/]+))?', array(
 			'methods'             => WP_REST_Server::READABLE,
 			'callback'            => array( $this, 'preview' ),
+			'args'                => array(
+				'slug' => array(
+					'type'              => 'string',
+					'required'          => 'true',
+					'sanitize_callback' => 'sanitize_key',
+				),
+				'version' => array(
+					'type'              => 'string',
+					'required'          => 'false',
+					'sanitize_callback' => static function ( $value ) {
+						if ( ! is_string( $value ) ) {
+							return '';
+						}
+						return preg_replace( '/[^0-9a-zA-Z.-]/', '', $value );
+					},
+				),
+				// If the theme isn't (yet) published, this can be set to force loading the post.
+				'preview_id' => array(
+					'type'              => 'integer',
+					'required'          => false,
+					'sanitize_callback' => 'absint',
+				),
+				// Whether to enable WP_DEBUG. ie. for testing.
+				'debug' => array(
+					'type'              => 'boolean',
+					'required'          => false,
+					'default'           => false,
+					'sanitize_callback' => 'rest_sanitize_boolean',
+				),
+				// Whether to install the Theme Unit TestData.
+				'install_theme_testdata' => array(
+					'type'              => 'boolean',
+					'required'          => false,
+					'default'           => false,
+					'sanitize_callback' => 'rest_sanitize_boolean',
+				),
+				// Whether to install the Theme Previewer plugins.
+				'theme_previewer' => array(
+					'type'              => 'boolean',
+					'required'          => false,
+					'default'           => true,
+					'sanitize_callback' => 'rest_sanitize_boolean',
+				),
+			),
 			'permission_callback' => '__return_true',
 		) );
 
 		register_rest_route( 'themes/v1', 'preview-blueprint/(?<slug>[^/]+)', array(
 			'methods'             => WP_REST_Server::CREATABLE,
 			'callback'            => array( $this, 'set_blueprint' ),
+			'args'                => array(
+				'slug' => array(
+					'type'              => 'string',
+					'required'          => 'true',
+					'sanitize_callback' => 'sanitize_key',
+				),
+			),
 			'permission_callback' => function( $request ) {
-				$theme_data    = wporg_themes_theme_information( $request['slug'] );
-				$theme_package = new WPORG_Themes_Repo_Package( $theme_data->slug );
+				$theme_data    = wporg_themes_theme_information( $request['slug'] ?? '' );
+				$theme_package = new WPORG_Themes_Repo_Package( $theme_data->slug ?? '', $request['version'] ?? false );
 
 				if ( ! empty( $theme_data->error ) || ! $theme_package->post_author ) {
 					return false;
@@ -36,13 +87,26 @@ class Theme_Preview {
 	 * Generate a Blueprint for a theme preview.
 	 */
 	function preview( $request ) {
+		// If the theme isn't (yet) published, use the post_id hint.
+		if ( is_numeric( $request->get_param( 'preview_id' ) ) ) {
+			$preview_post = get_post( (int) $request->get_param( 'preview_id' ) );
+			if (
+				$preview_post &&
+				'repopackage' === $preview_post->post_type &&
+				'publish' !== $preview_post->post_status &&
+				$preview_post->post_name === $request->get_param( 'slug' )
+			) {
+				$GLOBALS['post'] = $preview_post;
+			}
+		}
+
 		$theme_data = wporg_themes_theme_information( $request->get_param( 'slug' ) );
 
 		if ( ! empty( $theme_data->error ) ) {
 			return new WP_Error( 'error', $theme_data->error );
 		}
 
-		return $this->build_blueprint( $theme_data );
+		return $this->build_blueprint( $request, $theme_data, $request['version'] ?? false );
 	}
 
 	/**
@@ -69,21 +133,21 @@ class Theme_Preview {
 		// Save the blueprint.
 		update_post_meta( $theme_package->ID, 'preview_blueprint', $decoded_blueprint );
 
-		return $this->build_blueprint( $theme_data );
+		return $this->build_blueprint( $request, $theme_data, false );
 	}
 
 	/**
 	 * Generate a blueprint for previewing a theme.
 	 */
-	function build_blueprint( $theme_data ) {
-		$theme_package   = new WPORG_Themes_Repo_Package( $theme_data->slug );
+	function build_blueprint( $request, $theme_data, $version = false ) {
+		$theme_package   = new WPORG_Themes_Repo_Package( $theme_data->slug, $version );
 		$parent_package  = $theme_data->template ? new WPORG_Themes_Repo_Package( $theme_data->template ) : false;
 		$theme_blueprint = $theme_package->preview_blueprint;
 
 		// Base blueprint.
 		$blueprint = [
 			'preferredVersions' => [
-				'php' => '8.0',
+				'php' => defined( 'RECOMMENDED_PHP' ) ? RECOMMENDED_PHP : substr( phpversion(), 0, 3 ),
 				'wp'  => 'latest'
 			],
 			// Sadly many themes require the full kitchen-sink.
@@ -135,19 +199,37 @@ class Theme_Preview {
 				'username' => 'admin',
 				'password' => 'password'
 			],
+			! $request->get_param( 'debug' ) ? false :
+				[
+					'step' => 'defineWpConfigConsts',
+					'consts' => [
+						'WP_DEBUG' => true
+					]
+				],
 			// Set the default site details. The theme blueprint may replace this.
 			[
 				'step'    => 'setSiteOptions',
 				'options' => [
-					'blogname'        => $theme_data->name,
+					'blogname'        => $version ? "$theme_data->name $version" : $theme_data->name,
 					'blogdescription' => preg_replace( '![.].+$!',  '.', $theme_data->sections['description'] ), // First sentence only.
+				]
+			],
+			// Special case: BuddyPress.
+			! ( $theme_data->tags && in_array( 'buddypress', $theme_data->tags, true ) ) ? false : [
+				'step' => 'installPlugin',
+				'pluginData' => [
+					'resource' => 'wordpress.org/plugins',
+					'slug'     => 'buddypress',
+				],
+				'options' => [
+					'activate' => true
 				]
 			],
 			// Note: The following use `url` to allow setting the caption to the proper theme name.
 			// Install parent theme.
 			empty( $theme_data->template ) ? false : [
 				'step'         => 'installTheme',
-				'themeZipFile' => [
+				'themeData' => [
 					'resource' => 'url',
 					'url'      => $parent_package->download_url(),
 					'caption'  => "Downloading {$parent_package->post_title}",
@@ -159,10 +241,14 @@ class Theme_Preview {
 			// Install the theme.
 			[
 				'step'         => 'installTheme',
-				'themeZipFile' => [
+				'themeData' => [
 					'resource' => 'url',
 					'url'      => $theme_package->download_url(),
-					'caption'  => "Downloading {$theme_package->post_title}",
+					'caption'  => "Downloading {$theme_package->post_title}" . ( $version ? " $version" : '' ),
+				],
+				'options' => [
+					// Import the Starter Content if the theme didn't provide a blueprint.
+					'importStarterContent' => ( ! $theme_blueprint ),
 				]
 			]
 		];
@@ -174,17 +260,28 @@ class Theme_Preview {
 				// Don't install assets from URLs.
 				if (
 					! empty( $step['themeZipFile']['url'] ) ||
-					! empty( $step['pluginZipFile']['url'] )
+					! empty( $step['themeData']['url'] ) ||
+					! empty( $step['pluginZipFile']['url'] ) ||
+					! empty( $step['pluginData']['url'] )
 				) {
 					return false;
 				}
 
 				// Don't need to install the theme again.
 				if ( 'installTheme' === $step['step'] ) {
-					if ( $theme_data->slug === ( $step['themeZipFile']['slug'] ?? '' ) ) {
+					if (
+						$theme_data->slug === ( $step['themeZipFile']['slug'] ?? '' ) ||
+						$theme_data->slug === ( $step['themeData']['slug'] ?? '' )
+					) {
 						return false;
 					}
-					if ( ! empty( $theme_data->template ) && $theme_data->template === ( $step['themeZipFile']['slug'] ?? '' ) ) {
+					if (
+						! empty( $theme_data->template ) &&
+						(
+							$theme_data->template === ( $step['themeZipFile']['slug'] ?? '' ) ||
+							$theme_data->template === ( $step['themeData']['slug'] ?? '' )
+						)
+					) {
 						return false;
 					}
 				}
@@ -193,37 +290,39 @@ class Theme_Preview {
 			}
 		);
 
-		// Fill in a theme starter content step if specified.
-		// See: `installThemeStarterContent`. https://github.com/WordPress/wordpress-playground/pull/1521
-		foreach ( $theme_steps as $i => $step ) {
-			if ( 'installThemeStarterContent' === $step['step'] ) {
-				$theme_steps[ $i ] = $this->get_install_starter_content_step();
-			}
+		// Install the Theme Previewer plugins.
+		if ( $request->get_param( 'theme_previewer' ) ) {
+			/*
+			 * TODO: These artifacts need to be hosted somewhere better.
+			 */
+
+			$final_steps[] = [
+				'step' => 'installPlugin',
+				'pluginData' => [
+					'resource' => 'url',
+					'url'      => 'https://raw.githubusercontent.com/WordPress/wordpress.org/trunk/wp-themes.com/public_html/wp-content/plugins/pattern-page.zip',
+				],
+			];
+			$final_steps[] = [
+				'step' => 'installPlugin',
+				'pluginData' => [
+					'resource' => 'url',
+					'url'      => 'https://raw.githubusercontent.com/WordPress/wordpress.org/trunk/wp-themes.com/public_html/wp-content/plugins/style-variations.zip',
+				],
+			];
 		}
 
-		// If the theme didn't provide a blueprint, we'll also install the Starter Content. This must be done last.
-		// See also: `installThemeStarterContent`. https://github.com/WordPress/wordpress-playground/pull/1521
-		if ( ! $theme_blueprint ) {
-			$final_steps[] = $this->get_install_starter_content_step();
+		// Install the Theme TestData if requested.
+		if ( $request->get_param( 'install_theme_testdata' ) ) {
+			$final_steps[] = [
+				'step' => 'importWxr',
+				'file' => [
+					'resource' => 'url',
+					'url'      => 'https://raw.githubusercontent.com/WordPress/theme-test-data/master/themeunittestdata.wordpress.xml',
+					'caption'  => 'Downloading theme testing content'
+				]
+			];
 		}
-
-		/*
-		 * TODO: These artifacts need to be hosted somewhere better. 
-		 */
-		$final_steps[] = [
-			'step' => 'installPlugin',
-			'pluginZipFile' => [
-				'resource' => 'url',
-				'url'      => 'https://raw.githubusercontent.com/WordPress/wordpress.org/trunk/wp-themes.com/public_html/wp-content/plugins/pattern-page.zip',
-			],
-		];
-		$final_steps[] = [
-			'step' => 'installPlugin',
-			'pluginZipFile' => [
-				'resource' => 'url',
-				'url'      => 'https://raw.githubusercontent.com/WordPress/wordpress.org/trunk/wp-themes.com/public_html/wp-content/plugins/style-variations.zip',
-			],
-		];
 
 		// Set the steps.
 		$blueprint['steps'] = array_merge(
@@ -233,50 +332,6 @@ class Theme_Preview {
 		);
 
 		return $blueprint;
-	}
-
-	/**
-	 * Returns a formed step to install the starter content.
-	 */
-	function get_install_starter_content_step() {
-		return [
-			'step' => 'runPHP',
-			'code' => '<?php
-				playground_add_filter( "plugins_loaded", "importThemeStarterContent_plugins_loaded", 0 );
-				function importThemeStarterContent_plugins_loaded() {
-					/* Set as the admin user, this ensures we can customize the site. */
-					wp_set_current_user(
-						get_users( [ "role" => "Administrator" ] )[0]
-					);
-
-					/*
-					 * Simulate this request as a ajax customizer save, with the current theme in preview mode.
-					 *
-					 * See _wp_customize_include()
-					 */
-					add_filter( "wp_doing_ajax", "__return_true" );
-					$_REQUEST["action"]          = "customize_save";
-					$_REQUEST["wp_customize"]    = "on";
-					$_REQUEST["customize_theme"] = get_stylesheet();
-					$_GET                        = $_REQUEST;
-
-					/* Force the site to be fresh, although it should already be, some themes require this. */
-					add_filter( "pre_option_fresh_site", "__return_true" );
-				}
-
-				require "/wordpress/wp-load.php";
-
-				if ( ! get_theme_starter_content() ) {
-					return;
-				}
-
-				/* Import the Starter Content. */
-				$wp_customize->import_theme_starter_content();
-
-				/* Publish the changeset, which publishes the starter content. */
-				wp_publish_post( $wp_customize->changeset_post_id() );
-			'
-		];
 	}
 }
 new Theme_Preview();

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/rest-api/class-theme-preview.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/rest-api/class-theme-preview.php
@@ -57,6 +57,32 @@ class Theme_Preview {
 			'permission_callback' => '__return_true',
 		) );
 
+		register_rest_route( 'themes/v1', 'review-blueprint/((?<post_id>[\d]+)-)?(?<slug>[^/]+)/(?<version>[0-9a-z.-_]+)', array(
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => array( $this, 'review' ),
+			'args'                => array(
+				'slug' => array(
+					'type'              => 'string',
+					'required'          => true,
+					'sanitize_callback' => 'sanitize_key',
+				),
+				'version' => array(
+					'type'              => 'string',
+					'required'          => true,
+					'sanitize_callback' => static function ( $value ) {
+						return is_string( $value ) ? $value : '';
+					},
+				),
+				// If the theme isn't (yet) published, this can be set to force loading the post.
+				'post_id' => array(
+					'type'              => 'integer',
+					'required'          => false,
+					'sanitize_callback' => 'absint',
+				)
+			),
+			'permission_callback' => '__return_true',
+		) );
+
 		register_rest_route( 'themes/v1', 'preview-blueprint/(?<slug>[^/]+)', array(
 			'methods'             => WP_REST_Server::CREATABLE,
 			'callback'            => array( $this, 'set_blueprint' ),
@@ -84,29 +110,37 @@ class Theme_Preview {
 	}
 
 	/**
+	 * Generate a Blueprint for a theme review.
+	 */
+	function review( $request ) {
+		// If the theme isn't (yet) published, use the post_id hint.
+		$preview_post = get_post( (int) $request->get_param( 'post_id' ) );
+		if (
+			$preview_post &&
+			'repopackage' === $preview_post->post_type &&
+			'publish' !== $preview_post->post_status &&
+			$preview_post->post_name === $request->get_param( 'slug' )
+		) {
+			$GLOBALS['post'] = $preview_post;
+		}
+
+		return $this->build_blueprint( $request, [
+			'version' => $request->get_param( 'version' ),
+			'review'  => true,
+		] );
+	}
+
+	/**
 	 * Generate a Blueprint for a theme preview.
 	 */
 	function preview( $request ) {
-		// If the theme isn't (yet) published, use the post_id hint.
-		if ( is_numeric( $request->get_param( 'preview_id' ) ) ) {
-			$preview_post = get_post( (int) $request->get_param( 'preview_id' ) );
-			if (
-				$preview_post &&
-				'repopackage' === $preview_post->post_type &&
-				'publish' !== $preview_post->post_status &&
-				$preview_post->post_name === $request->get_param( 'slug' )
-			) {
-				$GLOBALS['post'] = $preview_post;
-			}
-		}
-
 		$theme_data = wporg_themes_theme_information( $request->get_param( 'slug' ) );
 
 		if ( ! empty( $theme_data->error ) ) {
 			return new WP_Error( 'error', $theme_data->error );
 		}
 
-		return $this->build_blueprint( $request, $theme_data, $request['version'] ?? false );
+		return $this->build_blueprint( $request, $theme_data );
 	}
 
 	/**
@@ -139,7 +173,9 @@ class Theme_Preview {
 	/**
 	 * Generate a blueprint for previewing a theme.
 	 */
-	function build_blueprint( $request, $theme_data, $version = false ) {
+	function build_blueprint( $request, $theme_data, $params ) {
+		$is_theme_review = $params['review'] ?? false;
+		$version         = $params['version'] ?? false;
 		$theme_package   = new WPORG_Themes_Repo_Package( $theme_data->slug, $version );
 		$parent_package  = $theme_data->template ? new WPORG_Themes_Repo_Package( $theme_data->template ) : false;
 		$theme_blueprint = $theme_package->preview_blueprint;
@@ -199,13 +235,6 @@ class Theme_Preview {
 				'username' => 'admin',
 				'password' => 'password'
 			],
-			! $request->get_param( 'debug' ) ? false :
-				[
-					'step' => 'defineWpConfigConsts',
-					'consts' => [
-						'WP_DEBUG' => true
-					]
-				],
 			// Set the default site details. The theme blueprint may replace this.
 			[
 				'step'    => 'setSiteOptions',
@@ -291,7 +320,7 @@ class Theme_Preview {
 		);
 
 		// Install the Theme Previewer plugins.
-		if ( $request->get_param( 'theme_previewer' ) ) {
+		if ( ! $is_theme_review ) {
 			/*
 			 * TODO: These artifacts need to be hosted somewhere better.
 			 */
@@ -312,8 +341,29 @@ class Theme_Preview {
 			];
 		}
 
-		// Install the Theme TestData if requested.
-		if ( $request->get_param( 'install_theme_testdata' ) ) {
+		// Theme Review specifics.
+		if ( $is_theme_review ) {
+			// Enable Debug mode.
+			$final_steps[] = [
+				'step' => 'defineWpConfigConsts',
+				'consts' => [
+					'WP_DEBUG' => true
+				]
+			];
+
+			// Install Theme Check.
+			$final_steps[] = [
+				'step' => 'installPlugin',
+				'pluginData' => [
+					'resource' => 'wordpress.org/plugins',
+					'slug'     => 'theme-check',
+				],
+				'options' => [
+					'activate' => true
+				]
+			];
+
+			// Install the test content.
 			$final_steps[] = [
 				'step' => 'importWxr',
 				'file' => [

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/rest-api/class-theme-preview.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/rest-api/class-theme-preview.php
@@ -7,60 +7,30 @@ use WPORG_Themes_Repo_Package;
 class Theme_Preview {
 
 	function __construct() {
-		register_rest_route( 'themes/v1', 'preview-blueprint/(?<slug>[^/]+)(/(?<version>[^/]+))?', array(
+		register_rest_route( 'themes/v1', 'preview-blueprint/(?<slug>[^/]+)', array(
 			'methods'             => WP_REST_Server::READABLE,
 			'callback'            => array( $this, 'preview' ),
+			'permission_callback' => '__return_true',
 			'args'                => array(
 				'slug' => array(
 					'type'              => 'string',
 					'required'          => 'true',
 					'sanitize_callback' => 'sanitize_key',
 				),
-				'version' => array(
-					'type'              => 'string',
-					'required'          => 'false',
-					'sanitize_callback' => static function ( $value ) {
-						if ( ! is_string( $value ) ) {
-							return '';
-						}
-						return preg_replace( '/[^0-9a-zA-Z.-]/', '', $value );
-					},
-				),
-				// If the theme isn't (yet) published, this can be set to force loading the post.
-				'preview_id' => array(
-					'type'              => 'integer',
-					'required'          => false,
-					'sanitize_callback' => 'absint',
-				),
-				// Whether to enable WP_DEBUG. ie. for testing.
-				'debug' => array(
-					'type'              => 'boolean',
-					'required'          => false,
-					'default'           => false,
-					'sanitize_callback' => 'rest_sanitize_boolean',
-				),
-				// Whether to install the Theme Unit TestData.
-				'install_theme_testdata' => array(
-					'type'              => 'boolean',
-					'required'          => false,
-					'default'           => false,
-					'sanitize_callback' => 'rest_sanitize_boolean',
-				),
-				// Whether to install the Theme Previewer plugins.
-				'theme_previewer' => array(
-					'type'              => 'boolean',
-					'required'          => false,
-					'default'           => true,
-					'sanitize_callback' => 'rest_sanitize_boolean',
-				),
 			),
-			'permission_callback' => '__return_true',
 		) );
 
 		register_rest_route( 'themes/v1', 'review-blueprint/((?<post_id>[\d]+)-)?(?<slug>[^/]+)/(?<version>[0-9a-z.-_]+)', array(
 			'methods'             => WP_REST_Server::READABLE,
 			'callback'            => array( $this, 'review' ),
+			'permission_callback' => '__return_true',
 			'args'                => array(
+				// If the theme isn't (yet) published, this can be set to force loading the post.
+				'post_id' => array(
+					'type'              => 'integer',
+					'required'          => false,
+					'sanitize_callback' => 'absint',
+				),
 				'slug' => array(
 					'type'              => 'string',
 					'required'          => true,
@@ -73,14 +43,7 @@ class Theme_Preview {
 						return is_string( $value ) ? $value : '';
 					},
 				),
-				// If the theme isn't (yet) published, this can be set to force loading the post.
-				'post_id' => array(
-					'type'              => 'integer',
-					'required'          => false,
-					'sanitize_callback' => 'absint',
-				)
 			),
-			'permission_callback' => '__return_true',
 		) );
 
 		register_rest_route( 'themes/v1', 'preview-blueprint/(?<slug>[^/]+)', array(

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/rest-api/class-theme-preview.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/rest-api/class-theme-preview.php
@@ -202,7 +202,7 @@ class Theme_Preview {
 			[
 				'step'    => 'setSiteOptions',
 				'options' => [
-					'blogname'        => $version ? "$theme_data->name $version" : $theme_data->name,
+					'blogname'        => $theme_data->name . ( $version ? " $version" : '' ),
 					'blogdescription' => preg_replace( '![.].+$!',  '.', $theme_data->sections['description'] ), // First sentence only.
 				]
 			],

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/rest-api/class-theme-preview.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/rest-api/class-theme-preview.php
@@ -20,7 +20,7 @@ class Theme_Preview {
 			),
 		) );
 
-		register_rest_route( 'themes/v1', 'review-blueprint/((?<post_id>[\d]+)-)?(?<slug>[^/]+)/(?<version>[0-9a-z.-_]+)', array(
+		register_rest_route( 'themes/v1', 'review-blueprint/((?<post_id>[\d]+)-)?(?<slug>[^/]+)/(?<version>[0-9a-z.-_]+)?', array(
 			'methods'             => WP_REST_Server::READABLE,
 			'callback'            => array( $this, 'review' ),
 			'permission_callback' => '__return_true',
@@ -38,7 +38,7 @@ class Theme_Preview {
 				),
 				'version' => array(
 					'type'     => 'string',
-					'required' => true,
+					'required' => false,
 				),
 			),
 		) );
@@ -132,8 +132,17 @@ class Theme_Preview {
 
 	/**
 	 * Generate a blueprint for previewing a theme.
+	 *
+	 * @param WP_REST_Request $request The REST request.
+	 * @param object $theme_data Theme data as returned by wporg_themes_theme_information
+	 * @param array $params {
+	 * 		Optional parameters.
+	 * 		@type bool $review If true, generate a blueprint for theme review.
+	 * 		@type string $version Optional. The version string, empty for latest version.
+	 * }
+	 * @return array The blueprint.
 	 */
-	function build_blueprint( $request, $theme_data, $params ) {
+	function build_blueprint( $request, $theme_data, $params = array() ) {
 		$is_theme_review = $params['review'] ?? false;
 		$version         = $params['version'] ?? false;
 		$theme_package   = new WPORG_Themes_Repo_Package( $theme_data->slug, $version );

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/rest-api/class-theme-preview.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/rest-api/class-theme-preview.php
@@ -37,11 +37,8 @@ class Theme_Preview {
 					'sanitize_callback' => 'sanitize_key',
 				),
 				'version' => array(
-					'type'              => 'string',
-					'required'          => true,
-					'sanitize_callback' => static function ( $value ) {
-						return is_string( $value ) ? $value : '';
-					},
+					'type'     => 'string',
+					'required' => true,
 				),
 			),
 		) );


### PR DESCRIPTION
See https://meta.trac.wordpress.org/ticket/8077

This updates the preview endpoint to handle theme previews for themes.trac, and adds a few options.

This is still in need of a cleanup I suspect, so PR'ing it for now.