### PR TITLE
Theme Previews: Correctly use WP_Post objects for Menu Items

### DIFF
--- a/wp-themes.com/public_html/wp-content/mu-plugins/pub/starter-content.php
+++ b/wp-themes.com/public_html/wp-content/mu-plugins/pub/starter-content.php
@@ -337,7 +337,7 @@ class Starter_Content {
 						}
 
 						if ( ! empty( $item['title'] ) && ! empty( $item['url'] ) ) {
-							$menu_items[] = (object) $item;
+							$menu_items[] = new \WP_Post( (object) $item );
 							continue;
 						}
 
@@ -354,7 +354,7 @@ class Starter_Content {
 								$item['url']   = get_permalink( $id );
 								$item['title'] = $post_data['post_title'];
 
-								$menu_items[] = (object) $item;
+								$menu_items[] = new \WP_Post( (object) $item );
 								continue;
 							}
 						}


### PR DESCRIPTION
Menu items are expected to be WP_Post objects, not plain objects.

See https://wordpress.slack.com/archives/C02RP4Y3K/p1768802683101059?thread_ts=1768801469.528159&cid=C02RP4Y3K