### PR TITLE
mu-plugins/downloads - drop width and give some more space

### DIFF
--- a/global.wordpress.org/public_html/wp-content/mu-plugins/downloads/rosetta-downloads.php
+++ b/global.wordpress.org/public_html/wp-content/mu-plugins/downloads/rosetta-downloads.php
@@ -150,10 +150,10 @@ class Rosetta_Downloads {
 				?>
 			</p>
 
-			<table class="widefat fixed striped" style="max-width:400px">
+			<table class="widefat fixed striped" style="max-width:410px">
 				<thead>
 					<tr>
-						<th scope="col" style="width:80px"><?php _e( 'Locale', 'rosetta' ); ?></th>
+						<th scope="col"><?php _e( 'Locale', 'rosetta' ); ?></th>
 						<th scope="col" style="text-align:right"><?php _e( 'Release Package', 'rosetta' ); ?></th>
 						<th scope="col" style="text-align:right"><?php _e( 'Language Pack', 'rosetta' ); ?></th>
 					</tr>


### PR DESCRIPTION
fixes #527

This PR drops with for the locale column. So every locale is a single liner. It adds 10px to max-width for the whole table. So we are more future-proof when we add new locales or long translations. And it does not lose its clarity.

screenshots are provided in #527 