### PR TITLE
Plugin Directory: Validate the required parameter for the bulk stats update endpoint

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/api/routes/class-internal-stats.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/api/routes/class-internal-stats.php
@@ -23,6 +23,21 @@ class Internal_Stats extends Base {
 			'methods'             => \WP_REST_Server::CREATABLE,
 			'callback'            => array( $this, 'bulk_update_stats' ),
 			'permission_callback' => array( $this, 'permission_check_internal_api_bearer' ),
+			'args' => array(
+				'plugins' => array(
+					'required'             => true,
+					'type'                 => 'object',
+					'additionalProperties' => array(
+						'type'       => 'object',
+						'properties' => array(
+							'active_installs'          => array( 'type' => 'integer' ),
+							'usage'                    => array( 'type' => 'object' ),
+							'support_threads'          => array( 'type' => 'integer' ),
+							'support_threads_resolved' => array( 'type' => 'integer' ),
+						),
+					),
+				),
+			),
 		) );
 	}
 


### PR DESCRIPTION
## Summary
- The `/plugins/v1/update-stats` endpoint didn't define any argument requirements, so requests missing the `plugins` parameter would reach the callback and trigger a PHP warning when iterating over a null value.
- Adds a schema definition that validates the shape and types of the incoming data at the REST API layer, rejecting invalid requests before the callback runs.

## Test plan
- [ ] Confirm valid requests with a `plugins` object still work as expected
- [ ] Confirm requests missing `plugins` return a REST API validation error instead of triggering a PHP warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)