### PR TITLE
Plugin Directory: Add `common-plugin` rejection reason for duplicate/common plugin submissions

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-template.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-template.php
@@ -1086,7 +1086,7 @@ class Template {
 			'banned'               => 'Banned developer trying to sneak back in',
 			'author-request'       => 'Author requested not to continue',
 			'security'             => 'Security concerns',
-			'common'               => 'Common plugin',
+			'common-plugin'        => 'Common plugin',
 			'other'                => 'OTHER: See notes',
 		);
 	}

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-template.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-template.php
@@ -1086,6 +1086,7 @@ class Template {
 			'banned'               => 'Banned developer trying to sneak back in',
 			'author-request'       => 'Author requested not to continue',
 			'security'             => 'Security concerns',
+			'common'               => 'Common plugin',
 			'other'                => 'OTHER: See notes',
 		);
 	}

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-plugin-rejected.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-plugin-rejected.php
@@ -98,6 +98,25 @@ We ask you <strong>not</strong> resubmit the plugin, and reply to this email ins
 		);
 	}
 
+	public function reason_common_plugin() {
+		return __(
+			"We have rejected your plugin submission because it addresses a functionality (e.g., scroll to top, post duplication, maintenance mode, post view counter, log viewer, admin dashboard notes, image optimisation, etc) that is already widely available in the directory.
+
+The WordPress plugin ecosystem thrives on innovation, and we encourage you to explore its vast potential by creating unique solutions that fill unmet needs.
+
+Please consider developing plugins that offer fresh value to users. We'd be excited to review your plugin in the future!
+
+<strong>What to do next</strong>
+
+Don't worry! We encourage you to iterate and submit something new-WordPress's potential is limitless!
+
+Please do not resubmit the plugin, even if you believe we are incorrect.
+
+Instead, reply to this email and explain the situation so we can properly direct you forward. If you resubmit this plugin without replying and communicating with us first, your account will be suspended.",
+			'wporg-plugins'
+		);
+	}
+
 	public function reason_duplicate_copy() {
 		return __(
 			"Your plugin has been rejected because it is a duplicate of another plugin, already hosted on WordPress.org


### PR DESCRIPTION
This PR adds a new rejection reason, `common-plugin`, to better classify plugin submissions that repeat functionality already widely available in the directory.

**What changed**  
1. Added a new rejection reason key/value in `Template::get_rejection_reasons()`:  
   - Key: `common-plugin`  
   - Label: `Common plugin`
2. Added the corresponding rejection email reason handler for `common-plugin` in `Plugin_Rejected` so the correct message is sent when selected.
3. Ensured the new reason is available in the existing rejection reason dropdowns and stored via `_rejection_reason` like other reasons.

**Why**  
We currently group these cases under broader reasons (often `other` or `duplicate`), which makes reporting and reviewer workflows less precise.  
`common-plugin` gives us a clearer, explicit classification for submissions that are redundant in the directory.

**Testing**  
1. Open a plugin in wp-admin and change status to `rejected`.  
2. Confirm `Common plugin` appears in the rejection reason dropdown.  
3. Save and verify `_rejection_reason` is stored as `common-plugin` in post meta.  
4. Trigger/send the rejection email and confirm the new reason-specific content is used (not fallback `other`).  
5. Verify existing rejection reasons continue to work unchanged.

**Notes**  
- Backward compatible: existing rejection reason keys and flows are unchanged.  
- This only introduces a new option and reason template; no migration required.