### PR TITLE
Environments: add local dev environment for jobs.wordpress.net

### DIFF
--- a/environments/README.md
+++ b/environments/README.md
@@ -47,6 +47,24 @@ npm run plugins:refresh
 npx wp-env run cli wp <command>
 ```
 
+### Jobs
+
+A local instance of jobs.wordpress.net with the JobsWP plugin, theme, sample job categories, and sample job posts.
+
+**Start:**
+
+```bash
+npm run jobs:env start
+```
+
+**Access:** `http://localhost:8888`
+
+**WP CLI:**
+
+```bash
+npm run jobs:env -- run cli -- wp <command>
+```
+
 ### Handbook (in-plugin)
 
 The Handbook plugin has its own `.wp-env.json` in `wordpress.org/public_html/wp-content/plugins/handbook/`.
@@ -67,14 +85,17 @@ npx wp-env run phpunit phpunit -c /var/www/html/wp-content/plugins/handbook/phpu
 ## Common Commands
 
 ```bash
-# Stop the environment
+# Stop an environment (replace plugins with jobs, etc.)
 npm run plugins:env stop
+npm run jobs:env stop
 
-# Destroy the environment (removes all data)
+# Destroy an environment (removes all data)
 npm run plugins:env destroy
+npm run jobs:env destroy
 
 # View logs
 npm run plugins:env logs
+npm run jobs:env logs
 ```
 
 All commands should be run from the `environments/` directory unless otherwise noted.

--- a/environments/jobs/.wp-env.json
+++ b/environments/jobs/.wp-env.json
@@ -1,0 +1,20 @@
+{
+	"core": "WordPress/WordPress#master",
+	"phpVersion": "8.4",
+	"testsEnvironment": false,
+	"plugins": [
+		"../jobs.wordpress.net/public_html/wp-content/plugins/jobswp"
+	],
+	"themes": [
+		"../jobs.wordpress.net/public_html/wp-content/themes/jobswp"
+	],
+	"mappings": {
+		"wp-content/mu-plugins/wporg-dev-login.php": "./mocks/wporg-dev-login.php"
+	},
+	"lifecycleScripts": {
+		"afterStart": "bash jobs/bin/after-start.sh"
+	},
+	"config": {
+		"WP_DEBUG": true
+	}
+}

--- a/environments/jobs/bin/after-start.sh
+++ b/environments/jobs/bin/after-start.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+#
+# Runs after wp-env start. Sets up permalinks, creates pages, job categories, and sample jobs.
+#
+
+CONFIG="--config jobs/.wp-env.json"
+WP="npx wp-env $CONFIG run cli --"
+
+# Set site title and description to match the public site.
+$WP wp option update blogname 'WordPress Jobs'
+$WP wp option update blogdescription 'WordPress related Job Postings'
+
+# Set up permalinks.
+$WP wp rewrite structure '/%postname%/' --hard
+
+# Activate the jobswp theme.
+$WP wp theme activate jobswp
+
+# Create pages that exist on jobs.wordpress.net (if they don't already exist).
+echo "Creating pages..."
+$WP wp post create --post_type=page --post_status=publish --post_title='Post a Job' --post_name='post-a-job' --porcelain > /dev/null 2>&1 && echo "  Created page: /post-a-job/" || true
+$WP wp post create --post_type=page --post_status=publish --post_title='Remove a Job' --post_name='remove-a-job' --porcelain > /dev/null 2>&1 && echo "  Created page: /remove-a-job/" || true
+
+# Create job categories.
+echo "Creating job categories..."
+declare -A CATEGORIES=(
+	[contributor]="Contributor"
+	[design]="Design"
+	[development]="Development"
+	[general]="General"
+	[migration]="Migration"
+	[performance]="Performance"
+	[plugin-development]="Plugin Development"
+	[support]="Support"
+	[theme-customization]="Theme Customization"
+	[translation]="Translation"
+	[writing]="Writing"
+)
+for SLUG in "${!CATEGORIES[@]}"; do
+	NAME="${CATEGORIES[$SLUG]}"
+	$WP wp term create job_category "$NAME" --slug="$SLUG" > /dev/null 2>&1 && echo "  Created category: $NAME ($SLUG)" || true
+done
+
+# Create sample job posts so the homepage is not empty (skip if already seeded).
+EXISTING=$($WP wp post list --post_type=job --posts_per_page=1 --format=count 2>/dev/null)
+if [ "$EXISTING" -gt 0 ] 2>/dev/null; then
+	echo "Sample jobs already exist, skipping..."
+else
+	echo "Creating sample jobs..."
+
+	# Note: --tax_input for wp post create is supported in entity-command v2.8.6+,
+	# but the wp-env bundled WP-CLI may not include it yet. Terms are assigned
+	# separately via wp post term set for compatibility.
+	JOB1=$($WP wp post create --post_type=job --post_status=publish \
+		--post_title='Senior WordPress Developer' \
+		--post_content='We are looking for an experienced WordPress developer to join our team. You will be responsible for building custom plugins and themes.' \
+		'--meta_input={"jobtype":"ft","location":"Remote","company":"Starter Corp"}' \
+		--porcelain 2>/dev/null) && echo "  Created job: Senior WordPress Developer" || true
+	[ -n "$JOB1" ] && $WP wp post term set "$JOB1" job_category development > /dev/null 2>&1
+
+	JOB2=$($WP wp post create --post_type=job --post_status=publish \
+		--post_title='WordPress Theme Designer' \
+		--post_content='Seeking a creative designer with WordPress theme development experience. Must have strong CSS and design skills.' \
+		'--meta_input={"jobtype":"ppt","location":"New York, NY","company":"Design Studio"}' \
+		--porcelain 2>/dev/null) && echo "  Created job: WordPress Theme Designer" || true
+	[ -n "$JOB2" ] && $WP wp post term set "$JOB2" job_category design > /dev/null 2>&1
+
+	JOB3=$($WP wp post create --post_type=job --post_status=publish \
+		--post_title='Plugin Support Specialist' \
+		--post_content='Help our users get the most out of our WordPress plugins. Provide technical support and write documentation.' \
+		'--meta_input={"jobtype":"pt","location":"Remote","company":"Plugin Inc"}' \
+		--porcelain 2>/dev/null) && echo "  Created job: Plugin Support Specialist" || true
+	[ -n "$JOB3" ] && $WP wp post term set "$JOB3" job_category support > /dev/null 2>&1
+fi
+
+echo "Jobs environment ready!"

--- a/environments/package.json
+++ b/environments/package.json
@@ -8,7 +8,8 @@
 	"scripts": {
 		"plugins:env": "wp-env --config plugin-directory/.wp-env.json",
 		"plugins:import": "npm run plugins:env -- run cli -- php wp-content/plugins/plugin-directory/bin/import-plugin.php --create --plugin",
-		"plugins:refresh": "npm run plugins:env -- run cli -- wp option delete wporg_env_imported && npm run plugins:env -- run cli wp eval-file wp-content/env-bin/import-plugins.php"
+		"plugins:refresh": "npm run plugins:env -- run cli -- wp option delete wporg_env_imported && npm run plugins:env -- run cli wp eval-file wp-content/env-bin/import-plugins.php",
+		"jobs:env": "wp-env --config jobs/.wp-env.json"
 	},
 	"devDependencies": {
 		"@wordpress/env": "^11"


### PR DESCRIPTION
## Summary

- Adds a `wp-env` configuration for the jobs.wordpress.net site in `environments/jobs/`
- Includes the `jobswp` plugin and theme, with a dev-login mock for easy local authentication
- Seeds 11 job categories matching the live site (Contributor, Design, Development, General, Migration, Performance, Plugin Development, Support, Theme Customization, Translation, Writing)
- Creates 3 sample job posts with meta fields (job type, location, company) and taxonomy assignments
- Adds `jobs:env` npm script and updates README with usage docs
- Idempotent: repeated `wp-env start` calls skip job creation if posts already exist

## Test plan

- [ ] Run `cd environments && npm run jobs:env start`
- [ ] Visit `http://localhost:8888` and verify job categories and sample jobs display with correct type/location
- [ ] Visit `http://localhost:8888/post-a-job/` and verify the job submission form renders
- [ ] Visit `http://localhost:8888/wp-login.php` and verify the dev login button works
- [ ] Run `npm run jobs:env stop` to verify clean shutdown

Generated with [Claude Code](https://claude.com/claude-code)