### PR TITLE
Support Forums: Guard get_blog_details() to avoid a fatal error

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-hooks.php
+++ b/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-hooks.php
@@ -144,7 +144,7 @@ class Hooks {
 		add_filter( 'pre_oembed_result', array( $this, 'pre_oembed_result_dont_embed_wordpress_org_anchors' ), 20, 2 );
 
 		// Break users sessions / passwords when they get blocked, on the main forums only.
-		if ( 'wordpress.org' === get_blog_details()->domain ) {
+		if ( function_exists( 'get_blog_details' ) && 'wordpress.org' === get_blog_details()->domain ) {
 			add_filter( 'bbp_set_user_role', array( $this, 'user_blocked_password_handler' ), 10, 3 );
 		}
 	}


### PR DESCRIPTION
Similar to https://github.com/WordPress/wporg-mu-plugins/pull/718

## Summary

When I tried to set up a local environment for a forum site, I noticed that wp-env was causing a critical error.

```bash
 npm run wp-env start -- --update                                                                            255 ✘  37s 

> wporg-parent-2021-project@1.0.0 wp-env
> wp-env start --update

✖ Error while running docker compose command.
WordPress is already installed.
Success: Updated the constant 'FS_METHOD' in the 'wp-config.php' file with the value 'direct'.
Success: Updated the constant 'WP_DEBUG' in the 'wp-config.php' file with the raw value 'true'.
Success: Updated the constant 'SCRIPT_DEBUG' in the 'wp-config.php' file with the raw value 'true'.
Success: Updated the constant 'WP_ENVIRONMENT_TYPE' in the 'wp-config.php' file with the value 'local'.
Success: Updated the constant 'WP_PHP_BINARY' in the 'wp-config.php' file with the value 'php'.
Success: Updated the constant 'WP_TESTS_EMAIL' in the 'wp-config.php' file with the value 'admin@example.org'.
Success: Updated the constant 'WP_TESTS_TITLE' in the 'wp-config.php' file with the value 'Test Blog'.
Success: Updated the constant 'WP_TESTS_DOMAIN' in the 'wp-config.php' file with the value 'localhost:8898'.
Success: Updated the constant 'WP_SITEURL' in the 'wp-config.php' file with the value 'http://localhost:8898'.
Success: Updated the constant 'WP_HOME' in the 'wp-config.php' file with the value 'http://localhost:8898'.
Success: Updated the constant 'WP_DEBUG_LOG' in the 'wp-config.php' file with the value '/tmp/wp-errors.log'.
Success: Updated the constant 'JETPACK_DEV_DEBUG' in the 'wp-config.php' file with the raw value 'true'.
Success: Updated the constant 'WPORG_SANDBOXED' in the 'wp-config.php' file with the raw value 'true'.
Success: Plugin already activated.
time="2026-04-26T20:22:14+09:00" level=warning msg="/home/t-hamano/wp-env/266e76f030e738a45eab992e07d8d247/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion"
 Container 266e76f030e738a45eab992e07d8d247-mysql-1  Running
 Container 266e76f030e738a45eab992e07d8d247-wordpress-1  Running
Warning: Plugin 'bbpress' is already active.
Fatal error: Uncaught Error: Call to undefined function WordPressdotorg\Forums\get_blog_details() in /var/www/html/wp-content/plugins/support-forums/inc/class-hooks.php:147
Stack trace:
#0 /var/www/html/wp-content/plugins/support-forums/inc/class-plugin.php(71): WordPressdotorg\Forums\Hooks->__construct()
#1 /var/www/html/wp-content/plugins/support-forums/inc/class-plugin.php(59): WordPressdotorg\Forums\Plugin->__construct()
#2 /var/www/html/wp-content/plugins/support-forums/support-forums.php(48): WordPressdotorg\Forums\Plugin::get_instance()
#3 /var/www/html/wp-admin/includes/plugin.php(2382): include_once('/var/www/html/w...')
#4 /var/www/html/wp-admin/includes/plugin.php(673): plugin_sandbox_scrape('support-forums/...')
#5 phar:///usr/local/bin/wp/vendor/wp-cli/extension-command/src/Plugin_Command.php(386): activate_plugin('support-forums/...', '', false)
#6 [internal function]: Plugin_Command->activate(Array, Array)
#7 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php(100): call_user_func(Array, Array, Array)
#8 [internal function]: WP_CLI\Dispatcher\CommandFactory::WP_CLI\Dispatcher\{closure}(Array, Array)
#9 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php(497): call_user_func(Object(Closure), Array, Array)
#10 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(470): WP_CLI\Dispatcher\Subcommand->invoke(Array, Array, Array)
#11 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(493): WP_CLI\Runner->run_command(Array, Array)
#12 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(1295): WP_CLI\Runner->run_command_and_exit()
#13 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php(28): WP_CLI\Runner->start()
#14 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/bootstrap.php(84): WP_CLI\Bootstrap\LaunchRunner->process(Object(WP_CLI\Bootstrap\BootstrapState))
#15 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/wp-cli.php(35): WP_CLI\bootstrap()
#16 phar:///usr/local/bin/wp/php/boot-phar.php(20): include('phar:///usr/loc...')
#17 /usr/local/bin/wp(4): include('phar:///usr/loc...')
#18 {main}
  thrown in /var/www/html/wp-content/plugins/support-forums/inc/class-hooks.php on line 147
```

## Testing Instructions

Run `npmrn wp-env start` using the `.wp-env.override.json` file as follows.

```json
{
	"plugins": [
		"https://downloads.wordpress.org/plugin/bbpress.latest-stable.zip",
		"../path/to/wordpress.org/wordpress.org/public_html/wp-content/plugins/support-forums"
	]
}
```