### PR TITLE
Add repository-wide PHPCS specification and PR enforcement workflow

### DIFF
--- a/.github/bin/phpcs-branch.php
+++ b/.github/bin/phpcs-branch.php
@@ -1,0 +1,88 @@
+#!/usr/bin/php
+<?php
+/**
+ * Report on phpcs violations that are introduced in the current branch (not trunk).
+ * Runs `phpcs` as normal on new files, and `phpcs-changed` on modified files. `phpcs-changed` will only report
+ * on changed lines in each modified file.
+ *
+ * How to use: BASE_REF=trunk php .github/bin/phpcs-branch.php
+ */
+
+// phpcs:ignoreFile
+namespace WordPressOrg\Bin\PHPCS_Changed;
+
+function run_phpcs( $file, $bin_dir ) {
+	exec( "$bin_dir/phpcs $file -snq", $output, $exec_exit_status );
+	echo implode( "\n", $output );
+	return $exec_exit_status;
+}
+
+/*
+ * Note: This differs from the typical usage of phpcs-changed, which suggests piping in the file contents.
+ * Here, we create temporary files instead, because piping in the contents causes phpcs-changed to misbehave
+ * when the file contains special characters (like escape sequences such as '\\').
+ */
+function run_phpcs_changed( $file, $git, $base_branch, $bin_dir ) {
+	$name = basename( $file );
+	exec( "$git diff $base_branch $file > $name.diff" );
+
+	exec( "$git show $base_branch:$file > $name.test.php" );
+	exec( "$bin_dir/phpcs $name.test.php --standard=./phpcs.xml.dist --report=json -snq > $name.orig.phpcs" );
+
+	exec( "cat $file > $name.test.php" );
+	exec( "$bin_dir/phpcs $name.test.php --standard=./phpcs.xml.dist --report=json -snq > $name.phpcs" );
+
+	$cmd = "$bin_dir/phpcs-changed --diff $name.diff --phpcs-orig $name.orig.phpcs --phpcs-new $name.phpcs";
+	exec( $cmd, $output, $exec_exit_status );
+	echo implode( "\n", $output );
+	echo "\n";
+
+	exec( "rm $name.diff $name.test.php $name.orig.phpcs $name.phpcs" );
+	return $exec_exit_status;
+}
+
+function main() {
+	$base_branch = 'remotes/origin/' . getenv( 'BASE_REF' );
+	$git_dir     = dirname( dirname( __DIR__ ) );
+	$bin_dir     = dirname( dirname( __DIR__ ) ) . '/vendor/bin';
+	$git         = "git -C $git_dir";
+
+	try {
+		echo "\nScanning changed files...\n";
+		$status = 0;
+
+		$affected_files = shell_exec( "$git diff $base_branch --name-status --diff-filter=AM 2>&1 | grep .php$" );
+		$affected_files = explode( "\n", trim( $affected_files ) );
+
+		foreach ( $affected_files as $record ) {
+			if ( ! $record ) {
+				continue;
+			}
+
+			list( $change, $file ) = explode( "\t", trim( $record ) );
+			$cmd_status = 0;
+
+			switch ( $change ) {
+				case 'M':
+					$cmd_status = run_phpcs_changed( $file, $git, $base_branch, $bin_dir );
+					break;
+
+				case 'A':
+					$cmd_status = run_phpcs( $file, $bin_dir );
+					break;
+			}
+
+			// If any cmd exits with 1, we want to exit with 1.
+			$status |= $cmd_status;
+		}
+
+	} catch ( \Exception $exception ) {
+		echo "\nAborting because of error: {$exception->getMessage()} \n";
+		$status = 1;
+
+	}
+
+	exit( $status );
+}
+
+main();

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -1,0 +1,43 @@
+name: Static Analysis (PHP Linting)
+
+on:
+  pull_request:
+    paths:
+    - '**.php'
+    - phpcs.xml.dist
+    - composer.json
+    - .github/workflows/phpcs.yml
+    - .github/bin/phpcs-branch.php
+  push:
+    branches: [trunk]
+    paths:
+    - '**.php'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  phpcs:
+    name: PHP Coding Standards
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.4'
+        coverage: none
+        tools: composer:v2
+      env:
+        COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Install Composer dependencies
+      run: composer install --no-interaction --prefer-dist
+
+    - name: Lint PHP
+      run: BASE_REF=${{ github.base_ref }} php .github/bin/phpcs-branch.php

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
+vendor/
 .svn/

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,22 @@
+{
+	"name": "wordpress/wordpress.org",
+	"description": "WordPress.org website code",
+	"homepage": "https://wordpress.org",
+	"license": "GPL-2.0-or-later",
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
+	},
+	"require-dev": {
+		"dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",
+		"wp-coding-standards/wpcs": "^3.3.0",
+		"phpcompatibility/phpcompatibility-wp": "*",
+		"sirbrillig/phpcs-changed": "^2.12.0"
+	},
+	"scripts": {
+		"lint": "phpcs",
+		"format": "phpcbf -p",
+		"phpcs-changed": "BASE_REF=trunk php .github/bin/phpcs-branch.php"
+	}
+}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -82,9 +82,14 @@
 		<exclude name="Squiz.Commenting.FileComment.Missing" />
 		<exclude name="Squiz.Commenting.ClassComment.Missing" />
 		<exclude name="Squiz.Commenting.FunctionComment.MissingParamTag" />
+		<exclude name="Squiz.Commenting.FunctionComment.Missing" />
 		<exclude name="Generic.Commenting.DocComment.MissingShort" />
 		<exclude name="Squiz.Commenting.VariableComment.Missing" />
 		<exclude name="Squiz.Commenting.VariableComment.MissingVar" />
+
+		<!-- Requiring full stops on inline/param comments is pedantic. -->
+		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar" />
+		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop" />
 
 		<!-- Package tags add clutter without value. -->
 		<exclude name="Squiz.Commenting.FileComment.MissingPackageTag" />
@@ -107,6 +112,16 @@
 
 		<!-- WordPress translators comments require no space after //. -->
 		<exclude name="Squiz.Commenting.InlineComment.NoSpaceBefore" />
+	</rule>
+
+	<!-- Commented-out code is sometimes intentional for reference. -->
+	<rule ref="Squiz.PHP.CommentedOutCode.Found">
+		<severity>0</severity>
+	</rule>
+
+	<!-- Custom capabilities are valid in the WordPress.org environment. -->
+	<rule ref="WordPress.WP.Capabilities.Unknown">
+		<severity>0</severity>
 	</rule>
 
 	<rule ref="WordPress-Extra">

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,6 +9,9 @@
 	<!-- Exclude 3rd-party files -->
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<exclude-pattern>*/plugins/plugin-directory/libs/*</exclude-pattern>
+	<exclude-pattern>*/plugins/theme-directory/lib/*</exclude-pattern>
+	<exclude-pattern>*/plugins/wpf-stripe/stripe-php/*</exclude-pattern>
 
 	<!-- Exclude JS/CSS files. -->
 	<exclude-pattern>*.js[x]?</exclude-pattern>
@@ -19,7 +22,7 @@
 	<arg name="extensions" value="php" />
 
 	<!-- WordPress.org runs recent versions of WordPress. -->
-	<config name="minimum_wp_version" value="6.8"/>
+	<config name="minimum_wp_version" value="6.9"/>
 
 	<!-- Check for PHP cross-version compatibility. -->
 	<config name="testVersion" value="8.4-"/>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,120 @@
+<?xml version="1.0" ?>
+<ruleset name="WordPress.org Coding Standards">
+	<description>Apply customized version of WordPress Coding Standards to WordPress.org PHP scripts.</description>
+
+	<!-- Show sniff codes in all reports -->
+	<arg value="ps" />
+	<arg name="colors" />
+
+	<!-- Exclude 3rd-party files -->
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+	<exclude-pattern>*/node_modules/*</exclude-pattern>
+
+	<!-- Exclude JS/CSS files. -->
+	<exclude-pattern>*.js[x]?</exclude-pattern>
+	<exclude-pattern>*.[s]?css</exclude-pattern>
+
+	<!-- Scan all (php) files in the current folder and subfolders -->
+	<file>.</file>
+	<arg name="extensions" value="php" />
+
+	<!-- WordPress.org runs recent versions of WordPress. -->
+	<config name="minimum_wp_version" value="6.8"/>
+
+	<!-- Check for PHP cross-version compatibility. -->
+	<config name="testVersion" value="8.4-"/>
+	<rule ref="PHPCompatibilityWP"/>
+
+	<rule ref="WordPress-Core">
+		<!-- Allow embedded PHP tags on a single line. -->
+		<exclude name="Squiz.PHP.EmbeddedPhp.ContentAfterOpen" />
+		<exclude name="Squiz.PHP.EmbeddedPhp.ContentBeforeEnd" />
+
+		<!-- Class file names are not always predictable. -->
+		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />
+
+		<!-- Translators comments are a judgement call. -->
+		<exclude name="WordPress.WP.I18n.MissingTranslatorsComment" />
+
+		<!-- Not practical for a large and varied codebase. -->
+		<exclude name="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound" />
+		<exclude name="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound" />
+		<exclude name="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound" />
+
+		<!-- Aligning things can make the code more readable. -->
+		<exclude name="WordPress.WhiteSpace.PrecisionAlignment.Found" />
+		<exclude name="Generic.Functions.FunctionCallArgumentSpacing.TooMuchSpaceAfterComma" />
+		<exclude name="WordPress.WhiteSpace.OperatorSpacing.SpacingBefore" />
+		<exclude name="WordPress.Arrays.ArrayDeclarationSpacing.SpaceBeforeArrayCloser" />
+		<exclude name="PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket" />
+		<exclude name="PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket" />
+		<exclude name="Squiz.Strings.ConcatenationSpacing.PaddingFound" />
+
+		<!-- There are cases where having multiple items on a single line is appropriate. -->
+		<exclude name="WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine" />
+		<exclude name="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket" />
+		<exclude name="PEAR.Functions.FunctionCallSignature.CloseBracketLine" />
+
+		<!-- Short array syntax is already used throughout the codebase. -->
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
+		<exclude name="Universal.Arrays.DisallowShortArraySyntax"/>
+
+		<!-- The <?php and ?> tags can be on a line with content in templates. -->
+		<exclude name="Squiz.PHP.EmbeddedPhp.ContentBeforeOpen" />
+		<exclude name="Squiz.PHP.EmbeddedPhp.ContentAfterEnd" />
+
+		<!-- trigger_error() is used for logging in production. -->
+		<exclude name="WordPress.PHP.DevelopmentFunctions.error_log_trigger_error" />
+
+		<!-- print_r() is acceptable in CLI and debugging contexts. -->
+		<exclude name="WordPress.PHP.DevelopmentFunctions.error_log_print_r" />
+
+		<!-- Warn about mis-aligned array items, but don't automatically "fix" them. -->
+		<exclude phpcbf-only="true" name="PEAR.Functions.FunctionCallSignature" />
+	</rule>
+
+	<rule ref="WordPress-Docs">
+		<!-- Descriptive names make explicit comments unnecessary in many cases. -->
+		<exclude name="Squiz.Commenting.FunctionComment.MissingParamComment" />
+		<exclude name="Squiz.Commenting.FileComment.Missing" />
+		<exclude name="Squiz.Commenting.ClassComment.Missing" />
+		<exclude name="Squiz.Commenting.FunctionComment.MissingParamTag" />
+		<exclude name="Generic.Commenting.DocComment.MissingShort" />
+		<exclude name="Squiz.Commenting.VariableComment.Missing" />
+		<exclude name="Squiz.Commenting.VariableComment.MissingVar" />
+
+		<!-- Package tags add clutter without value. -->
+		<exclude name="Squiz.Commenting.FileComment.MissingPackageTag" />
+
+		<!-- We only use basic exceptions. -->
+		<exclude name="Squiz.Commenting.FunctionComment.EmptyThrows" />
+
+		<!-- Whitespace makes things more readable. -->
+		<exclude name="Squiz.Commenting.FileComment.SpacingAfterOpen" />
+
+		<!-- Valid in some cases like closing tags from another file. -->
+		<exclude name="Squiz.Commenting.InlineComment.SpacingAfter" />
+
+		<!-- Not wrong for WordPress plugin file headers. -->
+		<exclude name="Squiz.Commenting.FileComment.WrongStyle" />
+
+		<!-- Class comments are often omitted, causing PHPCS to confuse plugin headers for class comments. -->
+		<exclude name="Squiz.Commenting.ClassComment.WrongStyle" />
+		<exclude name="Squiz.Commenting.ClassComment.SpacingAfter" />
+
+		<!-- WordPress translators comments require no space after //. -->
+		<exclude name="Squiz.Commenting.InlineComment.NoSpaceBefore" />
+	</rule>
+
+	<rule ref="WordPress-Extra">
+		<!-- Allow use statements right after namespace. -->
+		<exclude name="PSR2.Namespaces.NamespaceDeclaration.BlankLineAfter" />
+
+		<!-- Allow short ternary operator (?:). -->
+		<exclude name="Universal.Operators.DisallowShortTernary" />
+
+		<!-- Nonce verification is often handled at a higher level. -->
+		<exclude name="WordPress.Security.NonceVerification.Missing" />
+		<exclude name="WordPress.Security.NonceVerification.Recommended" />
+	</rule>
+</ruleset>


### PR DESCRIPTION
## Summary
- Adds `phpcs.xml.dist` with WordPress-Core, WordPress-Docs, and WordPress-Extra rules (modeled after WordCamp.org), including PHPCompatibility checks for PHP 8.4+
- Adds GitHub Actions workflow that uses `phpcs-changed` to only flag **new violations** on changed lines, avoiding noise from pre-existing issues
- Adds root `composer.json` with dev dependencies for local linting (`composer lint`, `composer phpcs-changed`)
- Adds `vendor/` to `.gitignore`

This replaces the approach in #572 with one consistent with how WordCamp.org handles PHPCS — using `phpcs-changed` to incrementally enforce standards without blocking PRs on pre-existing violations.

Fixes #571.

## Test plan
- [ ] Verify the workflow runs on PRs that modify PHP files
- [ ] Verify only new/changed lines are flagged, not pre-existing violations
- [ ] Verify `composer install && composer lint` works locally
- [ ] Verify `composer phpcs-changed` works locally against trunk

🤖 Generated with [Claude Code](https://claude.com/claude-code)