### PR TITLE
Fix Trac prefs layout alignment on report and query views

### DIFF
--- a/buddypress.org/public_html/wp-content/themes/bb-base/style-trac.css
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/style-trac.css
@@ -658,6 +658,45 @@ body.trac .inlinebuttons input[type=submit] {
 	font-weight: 400;
 }
 
+body.trac #content.report #prefs,
+body.trac #content.query #prefs {
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+	gap: 10px;
+	flex-wrap: wrap;
+}
+
+body.trac #content.report #prefs > div,
+body.trac #content.query #prefs > div {
+	margin: 0;
+}
+
+body.trac #content.report #prefs label,
+body.trac #content.query #prefs label {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+}
+
+body.trac #content.report #prefs label input[type="text"],
+body.trac #content.query #prefs label input[type="text"] {
+	margin: 0;
+	width: 6em;
+	max-width: 100%;
+}
+
+body.trac #content.report #prefs .buttons,
+body.trac #content.query #prefs .buttons {
+	margin: 0;
+	text-align: left;
+}
+
+body.trac #content.report #prefs .buttons input[type="submit"],
+body.trac #content.query #prefs .buttons input[type="submit"] {
+	margin: 0;
+}
+
 /* Roadmap */
 body.trac div.milestone {
 	margin: 0;


### PR DESCRIPTION
This change improves the layout of the Trac preferences controls on
**report** and **query** views.

By switching the prefs container to a flex layout in these contexts,
the controls are aligned consistently and no longer wrap awkwardly
or push the submit button out of place.

The update is intentionally scoped to:
- `#content.report #prefs`
- `#content.query #prefs`

so it does not affect ticket, admin, or other Trac views.

Related: https://bbpress.trac.wordpress.org/ticket/3662

