### PR TITLE
Add GitHub Actions workflow for standalone PHP unit tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,53 @@
+name: Unit Tests
+
+on:
+  push:
+    branches: [ trunk ]
+  pull_request:
+    branches: [ trunk ]
+
+jobs:
+  # Standalone PHP tests — no WordPress or database dependency.
+  php-standalone:
+    name: "PHP: ${{ matrix.name }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Serve Happy API
+            working-directory: api.wordpress.org/public_html/core/serve-happy/1.0
+            phpunit-args: "--no-configuration --exclude-group serve-happy-live-http --bootstrap tests/bootstrap.php tests/"
+          - name: Browse Happy API
+            working-directory: api.wordpress.org/public_html/core/browse-happy/1.0
+            phpunit-args: "--no-configuration tests/phpunit/tests/"
+          - name: Slack Trac Bot
+            working-directory: common/includes/tests/slack/trac
+            phpunit-args: "bot.php"
+          - name: Slack Props Library
+            working-directory: common/includes/slack/props/tests
+            phpunit-args: "--bootstrap /tmp/phpunit-bootstrap.php ."
+            bootstrap: wpdb-stub
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.4"
+          tools: phpunit:^11
+
+      - name: Create wpdb stub bootstrap
+        if: matrix.bootstrap == 'wpdb-stub'
+        run: |
+          cat > /tmp/phpunit-bootstrap.php << 'PHPEOF'
+          <?php
+          class wpdbStub {
+              public function prepare( $query, ...$args ) { return $query; }
+              public function get_results( $query, $output = 'OBJECT' ) { return []; }
+          }
+          PHPEOF
+
+      - name: Run PHPUnit
+        working-directory: ${{ matrix.working-directory }}
+        run: phpunit ${{ matrix.phpunit-args }}

--- a/api.wordpress.org/public_html/core/browse-happy/1.0/tests/phpunit/tests/browse-happy.php
+++ b/api.wordpress.org/public_html/core/browse-happy/1.0/tests/phpunit/tests/browse-happy.php
@@ -853,6 +853,12 @@ class Tests_Browse_Happy extends \PHPUnit\Framework\TestCase {
 			return;
 		}
 
+		// Internet Explorer is always flagged as needing an upgrade.
+		if ( 'Internet Explorer' === $parsed['name'] ) {
+			$this->assertTrue( $parsed['upgrade'] );
+			return;
+		}
+
 		$versions = get_browser_current_versions();
 
 		if ( ! empty( $versions[ $parsed['name'] ] ) ) {

--- a/api.wordpress.org/public_html/core/serve-happy/1.0/tests/bootstrap.php
+++ b/api.wordpress.org/public_html/core/serve-happy/1.0/tests/bootstrap.php
@@ -5,11 +5,6 @@ if ( function_exists( 'xdebug_disable' ) ) {
 	xdebug_disable();
 }
 
-// PHP 6+ Compatibility.
-if ( class_exists( '\PHPUnit\Runner\Version' ) && version_compare( \PHPUnit\Runner\Version::id(), '6.0', '>=' ) ) {
-	class_alias( '\PHPUnit\Framework\TestCase', 'PHPUnit_Framework_TestCase' );
-}
-
 // Error Output handler for the API.
 function bail( $code, $message, $status = 400, $http_code_text = '' ) {
 	return compact( 'code', 'message', 'status' );

--- a/api.wordpress.org/public_html/core/serve-happy/1.0/tests/tests.php
+++ b/api.wordpress.org/public_html/core/serve-happy/1.0/tests/tests.php
@@ -1,11 +1,11 @@
 <?php
 namespace WordPressdotorg\API\Serve_Happy;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group serve-happy
  */
-class Tests_API_Responses extends PHPUnit_Framework_TestCase {
+class Tests_API_Responses extends TestCase {
 
 	function dataprovider_determine_request_valid() {
 		return [

--- a/common/includes/tests/slack/trac/bot.php
+++ b/common/includes/tests/slack/trac/bot.php
@@ -2,7 +2,7 @@
 
 require dirname( dirname( dirname( __DIR__ ) ) ) . '/slack/autoload.php';
 
-class Test_Slack_Trac_Bot extends PHPUnit_Framework_TestCase {
+class Test_Slack_Trac_Bot extends \PHPUnit\Framework\TestCase {
 	function test_commit_parse() {
 		$post_data = $this->mock_post_data( '[1234] r12345 r897-core https://core.trac.wordpress.org/changeset/11223' );
 		$receiving = new \Dotorg\Slack\Trac\Bot( $post_data );


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/unit-tests.yml` with standalone PHP tests on **PHP 8.4** + **PHPUnit 11**
- Runs 4 test suites via matrix (no WordPress or database dependency):
  - Serve Happy API
  - Browse Happy API
  - Slack Trac Bot
  - Slack Props Library
- Updates Serve Happy and Slack Trac Bot tests to use modern `PHPUnit\Framework\TestCase` (required by PHPUnit 11)
- Removes redundant `class_alias` shim from Serve Happy bootstrap
- Fixes Browse Happy test: Internet Explorer is always flagged as needing an upgrade
- Uses `--no-configuration` to bypass legacy phpunit.xml attributes incompatible with PHPUnit 10+

## Test plan
- [x] All 4 standalone PHP test suites pass in CI on PHP 8.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)