### PR TITLE
Five for the Future: Redesign /pledges/ as a ranked contributor directory

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/content-pledge.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/content-pledge.php
@@ -76,6 +76,15 @@ $is_initially_hidden = 'independent' !== $status_class;
 				}
 				?>
 			</span>
+			<span class="pledges-card-active pledges-card-active-<?php echo esc_attr( $active_class ); ?>">
+				<?php
+				echo esc_html( sprintf(
+					/* translators: %s: relative time bucket, e.g. "3 days ago" */
+					__( 'active %s', 'wporg-5ftf' ),
+					$active_bucket
+				) );
+				?>
+			</span>
 		</div>
 
 		<p class="pledges-card-summary">
@@ -143,15 +152,6 @@ $is_initially_hidden = 'independent' !== $status_class;
 	</div>
 
 	<aside class="pledges-card-meta">
-		<span class="pledges-card-active pledges-card-active-<?php echo esc_attr( $active_class ); ?>">
-			<?php
-			echo esc_html( sprintf(
-				/* translators: %s: relative time bucket, e.g. "3 days ago" */
-				__( 'active %s', 'wporg-5ftf' ),
-				$active_bucket
-			) );
-			?>
-		</span>
 		<span class="pledges-card-weight">
 			<strong><?php echo esc_html( number_format_i18n( $weighted ) ); ?></strong>
 			<span class="pledges-card-weight-label"><?php esc_html_e( 'weighted', 'wporg-5ftf' ); ?></span>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/content-pledge.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/content-pledge.php
@@ -94,8 +94,8 @@ $is_initially_hidden = 'independent' !== $status_class;
 				$parts = array();
 				if ( $high > 0 ) {
 					$parts[] = sprintf(
-						/* translators: 1: <strong> tag, 2: number of high-weight contributions, 3: </strong> tag */
-						_n( '%1$s%2$d high-weight%3$s contribution', '%1$s%2$d high-weight%3$s contributions', $high, 'wporg-5ftf' ),
+						/* translators: 1: <strong> tag, 2: number of high-impact contributions, 3: </strong> tag */
+						_n( '%1$s%2$d high-impact%3$s contribution', '%1$s%2$d high-impact%3$s contributions', $high, 'wporg-5ftf' ),
 						'<strong>',
 						$high,
 						'</strong>'
@@ -103,8 +103,8 @@ $is_initially_hidden = 'independent' !== $status_class;
 				}
 				if ( $medium > 0 ) {
 					$parts[] = sprintf(
-						/* translators: 1: <strong> tag, 2: number of medium-weight contributions, 3: </strong> tag */
-						_n( '%1$s%2$d medium%3$s contribution', '%1$s%2$d medium%3$s contributions', $medium, 'wporg-5ftf' ),
+						/* translators: 1: <strong> tag, 2: number of medium-impact contributions, 3: </strong> tag */
+						_n( '%1$s%2$d medium-impact%3$s contribution', '%1$s%2$d medium-impact%3$s contributions', $medium, 'wporg-5ftf' ),
 						'<strong>',
 						$medium,
 						'</strong>'
@@ -143,7 +143,7 @@ $is_initially_hidden = 'independent' !== $status_class;
 			} else {
 				echo esc_html( sprintf(
 					/* translators: %d: window in days */
-					__( 'No verified contributions in the last %d days.', 'wporg-5ftf' ),
+					__( 'No tracked contributions in the last %d days.', 'wporg-5ftf' ),
 					$window_days
 				) );
 			}
@@ -154,7 +154,7 @@ $is_initially_hidden = 'independent' !== $status_class;
 	<aside class="pledges-card-meta">
 		<span class="pledges-card-weight">
 			<strong><?php echo esc_html( number_format_i18n( $weighted ) ); ?></strong>
-			<span class="pledges-card-weight-label"><?php esc_html_e( 'weighted', 'wporg-5ftf' ); ?></span>
+			<span class="pledges-card-weight-label"><?php esc_html_e( 'impact', 'wporg-5ftf' ); ?></span>
 		</span>
 	</aside>
 </article>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/content-pledge.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/content-pledge.php
@@ -25,13 +25,16 @@ $medium      = (int) ( $contributor['_metrics_medium'] ?? 0 );
 $top_repos   = $contributor['_metrics_top_repos'] ?? array();
 $window_days = (int) ( $contributor['_metrics_window_days'] ?? ContributionMetrics\WINDOW_DAYS_DEFAULT );
 
-// Data attributes used by client-side filter / sort.
+// Data attributes used by client-side filter. `data-active` lets the JS exclude
+// inactive cards from the "active contributors" result count and toggle the
+// inactive divider when filters empty its section.
 $row_attrs = array(
 	'data-rank'        => (int) ( $contributor['_rank'] ?? 0 ),
 	'data-weighted'    => $weighted,
 	'data-raw'         => $high + $medium,
 	'data-name'        => strtolower( $contributor['name'] ?? '' ),
 	'data-sponsorship' => $status_class,
+	'data-active'      => $weighted > 0 ? '1' : '0',
 );
 
 $attrs_html = '';
@@ -39,9 +42,15 @@ foreach ( $row_attrs as $k => $v ) {
 	$attrs_html .= sprintf( ' %s="%s"', esc_attr( $k ), esc_attr( $v ) );
 }
 
+// Default sponsorship filter is "Independent" (matches the JS state and the
+// is-on chip in page-pledges.php). Pre-hide sponsored cards so the browser
+// paints the filtered view immediately; otherwise the footer-loaded JS hides
+// them after first paint, producing a visible flash of every card.
+$is_initially_hidden = 'independent' !== $status_class;
+
 ?>
 
-<article class="pledges-card" <?php echo $attrs_html; // phpcs:ignore WordPress.Security.EscapeOutput ?>>
+<article class="pledges-card"<?php echo $is_initially_hidden ? ' hidden' : ''; ?> <?php echo $attrs_html; // phpcs:ignore WordPress.Security.EscapeOutput ?>>
 	<span class="pledges-card-rank" aria-hidden="true"><?php echo esc_html( str_pad( (string) $contributor['_rank'], 2, '0', STR_PAD_LEFT ) ); ?></span>
 
 	<div class="pledges-card-avatar">
@@ -86,7 +95,7 @@ foreach ( $row_attrs as $k => $v ) {
 				if ( $medium > 0 ) {
 					$parts[] = sprintf(
 						/* translators: 1: <strong> tag, 2: number of medium-weight contributions, 3: </strong> tag */
-						_n( '%1$s%2$d medium%3$s', '%1$s%2$d medium%3$s', $medium, 'wporg-5ftf' ),
+						_n( '%1$s%2$d medium%3$s contribution', '%1$s%2$d medium%3$s contributions', $medium, 'wporg-5ftf' ),
 						'<strong>',
 						$medium,
 						'</strong>'

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/content-pledge.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/content-pledge.php
@@ -94,14 +94,20 @@ foreach ( $row_attrs as $k => $v ) {
 					$repo_short = array_map(
 						function ( $r ) {
 							$slash = strrpos( $r, '/' );
-							return $slash !== false ? substr( $r, $slash + 1 ) : $r;
+							return false !== $slash ? substr( $r, $slash + 1 ) : $r;
 						},
 						array_slice( $top_repos, 0, 2 )
+					);
+					$repo_html  = array_map(
+						function ( $r ) {
+							return '<strong>' . esc_html( $r ) . '</strong>';
+						},
+						$repo_short
 					);
 					$summary   .= ' &middot; ' . sprintf(
 						/* translators: %s: comma-separated list of GitHub repo short names */
 						__( 'in %s', 'wporg-5ftf' ),
-						implode( ', ', array_map( function ( $r ) { return '<strong>' . esc_html( $r ) . '</strong>'; }, $repo_short ) )
+						implode( ', ', $repo_html )
 					);
 				}
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/content-pledge.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/content-pledge.php
@@ -23,7 +23,7 @@ $weighted    = (int) ( $contributor['_metrics_weighted'] ?? 0 );
 $high        = (int) ( $contributor['_metrics_high'] ?? 0 );
 $medium      = (int) ( $contributor['_metrics_medium'] ?? 0 );
 $top_repos   = $contributor['_metrics_top_repos'] ?? array();
-$window_days = (int) ( $contributor['_metrics_window_days'] ?? 90 );
+$window_days = (int) ( $contributor['_metrics_window_days'] ?? ContributionMetrics\WINDOW_DAYS_DEFAULT );
 
 // Data attributes used by client-side filter / sort.
 $row_attrs = array(
@@ -76,16 +76,20 @@ foreach ( $row_attrs as $k => $v ) {
 				$parts = array();
 				if ( $high > 0 ) {
 					$parts[] = sprintf(
-						/* translators: %d: number of high-weight contributions */
-						_n( '<strong>%d high-weight</strong> contribution', '<strong>%d high-weight</strong> contributions', $high, 'wporg-5ftf' ),
-						$high
+						/* translators: 1: <strong> tag, 2: number of high-weight contributions, 3: </strong> tag */
+						_n( '%1$s%2$d high-weight%3$s contribution', '%1$s%2$d high-weight%3$s contributions', $high, 'wporg-5ftf' ),
+						'<strong>',
+						$high,
+						'</strong>'
 					);
 				}
 				if ( $medium > 0 ) {
 					$parts[] = sprintf(
-						/* translators: %d: number of medium-weight contributions */
-						_n( '<strong>%d medium</strong>', '<strong>%d medium</strong>', $medium, 'wporg-5ftf' ),
-						$medium
+						/* translators: 1: <strong> tag, 2: number of medium-weight contributions, 3: </strong> tag */
+						_n( '%1$s%2$d medium%3$s', '%1$s%2$d medium%3$s', $medium, 'wporg-5ftf' ),
+						'<strong>',
+						$medium,
+						'</strong>'
 					);
 				}
 				$summary = implode( ' &middot; ', $parts );

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/content-pledge.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/content-pledge.php
@@ -12,22 +12,130 @@ defined( 'WPINC' ) || die();
  * @var array $contributor
  */
 
+$is_sponsored = ! empty( $contributor['sponsored'] );
+$status_class = $is_sponsored ? 'sponsored' : 'independent';
+$status_label = $is_sponsored ? __( 'Sponsored', 'wporg-5ftf' ) : __( 'Independent', 'wporg-5ftf' );
+
+$active_class  = $contributor['_metrics_active_class'] ?? 'active-stale';
+$active_bucket = $contributor['_metrics_active_bucket'] ?? __( 'over 6 months ago', 'wporg-5ftf' );
+
+$weighted    = (int) ( $contributor['_metrics_weighted'] ?? 0 );
+$high        = (int) ( $contributor['_metrics_high'] ?? 0 );
+$medium      = (int) ( $contributor['_metrics_medium'] ?? 0 );
+$top_repos   = $contributor['_metrics_top_repos'] ?? array();
+$window_days = (int) ( $contributor['_metrics_window_days'] ?? 90 );
+
+// Data attributes used by client-side filter / sort.
+$row_attrs = array(
+	'data-rank'        => (int) ( $contributor['_rank'] ?? 0 ),
+	'data-weighted'    => $weighted,
+	'data-raw'         => $high + $medium,
+	'data-name'        => strtolower( $contributor['name'] ?? '' ),
+	'data-sponsorship' => $status_class,
+);
+
+$attrs_html = '';
+foreach ( $row_attrs as $k => $v ) {
+	$attrs_html .= sprintf( ' %s="%s"', esc_attr( $k ), esc_attr( $v ) );
+}
+
 ?>
 
-<div class="team-contributor">
-	<?php echo wp_kses_post( get_avatar( $contributor['email'] ) ); ?>
+<article class="pledges-card" <?php echo $attrs_html; // phpcs:ignore WordPress.Security.EscapeOutput ?>>
+	<span class="pledges-card-rank" aria-hidden="true"><?php echo esc_html( str_pad( (string) $contributor['_rank'], 2, '0', STR_PAD_LEFT ) ); ?></span>
 
-	<p class="contributor-name">
-		<?php echo esc_html( $contributor['name'] ); ?>
+	<div class="pledges-card-avatar">
+		<?php echo wp_kses_post( get_avatar( $contributor['email'], 56 ) ); ?>
+	</div>
 
-		<?php echo wp_kses_data( sprintf(
-			"(<a href='%s'>@%s</a>)",
-			'https://profiles.wordpress.org/' . $contributor['username'] . '/',
-			$contributor['username']
-		) ); ?>
-	</p>
+	<div class="pledges-card-body">
+		<div class="pledges-card-identity">
+			<a class="pledges-card-name" href="<?php echo esc_url( 'https://profiles.wordpress.org/' . $contributor['username'] . '/' ); ?>">
+				<?php echo esc_html( $contributor['name'] ); ?>
+			</a>
+			<span class="pledges-card-handle">@<?php echo esc_html( $contributor['username'] ); ?></span>
+			<span class="pledges-card-status pledges-card-status-<?php echo esc_attr( $status_class ); ?>">
+				<?php
+				if ( $is_sponsored && ! empty( $contributor['pledge_url'] ) ) {
+					printf(
+						'<a href="%s">%s</a>',
+						esc_url( $contributor['pledge_url'] ),
+						esc_html( $status_label )
+					);
+				} else {
+					echo esc_html( $status_label );
+				}
+				?>
+			</span>
+		</div>
 
-	<p class="contributor-bio">
-		<?php echo wp_kses_data( $contributor['bio'] ); ?>
-	</p>
-</div>
+		<p class="pledges-card-summary">
+			<?php
+			if ( $weighted > 0 ) {
+				// Build summary from real signals: count breakdown + top repos.
+				$parts = array();
+				if ( $high > 0 ) {
+					$parts[] = sprintf(
+						/* translators: %d: number of high-weight contributions */
+						_n( '<strong>%d high-weight</strong> contribution', '<strong>%d high-weight</strong> contributions', $high, 'wporg-5ftf' ),
+						$high
+					);
+				}
+				if ( $medium > 0 ) {
+					$parts[] = sprintf(
+						/* translators: %d: number of medium-weight contributions */
+						_n( '<strong>%d medium</strong>', '<strong>%d medium</strong>', $medium, 'wporg-5ftf' ),
+						$medium
+					);
+				}
+				$summary = implode( ' &middot; ', $parts );
+
+				if ( ! empty( $top_repos ) ) {
+					$repo_short = array_map(
+						function ( $r ) {
+							$slash = strrpos( $r, '/' );
+							return $slash !== false ? substr( $r, $slash + 1 ) : $r;
+						},
+						array_slice( $top_repos, 0, 2 )
+					);
+					$summary   .= ' &middot; ' . sprintf(
+						/* translators: %s: comma-separated list of GitHub repo short names */
+						__( 'in %s', 'wporg-5ftf' ),
+						implode( ', ', array_map( function ( $r ) { return '<strong>' . esc_html( $r ) . '</strong>'; }, $repo_short ) )
+					);
+				}
+
+				$summary .= ' ' . sprintf(
+					/* translators: %d: window in days */
+					esc_html__( 'in the last %d days.', 'wporg-5ftf' ),
+					$window_days
+				);
+
+				echo wp_kses_data( $summary );
+			} else {
+				echo esc_html( sprintf(
+					/* translators: %d: window in days */
+					__( 'No verified contributions in the last %d days.', 'wporg-5ftf' ),
+					$window_days
+				) );
+			}
+			?>
+		</p>
+	</div>
+
+	<aside class="pledges-card-meta">
+		<span class="pledges-card-active pledges-card-active-<?php echo esc_attr( $active_class ); ?>">
+			<?php
+			echo esc_html( sprintf(
+				/* translators: %s: relative time bucket, e.g. "3 days ago" */
+				__( 'active %s', 'wporg-5ftf' ),
+				$active_bucket
+			) );
+			?>
+		</span>
+		<span class="pledges-card-weight">
+			<strong><?php echo esc_html( number_format_i18n( $weighted ) ); ?></strong>
+			<span class="pledges-card-weight-label"><?php esc_html_e( 'weighted', 'wporg-5ftf' ); ?></span>
+		</span>
+	</aside>
+</article>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/css/page-pledges.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/css/page-pledges.css
@@ -170,7 +170,7 @@
 	flex-wrap: wrap;
 	align-items: center;
 	gap: 10px 18px;
-	margin-bottom: 8px;
+	margin-bottom: 14px;
 }
 
 .pledges-filters {
@@ -247,7 +247,7 @@
 }
 
 .pledges-sort-label {
-	margin: 6px 0 16px;
+	margin: 4px 0 16px;
 	display: flex;
 	gap: 10px;
 	align-items: baseline;
@@ -514,11 +514,53 @@
 	cursor: pointer;
 }
 
+/* Secondary suggestion inside the empty state — e.g. "Show inactive
+   contributors" when the active grid is empty. Demoted vs. the primary
+   "Clear filters" button so the hierarchy stays clear. */
+.pledges-empty-extra {
+	margin: 14px 0 0;
+	font-size: 14px;
+	line-height: 1.5;
+}
+
+.pledges-empty-extra a {
+	color: var(--wp--preset--color--blueberry-1, #3858e9);
+	text-decoration: none;
+	font-weight: 500;
+}
+
+.pledges-empty-extra a:hover,
+.pledges-empty-extra a:focus {
+	text-decoration: underline;
+}
+
 /* ------------------------------------------------------------------ */
 /* Narrow (< 720px) layout — collapse card columns                     */
 /* ------------------------------------------------------------------ */
 
 @media (max-width: 720px) {
+	/* Health banner: let the descriptor + chips wrap onto multiple rows
+	   instead of clipping the descriptor against the right-aligned chips
+	   (which produced a stray partial-character artifact at narrow widths,
+	   e.g. "844 (" on the Meta page). */
+	.pledges-health {
+		flex-wrap: wrap;
+		align-items: center;
+		row-gap: 6px;
+	}
+
+	.pledges-health-text {
+		overflow: visible;
+		white-space: normal;
+		text-overflow: clip;
+	}
+
+	.pledges-health-split {
+		flex-basis: 100%;
+		margin-left: 0;
+		justify-content: flex-start;
+	}
+
 	/* Drop the dedicated rank column on narrow viewports. The body text was
 	   getting squeezed to ~170px on a 375px screen — 7+ wrapped lines per card.
 	   The rank moves into a small corner badge (top-right), the avatar column
@@ -535,15 +577,15 @@
 
 	.pledges-card-rank {
 		position: absolute;
-		top: 12px;
+		top: 14px;
 		right: 14px;
-		font-size: 16px;
+		font-size: 13px;
 		font-weight: 600;
-		padding: 2px 8px;
+		padding: 1px 7px;
 		background: var(--wp--preset--color--light-grey-2, #f6f7f7);
-		color: var(--wp--preset--color--charcoal-3, #5d6166);
+		color: var(--wp--preset--color--charcoal-4, #757a82);
 		border-radius: 4px;
-		line-height: 1.4;
+		line-height: 1.5;
 		letter-spacing: 0;
 	}
 
@@ -561,18 +603,25 @@
 		grid-column: 2;
 		grid-row: 1;
 		/* Reserve space for the rank badge so the identity row doesn't crash
-		   into it on narrow widths. */
+		   into it on narrow widths. 44px clears the 2-digit badge with ~6px
+		   breathing room without forcing the name+handle to wrap to two lines. */
 		padding-right: 44px;
 	}
 
 	.pledges-card-meta {
 		grid-column: 1 / 3;
 		grid-row: 2;
-		justify-content: flex-end;
+		justify-content: center;
 		min-width: 0;
 		margin-top: 4px;
 		padding-top: 10px;
 		border-top: 1px solid var(--wp--preset--color--light-grey-2, #f6f7f7);
+	}
+
+	/* Center the weighted stat in the mobile footer so the empty left half
+	   doesn't make the card feel asymmetric. */
+	.pledges-card-weight {
+		align-items: center;
 	}
 
 	/* The active pill lives in the identity row now; let it wrap with the

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/css/page-pledges.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/css/page-pledges.css
@@ -281,7 +281,7 @@
 
 .pledges-card {
 	display: grid;
-	grid-template-columns: 40px 56px 1fr auto;
+	grid-template-columns: 56px 56px 1fr auto;
 	gap: 18px;
 	padding: 16px 18px;
 	border: 1px solid var(--wp--preset--color--light-grey-1, #e6e7e9);
@@ -304,12 +304,13 @@
 
 .pledges-card-rank {
 	font-family: ui-monospace, "Menlo", monospace;
-	font-size: 14px;
-	font-weight: 600;
-	color: var(--wp--preset--color--charcoal-3, #5d6166);
+	font-size: 28px;
+	font-weight: 700;
+	color: var(--wp--preset--color--charcoal-2, #2c3338);
 	font-variant-numeric: tabular-nums;
 	text-align: right;
-	line-height: 1.2;
+	line-height: 1;
+	letter-spacing: -.02em;
 }
 
 .pledges-card-avatar img {
@@ -326,7 +327,7 @@
 .pledges-card-identity {
 	display: flex;
 	flex-wrap: wrap;
-	align-items: baseline;
+	align-items: center;
 	gap: 6px 12px;
 	margin-bottom: 6px;
 }
@@ -395,10 +396,9 @@
 
 .pledges-card-meta {
 	display: flex;
-	flex-direction: column;
-	align-items: flex-end;
-	gap: 6px;
-	min-width: 120px;
+	align-items: center;
+	justify-content: flex-end;
+	min-width: 96px;
 }
 
 .pledges-card-active {
@@ -519,18 +519,67 @@
 /* ------------------------------------------------------------------ */
 
 @media (max-width: 720px) {
+	/* Drop the dedicated rank column on narrow viewports. The body text was
+	   getting squeezed to ~170px on a 375px screen — 7+ wrapped lines per card.
+	   The rank moves into a small corner badge (top-right), the avatar column
+	   stays leftmost, body gets the full remaining width, and the weighted
+	   score becomes a full-width footer separated by a thin rule. */
 	.pledges-card {
-		grid-template-columns: 36px 56px 1fr;
+		position: relative;
+		grid-template-columns: 48px 1fr;
 		grid-template-rows: auto auto;
+		gap: 10px 14px;
+		padding: 16px 14px;
+		align-items: start;
+	}
+
+	.pledges-card-rank {
+		position: absolute;
+		top: 12px;
+		right: 14px;
+		font-size: 16px;
+		font-weight: 600;
+		padding: 2px 8px;
+		background: var(--wp--preset--color--light-grey-2, #f6f7f7);
+		color: var(--wp--preset--color--charcoal-3, #5d6166);
+		border-radius: 4px;
+		line-height: 1.4;
+		letter-spacing: 0;
+	}
+
+	.pledges-card-avatar {
+		grid-column: 1;
+		grid-row: 1;
+	}
+
+	.pledges-card-avatar img {
+		width: 48px;
+		height: 48px;
+	}
+
+	.pledges-card-body {
+		grid-column: 2;
+		grid-row: 1;
+		/* Reserve space for the rank badge so the identity row doesn't crash
+		   into it on narrow widths. */
+		padding-right: 44px;
 	}
 
 	.pledges-card-meta {
-		grid-column: 2 / 4;
-		flex-direction: row;
-		align-items: center;
-		justify-content: flex-start;
-		gap: 12px;
+		grid-column: 1 / 3;
+		grid-row: 2;
+		justify-content: flex-end;
 		min-width: 0;
+		margin-top: 4px;
+		padding-top: 10px;
+		border-top: 1px solid var(--wp--preset--color--light-grey-2, #f6f7f7);
+	}
+
+	/* The active pill lives in the identity row now; let it wrap with the
+	   other chips (status, etc.) instead of taking its own line. */
+	.pledges-card-active {
+		font-size: 12px;
+		padding: 2px 8px;
 	}
 
 	.pledges-toolbar {
@@ -544,6 +593,26 @@
 
 	.pledges-sort {
 		justify-content: flex-end;
+	}
+
+	/* Tighter "How this page works" affordance — the desktop padding eats
+	   ~340px vertical on mobile, pushing the directory below the fold. */
+	.pledges-howitworks {
+		grid-template-columns: 22px 1fr auto;
+		gap: 10px;
+		padding: 12px 14px;
+		font-size: 14px;
+	}
+
+	.pledges-howitworks-icon {
+		width: 18px;
+		height: 18px;
+		font-size: 11px;
+	}
+
+	.pledges-howitworks-body p {
+		font-size: 14px;
+		line-height: 1.5;
 	}
 }
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/css/page-pledges.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/css/page-pledges.css
@@ -1,0 +1,553 @@
+/*
+ * Page Pledges — Five for the Future redesign Page 1.
+ * Replaces the legacy flat list with a ranked directory of contributors.
+ *
+ * Uses theme.json tokens where possible (var(--wp--preset--color--*),
+ * var(--wp--preset--font-family--*)) so it stays aligned with the parent theme.
+ *
+ * Note on units: the make.* theme sets html { font-size: 10px } (a "62.5%"
+ * convention), so 1rem = 10px on these pages, not 16px. To match the body's
+ * actual visual size (16px), this stylesheet uses px values for typography.
+ */
+
+/* ------------------------------------------------------------------ */
+/* Hero                                                                */
+/* ------------------------------------------------------------------ */
+
+.template-pledges .page-header.pledges-hero {
+	margin-bottom: 24px;
+	padding-bottom: 16px;
+}
+
+.template-pledges .pledges-hero .page-title {
+	margin: 0 0 4px;
+	font-size: 32px;
+	line-height: 1.15;
+	letter-spacing: -.01em;
+	font-weight: 600;
+}
+
+.template-pledges .pledges-subtitle {
+	margin: 0;
+	color: var(--wp--preset--color--charcoal-3, #5d6166);
+	font-size: 16px;
+	line-height: 1.5;
+}
+
+/* ------------------------------------------------------------------ */
+/* "How this page works" affordance                                    */
+/* ------------------------------------------------------------------ */
+
+.pledges-howitworks {
+	display: grid;
+	grid-template-columns: 28px 1fr auto;
+	gap: 12px;
+	align-items: start;
+	background: var(--wp--preset--color--light-grey-2, #f6f7f7);
+	border: 1px solid var(--wp--preset--color--light-grey-1, #e6e7e9);
+	border-radius: 8px;
+	padding: 14px 16px;
+	margin-bottom: 24px;
+	font-size: 15px;
+	line-height: 1.5;
+}
+
+.pledges-howitworks.is-dismissed {
+	display: none;
+}
+
+.pledges-howitworks-icon {
+	width: 22px;
+	height: 22px;
+	border-radius: 50%;
+	background: var(--wp--preset--color--blueberry-1, #3858e9);
+	color: #fff;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	font-weight: 700;
+	font-size: 13px;
+	line-height: 1;
+	font-family: var(--wp--preset--font-family--inter, system-ui, sans-serif);
+	flex-shrink: 0;
+}
+
+.pledges-howitworks-body strong {
+	display: block;
+	margin-bottom: 4px;
+	font-weight: 600;
+	font-size: 15px;
+}
+
+.pledges-howitworks-body p {
+	margin: 0;
+	color: var(--wp--preset--color--charcoal-3, #5d6166);
+	line-height: 1.5;
+	font-size: 15px;
+}
+
+.pledges-howitworks-dismiss {
+	background: transparent;
+	border: none;
+	color: var(--wp--preset--color--charcoal-3, #5d6166);
+	font-size: 24px;
+	line-height: 1;
+	cursor: pointer;
+	padding: 0 6px;
+	border-radius: 4px;
+}
+
+.pledges-howitworks-dismiss:hover,
+.pledges-howitworks-dismiss:focus {
+	background: var(--wp--preset--color--light-grey-1, #e6e7e9);
+	color: var(--wp--preset--color--charcoal-1, #1d2327);
+}
+
+/* ------------------------------------------------------------------ */
+/* Health banner                                                       */
+/* ------------------------------------------------------------------ */
+
+.pledges-health {
+	display: flex;
+	align-items: baseline;
+	gap: 10px;
+	padding: 12px 16px;
+	background: #fff;
+	border: 1px solid var(--wp--preset--color--light-grey-1, #e6e7e9);
+	border-radius: 8px;
+	margin-bottom: 16px;
+	min-width: 0;
+}
+
+.pledges-health-num {
+	font-size: 22px;
+	font-weight: 700;
+	letter-spacing: -.01em;
+	color: var(--wp--preset--color--charcoal-1, #1d2327);
+	line-height: 1.1;
+	flex-shrink: 0;
+}
+
+.pledges-health-text {
+	color: var(--wp--preset--color--charcoal-3, #5d6166);
+	font-size: 14px;
+	line-height: 1.4;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.pledges-health-split {
+	margin-left: auto;
+	display: flex;
+	gap: 6px;
+	flex-shrink: 0;
+}
+
+.pledges-health-chip {
+	font-size: 12px;
+	padding: 3px 10px;
+	border-radius: 999px;
+	background: var(--wp--preset--color--light-grey-2, #f6f7f7);
+	border: 1px solid var(--wp--preset--color--light-grey-1, #e6e7e9);
+	line-height: 1.4;
+	white-space: nowrap;
+}
+
+.pledges-health-chip.sponsored {
+	background: rgba(56, 88, 233, .08);
+	border-color: rgba(56, 88, 233, .25);
+	color: var(--wp--preset--color--blueberry-1, #3858e9);
+}
+
+/* ------------------------------------------------------------------ */
+/* Toolbar (filters + sort)                                            */
+/* ------------------------------------------------------------------ */
+
+.pledges-toolbar {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 10px 18px;
+	margin-bottom: 8px;
+}
+
+.pledges-filters {
+	display: flex;
+	flex-wrap: nowrap;
+	align-items: center;
+	gap: 14px;
+	flex: 1 1 auto;
+	min-width: 0;
+}
+
+.pledges-filter-group {
+	display: flex;
+	flex-wrap: nowrap;
+	align-items: center;
+	gap: 4px;
+}
+
+.pledges-filter-label {
+	font-size: 11px;
+	letter-spacing: .04em;
+	text-transform: uppercase;
+	color: var(--wp--preset--color--charcoal-3, #5d6166);
+	font-weight: 600;
+	margin-right: 4px;
+	line-height: 1.4;
+	white-space: nowrap;
+}
+
+.pledges-chip {
+	font-family: var(--wp--preset--font-family--inter, system-ui, sans-serif);
+	font-size: 13px;
+	font-weight: 500;
+	padding: 4px 11px;
+	border-radius: 999px;
+	border: 1px solid var(--wp--preset--color--light-grey-1, #e6e7e9);
+	background: #fff;
+	color: var(--wp--preset--color--charcoal-2, #2c3338);
+	cursor: pointer;
+	text-decoration: none;
+	line-height: 1.4;
+	white-space: nowrap;
+	transition: background .12s, border-color .12s, color .12s;
+}
+
+.pledges-chip:hover,
+.pledges-chip:focus {
+	border-color: var(--wp--preset--color--charcoal-3, #5d6166);
+	color: var(--wp--preset--color--charcoal-1, #1d2327);
+}
+
+.pledges-chip.is-on,
+.pledges-chip.is-on:hover {
+	background: var(--wp--preset--color--charcoal-1, #1d2327);
+	border-color: var(--wp--preset--color--charcoal-1, #1d2327);
+	color: #fff;
+}
+
+.pledges-sort {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.pledges-sort-select {
+	font-family: var(--wp--preset--font-family--inter, system-ui, sans-serif);
+	font-size: 14px;
+	padding: 6px 12px;
+	border-radius: 6px;
+	border: 1px solid var(--wp--preset--color--light-grey-1, #e6e7e9);
+	background: #fff;
+	color: var(--wp--preset--color--charcoal-1, #1d2327);
+	line-height: 1.4;
+}
+
+.pledges-sort-label {
+	margin: 6px 0 16px;
+	display: flex;
+	gap: 10px;
+	align-items: baseline;
+	flex-wrap: wrap;
+	font-size: 15px;
+	color: var(--wp--preset--color--charcoal-3, #5d6166);
+	line-height: 1.5;
+}
+
+.pledges-sort-label strong {
+	color: var(--wp--preset--color--charcoal-1, #1d2327);
+	font-weight: 600;
+}
+
+.pledges-result-count {
+	font-size: 14px;
+	color: var(--wp--preset--color--charcoal-4, #757a82);
+	font-variant-numeric: tabular-nums;
+}
+
+/* ------------------------------------------------------------------ */
+/* Card grid                                                           */
+/* ------------------------------------------------------------------ */
+
+.pledges-grid {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	margin: 0;
+}
+
+.pledges-card {
+	display: grid;
+	grid-template-columns: 40px 56px 1fr auto;
+	gap: 18px;
+	padding: 16px 18px;
+	border: 1px solid var(--wp--preset--color--light-grey-1, #e6e7e9);
+	background: #fff;
+	border-radius: 8px;
+	transition: border-color .12s, box-shadow .12s, opacity .15s;
+	align-items: center;
+}
+
+/* Browser default `[hidden] { display: none }` is overridden by our
+   `.pledges-card { display: grid }` rule. Explicit override needed. */
+.pledges-card[hidden] {
+	display: none !important;
+}
+
+.pledges-card:hover {
+	border-color: var(--wp--preset--color--charcoal-4, #757a82);
+	box-shadow: 0 1px 2px rgba(0, 0, 0, .04);
+}
+
+.pledges-card-rank {
+	font-family: ui-monospace, "Menlo", monospace;
+	font-size: 14px;
+	font-weight: 600;
+	color: var(--wp--preset--color--charcoal-3, #5d6166);
+	font-variant-numeric: tabular-nums;
+	text-align: right;
+	line-height: 1.2;
+}
+
+.pledges-card-avatar img {
+	width: 56px;
+	height: 56px;
+	border-radius: 50%;
+	display: block;
+}
+
+.pledges-card-body {
+	min-width: 0;
+}
+
+.pledges-card-identity {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: baseline;
+	gap: 6px 12px;
+	margin-bottom: 6px;
+}
+
+.pledges-card-name {
+	font-weight: 600;
+	color: var(--wp--preset--color--charcoal-1, #1d2327);
+	text-decoration: none;
+	font-size: 18px;
+	line-height: 1.3;
+	letter-spacing: -.005em;
+}
+
+.pledges-card-name:hover,
+.pledges-card-name:focus {
+	color: var(--wp--preset--color--blueberry-1, #3858e9);
+	text-decoration: underline;
+}
+
+.pledges-card-handle {
+	color: var(--wp--preset--color--charcoal-4, #757a82);
+	font-size: 14px;
+	line-height: 1.3;
+}
+
+.pledges-card-status {
+	font-size: 12px;
+	font-weight: 500;
+	padding: 3px 10px;
+	border-radius: 999px;
+	letter-spacing: .02em;
+	line-height: 1.5;
+}
+
+.pledges-card-status a {
+	text-decoration: none;
+	color: inherit;
+}
+
+.pledges-card-status a:hover,
+.pledges-card-status a:focus {
+	text-decoration: underline;
+}
+
+.pledges-card-status-sponsored {
+	background: rgba(56, 88, 233, .08);
+	color: var(--wp--preset--color--blueberry-1, #3858e9);
+}
+
+.pledges-card-status-independent {
+	background: var(--wp--preset--color--light-grey-2, #f6f7f7);
+	color: var(--wp--preset--color--charcoal-3, #5d6166);
+}
+
+.pledges-card-summary {
+	margin: 0;
+	color: var(--wp--preset--color--charcoal-3, #5d6166);
+	font-size: 15px;
+	line-height: 1.5;
+}
+
+.pledges-card-summary strong {
+	color: var(--wp--preset--color--charcoal-1, #1d2327);
+	font-weight: 600;
+}
+
+.pledges-card-meta {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-end;
+	gap: 6px;
+	min-width: 120px;
+}
+
+.pledges-card-active {
+	font-size: 13px;
+	color: var(--wp--preset--color--charcoal-3, #5d6166);
+	background: var(--wp--preset--color--light-grey-2, #f6f7f7);
+	border: 1px solid var(--wp--preset--color--light-grey-1, #e6e7e9);
+	padding: 3px 10px;
+	border-radius: 999px;
+	white-space: nowrap;
+	line-height: 1.4;
+}
+
+.pledges-card-active-active-recent {
+	background: rgba(46, 125, 79, .1);
+	border-color: rgba(46, 125, 79, .25);
+	color: #1f6043;
+}
+
+.pledges-card-active-active-stale {
+	background: transparent;
+	border-style: dashed;
+	color: var(--wp--preset--color--charcoal-4, #757a82);
+}
+
+.pledges-card-weight {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-end;
+	gap: 2px;
+	color: var(--wp--preset--color--charcoal-1, #1d2327);
+}
+
+.pledges-card-weight strong {
+	font-size: 24px;
+	font-weight: 700;
+	line-height: 1;
+	letter-spacing: -.01em;
+	font-variant-numeric: tabular-nums;
+}
+
+.pledges-card-weight-label {
+	font-size: 11px;
+	letter-spacing: .06em;
+	text-transform: uppercase;
+	color: var(--wp--preset--color--charcoal-4, #757a82);
+	line-height: 1.3;
+}
+
+/* ------------------------------------------------------------------ */
+/* Inactive contributors — divider + opt-in toggle                     */
+/* ------------------------------------------------------------------ */
+
+.pledges-inactive-divider {
+	margin: 24px 0 8px;
+	padding-bottom: 8px;
+	border-bottom: 1px dashed var(--wp--preset--color--light-grey-1, #e6e7e9);
+	font-family: ui-monospace, "Menlo", monospace;
+	font-size: 12px;
+	letter-spacing: .04em;
+	text-transform: uppercase;
+	color: var(--wp--preset--color--charcoal-4, #757a82);
+	line-height: 1.4;
+}
+
+.pledges-inactive-toggle {
+	margin: 16px 0 0;
+	font-size: 15px;
+	text-align: center;
+	color: var(--wp--preset--color--charcoal-3, #5d6166);
+	line-height: 1.5;
+}
+
+.pledges-inactive-toggle a {
+	color: var(--wp--preset--color--blueberry-1, #3858e9);
+	text-decoration: none;
+	font-weight: 500;
+}
+
+.pledges-inactive-toggle a:hover,
+.pledges-inactive-toggle a:focus {
+	text-decoration: underline;
+}
+
+/* ------------------------------------------------------------------ */
+/* Empty state                                                         */
+/* ------------------------------------------------------------------ */
+
+.pledges-empty {
+	padding: 28px 20px;
+	text-align: center;
+	background: var(--wp--preset--color--light-grey-2, #f6f7f7);
+	border: 1px dashed var(--wp--preset--color--light-grey-1, #e6e7e9);
+	border-radius: 8px;
+	color: var(--wp--preset--color--charcoal-3, #5d6166);
+	font-size: 15px;
+	line-height: 1.5;
+}
+
+.pledges-empty[hidden] {
+	display: none;
+}
+
+.pledges-empty-reset {
+	margin-top: 10px;
+	background: var(--wp--preset--color--charcoal-1, #1d2327);
+	color: #fff;
+	border: none;
+	border-radius: 6px;
+	padding: 8px 16px;
+	font-size: 14px;
+	line-height: 1.4;
+	cursor: pointer;
+}
+
+/* ------------------------------------------------------------------ */
+/* Narrow (< 720px) layout — collapse card columns                     */
+/* ------------------------------------------------------------------ */
+
+@media (max-width: 720px) {
+	.pledges-card {
+		grid-template-columns: 36px 56px 1fr;
+		grid-template-rows: auto auto;
+	}
+
+	.pledges-card-meta {
+		grid-column: 2 / 4;
+		flex-direction: row;
+		align-items: center;
+		justify-content: flex-start;
+		gap: 12px;
+		min-width: 0;
+	}
+
+	.pledges-toolbar {
+		flex-direction: column;
+		align-items: stretch;
+	}
+
+	.pledges-filters {
+		flex-wrap: wrap;
+	}
+
+	.pledges-sort {
+		justify-content: flex-end;
+	}
+}
+
+/* Hide the legacy `.team-contributor` styling if anything still uses it. */
+.template-pledges-v2 .team-contributor {
+	display: none;
+}

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/css/page-pledges.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/css/page-pledges.css
@@ -551,3 +551,123 @@
 .template-pledges-v2 .team-contributor {
 	display: none;
 }
+
+/* ------------------------------------------------------------------ */
+/* Guide page — shown for teams without wired-up contribution data.    */
+/* ------------------------------------------------------------------ */
+
+.template-pledges-guide .pledges-guide-intro {
+	background: var(--wp--preset--color--light-grey-2, #f6f7f7);
+	border: 1px solid var(--wp--preset--color--light-grey-1, #e6e7e9);
+	border-radius: 8px;
+	padding: 16px 18px;
+	margin-bottom: 28px;
+	font-size: 15px;
+	line-height: 1.55;
+	color: var(--wp--preset--color--charcoal-2, #2c3338);
+}
+
+.template-pledges-guide .pledges-guide-intro p {
+	margin: 0 0 8px;
+}
+
+.template-pledges-guide .pledges-guide-intro p:last-child {
+	margin-bottom: 0;
+}
+
+.template-pledges-guide .pledges-guide-intro code {
+	background: #fff;
+	padding: 1px 5px;
+	border-radius: 4px;
+	font-size: 13px;
+}
+
+.pledges-guide-steps {
+	list-style: none;
+	counter-reset: pledges-guide;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.pledges-guide-step {
+	counter-increment: pledges-guide;
+	background: #fff;
+	border: 1px solid var(--wp--preset--color--light-grey-1, #e6e7e9);
+	border-radius: 8px;
+	padding: 18px 22px 18px 64px;
+	position: relative;
+}
+
+.pledges-guide-step::before {
+	content: counter( pledges-guide );
+	position: absolute;
+	left: 18px;
+	top: 18px;
+	width: 32px;
+	height: 32px;
+	border-radius: 50%;
+	background: var(--wp--preset--color--charcoal-1, #1d2327);
+	color: #fff;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-family: ui-monospace, "Menlo", monospace;
+	font-size: 14px;
+	font-weight: 600;
+	font-variant-numeric: tabular-nums;
+}
+
+.pledges-guide-step h3 {
+	margin: 0 0 6px;
+	font-size: 17px;
+	font-weight: 600;
+	letter-spacing: -.005em;
+	color: var(--wp--preset--color--charcoal-1, #1d2327);
+	line-height: 1.3;
+}
+
+.pledges-guide-step p {
+	margin: 0 0 8px;
+	font-size: 15px;
+	line-height: 1.55;
+	color: var(--wp--preset--color--charcoal-3, #5d6166);
+}
+
+.pledges-guide-step p:last-child {
+	margin-bottom: 0;
+}
+
+.pledges-guide-step code {
+	background: var(--wp--preset--color--light-grey-2, #f6f7f7);
+	padding: 1px 5px;
+	border-radius: 4px;
+	font-size: 13px;
+	color: var(--wp--preset--color--charcoal-1, #1d2327);
+}
+
+.pledges-guide-link {
+	display: inline-block;
+	font-size: 14px;
+	color: var(--wp--preset--color--blueberry-1, #3858e9);
+	text-decoration: none;
+	font-weight: 500;
+}
+
+.pledges-guide-link:hover,
+.pledges-guide-link:focus {
+	text-decoration: underline;
+}
+
+@media (max-width: 720px) {
+	.pledges-guide-step {
+		padding: 18px 18px 18px 18px;
+	}
+
+	.pledges-guide-step::before {
+		position: static;
+		margin-bottom: 10px;
+	}
+}

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/functions.php
@@ -70,6 +70,37 @@ function wporg_breathe_styles() {
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\wporg_breathe_styles', 11 );
 
 /**
+ * Enqueue the page-pledges assets here (rather than in the template body) so
+ * the stylesheet reaches <head> via wp_print_styles. Enqueuing inside the
+ * template runs after get_header() and would force a footer-emitted <link>,
+ * which causes a visible FOUC on the redesigned grid.
+ */
+function wporg_breathe_pledges_assets() {
+	if ( ! is_page_template( 'page-pledges.php' ) ) {
+		return;
+	}
+
+	$dir = get_stylesheet_directory();
+	$uri = get_stylesheet_directory_uri();
+
+	wp_enqueue_style(
+		'wporg-breathe-page-pledges',
+		$uri . '/css/page-pledges.css',
+		array( 'wporg-breathe' ),
+		filemtime( $dir . '/css/page-pledges.css' )
+	);
+
+	wp_enqueue_script(
+		'wporg-breathe-page-pledges',
+		$uri . '/js/page-pledges.js',
+		array(),
+		filemtime( $dir . '/js/page-pledges.js' ),
+		true
+	);
+}
+add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\wporg_breathe_pledges_assets', 12 );
+
+/**
  * Merge the support theme's theme.json into the parent theme.json.
  *
  * @param WP_Theme_JSON_Data $theme_json Parsed support theme.json.
@@ -215,15 +246,42 @@ function wporg_breathe_add_site_navigation_menus( $menus ) {
 		return;
 	}
 
+	// Build the "People" item once, gated on the team-pledges simulator being
+	// available on the current site. /pledges/ is a virtual page registered by
+	// mu-plugins/make-network/team-pledges.php, so prepending the link without
+	// the simulator results in a 404 on non-team subsites (and would fatal in
+	// page-pledges.php when get_current_team() returns null). Hoisted above the
+	// early returns so team sites without a primary nav still surface People.
+	$people_item = null;
+	if ( function_exists( 'WordPressdotorg\\Make\\Pledges\\get_current_team' ) ) {
+		$team = \WordPressdotorg\Make\Pledges\get_current_team();
+		if ( $team ) {
+			global $wp;
+			$people_url        = home_url( '/pledges/' );
+			$is_pledges_active = trailingslashit( $people_url ) === trailingslashit( home_url( $wp->request ) );
+			$people_item       = array(
+				'label'     => esc_html__( 'People', 'wporg-5ftf' ),
+				'url'       => esc_url( $people_url ),
+				'className' => $is_pledges_active ? 'current-menu-item' : '',
+			);
+		}
+	}
+
 	$local_nav_menu_object = wporg_breathe_get_local_nav_menu_object();
 
 	if ( ! $local_nav_menu_object ) {
+		if ( $people_item ) {
+			$menus['breathe'] = array( $people_item );
+		}
 		return _maybe_add_login_item_to_menu( $menus );
 	}
 
 	$menu_items = wp_get_nav_menu_items( $local_nav_menu_object->term_id );
 
 	if ( ! $menu_items || empty( $menu_items ) ) {
+		if ( $people_item ) {
+			$menus['breathe'] = array( $people_item );
+		}
 		return _maybe_add_login_item_to_menu( $menus );
 	}
 
@@ -238,20 +296,14 @@ function wporg_breathe_add_site_navigation_menus( $menus ) {
 				'className' => $is_current_page ? 'current-menu-item' : '',
 			);
 		},
-		// Limit local nav items to 5 to leave room for the prepended "People" item below.
-		array_slice( $menu_items, 0, 5 )
+		// Cap the inherited local-nav at 5 when we're prepending People (total = 6),
+		// or 6 when there's no People item to add.
+		array_slice( $menu_items, 0, $people_item ? 5 : 6 )
 	);
 
-	// Prepend "People" — Five for the Future team contributor directory.
-	global $wp;
-	$people_url        = home_url( '/pledges/' );
-	$is_pledges_active = trailingslashit( $people_url ) === trailingslashit( home_url( $wp->request ) );
-	$people_item       = array(
-		'label'     => esc_html__( 'People', 'wporg-5ftf' ),
-		'url'       => esc_url( $people_url ),
-		'className' => $is_pledges_active ? 'current-menu-item' : '',
-	);
-	array_unshift( $menu, $people_item );
+	if ( $people_item ) {
+		array_unshift( $menu, $people_item );
+	}
 
 	$menus['breathe'] = $menu;
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/functions.php
@@ -70,37 +70,6 @@ function wporg_breathe_styles() {
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\wporg_breathe_styles', 11 );
 
 /**
- * Enqueue the page-pledges assets here (rather than in the template body) so
- * the stylesheet reaches <head> via wp_print_styles. Enqueuing inside the
- * template runs after get_header() and would force a footer-emitted <link>,
- * which causes a visible FOUC on the redesigned grid.
- */
-function wporg_breathe_pledges_assets() {
-	if ( ! is_page_template( 'page-pledges.php' ) ) {
-		return;
-	}
-
-	$dir = get_stylesheet_directory();
-	$uri = get_stylesheet_directory_uri();
-
-	wp_enqueue_style(
-		'wporg-breathe-page-pledges',
-		$uri . '/css/page-pledges.css',
-		array( 'wporg-breathe' ),
-		filemtime( $dir . '/css/page-pledges.css' )
-	);
-
-	wp_enqueue_script(
-		'wporg-breathe-page-pledges',
-		$uri . '/js/page-pledges.js',
-		array(),
-		filemtime( $dir . '/js/page-pledges.js' ),
-		true
-	);
-}
-add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\wporg_breathe_pledges_assets', 12 );
-
-/**
  * Merge the support theme's theme.json into the parent theme.json.
  *
  * @param WP_Theme_JSON_Data $theme_json Parsed support theme.json.

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/functions.php
@@ -246,11 +246,12 @@ function wporg_breathe_add_site_navigation_menus( $menus ) {
 	global $wp;
 	$people_url        = home_url( '/pledges/' );
 	$is_pledges_active = trailingslashit( $people_url ) === trailingslashit( home_url( $wp->request ) );
-	array_unshift( $menu, array(
+	$people_item       = array(
 		'label'     => esc_html__( 'People', 'wporg-5ftf' ),
 		'url'       => esc_url( $people_url ),
 		'className' => $is_pledges_active ? 'current-menu-item' : '',
-	) );
+	);
+	array_unshift( $menu, $people_item );
 
 	$menus['breathe'] = $menu;
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/functions.php
@@ -238,9 +238,19 @@ function wporg_breathe_add_site_navigation_menus( $menus ) {
 				'className' => $is_current_page ? 'current-menu-item' : '',
 			);
 		},
-		// Limit local nav items to 6
-		array_slice( $menu_items, 0, 6 )
+		// Limit local nav items to 5 to leave room for the prepended "People" item below.
+		array_slice( $menu_items, 0, 5 )
 	);
+
+	// Prepend "People" — Five for the Future team contributor directory.
+	global $wp;
+	$people_url        = home_url( '/pledges/' );
+	$is_pledges_active = trailingslashit( $people_url ) === trailingslashit( home_url( $wp->request ) );
+	array_unshift( $menu, array(
+		'label'     => esc_html__( 'People', 'wporg-5ftf' ),
+		'url'       => esc_url( $people_url ),
+		'className' => $is_pledges_active ? 'current-menu-item' : '',
+	) );
 
 	$menus['breathe'] = $menu;
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/inc/contribution-metrics.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/inc/contribution-metrics.php
@@ -56,9 +56,9 @@ function team_to_trac( string $slug ): string {
 /**
  * Categorise a wporg_github_activity row's `category` field into a weight tier.
  *
- *   high   — merged PRs (pr_merge / pr_merged)
- *   medium — pushes (commits), opened/closed PRs, closed issues (triage action)
- *   low    — opened issues, reopened PRs, anything else
+ * High tier   — merged PRs (pr_merge / pr_merged).
+ * Medium tier — pushes (commits), opened/closed PRs, closed issues (triage action).
+ * Low tier    — opened issues, reopened PRs, anything else.
  *
  * @return string 'high' | 'medium' | 'low'
  */
@@ -135,8 +135,10 @@ function get_team_contribution_metrics( array $user_ids, string $team_slug, int 
 	// ------------------------------------------------------------------
 	$trac = team_to_trac( $team_slug );
 	if ( $trac ) {
+		// $trac is a value from a hardcoded whitelist (team_to_trac); $placeholders is "%d,%d,...".
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
 		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$rows = $wpdb->get_results( $wpdb->prepare(
 			"SELECT p.user_id, COUNT(*) AS n, MAX(r.date) AS last_ts
 			 FROM trac_{$trac}_props p
@@ -164,7 +166,9 @@ function get_team_contribution_metrics( array $user_ids, string $team_slug, int 
 	// ------------------------------------------------------------------
 	// 2. GitHub activity — tiered by category.
 	// ------------------------------------------------------------------
+	// $placeholders is "%d,%d,...", built from the $user_ids count.
 	// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
+	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 	$rows = $wpdb->get_results( $wpdb->prepare(
 		"SELECT user_id, category, repo, COUNT(*) AS n, MAX(ts) AS last_ts
 		 FROM wporg_github_activity
@@ -244,21 +248,30 @@ function format_active_bucket( $last_activity_ts ): array {
 	if ( $days_since <= 7 ) {
 		// translators: %d: number of days
 		$bucket = sprintf( _n( '%d day ago', '%d days ago', $days_since, 'wporg-5ftf' ), $days_since );
-		return array( 'bucket' => $bucket, 'class' => 'active-recent' );
+		return array(
+			'bucket' => $bucket,
+			'class'  => 'active-recent',
+		);
 	}
 
 	if ( $days_since <= 30 ) {
 		$weeks = max( 1, (int) round( $days_since / 7 ) );
 		// translators: %d: number of weeks
 		$bucket = sprintf( _n( '%d week ago', '%d weeks ago', $weeks, 'wporg-5ftf' ), $weeks );
-		return array( 'bucket' => $bucket, 'class' => 'active-month' );
+		return array(
+			'bucket' => $bucket,
+			'class'  => 'active-month',
+		);
 	}
 
 	if ( $days_since <= 180 ) {
 		$months = max( 1, (int) round( $days_since / 30 ) );
 		// translators: %d: number of months
 		$bucket = sprintf( _n( '%d month ago', '%d months ago', $months, 'wporg-5ftf' ), $months );
-		return array( 'bucket' => $bucket, 'class' => 'active-quarter' );
+		return array(
+			'bucket' => $bucket,
+			'class'  => 'active-quarter',
+		);
 	}
 
 	return array(

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/inc/contribution-metrics.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/inc/contribution-metrics.php
@@ -1,0 +1,268 @@
+<?php
+/**
+ * Contribution metrics for the team-pledges directory (Page 1 of the
+ * Five for the Future redesign).
+ *
+ * Returns per-user-id real counts of high-weight, medium-weight and
+ * low-weight contributions in a rolling window, aggregated from:
+ *
+ *   - trac_<team>_props      (release credits — high weight)
+ *   - trac_<team>_revisions  (committed work — medium weight, when author maps)
+ *   - wporg_github_activity  (PRs, pushes, issues — tiered by category)
+ *
+ * Weight tiers per spec:
+ *   weighted_volume = 3 * high_count + 1 * medium_count + 0 * low_count
+ *
+ * Bulk-queries the database (one query per signal source, GROUP BY user_id)
+ * and caches the result for an hour.
+ *
+ * @package WordPressdotorg\Make\Breathe_2024
+ */
+
+namespace WordPressdotorg\Make\Breathe_2024\ContributionMetrics;
+
+defined( 'WPINC' ) || die();
+
+const WINDOW_DAYS_DEFAULT = 30;
+const WINDOW_DAYS_ALLOWED = array( 30, 90, 180 );
+const CACHE_GROUP         = '5ftf';
+const CACHE_PREFIX        = '5ftf_contrib_metrics_v1_';
+
+/**
+ * Resolve a user-provided window-days value to one of the allowed buckets.
+ * Falls back to the default (90) on anything else.
+ */
+function resolve_window_days( $raw ): int {
+	$n = (int) $raw;
+	return in_array( $n, WINDOW_DAYS_ALLOWED, true ) ? $n : WINDOW_DAYS_DEFAULT;
+}
+
+/**
+ * Map a team slug (post_name of the make_site) to the internal "trac" key
+ * used by the trac_*_props / trac_*_revisions tables.
+ *
+ * Returns an empty string when the team has no Trac data source.
+ */
+function team_to_trac( string $slug ): string {
+	$map = array(
+		'core'       => 'core',
+		'meta'       => 'meta',
+		'bbpress'    => 'bbpress',
+		'buddypress' => 'buddypress',
+	);
+	return isset( $map[ $slug ] ) ? $map[ $slug ] : '';
+}
+
+/**
+ * Categorise a wporg_github_activity row's `category` field into a weight tier.
+ *
+ *   high   — merged PRs (pr_merge / pr_merged)
+ *   medium — pushes (commits), opened/closed PRs, closed issues (triage action)
+ *   low    — opened issues, reopened PRs, anything else
+ *
+ * @return string 'high' | 'medium' | 'low'
+ */
+function github_category_to_tier( string $category ): string {
+	switch ( $category ) {
+		case 'pr_merge':
+		case 'pr_merged':
+			return 'high';
+
+		case 'push':
+		case 'pr_opened':
+		case 'pr_closed':
+		case 'issue_closed':
+			return 'medium';
+
+		default:
+			return 'low';
+	}
+}
+
+/**
+ * Default empty metrics shape for a single user.
+ */
+function empty_metrics(): array {
+	return array(
+		'high_count'      => 0,
+		'medium_count'    => 0,
+		'low_count'       => 0,
+		'weighted_volume' => 0,
+		'last_activity'   => null,
+		'top_repos'       => array(),
+	);
+}
+
+/**
+ * Fetch contribution metrics for a list of contributor user_ids on a given team.
+ *
+ * @param int[]  $user_ids  WP.org user IDs.
+ * @param string $team_slug The team's post_name (e.g. "core", "meta").
+ *
+ * @return array<int, array> Keyed by user_id. Each entry contains:
+ *   - high_count
+ *   - medium_count
+ *   - low_count
+ *   - weighted_volume (3 * high + 1 * medium)
+ *   - last_activity (unix ts or null)
+ *   - top_repos (array of [repo => count] sorted desc)
+ */
+function get_team_contribution_metrics( array $user_ids, string $team_slug, int $window_days = WINDOW_DAYS_DEFAULT ): array {
+	$user_ids    = array_values( array_unique( array_map( 'absint', $user_ids ) ) );
+	$window_days = resolve_window_days( $window_days );
+	if ( empty( $user_ids ) ) {
+		return array();
+	}
+
+	$cache_key = CACHE_PREFIX . $team_slug . '_w' . $window_days . '_' . md5( implode( ',', $user_ids ) );
+	$cached    = wp_cache_get( $cache_key, CACHE_GROUP );
+	if ( false !== $cached ) {
+		return $cached;
+	}
+
+	global $wpdb;
+
+	$placeholders = implode( ',', array_fill( 0, count( $user_ids ), '%d' ) );
+	$args         = array_merge( $user_ids, array( $window_days ) );
+
+	$metrics = array();
+	foreach ( $user_ids as $uid ) {
+		$metrics[ $uid ] = empty_metrics();
+	}
+
+	// ------------------------------------------------------------------
+	// 1. Trac props (release credits) — high weight.
+	// ------------------------------------------------------------------
+	$trac = team_to_trac( $team_slug );
+	if ( $trac ) {
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
+		$rows = $wpdb->get_results( $wpdb->prepare(
+			"SELECT p.user_id, COUNT(*) AS n, MAX(r.date) AS last_ts
+			 FROM trac_{$trac}_props p
+			 INNER JOIN trac_{$trac}_revisions r ON r.id = p.revision
+			 WHERE p.user_id IN ($placeholders)
+			   AND r.date >= DATE_SUB(NOW(), INTERVAL %d DAY)
+			 GROUP BY p.user_id",
+			$args
+		) );
+		// phpcs:enable
+
+		foreach ( $rows as $r ) {
+			$uid = (int) $r->user_id;
+			if ( ! isset( $metrics[ $uid ] ) ) {
+				continue;
+			}
+			$metrics[ $uid ]['high_count'] += (int) $r->n;
+			$ts = $r->last_ts ? strtotime( $r->last_ts ) : 0;
+			if ( $ts > (int) $metrics[ $uid ]['last_activity'] ) {
+				$metrics[ $uid ]['last_activity'] = $ts;
+			}
+		}
+	}
+
+	// ------------------------------------------------------------------
+	// 2. GitHub activity — tiered by category.
+	// ------------------------------------------------------------------
+	// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
+	$rows = $wpdb->get_results( $wpdb->prepare(
+		"SELECT user_id, category, repo, COUNT(*) AS n, MAX(ts) AS last_ts
+		 FROM wporg_github_activity
+		 WHERE user_id IN ($placeholders)
+		   AND ts >= DATE_SUB(NOW(), INTERVAL %d DAY)
+		 GROUP BY user_id, category, repo",
+		$args
+	) );
+	// phpcs:enable
+
+	foreach ( $rows as $r ) {
+		$uid = (int) $r->user_id;
+		if ( ! isset( $metrics[ $uid ] ) ) {
+			continue;
+		}
+		$n    = (int) $r->n;
+		$tier = github_category_to_tier( (string) $r->category );
+
+		$metrics[ $uid ][ $tier . '_count' ] += $n;
+
+		if ( ! empty( $r->repo ) ) {
+			if ( ! isset( $metrics[ $uid ]['top_repos'][ $r->repo ] ) ) {
+				$metrics[ $uid ]['top_repos'][ $r->repo ] = 0;
+			}
+			$metrics[ $uid ]['top_repos'][ $r->repo ] += $n;
+		}
+
+		$ts = $r->last_ts ? strtotime( $r->last_ts ) : 0;
+		if ( $ts > (int) $metrics[ $uid ]['last_activity'] ) {
+			$metrics[ $uid ]['last_activity'] = $ts;
+		}
+	}
+
+	// ------------------------------------------------------------------
+	// Final shape: weighted_volume + sorted top_repos.
+	// ------------------------------------------------------------------
+	foreach ( $metrics as $uid => &$m ) {
+		$m['weighted_volume'] = ( 3 * $m['high_count'] ) + ( 1 * $m['medium_count'] );
+		arsort( $m['top_repos'] );
+		$m['top_repos'] = array_slice( $m['top_repos'], 0, 2, true );
+	}
+	unset( $m );
+
+	wp_cache_set( $cache_key, $metrics, CACHE_GROUP, HOUR_IN_SECONDS );
+	return $metrics;
+}
+
+/**
+ * Convert a unix timestamp to a coarse "active X ago" bucket and CSS class.
+ *
+ * Buckets keyed off non-low contribution recency, per spec:
+ *   today      — < 24h
+ *   N days     — within last 7d
+ *   N weeks    — 8d to 30d
+ *   N months   — 31d to 180d
+ *   over 6 months ago — older / unknown
+ *
+ * @return array { bucket: string, class: string }
+ */
+function format_active_bucket( $last_activity_ts ): array {
+	if ( ! $last_activity_ts ) {
+		return array(
+			'bucket' => __( 'over 6 months ago', 'wporg-5ftf' ),
+			'class'  => 'active-stale',
+		);
+	}
+
+	$days_since = max( 0, (int) floor( ( time() - (int) $last_activity_ts ) / DAY_IN_SECONDS ) );
+
+	if ( $days_since <= 1 ) {
+		return array(
+			'bucket' => __( 'today', 'wporg-5ftf' ),
+			'class'  => 'active-recent',
+		);
+	}
+
+	if ( $days_since <= 7 ) {
+		// translators: %d: number of days
+		$bucket = sprintf( _n( '%d day ago', '%d days ago', $days_since, 'wporg-5ftf' ), $days_since );
+		return array( 'bucket' => $bucket, 'class' => 'active-recent' );
+	}
+
+	if ( $days_since <= 30 ) {
+		$weeks = max( 1, (int) round( $days_since / 7 ) );
+		// translators: %d: number of weeks
+		$bucket = sprintf( _n( '%d week ago', '%d weeks ago', $weeks, 'wporg-5ftf' ), $weeks );
+		return array( 'bucket' => $bucket, 'class' => 'active-month' );
+	}
+
+	if ( $days_since <= 180 ) {
+		$months = max( 1, (int) round( $days_since / 30 ) );
+		// translators: %d: number of months
+		$bucket = sprintf( _n( '%d month ago', '%d months ago', $months, 'wporg-5ftf' ), $months );
+		return array( 'bucket' => $bucket, 'class' => 'active-quarter' );
+	}
+
+	return array(
+		'bucket' => __( 'over 6 months ago', 'wporg-5ftf' ),
+		'class'  => 'active-stale',
+	);
+}

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/inc/contribution-metrics.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/inc/contribution-metrics.php
@@ -48,7 +48,7 @@ function team_has_tracking_data( string $slug ): bool {
 
 /**
  * Resolve a user-provided window-days value to one of the allowed buckets.
- * Falls back to the default (90) on anything else.
+ * Falls back to WINDOW_DAYS_DEFAULT on anything else.
  */
 function resolve_window_days( $raw ): int {
 	$n = (int) $raw;
@@ -132,7 +132,11 @@ function get_team_contribution_metrics( array $user_ids, string $team_slug, int 
 		return array();
 	}
 
-	$cache_key = CACHE_PREFIX . $team_slug . '_w' . $window_days . '_' . md5( implode( ',', $user_ids ) );
+	// Sort so the cache key is order-independent: same user set hits the same key
+	// even if the upstream contributor list re-orders.
+	$cache_user_ids = $user_ids;
+	sort( $cache_user_ids );
+	$cache_key = CACHE_PREFIX . $team_slug . '_w' . $window_days . '_' . md5( implode( ',', $cache_user_ids ) );
 	$cached    = wp_cache_get( $cache_key, CACHE_GROUP );
 	if ( false !== $cached ) {
 		return $cached;

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/inc/contribution-metrics.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/inc/contribution-metrics.php
@@ -72,6 +72,32 @@ function team_to_trac( string $slug ): string {
 }
 
 /**
+ * Map a team slug to the GitHub repos whose activity counts toward that team's
+ * weighted_volume.
+ *
+ * The wporg_github_activity table collects events across every WordPress/* repo
+ * into a single global table. Without scoping, a contributor's PRs to unrelated
+ * repos (e.g. openverse, plugins) would inflate weighted_volume on every team
+ * page they appear on, and the "in <repo>" card summary would surface non-team
+ * repos as evidence of team contribution.
+ *
+ * Returns an empty array when the team has no mapped repos — the GitHub branch
+ * of get_team_contribution_metrics() is skipped in that case.
+ *
+ * Repo slugs match the value stored in wporg_github_activity.repo (typically
+ * 'owner/name' as reported by the GitHub webhook ingest).
+ *
+ * @return string[]
+ */
+function team_to_github_repos( string $slug ): array {
+	$map = array(
+		'core' => array( 'WordPress/wordpress-develop', 'WordPress/gutenberg' ),
+		'meta' => array( 'WordPress/wporg-main', 'WordPress/wporg-mu-plugins' ),
+	);
+	return isset( $map[ $slug ] ) ? $map[ $slug ] : array();
+}
+
+/**
  * Categorise a wporg_github_activity row's `category` field into a weight tier.
  *
  * High tier   — merged PRs (pr_merge / pr_merged).
@@ -186,20 +212,30 @@ function get_team_contribution_metrics( array $user_ids, string $team_slug, int 
 	}
 
 	// ------------------------------------------------------------------
-	// 2. GitHub activity — tiered by category.
+	// 2. GitHub activity — tiered by category. Scoped to the team's repo
+	//    allowlist so cross-team work doesn't leak into the directory.
 	// ------------------------------------------------------------------
-	// $placeholders is "%d,%d,...", built from the $user_ids count.
-	// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
-	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-	$rows = $wpdb->get_results( $wpdb->prepare(
-		"SELECT user_id, category, repo, COUNT(*) AS n, MAX(ts) AS last_ts
-		 FROM wporg_github_activity
-		 WHERE user_id IN ($placeholders)
-		   AND ts >= DATE_SUB(NOW(), INTERVAL %d DAY)
-		 GROUP BY user_id, category, repo",
-		$args
-	) );
-	// phpcs:enable
+	$github_repos = team_to_github_repos( $team_slug );
+	$rows         = array();
+	if ( ! empty( $github_repos ) ) {
+		$repo_placeholders = implode( ',', array_fill( 0, count( $github_repos ), '%s' ) );
+		$github_args       = array_merge( $user_ids, array( $window_days ), $github_repos );
+
+		// $placeholders / $repo_placeholders are built from internal counts only
+		// (user_id count and the hardcoded repo allowlist size).
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$rows = $wpdb->get_results( $wpdb->prepare(
+			"SELECT user_id, category, repo, COUNT(*) AS n, MAX(ts) AS last_ts
+			 FROM wporg_github_activity
+			 WHERE user_id IN ($placeholders)
+			   AND ts >= DATE_SUB(NOW(), INTERVAL %d DAY)
+			   AND repo IN ($repo_placeholders)
+			 GROUP BY user_id, category, repo",
+			$github_args
+		) );
+		// phpcs:enable
+	}
 
 	foreach ( $rows as $r ) {
 		$uid = (int) $r->user_id;
@@ -218,9 +254,15 @@ function get_team_contribution_metrics( array $user_ids, string $team_slug, int 
 			$metrics[ $uid ]['top_repos'][ $r->repo ] += $n;
 		}
 
-		$ts = $r->last_ts ? strtotime( $r->last_ts ) : 0;
-		if ( $ts > (int) $metrics[ $uid ]['last_activity'] ) {
-			$metrics[ $uid ]['last_activity'] = $ts;
+		// Per spec, the active-X-ago bucket is keyed off non-low recency only.
+		// Low-tier signals (opened issues, reopened PRs) don't count toward
+		// weighted_volume, so they shouldn't make a card render "active today"
+		// while its body says "no verified contributions in the last N days".
+		if ( 'low' !== $tier ) {
+			$ts = $r->last_ts ? strtotime( $r->last_ts ) : 0;
+			if ( $ts > (int) $metrics[ $uid ]['last_activity'] ) {
+				$metrics[ $uid ]['last_activity'] = $ts;
+			}
 		}
 	}
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/inc/contribution-metrics.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/inc/contribution-metrics.php
@@ -213,7 +213,7 @@ function get_team_contribution_metrics( array $user_ids, string $team_slug, int 
 
 	// ------------------------------------------------------------------
 	// 2. GitHub activity — tiered by category. Scoped to the team's repo
-	//    allowlist so cross-team work doesn't leak into the directory.
+	// allowlist so cross-team work doesn't leak into the directory.
 	// ------------------------------------------------------------------
 	$github_repos = team_to_github_repos( $team_slug );
 	$rows         = array();

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/inc/contribution-metrics.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/inc/contribution-metrics.php
@@ -29,6 +29,24 @@ const CACHE_GROUP         = '5ftf';
 const CACHE_PREFIX        = '5ftf_contrib_metrics_v1_';
 
 /**
+ * Teams that currently have wired-up contribution tracking. Other teams render
+ * an invitation/guide page (page-pledges.php branches on this).
+ *
+ * To enable a new team:
+ *   1. Define what counts as a verified contribution with the team.
+ *   2. Wire the data source into get_team_contribution_metrics().
+ *   3. Add the team's post_name slug to this list.
+ */
+const TEAMS_WITH_DATA = array( 'core', 'meta' );
+
+/**
+ * Whether the given team has wired-up contribution tracking.
+ */
+function team_has_tracking_data( string $slug ): bool {
+	return in_array( $slug, TEAMS_WITH_DATA, true );
+}
+
+/**
  * Resolve a user-provided window-days value to one of the allowed buckets.
  * Falls back to the default (90) on anything else.
  */

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/js/page-pledges.js
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/js/page-pledges.js
@@ -22,7 +22,9 @@
 		grid.querySelectorAll( '.pledges-card' )
 	);
 	var resultCount = document.getElementById( 'pledges-result-count' );
+	var resultPhrase = document.getElementById( 'pledges-result-phrase' );
 	var emptyState = document.getElementById( 'pledges-empty' );
+	var divider = grid.querySelector( '.pledges-inactive-divider' );
 	var hiwBanner = document.getElementById( 'pledges-howitworks' );
 	var hiwDismiss = hiwBanner && hiwBanner.querySelector( '.pledges-howitworks-dismiss' );
 	var hiwKey = 'wporg-pledges-hiw-dismissed';
@@ -59,7 +61,11 @@
 	function apply() {
 		// Filter (visibility) + re-rank visible cards. Server-side order is preserved
 		// (already sorted by weighted_volume desc in page-pledges.php).
-		var visibleCount = 0;
+		// `activeVisible` drives the result count beneath "active contributors";
+		// `rankCounter` numbers every visible card sequentially across the divider.
+		var activeVisible = 0;
+		var inactiveVisible = 0;
+		var rankCounter = 0;
 		cards.forEach( function ( card ) {
 			var matches = true;
 			if ( state.sponsorship !== 'all' && card.dataset.sponsorship !== state.sponsorship ) {
@@ -67,22 +73,47 @@
 			}
 			card.hidden = ! matches;
 			if ( matches ) {
-				visibleCount++;
+				rankCounter++;
 				var rankEl = card.querySelector( '.pledges-card-rank' );
 				if ( rankEl ) {
-					rankEl.textContent = String( visibleCount ).padStart( 2, '0' );
+					rankEl.textContent = String( rankCounter ).padStart( 2, '0' );
+				}
+				if ( card.dataset.active === '1' ) {
+					activeVisible++;
+				} else {
+					inactiveVisible++;
 				}
 			}
 		} );
 
-		// Empty state.
-		if ( emptyState ) {
-			emptyState.hidden = visibleCount > 0;
+		// Hide the inactive divider when the current filter empties its section,
+		// so users don't see an orphan "N contributors with no verified..." label.
+		if ( divider ) {
+			divider.hidden = inactiveVisible === 0;
 		}
 
-		// Result count.
+		// Empty state shows only when nothing is visible at all.
+		if ( emptyState ) {
+			emptyState.hidden = ( activeVisible + inactiveVisible ) > 0;
+		}
+
+		// Result count is "active contributors" — inactive cards don't belong here.
 		if ( resultCount ) {
-			resultCount.textContent = visibleCount;
+			resultCount.textContent = activeVisible;
+		}
+
+		// Rebuild the phrase so the singular/plural form follows the live visible
+		// count instead of being frozen at the server-rendered $active_count.
+		// (Two-form approximation; for fully plural-aware locales we'd swap this
+		// for wp.i18n._n once the script depends on @wordpress/i18n.)
+		if ( resultPhrase ) {
+			var total = parseInt( resultPhrase.dataset.total || '0', 10 );
+			var template = activeVisible === 1
+				? resultPhrase.dataset.singular
+				: resultPhrase.dataset.plural;
+			if ( template ) {
+				resultPhrase.textContent = template.replace( '%d', String( total ) );
+			}
 		}
 	}
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/js/page-pledges.js
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/js/page-pledges.js
@@ -1,12 +1,13 @@
 /*
  * Page Pledges — Five for the Future redesign Page 1.
- * Client-side filter + sort over the cards already rendered server-side.
+ * Client-side filter over the cards already rendered server-side.
  *
- * Filters: sponsorship (all/independent/sponsored). Time window is currently a
- * UI-only placeholder until contribution-window aggregation ships.
+ * Filters: sponsorship (all/independent/sponsored). The time window is server-side
+ * (?window=30|90|180); chips are <a> links that reload the page so the aggregator
+ * runs against the new window.
  *
- * Sorts: weighted (default), raw, alpha. Non-destructive — all cards stay in DOM,
- * order is rewritten via Array.prototype.sort and re-appended.
+ * Visibility is non-destructive — all cards stay in DOM, hidden via the `hidden`
+ * attribute, and visible cards are re-ranked from 01 on every state change.
  */
 
 ( function () {
@@ -27,9 +28,7 @@
 	var hiwKey = 'wporg-pledges-hiw-dismissed';
 
 	var state = {
-		window: '30',
 		sponsorship: 'independent',
-		sort: 'weighted',
 	};
 
 	/**
@@ -55,32 +54,13 @@
 	}
 
 	/**
-	 * Apply filter + sort + render counts.
+	 * Apply filter + render counts.
 	 */
 	function apply() {
-		// Sort.
-		var sortKey = state.sort;
-		var sorted = cards.slice().sort( function ( a, b ) {
-			if ( sortKey === 'weighted' ) {
-				return parseInt( b.dataset.weighted || '0', 10 ) - parseInt( a.dataset.weighted || '0', 10 );
-			}
-			if ( sortKey === 'raw' ) {
-				return parseInt( b.dataset.raw || '0', 10 ) - parseInt( a.dataset.raw || '0', 10 );
-			}
-			if ( sortKey === 'alpha' ) {
-				return ( a.dataset.name || '' ).localeCompare( b.dataset.name || '' );
-			}
-			return 0;
-		} );
-
-		// Re-append in sorted order.
-		sorted.forEach( function ( card ) {
-			grid.appendChild( card );
-		} );
-
-		// Filter (visibility) + re-rank visible cards in sorted order.
+		// Filter (visibility) + re-rank visible cards. Server-side order is preserved
+		// (already sorted by weighted_volume desc in page-pledges.php).
 		var visibleCount = 0;
-		sorted.forEach( function ( card ) {
+		cards.forEach( function ( card ) {
 			var matches = true;
 			if ( state.sponsorship !== 'all' && card.dataset.sponsorship !== state.sponsorship ) {
 				matches = false;

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/js/page-pledges.js
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/js/page-pledges.js
@@ -1,0 +1,148 @@
+/*
+ * Page Pledges — Five for the Future redesign Page 1.
+ * Client-side filter + sort over the cards already rendered server-side.
+ *
+ * Filters: sponsorship (all/independent/sponsored). Time window is currently a
+ * UI-only placeholder until contribution-window aggregation ships.
+ *
+ * Sorts: weighted (default), raw, alpha. Non-destructive — all cards stay in DOM,
+ * order is rewritten via Array.prototype.sort and re-appended.
+ */
+
+( function () {
+	'use strict';
+
+	var grid = document.getElementById( 'pledges-grid' );
+	if ( ! grid ) {
+		return;
+	}
+
+	var cards = Array.prototype.slice.call(
+		grid.querySelectorAll( '.pledges-card' )
+	);
+	var resultCount = document.getElementById( 'pledges-result-count' );
+	var emptyState = document.getElementById( 'pledges-empty' );
+	var hiwBanner = document.getElementById( 'pledges-howitworks' );
+	var hiwDismiss = hiwBanner && hiwBanner.querySelector( '.pledges-howitworks-dismiss' );
+	var hiwKey = 'wporg-pledges-hiw-dismissed';
+
+	var state = {
+		window: '30',
+		sponsorship: 'independent',
+		sort: 'weighted',
+	};
+
+	/**
+	 * Restore "How this page works" banner dismiss state from localStorage.
+	 */
+	if ( hiwBanner && hiwDismiss ) {
+		try {
+			if ( window.localStorage.getItem( hiwKey ) === '1' ) {
+				hiwBanner.classList.add( 'is-dismissed' );
+			}
+		} catch ( e ) {
+			/* ignore */
+		}
+
+		hiwDismiss.addEventListener( 'click', function () {
+			hiwBanner.classList.add( 'is-dismissed' );
+			try {
+				window.localStorage.setItem( hiwKey, '1' );
+			} catch ( e ) {
+				/* ignore */
+			}
+		} );
+	}
+
+	/**
+	 * Apply filter + sort + render counts.
+	 */
+	function apply() {
+		// Sort.
+		var sortKey = state.sort;
+		var sorted = cards.slice().sort( function ( a, b ) {
+			if ( sortKey === 'weighted' ) {
+				return parseInt( b.dataset.weighted || '0', 10 ) - parseInt( a.dataset.weighted || '0', 10 );
+			}
+			if ( sortKey === 'raw' ) {
+				return parseInt( b.dataset.raw || '0', 10 ) - parseInt( a.dataset.raw || '0', 10 );
+			}
+			if ( sortKey === 'alpha' ) {
+				return ( a.dataset.name || '' ).localeCompare( b.dataset.name || '' );
+			}
+			return 0;
+		} );
+
+		// Re-append in sorted order.
+		sorted.forEach( function ( card ) {
+			grid.appendChild( card );
+		} );
+
+		// Filter (visibility) + re-rank visible cards in sorted order.
+		var visibleCount = 0;
+		sorted.forEach( function ( card ) {
+			var matches = true;
+			if ( state.sponsorship !== 'all' && card.dataset.sponsorship !== state.sponsorship ) {
+				matches = false;
+			}
+			card.hidden = ! matches;
+			if ( matches ) {
+				visibleCount++;
+				var rankEl = card.querySelector( '.pledges-card-rank' );
+				if ( rankEl ) {
+					rankEl.textContent = String( visibleCount ).padStart( 2, '0' );
+				}
+			}
+		} );
+
+		// Empty state.
+		if ( emptyState ) {
+			emptyState.hidden = visibleCount > 0;
+		}
+
+		// Result count.
+		if ( resultCount ) {
+			resultCount.textContent = visibleCount;
+		}
+	}
+
+	/**
+	 * Wire BUTTON chips for client-side filtering. <a> chips (time window)
+	 * navigate via URL and reload — handled by the browser, not JS.
+	 */
+	document.querySelectorAll( 'button.pledges-chip' ).forEach( function ( chip ) {
+		chip.addEventListener( 'click', function () {
+			var filter = chip.dataset.filter;
+			var value = chip.dataset.value;
+			if ( ! filter ) {
+				return;
+			}
+			document
+				.querySelectorAll( 'button.pledges-chip[data-filter="' + filter + '"]' )
+				.forEach( function ( c ) {
+					c.classList.remove( 'is-on' );
+				} );
+			chip.classList.add( 'is-on' );
+			state[ filter ] = value;
+			apply();
+		} );
+	} );
+
+	/**
+	 * Empty-state reset.
+	 */
+	var resetBtn = document.querySelector( '.pledges-empty-reset' );
+	if ( resetBtn ) {
+		resetBtn.addEventListener( 'click', function () {
+			document
+				.querySelectorAll( '.pledges-chip[data-filter="sponsorship"]' )
+				.forEach( function ( c ) {
+					c.classList.toggle( 'is-on', c.dataset.value === 'all' );
+				} );
+			state.sponsorship = 'all';
+			apply();
+		} );
+	}
+
+	apply();
+} )();

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/js/page-pledges.js
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/js/page-pledges.js
@@ -25,6 +25,10 @@
 	var resultPhrase = document.getElementById( 'pledges-result-phrase' );
 	var emptyState = document.getElementById( 'pledges-empty' );
 	var divider = grid.querySelector( '.pledges-inactive-divider' );
+	// When the empty state is showing, the empty-state-extra link already offers
+	// "Show inactive contributors" — the standalone toggle below would just
+	// duplicate the same CTA, so hide it whenever the empty state is on.
+	var inactiveToggle = document.querySelector( '.pledges-inactive-toggle' );
 	var hiwBanner = document.getElementById( 'pledges-howitworks' );
 	var hiwDismiss = hiwBanner && hiwBanner.querySelector( '.pledges-howitworks-dismiss' );
 	var hiwKey = 'wporg-pledges-hiw-dismissed';
@@ -93,8 +97,15 @@
 		}
 
 		// Empty state shows only when nothing is visible at all.
+		var showEmpty = ( activeVisible + inactiveVisible ) === 0;
 		if ( emptyState ) {
-			emptyState.hidden = ( activeVisible + inactiveVisible ) > 0;
+			emptyState.hidden = ! showEmpty;
+		}
+
+		// Hide the standalone "Show inactive" toggle when the empty state takes
+		// over — the empty state already carries the same CTA inline.
+		if ( inactiveToggle ) {
+			inactiveToggle.hidden = showEmpty;
 		}
 
 		// Result count is "active contributors" — inactive cards don't belong here.

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
@@ -19,6 +19,118 @@ require_once __DIR__ . '/inc/contribution-metrics.php';
 get_header();
 
 $current_team = Pledges\get_current_team();
+
+wp_enqueue_style(
+	'wporg-breathe-page-pledges',
+	get_stylesheet_directory_uri() . '/css/page-pledges.css',
+	array( 'wporg-breathe' ),
+	filemtime( __DIR__ . '/css/page-pledges.css' )
+);
+
+// ------------------------------------------------------------------
+// Teams without wired-up tracking get an invitation page instead of
+// the directory. Renders the legacy /pledges/ context as an invite to
+// help bring contribution tracking to the team.
+// ------------------------------------------------------------------
+if ( ! ContributionMetrics\team_has_tracking_data( $current_team->post_name ) ) {
+	$team_slug    = $current_team->post_name;
+	$handbook_url = 'https://make.wordpress.org/' . $team_slug . '/handbook/';
+	/* translators: %s: team name */
+	$handbook_label = sprintf( __( 'Open the %s Handbook', 'wporg-5ftf' ), $current_team->post_title );
+	?>
+	<div id="primary" class="content-area">
+		<div class="site-content template-pledges template-pledges-guide" role="main">
+
+			<header class="page-header pledges-hero">
+				<h1 class="page-title">
+					<?php echo esc_html( sprintf( __( 'People contributing to %s', 'wporg-5ftf' ), $current_team->post_title ) ); ?>
+				</h1>
+				<p class="pledges-subtitle">
+					<?php esc_html_e( 'Help bring contribution tracking to this team.', 'wporg-5ftf' ); ?>
+				</p>
+			</header>
+
+			<article id="post-pledges" class="page type-page status-publish hentry pledges-article">
+				<div class="entry-content">
+
+					<div class="pledges-guide-intro">
+						<p>
+							<?php
+							echo wp_kses_data( sprintf(
+								/* translators: %s: team name */
+								__( 'We don\'t yet have automated contribution tracking for the <strong>%s</strong> team. Sponsors, recruiters, and team reps can\'t see who is shipping verified work — only a list of people who opted in.', 'wporg-5ftf' ),
+								esc_html( $current_team->post_title )
+							) );
+							?>
+						</p>
+						<p>
+							<strong><?php esc_html_e( 'You could lead this. Here is the path:', 'wporg-5ftf' ); ?></strong>
+						</p>
+					</div>
+
+					<ol class="pledges-guide-steps">
+						<li class="pledges-guide-step">
+							<h3><?php esc_html_e( 'Review the team handbook', 'wporg-5ftf' ); ?></h3>
+							<p><?php esc_html_e( 'Read it cover to cover. Understand what this team works on, how decisions get made, who the team reps are, and what existing recognition looks like.', 'wporg-5ftf' ); ?></p>
+							<p><a class="pledges-guide-link" href="<?php echo esc_url( $handbook_url ); ?>"><?php echo esc_html( $handbook_label ); ?></a></p>
+						</li>
+
+						<li class="pledges-guide-step">
+							<h3><?php esc_html_e( 'Join the team on Slack', 'wporg-5ftf' ); ?></h3>
+							<p>
+								<?php
+								echo wp_kses_data( sprintf(
+									/* translators: %s: team channel name e.g. #core */
+									__( 'Most coordination happens in <code>#%s</code> on the Make WordPress Slack workspace.', 'wporg-5ftf' ),
+									esc_html( $team_slug )
+								) );
+								?>
+							</p>
+							<p><a class="pledges-guide-link" href="https://make.wordpress.org/chat/"><?php esc_html_e( 'Get a Slack account', 'wporg-5ftf' ); ?></a></p>
+						</li>
+
+						<li class="pledges-guide-step">
+							<h3><?php esc_html_e( 'Attend one or two team meetings', 'wporg-5ftf' ); ?></h3>
+							<p><?php esc_html_e( 'Meeting times are in the handbook. Show up, introduce yourself, listen. Do not propose anything yet — just get a sense of the rhythm and the open work.', 'wporg-5ftf' ); ?></p>
+						</li>
+
+						<li class="pledges-guide-step">
+							<h3><?php esc_html_e( 'Propose a metrics discussion', 'wporg-5ftf' ); ?></h3>
+							<p><?php esc_html_e( 'Once you have earned standing in the team, propose a discussion (in a meeting or async) to define what counts as a verified contribution. What types of work? What weights? Which signals should be tracked, and which intentionally ignored?', 'wporg-5ftf' ); ?></p>
+						</li>
+
+						<li class="pledges-guide-step">
+							<h3><?php esc_html_e( 'Collect, store, and cache the agreed metrics', 'wporg-5ftf' ); ?></h3>
+							<p><?php esc_html_e( 'Wire the agreed signals into the wp.org data pipeline alongside the existing Trac and GitHub aggregation. Add per-source ingest, indexed storage, and hour-cached aggregation matching the existing pattern.', 'wporg-5ftf' ); ?></p>
+						</li>
+
+						<li class="pledges-guide-step">
+							<h3><?php esc_html_e( 'Wire this page up', 'wporg-5ftf' ); ?></h3>
+							<p>
+								<?php
+								echo wp_kses_data( sprintf(
+									/* translators: 1: file path, 2: constant name */
+									__( 'Update <code>%1$s</code> to include the team and its new data source, then add the team\'s slug to <code>%2$s</code>. This page will switch from this guide to the contributor directory automatically.', 'wporg-5ftf' ),
+									'inc/contribution-metrics.php',
+									'TEAMS_WITH_DATA'
+								) );
+								?>
+							</p>
+						</li>
+					</ol>
+
+				</div>
+			</article>
+
+		</div>
+	</div>
+	<div style="display: none;"><div id="content"></div></div>
+	<?php
+	get_sidebar();
+	get_footer();
+	return;
+}
+
 $contributors = Pledges\get_team_contributors(
 	$current_team->post_name,
 	$current_team->post_title
@@ -88,12 +200,6 @@ foreach ( $contributors as $c ) {
 	}
 }
 
-wp_enqueue_style(
-	'wporg-breathe-page-pledges',
-	get_stylesheet_directory_uri() . '/css/page-pledges.css',
-	array( 'wporg-breathe' ),
-	filemtime( __DIR__ . '/css/page-pledges.css' )
-);
 wp_enqueue_script(
 	'wporg-breathe-page-pledges',
 	get_stylesheet_directory_uri() . '/js/page-pledges.js',

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
@@ -73,7 +73,7 @@ if ( ! ContributionMetrics\team_has_tracking_data( $current_team->post_name ) ) 
 							<?php
 							echo wp_kses_data( sprintf(
 								/* translators: %s: team name */
-								__( 'We don\'t yet have automated contribution tracking for the <strong>%s</strong> team. Sponsors, recruiters, and team reps can\'t see who is shipping verified work — only a list of people who opted in.', 'wporg-5ftf' ),
+								__( 'We don\'t yet have automated contribution tracking for the <strong>%s</strong> team. Sponsors, recruiters, and team reps can\'t see who is shipping tracked work — only a list of people who opted in.', 'wporg-5ftf' ),
 								esc_html( $current_team->post_title )
 							) );
 							?>
@@ -111,7 +111,7 @@ if ( ! ContributionMetrics\team_has_tracking_data( $current_team->post_name ) ) 
 
 						<li class="pledges-guide-step">
 							<h3><?php esc_html_e( 'Propose a metrics discussion', 'wporg-5ftf' ); ?></h3>
-							<p><?php esc_html_e( 'Once you have earned standing in the team, propose a discussion (in a meeting or async) to define what counts as a verified contribution. What types of work? What weights? Which signals should be tracked, and which intentionally ignored?', 'wporg-5ftf' ); ?></p>
+							<p><?php esc_html_e( 'Once you have earned standing in the team, propose a discussion (in a meeting or async) to define what counts as a tracked contribution. What types of work? What impact levels? Which signals should be tracked, and which intentionally ignored?', 'wporg-5ftf' ); ?></p>
 						</li>
 
 						<li class="pledges-guide-step">
@@ -239,7 +239,7 @@ foreach ( $contributors as $c ) {
 						<div class="pledges-howitworks-body">
 							<strong><?php esc_html_e( 'How this page works', 'wporg-5ftf' ); ?></strong>
 							<p>
-								<?php esc_html_e( 'Contributors are ranked by weighted recent activity, not by pledged hours. Signals come from Trac props (release credits) and GitHub activity (merged PRs, pushes, closed issues), bucketed into high, medium, and low weight. Low-weight contributions (typo fixes, whitespace) don\'t factor into the ranking. Inactive contributors decay down the list automatically.', 'wporg-5ftf' ); ?>
+								<?php esc_html_e( 'Contributors are ranked by recent contribution impact, not by pledged hours. Activity is tracked from release credits in Trac and GitHub work (merged PRs, pushes, closed issues), sorted into high, medium, and low impact. Low-impact contributions (typo fixes, whitespace) don\'t factor into the ranking. Inactive contributors gradually drop down the list.', 'wporg-5ftf' ); ?>
 							</p>
 						</div>
 						<button type="button" class="pledges-howitworks-dismiss" aria-label="<?php esc_attr_e( 'Dismiss', 'wporg-5ftf' ); ?>">&times;</button>
@@ -253,7 +253,7 @@ foreach ( $contributors as $c ) {
 							// scopes the rank line below, not this banner. Don't conflate the two.
 							echo wp_kses_data( sprintf(
 								/* translators: %s: team name */
-								__( 'opted-in contributors to %s.', 'wporg-5ftf' ),
+								__( 'contributors to %s.', 'wporg-5ftf' ),
 								'<strong>' . esc_html( $current_team->post_title ) . '</strong>'
 							) );
 							?>
@@ -296,7 +296,7 @@ foreach ( $contributors as $c ) {
 							<?php
 							echo esc_html( sprintf(
 								/* translators: %d: window in days */
-								__( 'Ranked by weighted volume, last %d days.', 'wporg-5ftf' ),
+								__( 'Ranked by impact, last %d days.', 'wporg-5ftf' ),
 								$window_days
 							) );
 							?>
@@ -336,7 +336,7 @@ foreach ( $contributors as $c ) {
 						if ( $show_inactive && $inactive_contributors ) {
 							$inactive_label = sprintf(
 								/* translators: 1: count, 2: window in days */
-								_n( '%1$d contributor with no verified contributions in the last %2$d days', '%1$d contributors with no verified contributions in the last %2$d days', $inactive_count, 'wporg-5ftf' ),
+								_n( '%1$d contributor with no tracked contributions in the last %2$d days', '%1$d contributors with no tracked contributions in the last %2$d days', $inactive_count, 'wporg-5ftf' ),
 								$inactive_count,
 								$window_days
 							);
@@ -360,7 +360,7 @@ foreach ( $contributors as $c ) {
 									<?php
 									echo esc_html( sprintf(
 										/* translators: 1: count, 2: window in days */
-										_n( 'Show %1$d contributor with no verified contributions in the last %2$d days', 'Show %1$d contributors with no verified contributions in the last %2$d days', $inactive_count, 'wporg-5ftf' ),
+										_n( 'Show %1$d contributor with no tracked contributions in the last %2$d days', 'Show %1$d contributors with no tracked contributions in the last %2$d days', $inactive_count, 'wporg-5ftf' ),
 										$inactive_count,
 										$window_days
 									) );
@@ -395,7 +395,7 @@ foreach ( $contributors as $c ) {
 									<?php
 									echo esc_html( sprintf(
 										/* translators: 1: count, 2: window in days */
-										_n( 'Show %1$d contributor with no verified contributions in the last %2$d days', 'Show %1$d contributors with no verified contributions in the last %2$d days', $inactive_count, 'wporg-5ftf' ),
+										_n( 'Show %1$d contributor with no tracked contributions in the last %2$d days', 'Show %1$d contributors with no tracked contributions in the last %2$d days', $inactive_count, 'wporg-5ftf' ),
 										$inactive_count,
 										$window_days
 									) );

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
@@ -4,12 +4,17 @@
  * Template Name: Pledges
  *
  * Note: Pledges is a simulated page, rather than actually existing in the database; see `mu-plugins/make-network/team-pledges.php`.
+ *
+ * Page 1 of the Five for the Future redesign — team contributor directory.
+ * Output over intent: ranks contributors by recent shipped work, decays inactive contributors.
  */
 
 namespace WordPressdotorg\Make\Breathe_2024;
 use WordPressdotorg\Make\Pledges;
 
 defined( 'WPINC' ) || die();
+
+require_once __DIR__ . '/inc/contribution-metrics.php';
 
 get_header();
 
@@ -19,46 +24,255 @@ $contributors = Pledges\get_team_contributors(
 	$current_team->post_title
 );
 
+// ------------------------------------------------------------------
+// Real contribution metrics from Trac props + GitHub activity.
+// One bulk DB call per signal source, hour-cached.
+// ------------------------------------------------------------------
+$window_days = ContributionMetrics\resolve_window_days(
+	isset( $_GET['window'] ) ? $_GET['window'] : ContributionMetrics\WINDOW_DAYS_DEFAULT
+);
+
+$metrics = ContributionMetrics\get_team_contribution_metrics(
+	array_keys( $contributors ),
+	$current_team->post_name,
+	$window_days
+);
+
+foreach ( $contributors as $uid => &$c ) {
+	$m                            = isset( $metrics[ $uid ] ) ? $metrics[ $uid ] : ContributionMetrics\empty_metrics();
+	$bucket                       = ContributionMetrics\format_active_bucket( $m['last_activity'] );
+	$c['_metrics_high']           = (int) $m['high_count'];
+	$c['_metrics_medium']         = (int) $m['medium_count'];
+	$c['_metrics_low']            = (int) $m['low_count'];
+	$c['_metrics_weighted']       = (int) $m['weighted_volume'];
+	$c['_metrics_active_bucket']  = $bucket['bucket'];
+	$c['_metrics_active_class']   = $bucket['class'];
+	$c['_metrics_top_repos']      = array_keys( $m['top_repos'] );
+	$c['_metrics_window_days']    = $window_days;
+}
+unset( $c );
+
+uasort( $contributors, function( $a, $b ) {
+	return $b['_metrics_weighted'] - $a['_metrics_weighted'];
+} );
+
+// Split the list into active (verified output in window) vs inactive.
+// The spec is explicit: directory ranks by recent shipped work and decays
+// contributors who stopped. Inactive ones are hidden from the default view.
+$active_contributors   = array();
+$inactive_contributors = array();
+foreach ( $contributors as $uid => $c ) {
+	if ( (int) $c['_metrics_weighted'] > 0 ) {
+		$active_contributors[ $uid ] = $c;
+	} else {
+		$inactive_contributors[ $uid ] = $c;
+	}
+}
+
+// `?show_inactive=1` opt-in to render inactive ones too (still beneath the active list).
+$show_inactive = ! empty( $_GET['show_inactive'] );
+
+$total_count       = count( $contributors );
+$active_count      = count( $active_contributors );
+$inactive_count    = count( $inactive_contributors );
+$independent_count = 0;
+$sponsored_count   = 0;
+foreach ( $contributors as $c ) {
+	if ( ! empty( $c['sponsored'] ) ) {
+		$sponsored_count++;
+	} else {
+		$independent_count++;
+	}
+}
+
+wp_enqueue_style(
+	'wporg-breathe-page-pledges',
+	get_stylesheet_directory_uri() . '/css/page-pledges.css',
+	array( 'wporg-breathe' ),
+	filemtime( __DIR__ . '/css/page-pledges.css' )
+);
+wp_enqueue_script(
+	'wporg-breathe-page-pledges',
+	get_stylesheet_directory_uri() . '/js/page-pledges.js',
+	array(),
+	filemtime( __DIR__ . '/js/page-pledges.js' ),
+	true
+);
+
 ?>
 
 <div id="primary" class="content-area">
-	<?php // Note: if this has `id="content"` then Breathe will overwrite anything inside it. ?>
-	<div class="site-content template-pledges" role="main">
+	<div class="site-content template-pledges template-pledges-v2" role="main">
 
-		<header class="page-header">
+		<header class="page-header pledges-hero">
 			<h1 class="page-title">
-				<?php
-					esc_html_e( 'Pledged Contributors', 'wporg-5ftf' );
-				?>
+				<?php echo esc_html( sprintf( __( 'People contributing to %s', 'wporg-5ftf' ), $current_team->post_title ) ); ?>
 			</h1>
+			<p class="pledges-subtitle">
+				<?php esc_html_e( 'Ranked by recent shipped work, not by pledged hours.', 'wporg-5ftf' ); ?>
+			</p>
 		</header>
 
-		<article id="post-pledges" class="page type-page status-publish hentry">
+		<article id="post-pledges" class="page type-page status-publish hentry pledges-article">
 			<div class="entry-content">
-				<p>
-					These people have pledged time to contribute to <?php echo esc_html( $current_team->post_title ); ?> Team efforts! When looking for help on a project or program, try starting by reaching out to the people on this list!
-				</p>
 
-				<p>
-					If you'd like to add yourself to this list, you can <a href="https://wordpress.org/five-for-the-future/">sign up on the Five for the Future site</a>.
-				</p>
+				<?php if ( $contributors ) : ?>
 
-				<?php
+					<div class="pledges-howitworks" id="pledges-howitworks" role="note">
+						<div class="pledges-howitworks-icon" aria-hidden="true">i</div>
+						<div class="pledges-howitworks-body">
+							<strong><?php esc_html_e( 'How this page works', 'wporg-5ftf' ); ?></strong>
+							<p>
+								<?php esc_html_e( 'Contributors are ranked by weighted recent activity, not by pledged hours. Signals come from Trac props (release credits) and GitHub activity (merged PRs, pushes, closed issues), bucketed into high, medium, and low weight. Low-weight contributions (typo fixes, whitespace) don\'t factor into the ranking. Inactive contributors decay down the list automatically.', 'wporg-5ftf' ); ?>
+							</p>
+						</div>
+						<button type="button" class="pledges-howitworks-dismiss" aria-label="<?php esc_attr_e( 'Dismiss', 'wporg-5ftf' ); ?>">&times;</button>
+					</div>
 
-				if ( $contributors ) {
-					foreach( $contributors as $contributor ) {
-						// Not using get_template_part() because the included file needs access to `$contributor`.
-						require __DIR__ . '/content-pledge.php';
-					}
+					<div class="pledges-health" role="status">
+						<span class="pledges-health-num"><?php echo esc_html( number_format_i18n( $total_count ) ); ?></span>
+						<span class="pledges-health-text">
+							<?php
+							echo wp_kses_data( sprintf(
+								/* translators: 1: team name, 2: window in days */
+								__( 'opted-in contributors to %1$s in the last %2$d days.', 'wporg-5ftf' ),
+								'<strong>' . esc_html( $current_team->post_title ) . '</strong>',
+								$window_days
+							) );
+							?>
+						</span>
+						<span class="pledges-health-split">
+							<span class="pledges-health-chip independent"><strong><?php echo esc_html( number_format_i18n( $independent_count ) ); ?></strong> <?php esc_html_e( 'independent', 'wporg-5ftf' ); ?></span>
+							<span class="pledges-health-chip sponsored"><strong><?php echo esc_html( number_format_i18n( $sponsored_count ) ); ?></strong> <?php esc_html_e( 'sponsored', 'wporg-5ftf' ); ?></span>
+						</span>
+					</div>
 
-				} else {
-					echo wp_kses_post( sprintf(
-						__( 'Nobody has indicated that they\'re sponsored to contribute to this team. If you are, please <a href="%s">update your profile</a> to indicate that.', 'wporg-5ftf' ),
-						'https://profiles.wordpress.org/me/profile/edit/group/5/'
-					) );
-				}
+					<?php
+					// home_url('/pledges/') already includes the team site path, so no REQUEST_URI concat.
+					$base_url   = home_url( '/pledges/' );
+					$window_url = function ( $w ) use ( $base_url ) {
+						return $w === ContributionMetrics\WINDOW_DAYS_DEFAULT
+							? esc_url( $base_url )
+							: esc_url( add_query_arg( 'window', $w, $base_url ) );
+					};
+					?>
+					<div class="pledges-toolbar">
+						<div class="pledges-filters" role="group" aria-label="<?php esc_attr_e( 'Filter contributors', 'wporg-5ftf' ); ?>">
+							<div class="pledges-filter-group">
+								<span class="pledges-filter-label"><?php esc_html_e( 'Time window', 'wporg-5ftf' ); ?></span>
+								<a class="pledges-chip<?php echo 30 === $window_days ? ' is-on' : ''; ?>" href="<?php echo $window_url( 30 ); ?>"><?php esc_html_e( '30 days', 'wporg-5ftf' ); ?></a>
+								<a class="pledges-chip<?php echo 90 === $window_days ? ' is-on' : ''; ?>" href="<?php echo $window_url( 90 ); ?>"><?php esc_html_e( '90 days', 'wporg-5ftf' ); ?></a>
+								<a class="pledges-chip<?php echo 180 === $window_days ? ' is-on' : ''; ?>" href="<?php echo $window_url( 180 ); ?>"><?php esc_html_e( '6 months', 'wporg-5ftf' ); ?></a>
+							</div>
+							<div class="pledges-filter-group">
+								<span class="pledges-filter-label"><?php esc_html_e( 'Sponsorship', 'wporg-5ftf' ); ?></span>
+								<button type="button" class="pledges-chip" data-filter="sponsorship" data-value="all"><?php esc_html_e( 'All', 'wporg-5ftf' ); ?></button>
+								<button type="button" class="pledges-chip is-on" data-filter="sponsorship" data-value="independent"><?php esc_html_e( 'Independent', 'wporg-5ftf' ); ?></button>
+								<button type="button" class="pledges-chip" data-filter="sponsorship" data-value="sponsored"><?php esc_html_e( 'Sponsored', 'wporg-5ftf' ); ?></button>
+							</div>
+						</div>
+					</div>
 
-				?>
+					<p class="pledges-sort-label">
+						<strong>
+							<?php
+							echo esc_html( sprintf(
+								/* translators: %d: window in days */
+								__( 'Ranked by weighted volume, last %d days.', 'wporg-5ftf' ),
+								$window_days
+							) );
+							?>
+						</strong>
+						<span class="pledges-result-count">
+							<span id="pledges-result-count"><?php echo esc_html( $active_count ); ?></span>
+							<?php
+							echo esc_html( sprintf(
+								/* translators: 1: active count, 2: total count */
+								_n( 'active contributor (of %2$d total)', 'active contributors (of %2$d total)', $active_count, 'wporg-5ftf' ),
+								$active_count,
+								$total_count
+							) );
+							?>
+						</span>
+					</p>
+
+					<div class="pledges-grid" id="pledges-grid">
+						<?php
+						$rank = 0;
+						foreach ( $active_contributors as $contributor ) {
+							$rank++;
+							$contributor['_rank'] = $rank;
+							require __DIR__ . '/content-pledge.php';
+						}
+
+						if ( $show_inactive && $inactive_contributors ) {
+							?>
+							<div class="pledges-inactive-divider">
+								<span><?php
+									echo esc_html( sprintf(
+										/* translators: 1: count, 2: window in days */
+										_n( '%1$d contributor with no verified contributions in the last %2$d days', '%1$d contributors with no verified contributions in the last %2$d days', $inactive_count, 'wporg-5ftf' ),
+										$inactive_count,
+										$window_days
+									) );
+								?></span>
+							</div>
+							<?php
+							foreach ( $inactive_contributors as $contributor ) {
+								$rank++;
+								$contributor['_rank'] = $rank;
+								require __DIR__ . '/content-pledge.php';
+							}
+						}
+						?>
+					</div>
+
+					<?php if ( $inactive_contributors ) : ?>
+						<p class="pledges-inactive-toggle">
+							<?php if ( $show_inactive ) : ?>
+								<a href="<?php echo esc_url( remove_query_arg( 'show_inactive' ) ); ?>">
+									<?php
+									echo esc_html( sprintf(
+										/* translators: %d: count */
+										_n( 'Hide %d inactive contributor', 'Hide %d inactive contributors', $inactive_count, 'wporg-5ftf' ),
+										$inactive_count
+									) );
+									?>
+								</a>
+							<?php else : ?>
+								<a href="<?php echo esc_url( add_query_arg( 'show_inactive', '1' ) ); ?>">
+									<?php
+									echo esc_html( sprintf(
+										/* translators: 1: count, 2: window in days */
+										_n( 'Show %1$d contributor with no verified contributions in the last %2$d days', 'Show %1$d contributors with no verified contributions in the last %2$d days', $inactive_count, 'wporg-5ftf' ),
+										$inactive_count,
+										$window_days
+									) );
+									?>
+								</a>
+							<?php endif; ?>
+						</p>
+					<?php endif; ?>
+
+					<div class="pledges-empty" id="pledges-empty" hidden>
+						<p><?php esc_html_e( 'No contributors match the selected filters.', 'wporg-5ftf' ); ?></p>
+						<button type="button" class="pledges-empty-reset"><?php esc_html_e( 'Clear filters', 'wporg-5ftf' ); ?></button>
+					</div>
+
+				<?php else : ?>
+
+					<p>
+						<?php
+						echo wp_kses_post( sprintf(
+							/* translators: %s: profile edit URL */
+							__( 'Nobody has indicated that they\'re sponsored to contribute to this team. If you are, please <a href="%s">update your profile</a> to indicate that.', 'wporg-5ftf' ),
+							'https://profiles.wordpress.org/me/profile/edit/group/5/'
+						) );
+						?>
+					</p>
+
+				<?php endif; ?>
+
 			</div>
 		</article>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
@@ -16,13 +16,31 @@ defined( 'WPINC' ) || die();
 
 require_once __DIR__ . '/inc/contribution-metrics.php';
 
+// Enqueue BEFORE get_header() so wp_print_styles (priority 8 on wp_head)
+// flushes the <link> into <head>. Enqueuing after get_header() would miss
+// that flush and force the late-styles fallback to emit the <link> near
+// </body>, causing a visible FOUC on the redesigned grid.
+//
+// /pledges/ is a virtual route registered by the team-pledges mu-plugin, so
+// is_page_template() never reports it — we can't gate via wp_enqueue_scripts
+// in functions.php. Template-level enqueue is the correct seam.
+wp_enqueue_style(
+	'wporg-breathe-page-pledges',
+	get_stylesheet_directory_uri() . '/css/page-pledges.css',
+	array( 'wporg-breathe' ),
+	filemtime( __DIR__ . '/css/page-pledges.css' )
+);
+wp_enqueue_script(
+	'wporg-breathe-page-pledges',
+	get_stylesheet_directory_uri() . '/js/page-pledges.js',
+	array(),
+	filemtime( __DIR__ . '/js/page-pledges.js' ),
+	true
+);
+
 get_header();
 
 $current_team = Pledges\get_current_team();
-
-// page-pledges.css and js/page-pledges.js are enqueued from functions.php on
-// the wp_enqueue_scripts action so they reach <head> instead of being emitted
-// in the footer via late-styles fallback (which causes a visible FOUC).
 
 // ------------------------------------------------------------------
 // Teams without wired-up tracking get an invitation page instead of

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
@@ -354,9 +354,31 @@ foreach ( $contributors as $c ) {
 					<div class="pledges-empty" id="pledges-empty" hidden>
 						<p><?php esc_html_e( 'No contributors match the selected filters.', 'wporg-5ftf' ); ?></p>
 						<button type="button" class="pledges-empty-reset"><?php esc_html_e( 'Clear filters', 'wporg-5ftf' ); ?></button>
+						<?php if ( $inactive_contributors && ! $show_inactive ) : ?>
+							<p class="pledges-empty-extra">
+								<a href="<?php echo esc_url( add_query_arg( 'show_inactive', '1' ) ); ?>">
+									<?php
+									echo esc_html( sprintf(
+										/* translators: 1: count, 2: window in days */
+										_n( 'Show %1$d contributor with no verified contributions in the last %2$d days', 'Show %1$d contributors with no verified contributions in the last %2$d days', $inactive_count, 'wporg-5ftf' ),
+										$inactive_count,
+										$window_days
+									) );
+									?>
+								</a>
+							</p>
+						<?php endif; ?>
 					</div>
 
-					<?php if ( $inactive_contributors ) : ?>
+					<?php
+					// Standalone inactive toggle: only renders when there's an active list
+					// to anchor it to (or when inactive is already shown, so the user can
+					// hide it). When active_count is 0 the empty state already carries the
+					// "Show inactive" suggestion, so showing the standalone toggle below
+					// would just duplicate the same CTA.
+					$show_standalone_toggle = $inactive_contributors && ( $active_count > 0 || $show_inactive );
+					?>
+					<?php if ( $show_standalone_toggle ) : ?>
 						<p class="pledges-inactive-toggle">
 							<?php if ( $show_inactive ) : ?>
 								<a href="<?php echo esc_url( remove_query_arg( 'show_inactive' ) ); ?>">

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
@@ -351,6 +351,11 @@ foreach ( $contributors as $c ) {
 						?>
 					</div>
 
+					<div class="pledges-empty" id="pledges-empty" hidden>
+						<p><?php esc_html_e( 'No contributors match the selected filters.', 'wporg-5ftf' ); ?></p>
+						<button type="button" class="pledges-empty-reset"><?php esc_html_e( 'Clear filters', 'wporg-5ftf' ); ?></button>
+					</div>
+
 					<?php if ( $inactive_contributors ) : ?>
 						<p class="pledges-inactive-toggle">
 							<?php if ( $show_inactive ) : ?>
@@ -377,11 +382,6 @@ foreach ( $contributors as $c ) {
 							<?php endif; ?>
 						</p>
 					<?php endif; ?>
-
-					<div class="pledges-empty" id="pledges-empty" hidden>
-						<p><?php esc_html_e( 'No contributors match the selected filters.', 'wporg-5ftf' ); ?></p>
-						<button type="button" class="pledges-empty-reset"><?php esc_html_e( 'Clear filters', 'wporg-5ftf' ); ?></button>
-					</div>
 
 				<?php else : ?>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
@@ -20,12 +20,9 @@ get_header();
 
 $current_team = Pledges\get_current_team();
 
-wp_enqueue_style(
-	'wporg-breathe-page-pledges',
-	get_stylesheet_directory_uri() . '/css/page-pledges.css',
-	array( 'wporg-breathe' ),
-	filemtime( __DIR__ . '/css/page-pledges.css' )
-);
+// page-pledges.css and js/page-pledges.js are enqueued from functions.php on
+// the wp_enqueue_scripts action so they reach <head> instead of being emitted
+// in the footer via late-styles fallback (which causes a visible FOUC).
 
 // ------------------------------------------------------------------
 // Teams without wired-up tracking get an invitation page instead of
@@ -200,14 +197,6 @@ foreach ( $contributors as $c ) {
 	}
 }
 
-wp_enqueue_script(
-	'wporg-breathe-page-pledges',
-	get_stylesheet_directory_uri() . '/js/page-pledges.js',
-	array(),
-	filemtime( __DIR__ . '/js/page-pledges.js' ),
-	true
-);
-
 ?>
 
 <div id="primary" class="content-area">
@@ -242,11 +231,12 @@ wp_enqueue_script(
 						<span class="pledges-health-num"><?php echo esc_html( number_format_i18n( $total_count ) ); ?></span>
 						<span class="pledges-health-text">
 							<?php
+							// $total_count is the static opt-in roster (active + inactive); the window
+							// scopes the rank line below, not this banner. Don't conflate the two.
 							echo wp_kses_data( sprintf(
-								/* translators: 1: team name, 2: window in days */
-								__( 'opted-in contributors to %1$s in the last %2$d days.', 'wporg-5ftf' ),
-								'<strong>' . esc_html( $current_team->post_title ) . '</strong>',
-								$window_days
+								/* translators: %s: team name */
+								__( 'opted-in contributors to %s.', 'wporg-5ftf' ),
+								'<strong>' . esc_html( $current_team->post_title ) . '</strong>'
 							) );
 							?>
 						</span>
@@ -262,11 +252,13 @@ wp_enqueue_script(
 								<span class="pledges-filter-label"><?php esc_html_e( 'Time window', 'wporg-5ftf' ); ?></span>
 								<?php
 								// home_url('/pledges/') already includes the team site path, so no REQUEST_URI concat needed.
+								// Carry show_inactive forward so changing the window doesn't silently collapse the inactive list.
 								$pledges_url   = home_url( '/pledges/' );
+								$base_url      = $show_inactive ? add_query_arg( 'show_inactive', '1', $pledges_url ) : $pledges_url;
 								$default_w     = ContributionMetrics\WINDOW_DAYS_DEFAULT;
-								$url_for_30    = 30 === $default_w ? $pledges_url : add_query_arg( 'window', 30, $pledges_url );
-								$url_for_90    = 90 === $default_w ? $pledges_url : add_query_arg( 'window', 90, $pledges_url );
-								$url_for_180   = 180 === $default_w ? $pledges_url : add_query_arg( 'window', 180, $pledges_url );
+								$url_for_30    = 30 === $default_w ? $base_url : add_query_arg( 'window', 30, $base_url );
+								$url_for_90    = 90 === $default_w ? $base_url : add_query_arg( 'window', 90, $base_url );
+								$url_for_180   = 180 === $default_w ? $base_url : add_query_arg( 'window', 180, $base_url );
 								?>
 								<a class="pledges-chip<?php echo 30 === $window_days ? ' is-on' : ''; ?>" href="<?php echo esc_url( $url_for_30 ); ?>"><?php esc_html_e( '30 days', 'wporg-5ftf' ); ?></a>
 								<a class="pledges-chip<?php echo 90 === $window_days ? ' is-on' : ''; ?>" href="<?php echo esc_url( $url_for_90 ); ?>"><?php esc_html_e( '90 days', 'wporg-5ftf' ); ?></a>
@@ -291,16 +283,26 @@ wp_enqueue_script(
 							) );
 							?>
 						</strong>
+						<?php
+						// The result phrase is a JS-controlled template so the singular/plural
+						// form follows the visible-card count after client-side filtering, instead
+						// of being baked at render time against $active_count and drifting (e.g.
+						// "1 active contributors").
+						?>
 						<span class="pledges-result-count">
 							<span id="pledges-result-count"><?php echo esc_html( $active_count ); ?></span>
-							<?php
+							<span
+								id="pledges-result-phrase"
+								data-singular="<?php echo esc_attr__( 'active contributor (of %d total)', 'wporg-5ftf' ); ?>"
+								data-plural="<?php echo esc_attr__( 'active contributors (of %d total)', 'wporg-5ftf' ); ?>"
+								data-total="<?php echo esc_attr( $total_count ); ?>"
+							><?php
 							echo esc_html( sprintf(
-								/* translators: 1: active count, 2: total count */
-								_n( 'active contributor (of %2$d total)', 'active contributors (of %2$d total)', $active_count, 'wporg-5ftf' ),
-								$active_count,
+								/* translators: %d: total count */
+								_n( 'active contributor (of %d total)', 'active contributors (of %d total)', $active_count, 'wporg-5ftf' ),
 								$total_count
 							) );
-							?>
+							?></span>
 						</span>
 					</p>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
@@ -39,22 +39,25 @@ $metrics = ContributionMetrics\get_team_contribution_metrics(
 );
 
 foreach ( $contributors as $uid => &$c ) {
-	$m                            = isset( $metrics[ $uid ] ) ? $metrics[ $uid ] : ContributionMetrics\empty_metrics();
-	$bucket                       = ContributionMetrics\format_active_bucket( $m['last_activity'] );
-	$c['_metrics_high']           = (int) $m['high_count'];
-	$c['_metrics_medium']         = (int) $m['medium_count'];
-	$c['_metrics_low']            = (int) $m['low_count'];
-	$c['_metrics_weighted']       = (int) $m['weighted_volume'];
-	$c['_metrics_active_bucket']  = $bucket['bucket'];
-	$c['_metrics_active_class']   = $bucket['class'];
-	$c['_metrics_top_repos']      = array_keys( $m['top_repos'] );
-	$c['_metrics_window_days']    = $window_days;
+	$user_metrics                = isset( $metrics[ $uid ] ) ? $metrics[ $uid ] : ContributionMetrics\empty_metrics();
+	$bucket                      = ContributionMetrics\format_active_bucket( $user_metrics['last_activity'] );
+	$c['_metrics_high']          = (int) $user_metrics['high_count'];
+	$c['_metrics_medium']        = (int) $user_metrics['medium_count'];
+	$c['_metrics_low']           = (int) $user_metrics['low_count'];
+	$c['_metrics_weighted']      = (int) $user_metrics['weighted_volume'];
+	$c['_metrics_active_bucket'] = $bucket['bucket'];
+	$c['_metrics_active_class']  = $bucket['class'];
+	$c['_metrics_top_repos']     = array_keys( $user_metrics['top_repos'] );
+	$c['_metrics_window_days']   = $window_days;
 }
 unset( $c );
 
-uasort( $contributors, function( $a, $b ) {
-	return $b['_metrics_weighted'] - $a['_metrics_weighted'];
-} );
+uasort(
+	$contributors,
+	function ( $a, $b ) {
+		return $b['_metrics_weighted'] - $a['_metrics_weighted'];
+	}
+);
 
 // Split the list into active (verified output in window) vs inactive.
 // The spec is explicit: directory ranks by recent shipped work and decays
@@ -151,18 +154,19 @@ wp_enqueue_script(
 					// home_url('/pledges/') already includes the team site path, so no REQUEST_URI concat.
 					$base_url   = home_url( '/pledges/' );
 					$window_url = function ( $w ) use ( $base_url ) {
-						return $w === ContributionMetrics\WINDOW_DAYS_DEFAULT
-							? esc_url( $base_url )
-							: esc_url( add_query_arg( 'window', $w, $base_url ) );
+						if ( ContributionMetrics\WINDOW_DAYS_DEFAULT === $w ) {
+							return $base_url;
+						}
+						return add_query_arg( 'window', $w, $base_url );
 					};
 					?>
 					<div class="pledges-toolbar">
 						<div class="pledges-filters" role="group" aria-label="<?php esc_attr_e( 'Filter contributors', 'wporg-5ftf' ); ?>">
 							<div class="pledges-filter-group">
 								<span class="pledges-filter-label"><?php esc_html_e( 'Time window', 'wporg-5ftf' ); ?></span>
-								<a class="pledges-chip<?php echo 30 === $window_days ? ' is-on' : ''; ?>" href="<?php echo $window_url( 30 ); ?>"><?php esc_html_e( '30 days', 'wporg-5ftf' ); ?></a>
-								<a class="pledges-chip<?php echo 90 === $window_days ? ' is-on' : ''; ?>" href="<?php echo $window_url( 90 ); ?>"><?php esc_html_e( '90 days', 'wporg-5ftf' ); ?></a>
-								<a class="pledges-chip<?php echo 180 === $window_days ? ' is-on' : ''; ?>" href="<?php echo $window_url( 180 ); ?>"><?php esc_html_e( '6 months', 'wporg-5ftf' ); ?></a>
+								<a class="pledges-chip<?php echo 30 === $window_days ? ' is-on' : ''; ?>" href="<?php echo esc_url( $window_url( 30 ) ); ?>"><?php esc_html_e( '30 days', 'wporg-5ftf' ); ?></a>
+								<a class="pledges-chip<?php echo 90 === $window_days ? ' is-on' : ''; ?>" href="<?php echo esc_url( $window_url( 90 ) ); ?>"><?php esc_html_e( '90 days', 'wporg-5ftf' ); ?></a>
+								<a class="pledges-chip<?php echo 180 === $window_days ? ' is-on' : ''; ?>" href="<?php echo esc_url( $window_url( 180 ) ); ?>"><?php esc_html_e( '6 months', 'wporg-5ftf' ); ?></a>
 							</div>
 							<div class="pledges-filter-group">
 								<span class="pledges-filter-label"><?php esc_html_e( 'Sponsorship', 'wporg-5ftf' ); ?></span>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
@@ -297,12 +297,12 @@ foreach ( $contributors as $c ) {
 								data-plural="<?php echo esc_attr__( 'active contributors (of %d total)', 'wporg-5ftf' ); ?>"
 								data-total="<?php echo esc_attr( $total_count ); ?>"
 							><?php
-							echo esc_html( sprintf(
-								/* translators: %d: total count */
-								_n( 'active contributor (of %d total)', 'active contributors (of %d total)', $active_count, 'wporg-5ftf' ),
-								$total_count
-							) );
-							?></span>
+								echo esc_html( sprintf(
+									/* translators: %d: total count */
+									_n( 'active contributor (of %d total)', 'active contributors (of %d total)', $active_count, 'wporg-5ftf' ),
+									$total_count
+								) );
+								?></span>
 						</span>
 					</p>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
@@ -150,23 +150,21 @@ wp_enqueue_script(
 						</span>
 					</div>
 
-					<?php
-					// home_url('/pledges/') already includes the team site path, so no REQUEST_URI concat.
-					$base_url   = home_url( '/pledges/' );
-					$window_url = function ( $w ) use ( $base_url ) {
-						if ( ContributionMetrics\WINDOW_DAYS_DEFAULT === $w ) {
-							return $base_url;
-						}
-						return add_query_arg( 'window', $w, $base_url );
-					};
-					?>
 					<div class="pledges-toolbar">
 						<div class="pledges-filters" role="group" aria-label="<?php esc_attr_e( 'Filter contributors', 'wporg-5ftf' ); ?>">
 							<div class="pledges-filter-group">
 								<span class="pledges-filter-label"><?php esc_html_e( 'Time window', 'wporg-5ftf' ); ?></span>
-								<a class="pledges-chip<?php echo 30 === $window_days ? ' is-on' : ''; ?>" href="<?php echo esc_url( $window_url( 30 ) ); ?>"><?php esc_html_e( '30 days', 'wporg-5ftf' ); ?></a>
-								<a class="pledges-chip<?php echo 90 === $window_days ? ' is-on' : ''; ?>" href="<?php echo esc_url( $window_url( 90 ) ); ?>"><?php esc_html_e( '90 days', 'wporg-5ftf' ); ?></a>
-								<a class="pledges-chip<?php echo 180 === $window_days ? ' is-on' : ''; ?>" href="<?php echo esc_url( $window_url( 180 ) ); ?>"><?php esc_html_e( '6 months', 'wporg-5ftf' ); ?></a>
+								<?php
+								// home_url('/pledges/') already includes the team site path, so no REQUEST_URI concat needed.
+								$pledges_url   = home_url( '/pledges/' );
+								$default_w     = ContributionMetrics\WINDOW_DAYS_DEFAULT;
+								$url_for_30    = 30 === $default_w ? $pledges_url : add_query_arg( 'window', 30, $pledges_url );
+								$url_for_90    = 90 === $default_w ? $pledges_url : add_query_arg( 'window', 90, $pledges_url );
+								$url_for_180   = 180 === $default_w ? $pledges_url : add_query_arg( 'window', 180, $pledges_url );
+								?>
+								<a class="pledges-chip<?php echo 30 === $window_days ? ' is-on' : ''; ?>" href="<?php echo esc_url( $url_for_30 ); ?>"><?php esc_html_e( '30 days', 'wporg-5ftf' ); ?></a>
+								<a class="pledges-chip<?php echo 90 === $window_days ? ' is-on' : ''; ?>" href="<?php echo esc_url( $url_for_90 ); ?>"><?php esc_html_e( '90 days', 'wporg-5ftf' ); ?></a>
+								<a class="pledges-chip<?php echo 180 === $window_days ? ' is-on' : ''; ?>" href="<?php echo esc_url( $url_for_180 ); ?>"><?php esc_html_e( '6 months', 'wporg-5ftf' ); ?></a>
 							</div>
 							<div class="pledges-filter-group">
 								<span class="pledges-filter-label"><?php esc_html_e( 'Sponsorship', 'wporg-5ftf' ); ?></span>
@@ -210,18 +208,14 @@ wp_enqueue_script(
 						}
 
 						if ( $show_inactive && $inactive_contributors ) {
-							?>
-							<div class="pledges-inactive-divider">
-								<span><?php
-									echo esc_html( sprintf(
-										/* translators: 1: count, 2: window in days */
-										_n( '%1$d contributor with no verified contributions in the last %2$d days', '%1$d contributors with no verified contributions in the last %2$d days', $inactive_count, 'wporg-5ftf' ),
-										$inactive_count,
-										$window_days
-									) );
-								?></span>
-							</div>
-							<?php
+							$inactive_label = sprintf(
+								/* translators: 1: count, 2: window in days */
+								_n( '%1$d contributor with no verified contributions in the last %2$d days', '%1$d contributors with no verified contributions in the last %2$d days', $inactive_count, 'wporg-5ftf' ),
+								$inactive_count,
+								$window_days
+							);
+							echo '<div class="pledges-inactive-divider"><span>' . esc_html( $inactive_label ) . '</span></div>';
+
 							foreach ( $inactive_contributors as $contributor ) {
 								$rank++;
 								$contributor['_rank'] = $rank;


### PR DESCRIPTION
Replaces the legacy intent-driven flat list (every opted-in contributor with
hours-pledged badges) with an output-driven, ranked directory of people who
have actually shipped work on the team in a recent window. Inactive
contributors decay down the list automatically.

## Summary

- New `inc/contribution-metrics.php` aggregator: bulk-queries `trac_<team>_props`
  joined with `trac_<team>_revisions` (release credits, high weight) and
  `wporg_github_activity` (PRs/pushes/issues, tiered by category) for a list
  of user IDs in a 30/90/180-day window. One query per signal source, GROUP BY
  user_id, hour-cached. Returns `weighted_volume = 3*high + 1*medium`, last
  activity timestamp, and top 2 repos per contributor.
- `page-pledges.php` rewritten: ranked grid, time-window chips
  (?window=30|90|180), client-side sponsorship filter, server-side split into
  active vs inactive contributors with `?show_inactive=1` opt-in to render the
  inactive ones beneath. Default window is 30 days; default sponsorship filter
  is "Independent".
- `content-pledge.php` is now a card partial: rank, avatar, identity,
  weighted-summary line ("49 high-weight contributions, 92 medium, in
  gutenberg, wordpress-develop in the last 30 days"), recency pill, weighted
  score.
- `js/page-pledges.js`: client-side sponsorship filter + re-rank of visible
  cards on every state change. Time window navigates via URL (full reload) so
  the server-side window aggregation is honored.
- `css/page-pledges.css`: directory styles (hero, "how this page works"
  affordance with localStorage dismiss, health banner, filter chips, cards,
  inactive divider, narrow-viewport collapse). Uses theme.json tokens where
  possible. Uses px units because the make.* theme sets `html { font-size: 10px }`.
- `functions.php`: prepends a "People" item to the per-team local nav linking
  to `home_url('/pledges/')`, capped at 5 inherited items so the total stays
  at 6.

## Why

The current /pledges/ page on each team's make.* site (rendered by the
`team-pledges.php` mu-plugin) lists every contributor who has marked
themselves as opted-in via xprofile, regardless of whether they have shipped
anything recently. This makes the list noisy and unhelpful for sponsors and
team reps trying to see who is actively contributing. The new design ranks
people by verifiable, recent output (Trac props + GitHub activity) and
decays inactive contributors out of the default view.

The aggregator only counts non-low-weight signals — typo fixes and whitespace
changes don't move someone up the list.

## Test plan

- [ ] `/core/pledges/` renders the ranked directory with real data (Aki Hamano
      should appear near the top, sponsored as well as independent)
- [ ] `/meta/pledges/` and other team sites render with their own data
- [ ] Switching the time window (30 / 90 / 6 months) reloads with new data
- [ ] "Independent" / "Sponsored" / "All" filter buttons hide/show cards
      client-side and re-rank visible cards from 01
- [ ] `?show_inactive=1` reveals contributors with 0 verified contributions
      below a divider
- [ ] "How this page works" banner dismisses and stays dismissed via
      localStorage
- [ ] "People" appears as the first item in the per-team local nav and marks
      itself current when on the page
- [ ] Aggregator hits the cache on the second pageload (one set of queries
      per team per window per hour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
