### PR TITLE
Fix: Tickets menu on Changeset pages redirects to make core/reports/ page instead of opening tickets menu

### DIFF
--- a/wordpress.org/public_html/style/trac/wp-trac.js
+++ b/wordpress.org/public_html/style/trac/wp-trac.js
@@ -1752,7 +1752,10 @@ var wpTrac, coreKeywordList, gardenerKeywordList, hideFromNewTickets, reservedTe
 				// This seems to be the easiest place to find the current Ticket ID..
 				var canonical = $( 'link[rel="canonical"]' ).prop( 'href' );
 				if ( canonical ) {
-					ticket = canonical.match( /\/ticket\/(\d+)$/ )[1];
+					let match = canonical.match( /\/ticket\/(\d+)$/ );
+					if ( match && match[1] ) {
+						ticket = match[1];
+					}
 				}
 
 				if ( ! ticket ) {

--- a/wordpress.org/public_html/style/trac/wp-trac.js
+++ b/wordpress.org/public_html/style/trac/wp-trac.js
@@ -1752,10 +1752,7 @@ var wpTrac, coreKeywordList, gardenerKeywordList, hideFromNewTickets, reservedTe
 				// This seems to be the easiest place to find the current Ticket ID..
 				var canonical = $( 'link[rel="canonical"]' ).prop( 'href' );
 				if ( canonical ) {
-					let match = canonical.match( /\/ticket\/(\d+)$/ );
-					if ( match && match[1] ) {
-						ticket = match[1];
-					}
+					ticket = canonical.match( /\/ticket\/(\d+)$/ )?.[1];
 				}
 
 				if ( ! ticket ) {


### PR DESCRIPTION
## Issue

Meta ticket -- https://meta.trac.wordpress.org/ticket/8183

- There was a JS error on the page accessing the value from the null.
- Added a safe check before accessing.