### PR TITLE
Plugin Directory: Fix slug change dialog closing immediately

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-upload.php
@@ -261,7 +261,7 @@ class Upload {
 							);
 							?>
 							<?php if ( $can_change_slug ) : ?>
-								<a href="#" class="hide-if-no-js" onclick="this.nextElementSibling.showModal()"><?php _e( 'change', 'wporg-plugins' ); ?></a>
+								<a href="#" class="hide-if-no-js" onclick="event.preventDefault(); this.nextElementSibling.showModal()"><?php _e( 'change', 'wporg-plugins' ); ?></a>
 								<dialog class="slug-change hide-if-no-js">
 									<a onclick="this.parentNode.close()" class="close dashicons dashicons-no-alt"></a>
 									<strong><?php _e( 'Request to change your plugin slug', 'wporg-plugins' ); ?></strong>


### PR DESCRIPTION
## Summary

Fixes [Meta Trac #8205](https://meta.trac.wordpress.org/ticket/8205).

- The "change" link for the slug field on the plugin submission page used `href="#"` with an inline `onclick` to call `showModal()`, but the default `href="#"` navigation was not prevented, causing the dialog to close immediately after opening.
- Adds `event.preventDefault()` to the onclick handler to stop the hash navigation.

## Test plan

- [ ] Submit a plugin (or view a pending plugin with slug change enabled)
- [ ] Click the "change" link next to the assigned slug
- [ ] Verify the dialog opens and stays open
- [ ] Verify the dialog can be closed via the X button
- [ ] Verify slug change submission still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)