### PR TITLE
PHPCS: Allowlist custom capabilities instead of disabling the sniff

### DIFF
--- a/buddypress.org/public_html/wp-content/plugins/buddypress-org/buddypress-dot-org.php
+++ b/buddypress.org/public_html/wp-content/plugins/buddypress-org/buddypress-dot-org.php
@@ -52,8 +52,9 @@ add_action( 'bbp_admin_loaded', 'bporg_remove_dashboard_widget' );
  * @return if user is an admin
  */
 function bporg_admin_redirect() {
-	if ( is_super_admin() || current_user_can( 'edit_posts' ) )
+	if ( is_super_admin() || current_user_can( 'edit_posts' ) ) {
 		return;
+	}
 
 	// Allow registered unprivileged admin-ajax.php requests for
 	// profiles.wordpress.org to pass through.

--- a/buddypress.org/public_html/wp-content/plugins/buddypress-org/buddypress-dot-org.php
+++ b/buddypress.org/public_html/wp-content/plugins/buddypress-org/buddypress-dot-org.php
@@ -52,12 +52,7 @@ add_action( 'bbp_admin_loaded', 'bporg_remove_dashboard_widget' );
  * @return if user is an admin
  */
 function bporg_admin_redirect() {
-	if (       is_super_admin()
-			|| current_user_can( 'contributor'   )
-			|| current_user_can( 'author'        )
-			|| current_user_can( 'editor'        )
-			|| current_user_can( 'administrator' )
-		)
+	if ( is_super_admin() || current_user_can( 'edit_posts' ) )
 		return;
 
 	// Allow registered unprivileged admin-ajax.php requests for

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -44,9 +44,85 @@
 
 		<!-- Short array syntax is already used throughout the codebase. -->
 		<exclude name="Universal.Arrays.DisallowShortArraySyntax" />
+	</rule>
 
-		<!-- Custom capabilities are valid in the WordPress.org environment; an allowlist is proposed in PR #583. -->
-		<exclude name="WordPress.WP.Capabilities.Unknown" />
+	<!-- Custom capabilities used across the WordPress.org environment. -->
+	<rule ref="WordPress.WP.Capabilities">
+		<properties>
+			<property name="custom_capabilities" type="array">
+				<!-- Plugin Directory -->
+				<element value="plugin_add_committer"/>
+				<element value="plugin_add_support_rep"/>
+				<element value="plugin_admin_edit"/>
+				<element value="plugin_admin_view"/>
+				<element value="plugin_approve"/>
+				<element value="plugin_close"/>
+				<element value="plugin_dashboard_access"/>
+				<element value="plugin_disable"/>
+				<element value="plugin_edit"/>
+				<element value="plugin_edit_others"/>
+				<element value="plugin_edit_pending"/>
+				<element value="plugin_manage_releases"/>
+				<element value="plugin_reject"/>
+				<element value="plugin_remove_committer"/>
+				<element value="plugin_remove_support_rep"/>
+				<element value="plugin_review"/>
+				<element value="plugin_self_close"/>
+				<element value="plugin_self_transfer"/>
+				<element value="plugin_set_category"/>
+				<element value="plugin_set_section"/>
+				<element value="plugin_toggle_public_preview"/>
+				<!-- Theme Directory -->
+				<element value="suspend_themes"/>
+				<element value="reinstate_themes"/>
+				<element value="theme_configure_categorization_options"/>
+				<!-- PHPUnit Test Reporter -->
+				<element value="edit_results"/>
+				<element value="publish_results"/>
+				<element value="edit_others_results"/>
+				<element value="read_private_results"/>
+				<!-- Translation Events -->
+				<element value="manage_translation_events"/>
+				<element value="create_translation_event"/>
+				<element value="view_translation_event"/>
+				<element value="edit_translation_event"/>
+				<element value="trash_translation_event"/>
+				<element value="delete_translation_event"/>
+				<element value="edit_translation_event_attendees"/>
+				<element value="edit_translation_event_title"/>
+				<element value="edit_translation_event_description"/>
+				<element value="edit_translation_event_start"/>
+				<element value="edit_translation_event_end"/>
+				<element value="edit_translation_event_timezone"/>
+				<element value="edit_translation_event_attendance_mode"/>
+				<!-- Support Forums -->
+				<element value="keep_gate"/>
+				<element value="moderate"/>
+				<element value="throttle"/>
+				<element value="participate"/>
+				<element value="spectate"/>
+				<element value="assign_topic_tags"/>
+				<!-- Photo Directory -->
+				<element value="edit_photos"/>
+				<element value="delete_photos"/>
+				<element value="delete_others_photos"/>
+				<element value="publish_photos"/>
+				<element value="edit_others_photos"/>
+				<element value="edit_published_photos"/>
+				<element value="delete_published_photos"/>
+				<element value="delete_private_photos"/>
+				<element value="edit_private_photos"/>
+				<element value="read_private_photos"/>
+				<element value="manage_photo_tags"/>
+				<!-- Learn -->
+				<element value="manage_workshop_internal_notes"/>
+				<element value="edit_courses"/>
+				<element value="edit_lessons"/>
+				<element value="edit_any_learn_content"/>
+				<!-- HelpHub -->
+				<element value="manage_helphub"/>
+			</property>
+		</properties>
 	</rule>
 
 	<!-- PHPUnit requires test files to be named after the test class they contain. -->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -47,6 +47,7 @@
 	</rule>
 
 	<!-- Custom capabilities used across the WordPress.org environment. -->
+	<!-- Please note: Using custom capabilities is allowed, just document them here please! -->
 	<rule ref="WordPress.WP.Capabilities">
 		<properties>
 			<property name="custom_capabilities" type="array">

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -73,6 +73,8 @@
 				<element value="plugin_set_section"/>
 				<element value="plugin_toggle_public_preview"/>
 				<!-- Theme Directory -->
+				<element value="suspend_theme"/>
+				<element value="reinstate_theme"/>
 				<element value="suspend_themes"/>
 				<element value="reinstate_themes"/>
 				<element value="theme_configure_categorization_options"/>
@@ -96,6 +98,10 @@
 				<element value="edit_translation_event_timezone"/>
 				<element value="edit_translation_event_attendance_mode"/>
 				<!-- Support Forums -->
+				<element value="bbp_forums_admin"/>
+				<element value="edit_topic"/>
+				<element value="edit_reply"/>
+				<element value="read_topic"/>
 				<element value="keep_gate"/>
 				<element value="moderate"/>
 				<element value="throttle"/>

--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/moderation.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/moderation.php
@@ -291,7 +291,7 @@ class Moderation {
 		}
 
 		// Bail if user isn't a moderator.
-		if ( ! user_can( $user->ID, 'photos_moderator' ) ) {
+		if ( ! user_can( $user->ID, 'edit_photos' ) ) {
 			return $caps;
 		}
 

--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/moderation.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/moderation.php
@@ -291,7 +291,7 @@ class Moderation {
 		}
 
 		// Bail if user isn't a moderator.
-		if ( ! user_can( $user->ID, 'edit_photos' ) ) {
+		if ( empty( $caps['edit_photos'] ) ) {
 			return $caps;
 		}
 

--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/moderation.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/moderation.php
@@ -291,7 +291,7 @@ class Moderation {
 		}
 
 		// Bail if user isn't a moderator.
-		if ( empty( $caps['edit_photos'] ) ) {
+		if ( ! user_can( $user->ID, 'edit_photos' ) ) {
 			return $caps;
 		}
 

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/class-customizations.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/class-customizations.php
@@ -826,7 +826,7 @@ class Customizations {
 		if ( 'internal-note' === $comment->comment_type && isset( $_REQUEST['mode'] ) && 'single' === $_REQUEST['mode'] ) {
 			$allowed_actions = array( 'reply' => true );
 
-			if ( current_user_can( 'manage_comments' ) ) {
+			if ( current_user_can( 'moderate_comments' ) ) {
 				$allowed_actions['trash']     = true;
 				$allowed_actions['untrash']   = true;
 				$allowed_actions['quickedit'] = true;

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/tools/class-elasticsearch-status.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/tools/class-elasticsearch-status.php
@@ -27,14 +27,14 @@ class Elasticsearch_Status {
 			'plugin-tools',
 			'ES Index Status',
 			'ES Index Status',
-			'plugin_admin',
+			'plugin_approve',
 			'es-index-status',
 			array( $this, 'render' )
 		);
 	}
 
 	public function render() {
-		if ( ! current_user_can( 'plugin_admin' ) ) {
+		if ( ! current_user_can( 'plugin_approve' ) ) {
 			return;
 		}
 
@@ -249,7 +249,7 @@ class Elasticsearch_Status {
 	public function ajax_check_batch() {
 		check_ajax_referer( 'es-index-check-batch' );
 
-		if ( ! current_user_can( 'plugin_admin' ) ) {
+		if ( ! current_user_can( 'plugin_approve' ) ) {
 			wp_send_json_error( 'Permission denied.' );
 		}
 
@@ -294,7 +294,7 @@ class Elasticsearch_Status {
 	public function ajax_reindex() {
 		check_ajax_referer( 'es-index-check-batch' );
 
-		if ( ! current_user_can( 'plugin_admin' ) ) {
+		if ( ! current_user_can( 'plugin_approve' ) ) {
 			wp_send_json_error( 'Permission denied.' );
 		}
 


### PR DESCRIPTION
## Summary
- Replace the blanket `<severity>0</severity>` override on `WordPress.WP.Capabilities.Unknown` with an explicit allowlist of all custom capabilities used across the codebase, grouped by plugin.
- Fix four capability bugs surfaced by enabling the sniff:
  - **Plugin Directory:** ES Status tool used the role name `plugin_admin` instead of a capability — replaced with `plugin_approve`.
  - **Plugin Directory:** Comment row actions checked `manage_comments`, which is not a WordPress capability — replaced with `moderate_comments`.
  - **Photo Directory:** Moderation used the role name `photos_moderator` instead of a capability — replaced with `edit_photos`.
  - **BuddyPress:** Admin redirect checked four role names (`contributor`, `author`, `editor`, `administrator`) instead of capabilities — replaced with a single `edit_posts` check.

## Test plan
- [ ] Run `composer install && vendor/bin/phpcs --sniffs=WordPress.WP.Capabilities .` and confirm no warnings or errors
- [ ] Verify the Plugin Directory ES Index Status tool is still accessible to plugin admins
- [ ] Verify Plugin Directory internal note comment actions still work for reviewers
- [ ] Verify Photo Directory moderation capabilities still work for photo moderators
- [ ] Verify BuddyPress admin redirect still allows contributors and above into wp-admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)