### PR TITLE
Jobs theme: Sort jobs on the front page in reverse chronological order

### DIFF
--- a/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-home.php
+++ b/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-home.php
@@ -35,6 +35,14 @@ if ( $job_categories ) {
 	}
 }
 
+// Sort all jobs in reverse chronological order by date posted, making it easier to scan for newly posted jobs.
+usort(
+	$all_jobs,
+	static function ( $a, $b ) {
+		return array( $b->post_date, $b->ID ) <=> array( $a->post_date, $a->ID );
+	}
+);
+
 $remote_pct = $total_jobs > 0 ? round( ( $remote_count / $total_jobs ) * 100 ) : 0;
 ?>
 


### PR DESCRIPTION
Under the new theme, all of the jobs shown on the front page are listed in a single grid all together. However, their ordering is likely a bit of a vestige of the previous theme since they both first sort alphabetically by job category, and then within each category the jobs are listed reverse-chronologically. This made more sense in the previous theme since jobs were presented within their respective job categories.

There have multiple reports (at least via the site's contact form) that have pointed out that such an ordering for a singular listing of jobs makes it difficult to scan and identify potentially new jobs.

The front page list of jobs should just be shown in reverse chronological order by date posted. This is a more sensible and expected ordering.
