### PR TITLE
Trac: add "gutenberg-merge" keyword

### DIFF
--- a/wordpress.org/public_html/style/trac/wp-trac.js
+++ b/wordpress.org/public_html/style/trac/wp-trac.js
@@ -35,7 +35,8 @@ var wpTrac, coreKeywordList, gardenerKeywordList, hideFromNewTickets, reservedTe
 		'early' : 'Ticket should be addressed early in the next dev cycle.',
 		'i18n-change' : 'A string change, used only after string freeze.',
 		'good-first-bug': 'This ticket is great for a new contributor to work on, generally because it is easy or well-contained.',
-		'fixed-major': 'The commits of this ticket need to be backported.'
+		'fixed-major': 'The commits of this ticket need to be backported.',
+		'gutenberg-merge-request': 'This ticket is a backport request from the Gutenberg.'
 	};
 
 	coreFocusesList = {

--- a/wordpress.org/public_html/style/trac/wp-trac.js
+++ b/wordpress.org/public_html/style/trac/wp-trac.js
@@ -36,7 +36,7 @@ var wpTrac, coreKeywordList, gardenerKeywordList, hideFromNewTickets, reservedTe
 		'i18n-change' : 'A string change, used only after string freeze.',
 		'good-first-bug': 'This ticket is great for a new contributor to work on, generally because it is easy or well-contained.',
 		'fixed-major': 'The commits of this ticket need to be backported.',
-		'gutenberg-merge-request': 'This ticket is a backport request from the Gutenberg.'
+		'gutenberg-merge': 'This ticket is a backport request from the Gutenberg.'
 	};
 
 	coreFocusesList = {


### PR DESCRIPTION
See the discussion on Slack: https://wordpress.slack.com/archives/C08MVR1MU2K/p1760280270674979

The `gutenberg-merge` keyword has traditionally been used in the core track to indicate that a ticket is a backport from Gutenberg.

[List of tickets with the gutenberg-merge keyword](https://core.trac.wordpress.org/query?keywords=~gutenberg-merge)

However, since the keyword must be entered manually, I suggest adding it to the dropdown.

cc @aaronjorbin @dream-encode @priethor