### PR TITLE
Fix: Support link padding

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/client/components/plugin/style.scss
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/client/components/plugin/style.scss
@@ -284,7 +284,7 @@
 
 		a {
 			display: inline-block;
-			padding: 0.64rem 0 0.64rem 1.25rem;
+			padding: 0.64rem 1.25rem 0.64rem 1.25rem;
 			font-size: var(--wp--preset--font-size--normal);
 		}
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/client/components/plugin/style.scss
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/client/components/plugin/style.scss
@@ -284,7 +284,7 @@
 
 		a {
 			display: inline-block;
-			padding: 0.64rem 1.25rem 0.64rem 1.25rem;
+			padding: 0.64rem 1.25rem;
 			font-size: var(--wp--preset--font-size--normal);
 		}
 


### PR DESCRIPTION
### Description
Fixes the Support link/button having incorrect padding on plugin pages.

**Trac Ticket**: https://meta.trac.wordpress.org/ticket/8147

### Problem
The "Support" link on plugin pages (e.g., https://wordpress.org/plugins/sync-content-from-notion) had asymmetric padding, with the right padding missing. This caused the active state to appear visually unbalanced.

| Before | After |
|--------|--------|
| <img width="227" height="115" alt="support-button-defect" src="https://github.com/user-attachments/assets/4cbaf291-960f-4cb3-bf1b-479e990196d3" /> | <img width="227" height="115" alt="Screenshot 2025-12-13 at 1 57 15 PM" src="https://github.com/user-attachments/assets/5af39f3e-fd1d-46c6-b0e0-d226fa3fd59f" /> | 
