### PR TITLE
Slack: Add support for Workflow Keyword notifications in Slack integration

### DIFF
--- a/common/includes/slack/trac/comment-handler.php
+++ b/common/includes/slack/trac/comment-handler.php
@@ -25,6 +25,22 @@ class Comment_Handler {
 		if ( $firehose ) {
 			$this->send->send( $firehose );
 		}
+
+		// Send notifications for Workflow Keyword additions
+		$this->send_keyword_notifications();
+	}
+
+	function send_keyword_notifications() {
+		if ( empty( $this->keywords_added ) ) {
+			return;
+		}
+
+		foreach ( $this->keywords_added as $keyword ) {
+			$channels = $this->trac->get_keyword_channels( $keyword );
+			foreach ( $channels as $channel ) {
+				$this->send->send( $channel );
+			}
+		}
 	}
 
 	function process_message() {
@@ -168,6 +184,7 @@ class Comment_Handler {
 		array_shift( $lines );
 
 		$changes = $comment = array();
+		$this->keywords_added = array();
 
 		// Check if the summary of a ticket was changed.
 		if ( preg_match( '/ \(was: (.*)\)$/', $subject, $matches ) ) {
@@ -180,7 +197,14 @@ class Comment_Handler {
 
 				if ( preg_match( '~Attachment "([^"]+)" (added|removed)\.$~', $line, $matches ) ) { // * Attachment "test.txt" added/removed.
 					$changes[] = "_*attachment:*_ `{$matches[1]}` {$matches[2]}";
-				} else { // * status:  assigned => closed
+				} else { 
+					// Track keywords added for Workflow Keyword notifications.
+					if ( preg_match( '~^ \* keywords:  (.*) => (.*)$~', $line, $kw_matches ) ) {
+						$old_keywords = array_filter( array_map( 'trim', explode( ' ', $kw_matches[1] ) ) );
+						$new_keywords = array_filter( array_map( 'trim', explode( ' ', $kw_matches[2] ) ) );
+						$this->keywords_added = array_diff( $new_keywords, $old_keywords );
+					}
+					// Applies Slack formatting for other changes.
 					$changes[] = preg_replace( '~^ \* (.*?):  ~', '_*$1:*_ ', $line );
 				}
 			}

--- a/common/includes/slack/trac/config.php
+++ b/common/includes/slack/trac/config.php
@@ -60,6 +60,14 @@ class Core extends Trac {
 	);
 
 	/**
+	 * Workflow keywords that cause ticket updates to be piped to particular channels.
+	 * These trigger when the keyword is added to a ticket.
+	 */
+	protected $ticket_keyword_filters = array(
+		'needs-testing' => '#core-test',
+	);
+
+	/**
 	 * Components or focuses that cause new tickets to be piped to particular channels.
 	 */
 	protected $ticket_component_filters = array(

--- a/common/includes/slack/trac/trac.php
+++ b/common/includes/slack/trac/trac.php
@@ -23,6 +23,7 @@ class Trac implements User {
 
 	protected $commit_path_filters = array();
 	protected $ticket_component_filters = array();
+	protected $ticket_keyword_filters = array();
 
 	protected $color = '#0073aa';
 	protected $icon  = ':wordpress:';
@@ -282,6 +283,14 @@ class Trac implements User {
 
 	function get_firehose_channel() {
 		return $this->firehose_channel;
+	}
+
+	function get_keyword_channels( $keyword ) {
+		if ( isset( $this->ticket_keyword_filters[ $keyword ] ) ) {
+			$channel = $this->ticket_keyword_filters[ $keyword ];
+			return is_array( $channel ) ? array_keys( array_filter( $channel ) ) : array( $channel );
+		}
+		return array();
 	}
 
 	function get_ticket_format( $channel ) {


### PR DESCRIPTION
Closes: https://meta.trac.wordpress.org/ticket/8157

This is an improvement for the current version of `ticket_component_filters` but targetting Workflow Keyword changes in the firehose. 

When it detects in Changes for the "new" keywords and the diff between old and new is different, it will trigger the `send` from `\Dotorg\Slack\Send`

The advantage of this trigger, is that it's constantly parsing each new comment in the firehose, not only new tickets as in `ticket_component_filters`. Ideally also the rest of the triggers should be migrated to this system, because focuses and keywords can be introduced anywhere within a ticket, not only in the ticket OP. 

This is specially true for testing (`needs-testing`) workflow keyword, that its rarely added in the first ticket, as is a intermediate keyword that its added when people actually need testing.

I have not added any placeholder texts, and I'm just using the default message in `\Dotorg\Slack\Send`. But maybe in the future we could set some hardcoded messages in the code, maybe as an associative array, to customize a bit the thing.

