### PR TITLE
Bad Requests: Fix Pattern Directory URI check to match request path correctly

### DIFF
--- a/wordpress.org/public_html/wp-content/mu-plugins/pub/wporg-bad-request.php
+++ b/wordpress.org/public_html/wp-content/mu-plugins/pub/wporg-bad-request.php
@@ -209,7 +209,7 @@ add_action( 'send_headers', function() {
  * warnings downstream when the value is used in esc_attr().
  */
 add_action( 'send_headers', function() {
-	if ( ! str_contains( $_SERVER['REQUEST_URI'], 'wordpress.org/patterns/' ) ) {
+	if ( ! str_starts_with( $_SERVER['REQUEST_URI'], '/patterns/' ) ) {
 		return;
 	}
 


### PR DESCRIPTION
## Summary
- Replace `str_contains( $_SERVER['REQUEST_URI'], 'wordpress.org/patterns/' )` with `str_starts_with( $_SERVER['REQUEST_URI'], '/patterns/' )` for a more precise URI match
- `REQUEST_URI` is a path (e.g. `/patterns/...`), not a full URL, so matching against `wordpress.org/patterns/` was relying on a substring that wouldn't actually appear in the value

## Test plan
- [ ] Verify Pattern Directory pages at `/patterns/` still have non-scalar query parameters blocked
- [ ] Verify unrelated pages are not affected by the check

🤖 Generated with [Claude Code](https://claude.com/claude-code)