### PR TITLE
Add psykro to announce for core-test Slack channel

### DIFF
--- a/common/includes/slack/announce/config.php
+++ b/common/includes/slack/announce/config.php
@@ -302,6 +302,7 @@ function get_whitelist() {
 			'webtechpooja', // @Pooja Derashri on Slack
 			'oglekler',
 			'krupajnanda',
+            'psykro', // @Jonathan on Slack
 		) ),
 		'core-themes' => array_merge( get_committers(), array(
 			'anlino', // @andersnoren on Slack


### PR DESCRIPTION
This ticket fixes https://meta.trac.wordpress.org/ticket/8112