### PR TITLE
Show only latest zip in the admin column

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/list-table/class-plugin-posts.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/list-table/class-plugin-posts.php
@@ -705,6 +705,9 @@ class Plugin_Posts extends \WP_Posts_List_Table {
 			echo '-';
 			return;
 		}
+		
+		// Get only the last zip item.
+		$media = array_slice( $media, -1 );
 
 		foreach ( $media as $zip_file ) {
 			$zip_size = size_format( filesize( get_attached_file( $zip_file->ID ) ), 1 );


### PR DESCRIPTION
Sometimes there are several attached zip files for a plugin, but we are generally only interested in the latest one. This change will also make the UI more minimal.