### PR TITLE
Plugin Directory: Allow ins and del tags in plugin readmes

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/readme/class-parser.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/readme/class-parser.php
@@ -659,6 +659,8 @@ class Parser {
 			),
 			'dd'         => array(),
 			'li'         => array(),
+			'ins'        => array(),
+			'del'        => array(),
 			'h3'         => array(),
 			'h4'         => array(),
 		);


### PR DESCRIPTION
## Summary
Adds `<ins>` and `<del>` to the `$allowed` tags array in `class-parser.php`'s `filter_text()` method. The Markdown library already recognizes these as block-level tags (line 264), but `wp_kses()` was stripping them because they weren't in the allowed list.

Fixes #286.

## Test plan
- [ ] Add `<ins>text</ins>` and `<del>text</del>` to a plugin readme — they should render as inserted/deleted text instead of being stripped

🤖 Generated with [Claude Code](https://claude.com/claude-code)