### PR TITLE
Support Forums: Fix `--wp-admin-theme-color` CSS variable scope

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/sass/variables-site/_colors.scss
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/sass/variables-site/_colors.scss
@@ -1,3 +1,3 @@
-:root {
+body {
 	--wp-admin-theme-color: var(--wp--preset--color--blueberry-1);
 }


### PR DESCRIPTION
Closes: https://meta.trac.wordpress.org/ticket/8175

The `--wp-admin-theme-color` custom property is declared on `:root` referencing
`var(--wp--preset--color--blueberry-1)`, but that variable is only defined on
`body` by WordPress core's `global-styles-inline-css`. Since `:root` (`<html>`)
is the parent of `body`, the referenced variable is not available in that scope.

This changes the declaration from `:root` to `body` so both variables are
defined on the same element and the reference resolves correctly.

**Note:** I used AI to generate the PR description and title. The source code has been reviewed and tested by me locally before opening this PR.