### PR TITLE
Fix comment anchor scroll offset and allow ins/del in readmes

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/readme/class-parser.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/readme/class-parser.php
@@ -659,6 +659,8 @@ class Parser {
 			),
 			'dd'         => array(),
 			'li'         => array(),
+			'ins'        => array(),
+			'del'        => array(),
 			'h3'         => array(),
 			'h4'         => array(),
 		);

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/style.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/style.css
@@ -1164,6 +1164,7 @@ nav.o2-post-actions button {
 
 .o2-post-comments .o2-comment {
 	padding: var(--wp--preset--spacing--10) 0;
+	scroll-margin-top: 50px;
 }
 
 .o2-post-comments .o2-comment .o2-comment-header {


### PR DESCRIPTION
## Summary
- **#413**: Adds `scroll-margin-top: 50px` to `.o2-comment` in the Breathe 2024 theme so clicking a comment anchor link no longer causes the sticky header to obscure the username. Matches the existing `scroll-margin-top` already applied to `.toc-heading`.
- **#286**: Adds `<ins>` and `<del>` to the `$allowed` tags array in `class-parser.php`'s `filter_text()` method. The Markdown parser already recognizes these tags (line 264), but `wp_kses()` was stripping them because they weren't in the allowed list.

Fixes #413, fixes #286.

## Test plan
- [ ] Click a comment anchor link on a Make blog post — the username should be fully visible below the sticky header
- [ ] Add `<ins>text</ins>` and `<del>text</del>` to a plugin readme — they should render as inserted/deleted text instead of being stripped

🤖 Generated with [Claude Code](https://claude.com/claude-code)