### PR TITLE
Plugin Directory: Edit screen. Approve plugins with a double-click.

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/class-customizations.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/class-customizations.php
@@ -139,10 +139,10 @@ class Customizations {
 					wp_enqueue_script( 'plugin-admin-post-js', plugins_url( 'js/edit-form.js',PLUGIN_FILE ), array( 'wp-util', 'wp-lists', 'wp-api' ), filemtime( PLUGIN_DIR . '/js/edit-form.js') );
 
 					wp_localize_script( 'plugin-admin-post-js', 'pluginDirectory', array(
-						'approvePluginAYS'    => __( 'Are you sure you want to approve this plugin?', 'wporg-plugins' ),
-						'rejectPluginAYS'     => __( 'Are you sure you want to reject this plugin?', 'wporg-plugins' ),
-						'removeCommitterAYS'  => __( 'Are you sure you want to remove this committer?', 'wporg-plugins' ),
-						'removeSupportRepAYS' => __( 'Are you sure you want to remove this support rep?', 'wporg-plugins' ),
+						'approvePluginConfirm' => __( 'Double-click to Approve', 'wporg-plugins' ),
+						'rejectPluginAYS'      => __( 'Are you sure you want to reject this plugin?', 'wporg-plugins' ),
+						'removeCommitterAYS'   => __( 'Are you sure you want to remove this committer?', 'wporg-plugins' ),
+						'removeSupportRepAYS'  => __( 'Are you sure you want to remove this support rep?', 'wporg-plugins' ),
 					) );
 					break;
 

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/js/edit-form.js
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/js/edit-form.js
@@ -62,7 +62,29 @@
 				jQuery('#assigned_reviewer').val( userSettings.uid );
 
 			} else if ( 'approved' === status ) {
-				return confirm( pluginDirectory.approvePluginAYS );
+				var timeForDoubleClick = 1000;
+				var lastClick = $this.data( 'lastClick' ) || 0,
+					now = Date.now();
+
+				if ( now - lastClick > 0 && now - lastClick < timeForDoubleClick ) {
+					return true;
+				}
+
+				$this.data( 'lastClick', now );
+
+				// Make it clear that a double click is needed.
+				if ( ! $this.data( 'originalText' ) ) {
+					$this.data( 'originalText', $this.text() );
+				}
+
+				$this.text( pluginDirectory.approvePluginConfirm );
+
+				setTimeout( function() {
+					$this.text( $this.data( 'originalText' ) );
+					$this.data( 'lastClick', 0 );
+				}, timeForDoubleClick );
+
+				return false;
 
 			} else if ( 'rejected' === status ) {
 				return confirm( pluginDirectory.rejectPluginAYS );


### PR DESCRIPTION
The “Approve” button when editing a plugin currently relies on JavaScript’s `window.confirm()` to prevent accidental or invalid clicks.

While `window.confirm()` is amazing for this purpose, it can become slow and frustrating when managing many plugins. Each action requires waiting for the browser to display a modal dialog, and interact with it. On top of that, many browsers enforce an additional pause before the dialog becomes interactive (ironically to prevent accidental clicks on the modal).

A double click also prevents invalid clicks and does not introduce any delay or context change.

To clarify that a double-click is needed, the text "Approve" changes to "Double-click to Approve" when clicked once.

<img width="309" height="271" alt="image" src="https://github.com/user-attachments/assets/5f0eab52-3ba8-4009-a6d3-4f2fa18760e3" />
