### PR TITLE
Decodes plugin titles in email subjects and bodies

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-base.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-base.php
@@ -163,6 +163,13 @@ https://make.wordpress.org/plugins', 'wporg-plugins' );
 	}
 
 	/**
+	 * Return the plugin's title with HTML entities decoded for plain-text use (e.g., email subjects).
+	 */
+	protected function plugin_title() {
+		return html_entity_decode( $this->plugin->post_title, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+	}
+
+	/**
 	 * A simple way to convert a WP_User object to a displayable username.
 	 * This shouldn't be needed, but unfortunately often is on WordPress.org.
 	 */

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-committer-added.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-committer-added.php
@@ -22,7 +22,7 @@ class Committer_Added extends Base {
 		return sprintf(
 			/* translators: 1: Plugin Name */
 			__( 'New committer added to %s', 'wporg-plugins' ),
-			$this->plugin->post_title
+			$this->plugin_title()
 		);
 	}
 
@@ -52,7 +52,7 @@ If you believe this to be in error, please contact %7$s.', 'wporg-plugins' );
 			$email_text,
 			$this->user_text( $this->user ),
 			$this->user_text( $this->args['committer'] ),
-			$this->plugin->post_title,
+			$this->plugin_title(),
 			$this->user_text( $this->who ),
 			$committer_list,
 			$advanced_url,

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-generic-to-committers.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-generic-to-committers.php
@@ -48,7 +48,7 @@ class Generic_To_Committers extends Base {
 
 	private function replace_placeholders( $text ) {
 		$items = [
-			'###PLUGIN###'            => $this->plugin->post_title,
+			'###PLUGIN###'            => $this->plugin_title(),
 			'###URL###'               => get_permalink( $this->plugin ),
 			'###SLUG###'              => $this->plugin->post_name,
 			'###USER###'              => $this->user_text( $this->user ),

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-plugin-approved.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-plugin-approved.php
@@ -10,7 +10,7 @@ class Plugin_Approved extends Markdown_Base {
 		return sprintf(
 			/* translators: 1: Plugin Name */
 			__( '%s has been approved!', 'wporg-plugins' ),
-			$this->plugin->post_title
+			$this->plugin_title()
 		);
 	}
 
@@ -66,7 +66,7 @@ Enjoy!', 'wporg-plugins' );
 
 		return sprintf(
 			$email_text,
-			$this->plugin->post_title,
+			$this->plugin_title(),
 			$this->user->user_login,
 			$this->plugin->post_name,
 			"https://profiles.wordpress.org/{$this->user->user_nicename}/profile/edit/group/3/?screen=svn-password"

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-plugin-rejected.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-plugin-rejected.php
@@ -12,7 +12,7 @@ class Plugin_Rejected extends Markdown_Base {
 		return sprintf(
 			/* translators: 1: Plugin Name */
 			__( '%s has been rejected', 'wporg-plugins' ),
-			$this->plugin->post_title
+			$this->plugin_title()
 		);
 	}
 
@@ -20,7 +20,7 @@ class Plugin_Rejected extends Markdown_Base {
 		$placeholders = [
 			// Should be first, to allow placeholders in the rejection reasons too.
 			'###REASON###'          => $this->get_rejection_reason(),
-			'###NAME###'            => $this->plugin->post_title,
+			'###NAME###'            => $this->plugin_title(),
 			'###SLUG###'            => ( $this->args['slug'] ?? '' ) ?: $this->plugin->post_name,
 			'###SUBMISSION_DATE###' => $this->args['submission_date'],
 		];

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-plugin-submission.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-plugin-submission.php
@@ -9,7 +9,7 @@ class Plugin_Submission extends Markdown_Base {
 		return sprintf(
 			/* translators: 1: Plugin Name */
 			__( 'Successful Plugin Submission - %s', 'wporg-plugins' ),
-			$this->plugin->post_title
+			$this->plugin_title()
 		);
 	}
 
@@ -19,7 +19,7 @@ class Plugin_Submission extends Markdown_Base {
 	public function markdown() {
 
 		$placeholders = [
-			'###NAME###' => $this->plugin->post_title,
+			'###NAME###' => $this->plugin_title(),
 			'###SLUG###' => $this->plugin->post_name,
 		];
 

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-plugin-transferred.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-plugin-transferred.php
@@ -10,7 +10,7 @@ class Plugin_Transferred extends Base {
 		return sprintf(
 			/* translators: 1: Plugin Name */
 			__( '%s has been transferred', 'wporg-plugins' ),
-			$this->plugin->post_title
+			$this->plugin_title()
 		);
 	}
 
@@ -24,7 +24,7 @@ If you believe this to be in error, please contact %5$s immediately.', 'wporg-pl
 			$email_text,
 			$this->user_text( wp_get_current_user() ),
 			gmdate( 'Y-m-d H:i:s \G\M\T' ),
-			$this->plugin->post_title,
+			$this->plugin_title(),
 			$this->user_text( $this->args['owner'] ) . ' (' . $this->args['owner']->user_login . ')',
 			PLUGIN_TEAM_EMAIL
 		);

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-release-confirmation-enabled.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-release-confirmation-enabled.php
@@ -10,7 +10,7 @@ class Release_Confirmation_Enabled extends Base {
 		return sprintf(
 			/* translators: 1: Plugin Name */
 			__( 'Release confirmation now required for %s', 'wporg-plugins' ),
-			$this->plugin->post_title
+			$this->plugin_title()
 		);
 	}
 
@@ -31,7 +31,7 @@ For more information, please read the following handbook article:
 %6$s', 'wporg-plugins' ),
 			$this->user_text( $this->user ),
 			$this->user_text( $this->who ),
-			$this->plugin->post_title,
+			$this->plugin_title(),
 			get_permalink( $this->plugin ),
 			$this->plugin->post_name,
 			'https://developer.wordpress.org/plugins/wordpress-org/release-confirmation-emails/'

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-release-confirmation.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-release-confirmation.php
@@ -15,7 +15,7 @@ class Release_Confirmation extends Base {
 		return sprintf(
 			/* translators: 1: Plugin Name */
 			__( 'Pending release for %s', 'wporg-plugins' ),
-			$this->plugin->post_title
+			$this->plugin_title()
 		);
 	}
 

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-support-rep-added.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-support-rep-added.php
@@ -10,7 +10,7 @@ class Support_Rep_Added extends Base {
 		return sprintf(
 			/* translators: 1: Plugin Name */
 			__( 'New support rep added to %s', 'wporg-plugins' ),
-			$this->plugin->post_title
+			$this->plugin_title()
 		);
 	}
 
@@ -40,7 +40,7 @@ If you believe this to be in error, please contact %7$s.', 'wporg-plugins' );
 			$email_text,
 			$this->user_text( $this->user ),
 			$this->user_text( $this->args['rep'] ),
-			$this->plugin->post_title,
+			$this->plugin_title(),
 			$this->user_text( $this->who ),
 			$rep_list,
 			$advanced_url,


### PR DESCRIPTION
Introduces a helper method to ensure plugin titles are HTML entity decoded when used in email plain-text contexts. This prevents titles containing HTML entities from displaying incorrectly.

Updates all relevant email classes to utilize this new method for consistent output.

Trac Ticket : https://meta.trac.wordpress.org/ticket/8231