### PR TITLE
Plugin Directory: Allow 'for-X-and-TRADEMARK' pattern in plugin names

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-trademarks.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-trademarks.php
@@ -248,6 +248,13 @@ class Trademarks {
 						// Yes the slug ENDS with 'for-TRADEMARK'.
 						continue; // Check the next trademark
 					}
+
+					// Also allow pattern like "for-something-and-TRADEMARK".
+					$for_and_trademark = '-for-.*-and-' . preg_quote( $trademark, '/' ) . '$';
+					if ( preg_match( '/' . $for_and_trademark . '/', $plugin_slug ) ) {
+						// Slug contains 'for-{something}-and-TRADEMARK' at the end.
+						continue; // Check the next trademark
+					}
 				}
 
 				// The term cannot exist anywhere in the plugin slug, and it's not a for-use exception.


### PR DESCRIPTION
This update extends the trademark validation logic to support plugin names following the pattern "for-{service}-and-{trademark}", in addition to the existing "for-{trademark}" pattern.

This allows more natural plugin naming for integrations that connect multiple services, while still maintaining trademark protection requirements.

Examples of now-allowed names:
- "Integration for Service-X and WooCommerce"
- "Payment Gateway for Provider-Y and WooCommerce"
- "Connector for Platform-Z and WooCommerce"

The following patterns remain blocked (as expected):
- "WooCommerce Integration" (trademark at start)
- "My WooCommerce Extension" (trademark in middle)
- "Service and WooCommerce" (missing 'for' keyword)

All existing trademark validations remain intact and functional.