### PR TITLE
Fix: Add Dashicons dependency to ensure icons render correctly on Make WordPress sites

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/functions.php
@@ -57,7 +57,7 @@ function wporg_breathe_styles() {
 		filemtime( get_theme_root() . '/wporg-parent-2021/build/block-styles.css' )
 	);
 
-	wp_enqueue_style( 'wporg-breathe', get_stylesheet_uri(), array( 'p2-breathe' ), filemtime( __DIR__ . '/style.css' ) );
+	wp_enqueue_style( 'wporg-breathe', get_stylesheet_uri(), array( 'p2-breathe', 'dashicons' ), filemtime( __DIR__ . '/style.css' ) );
 
 	// Preload the heading font(s).
 	if ( is_callable( 'global_fonts_preload' ) ) {


### PR DESCRIPTION
### What?
Dashicons were not rendering correctly on several Make WordPress team sites (e.g., Hosting Handbook, Performance, AI, Program, Tide). The icons appeared as empty squares in places such as the “Show welcome box” option and the top bar beside some title.

### Why?
The Dashicons stylesheet was not being enqueued as a dependency of the main theme stylesheet (`wporg-breathe`). As a result, the font files required for Dashicons were not loaded, causing missing or broken icon displays.

### Fixes / Reference
This change adds `dashicons `as a dependency to the `wp_enqueue_style()` function that registers the `wporg-breathe` stylesheet, ensuring the Dashicons CSS is loaded consistently.

**Fixes:**

- [WordPress/hosting-handbook#361](https://github.com/WordPress/hosting-handbook/issues/361)
- [WordPress/performance#2239](https://github.com/WordPress/performance/issues/2239)
- [WordPress/wordpress.org#522](https://github.com/WordPress/wordpress.org/issues/522)

### Files Changed:
[functions.php](https://github.com/WordPress/wordpress.org/blob/trunk/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/functions.php)

**Updated Code:**
```
wp_enqueue_style(
    'wporg-breathe',
    get_stylesheet_uri(),
    array( 'p2-breathe', 'dashicons' ),
    filemtime( __DIR__ . '/style.css' )
);
```
@dd32 or
@SergeyBiryukov ,  when you have a moment, could you please review this PR? Your feedback would be greatly appreciated.