### PR TITLE
Breathe 2024: Add scroll-margin-top to comments for sticky header offset

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/style.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/style.css
@@ -1164,7 +1164,7 @@ nav.o2-post-actions button {
 
 .o2-post-comments .o2-comment {
 	padding: var(--wp--preset--spacing--10) 0;
-	scroll-margin-top: 50px;
+	scroll-margin-top: var(--wp--custom--local-navigation-bar--spacing--height, 50px);
 }
 
 .o2-post-comments .o2-comment .o2-comment-header {

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/style.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/style.css
@@ -1164,6 +1164,7 @@ nav.o2-post-actions button {
 
 .o2-post-comments .o2-comment {
 	padding: var(--wp--preset--spacing--10) 0;
+	scroll-margin-top: 50px;
 }
 
 .o2-post-comments .o2-comment .o2-comment-header {


### PR DESCRIPTION
## Summary
Adds `scroll-margin-top: 50px` to `.o2-comment` so clicking a comment anchor link no longer causes the sticky header to obscure the username on Make blogs. Matches the existing `scroll-margin-top` already applied to `.toc-heading`.

Fixes #413.

## Test plan
- [ ] Click a comment anchor link on a Make blog post (e.g. the right sidebar comment links) — the username should be fully visible below the sticky header

🤖 Generated with [Claude Code](https://claude.com/claude-code)