### PR TITLE
wporg-abilities: enable runtime checks in Plugin Check guide

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/wporg-abilities/plugins/plugin-directory/resources/class-plugin-check-guide.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-abilities/plugins/plugin-directory/resources/class-plugin-check-guide.php
@@ -44,6 +44,18 @@ class Plugin_Check_Guide extends Ability_Base {
 	 * @return array MCP resource contents array.
 	 */
 	public static function execute(): array {
+		/*
+		 * The blueprint below intentionally activates `--all` plugins and copies the
+		 * Plugin Check object-cache.php drop-in. Both are required for runtime checks
+		 * (enqueued script size/scope, non-blocking scripts, etc.) to register —
+		 * Plugin Check gates them on `is_plugin_active()` and on the drop-in being
+		 * present. Without both, only static checks run.
+		 *
+		 * The `cp` step must remain the LAST step. Plugin Check registers a WP-CLI
+		 * `after_invoke` hook that auto-deletes the drop-in whenever any `wp plugin`
+		 * subcommand finishes, so any `wp plugin …` step added after the `cp` will
+		 * silently revert runtime checks to static-only.
+		 */
 		return array(
 			array(
 				'uri'      => 'wporg://plugins/plugin-directory/plugin-check-guide',
@@ -68,7 +80,10 @@ Create one temporary file and run one command. This installs Plugin Check automa
 {
   "steps": [
     {"step": "installPlugin", "pluginData": {"resource": "wordpress.org/plugins", "slug": "plugin-check"}},
-    {"step": "wp-cli", "command": "wp plugin activate plugin-check"}
+    {"step": "wp-cli", "command": "wp plugin activate --all"},
+    {"step": "cp",
+      "fromPath": "/wordpress/wp-content/plugins/plugin-check/drop-ins/object-cache.copy.php",
+      "toPath": "/wordpress/wp-content/object-cache.php"}
   ]
 }
 ```


### PR DESCRIPTION
## Summary

The blueprint in the wporg-abilities Plugin Check guide resource only ran **static** checks. Plugin Check's **runtime** checks (enqueued script size/scope, non-blocking scripts, etc.) require:

1. The plugin under test to be active (Plugin Check gates runtime checks on `is_plugin_active()`).
2. Plugin Check's `object-cache.php` drop-in to be installed in `wp-content/` (so the runtime checks are registered at all — without it, `--checks=non_blocking_scripts` even errors with `Check with the slug "non_blocking_scripts" does not exist.`).

This matches the workaround called out in https://github.com/WordPress/plugin-check-action/issues/119.

## What changed

- `wp plugin activate plugin-check` → `wp plugin activate --all` so the mounted plugin is active.
- New `cp` step copies `plugin-check/drop-ins/object-cache.copy.php` to `wp-content/object-cache.php`.
- PHP code comment above the heredoc explaining the constraint for future editors — including that the `cp` step must remain LAST, because Plugin Check's WP-CLI `after_invoke` hook auto-deletes the drop-in whenever any `wp plugin` subcommand finishes.

## Verification

Tested with a local plugin (wp-approve-user) by enqueueing a script in `<head>` with no defer/async strategy:

**Before** (existing blueprint): `--checks=non_blocking_scripts` → `Error: Check with the slug "non_blocking_scripts" does not exist.` Default run reports zero runtime findings.

**After** (this PR): default run reports the runtime warnings:

```
WARNING  EnqueuedScriptsScope                   This script is being loaded in all frontend contexts.
WARNING  NonBlockingScripts.BlockingHeadScript  This script on http://… (with handle wpau-broken) is potentially blocking…
```

Plugin Check actually boots WordPress and renders multiple front-end URLs — the warning fires once per probed URL.

Props @swissspidy for flagging this on https://konstantin.obenland.it/2026/05/05/plugin-check-with-playground-cli/.

## Test plan
- [ ] Read the updated guide rendered via the MCP resource (`wporg://plugins/plugin-directory/plugin-check-guide`)
- [ ] Run the documented blueprint against a plugin with a known runtime issue and confirm runtime warnings surface