### PR TITLE
Add accordion panel styles to jobs FAQ page

### DIFF
--- a/jobs.wordpress.net/public_html/wp-content/themes/jobswp/style.css
+++ b/jobs.wordpress.net/public_html/wp-content/themes/jobswp/style.css
@@ -1314,6 +1314,33 @@ input[type="submit"].submit-job {
 	color: var(--color-deep-blueberry);
 }
 
+.page-faq .entry-content .wp-block-accordion-panel ul {
+	margin: var(--space-10) 0 0;
+	padding-left: var(--space-20);
+	list-style: disc;
+}
+
+.page-faq .entry-content .wp-block-accordion-panel ul ul {
+	margin-top: 4px;
+	list-style: circle;
+}
+
+.page-faq .entry-content .wp-block-accordion-panel li {
+	margin-bottom: 6px;
+	line-height: 1.6;
+}
+
+.page-faq .entry-content .wp-block-accordion-panel a {
+	color: var(--color-blueberry-1);
+	text-decoration: underline;
+	text-decoration-thickness: 1px;
+	text-underline-offset: 2px;
+}
+
+.page-faq .entry-content .wp-block-accordion-panel a:hover {
+	color: var(--color-deep-blueberry);
+}
+
 .page-faq .entry-content > p:first-child {
 	font-size: var(--font-size-base);
 	color: var(--color-charcoal-4);


### PR DESCRIPTION
## Summary

- Mirrors existing `dd` CSS rules for `.wp-block-accordion-panel` in the jobs FAQ page stylesheet
- Enables the FAQ at jobs.wordpress.net/faq/ to be converted from a definition list (`dl/dt/dd`) to accordion blocks while maintaining correct styling for lists and links

## Test plan

- [ ] After merging, update the FAQ page content at jobs.wordpress.net/wp-admin to use accordion blocks
- [ ] Verify list items render with proper markers and spacing
- [ ] Verify nested lists render correctly (disc → circle)
- [ ] Verify links display with correct color and underline styling
- [ ] Verify link hover state works correctly

Refs: https://github.com/WordPress/wordpress.org/issues/603