### PR TITLE
Bump servehappy versions

### DIFF
--- a/wordpress.org/public_html/wp-content/mu-plugins/pub/servehappy-config.php
+++ b/wordpress.org/public_html/wp-content/mu-plugins/pub/servehappy-config.php
@@ -19,8 +19,8 @@ define( 'MINIMUM_PHP', '7.2.24' );
 define( 'SUPPORTED_PHP', '8.3' );
 
 // The lowest branch of PHP which is receiving security updates.
-define( 'SECURE_PHP', '8.1' );
+define( 'SECURE_PHP', '8.2' );
 
 // The lowest branch of PHP which is still considered acceptable in WordPress.
 // Sites with a version lower than this will see the ServeHappy dashboard widget urging them to update.
-define( 'ACCEPTABLE_PHP', '8.1' );
+define( 'ACCEPTABLE_PHP', '8.2' );


### PR DESCRIPTION
related to https://core.trac.wordpress.org/ticket/64494

security fixes for PHP 8.1 ended on January 1, 2026

https://www.php.net/supported-versions.php