### PR TITLE
Events API: Wire up PHPUnit suite in CI to detect regressions and stale regional data

### DIFF
--- a/.github/workflows/events-api-live.yml
+++ b/.github/workflows/events-api-live.yml
@@ -22,12 +22,11 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "8.4"
-          tools: phpunit:^11
+          coverage: none
+
+      - name: Install composer dependencies
+        run: composer install --no-interaction --no-progress
 
       - name: Run live e2e + data-freshness groups
         working-directory: api.wordpress.org/public_html/events/1.0
-        run: |
-          phpunit --no-configuration \
-            --bootstrap tests/bootstrap.php \
-            --group e2e --group data-freshness \
-            tests/Test_Events.php
+        run: ${{ github.workspace }}/vendor/bin/phpunit --group e2e,data-freshness

--- a/.github/workflows/events-api-live.yml
+++ b/.github/workflows/events-api-live.yml
@@ -1,0 +1,33 @@
+name: Events API (live)
+
+# Runs the e2e and data-freshness groups against the live api.wordpress.org and
+# wordcamp.org services. Kept out of the PR matrix so transient external failures
+# do not block unrelated work.
+
+on:
+  schedule:
+    # Daily at 14:00 UTC.
+    - cron: '0 14 * * *'
+  workflow_dispatch:
+
+jobs:
+  events-api-live:
+    name: Events API live checks
+    if: github.repository == 'WordPress/wordpress.org'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.4"
+          tools: phpunit:^11
+
+      - name: Run live e2e + data-freshness groups
+        working-directory: api.wordpress.org/public_html/events/1.0
+        run: |
+          phpunit --no-configuration \
+            --bootstrap tests/bootstrap.php \
+            --group e2e --group data-freshness \
+            tests/Test_Events.php

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -23,7 +23,7 @@ jobs:
             phpunit-args: "--no-configuration tests/phpunit/tests/"
           - name: Events API
             working-directory: api.wordpress.org/public_html/events/1.0
-            phpunit-args: "--no-configuration --bootstrap tests/bootstrap.php --exclude-group needs-db tests/Test_Events.php"
+            phpunit-args: "--no-configuration --bootstrap tests/bootstrap.php --exclude-group needs-db --exclude-group e2e --exclude-group data-freshness tests/Test_Events.php"
           - name: Slack Trac Bot
             working-directory: common/includes/tests/slack/trac
             phpunit-args: "bot.php"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -19,13 +19,13 @@ jobs:
         include:
           - name: Serve Happy API
             working-directory: api.wordpress.org/public_html/core/serve-happy/1.0
-            phpunit-args: "--exclude-group serve-happy-live-http"
+            phpunit-args: ""
           - name: Browse Happy API
             working-directory: api.wordpress.org/public_html/core/browse-happy/1.0
             phpunit-args: ""
           - name: Events API
             working-directory: api.wordpress.org/public_html/events/1.0
-            phpunit-args: "--exclude-group needs-db,e2e,data-freshness"
+            phpunit-args: ""
           - name: Slack Trac Bot
             working-directory: common/includes/tests/slack/trac
             phpunit-args: "--no-configuration bot.php"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   # Standalone PHP tests — no WordPress or database dependency.
+  # Uses the project's composer-installed PHPUnit 9 + yoast/phpunit-polyfills,
+  # matching the version that WordPress Core ships its test bootstrap for.
   php-standalone:
     name: "PHP: ${{ matrix.name }}"
     if: github.event_name == 'pull_request' || github.repository == 'WordPress/wordpress.org'
@@ -17,19 +19,19 @@ jobs:
         include:
           - name: Serve Happy API
             working-directory: api.wordpress.org/public_html/core/serve-happy/1.0
-            phpunit-args: "--no-configuration --exclude-group serve-happy-live-http --bootstrap tests/bootstrap.php tests/"
+            phpunit-args: "--exclude-group serve-happy-live-http"
           - name: Browse Happy API
             working-directory: api.wordpress.org/public_html/core/browse-happy/1.0
-            phpunit-args: "--no-configuration tests/phpunit/tests/"
+            phpunit-args: ""
           - name: Events API
             working-directory: api.wordpress.org/public_html/events/1.0
-            phpunit-args: "--no-configuration --bootstrap tests/bootstrap.php --exclude-group needs-db --exclude-group e2e --exclude-group data-freshness tests/Test_Events.php"
+            phpunit-args: "--exclude-group needs-db,e2e,data-freshness"
           - name: Slack Trac Bot
             working-directory: common/includes/tests/slack/trac
-            phpunit-args: "bot.php"
+            phpunit-args: "--no-configuration bot.php"
           - name: Slack Props Library
             working-directory: common/includes/slack/props/tests
-            phpunit-args: "--bootstrap /tmp/phpunit-bootstrap.php ."
+            phpunit-args: "--no-configuration --bootstrap /tmp/phpunit-bootstrap.php ."
             bootstrap: wpdb-stub
     steps:
       - uses: actions/checkout@v4
@@ -38,7 +40,10 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "8.4"
-          tools: phpunit:^11
+          coverage: none
+
+      - name: Install composer dependencies
+        run: composer install --no-interaction --no-progress
 
       - name: Create wpdb stub bootstrap
         if: matrix.bootstrap == 'wpdb-stub'
@@ -53,7 +58,7 @@ jobs:
 
       - name: Run PHPUnit
         working-directory: ${{ matrix.working-directory }}
-        run: phpunit ${{ matrix.phpunit-args }}
+        run: ${{ github.workspace }}/vendor/bin/phpunit ${{ matrix.phpunit-args }}
 
   # WordPress-dependent PHP tests — require wp-env (Docker).
   php-wordpress:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,6 +21,9 @@ jobs:
           - name: Browse Happy API
             working-directory: api.wordpress.org/public_html/core/browse-happy/1.0
             phpunit-args: "--no-configuration tests/phpunit/tests/"
+          - name: Events API
+            working-directory: api.wordpress.org/public_html/events/1.0
+            phpunit-args: "--no-configuration --bootstrap tests/bootstrap.php --exclude-group needs-db tests/Test_Events.php"
           - name: Slack Trac Bot
             working-directory: common/includes/tests/slack/trac
             phpunit-args: "bot.php"

--- a/api.wordpress.org/public_html/core/browse-happy/1.0/phpunit.xml
+++ b/api.wordpress.org/public_html/core/browse-happy/1.0/phpunit.xml
@@ -1,4 +1,5 @@
 <phpunit
+	bootstrap="tests/bootstrap.php"
 	backupGlobals="false"
 	colors="true"
 	convertErrorsToExceptions="true"
@@ -7,7 +8,7 @@
 	>
 	<testsuites>
 		<testsuite name="browse-happy-api">
-			<directory suffix=".php">tests/</directory>
+			<directory suffix=".php">tests/phpunit/tests/</directory>
 		</testsuite>
 	</testsuites>
 </phpunit>

--- a/api.wordpress.org/public_html/core/browse-happy/1.0/tests/bootstrap.php
+++ b/api.wordpress.org/public_html/core/browse-happy/1.0/tests/bootstrap.php
@@ -1,0 +1,6 @@
+<?php
+// Load the project's composer autoloader (PHPUnit, yoast/phpunit-polyfills).
+require_once dirname( __DIR__, 6 ) . '/vendor/autoload.php';
+
+// Load the API parser the tests exercise.
+require_once dirname( __DIR__ ) . '/parse.php';

--- a/api.wordpress.org/public_html/core/browse-happy/1.0/tests/phpunit/tests/browse-happy.php
+++ b/api.wordpress.org/public_html/core/browse-happy/1.0/tests/phpunit/tests/browse-happy.php
@@ -1,7 +1,5 @@
 <?php
 
-include dirname( __FILE__ ) . '/../../../parse.php';
-
 /**
  *
  * @group browse-happy
@@ -18,7 +16,7 @@ class Tests_Browse_Happy extends \PHPUnit\Framework\TestCase {
 	 *     }
 	 * }
 	 */
-	function data_browse_happy() {
+	public static function data_browse_happy() {
 		return [
 
 			// Amazon Silk

--- a/api.wordpress.org/public_html/core/serve-happy/1.0/phpunit.xml
+++ b/api.wordpress.org/public_html/core/serve-happy/1.0/phpunit.xml
@@ -1,22 +1,21 @@
 <phpunit
+	bootstrap="tests/bootstrap.php"
 	backupGlobals="false"
 	colors="true"
 	convertErrorsToExceptions="true"
 	convertNoticesToExceptions="true"
 	convertWarningsToExceptions="true"
 	>
-	<groups>
-		<include>
-			<group>serve-happy</group>
-		</include>
-		<exclude>
-			<group>serve-happy-live-http</group>
-		</exclude>
-	</groups>
 	<testsuites>
-		<testsuite>
+		<testsuite name="serve-happy">
 			<directory suffix=".php">tests/</directory>
+			<exclude>tests/bootstrap.php</exclude>
 		</testsuite>
 	</testsuites>
+	<!--
+		Groups:
+		* serve-happy            Default; pure-logic tests.
+		* serve-happy-live-http  Hits api.wordpress.org. Excluded in standalone CI.
+	-->
 </phpunit>
 

--- a/api.wordpress.org/public_html/core/serve-happy/1.0/phpunit.xml
+++ b/api.wordpress.org/public_html/core/serve-happy/1.0/phpunit.xml
@@ -15,7 +15,12 @@
 	<!--
 		Groups:
 		* serve-happy            Default; pure-logic tests.
-		* serve-happy-live-http  Hits api.wordpress.org. Excluded in standalone CI.
+		* serve-happy-live-http  Hits api.wordpress.org. Opt in with `group serve-happy-live-http`.
 	-->
+	<groups>
+		<exclude>
+			<group>serve-happy-live-http</group>
+		</exclude>
+	</groups>
 </phpunit>
 

--- a/api.wordpress.org/public_html/core/serve-happy/1.0/tests/bootstrap.php
+++ b/api.wordpress.org/public_html/core/serve-happy/1.0/tests/bootstrap.php
@@ -1,6 +1,9 @@
 <?php
 namespace WordPressdotorg\API\Serve_Happy;
 
+// Load the project's composer autoloader (PHPUnit, yoast/phpunit-polyfills).
+require_once dirname( __DIR__, 6 ) . '/vendor/autoload.php';
+
 if ( function_exists( 'xdebug_disable' ) ) {
 	xdebug_disable();
 }

--- a/api.wordpress.org/public_html/core/serve-happy/1.0/tests/tests.php
+++ b/api.wordpress.org/public_html/core/serve-happy/1.0/tests/tests.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
  */
 class Tests_API_Responses extends TestCase {
 
-	function dataprovider_determine_request_valid() {
+	public static function dataprovider_determine_request_valid() {
 		return [
 			[
 				[ 'php_version' => '5.2.9' ],
@@ -50,7 +50,7 @@ class Tests_API_Responses extends TestCase {
 		$this->assertArrayHasKey( 'is_acceptable', $output );
 	}
 
-	function dataprovider_determine_request_invalid() {
+	public static function dataprovider_determine_request_invalid() {
 		return [
 			[
 				[],
@@ -106,7 +106,7 @@ class Tests_API_Responses extends TestCase {
 		$this->assertSame( $expected, $output );
 	}
 
-	function dataprovider_parse_request_valid() {
+	public static function dataprovider_parse_request_valid() {
 		// Test recommended PHP version is always returned.
 		$data = [
 			[

--- a/api.wordpress.org/public_html/events/1.0/index.php
+++ b/api.wordpress.org/public_html/events/1.0/index.php
@@ -1720,4 +1720,6 @@ function get_bounded_coordinates( $lat, $lon, $distance_in_km = 50 ) {
 	);
 }
 
-main();
+if ( ! defined( 'WPORG_RUNNING_TESTS' ) || ! WPORG_RUNNING_TESTS ) {
+	main();
+}

--- a/api.wordpress.org/public_html/events/1.0/phpunit.xml.dist
+++ b/api.wordpress.org/public_html/events/1.0/phpunit.xml.dist
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<phpunit
+	bootstrap="tests/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	>
+	<testsuites>
+		<testsuite name="events-api">
+			<directory suffix=".php">tests/</directory>
+			<exclude>tests/bootstrap.php</exclude>
+		</testsuite>
+	</testsuites>
+	<!--
+		Groups:
+		* unit            Pure-logic tests; the standalone CI default.
+		* needs-db        Requires a WordPress.org sandbox (init.php / hyperdb / Geonames / ip2location).
+		* e2e             Hits the live api.wordpress.org Events endpoint.
+		* data-freshness  Resolves regional wordcamp.org hosts to flag stale entries.
+
+		The unit-tests workflow excludes the needs-db, e2e, and data-freshness groups.
+		The events-api-live workflow runs only the e2e and data-freshness groups.
+	-->
+</phpunit>

--- a/api.wordpress.org/public_html/events/1.0/phpunit.xml.dist
+++ b/api.wordpress.org/public_html/events/1.0/phpunit.xml.dist
@@ -15,12 +15,19 @@
 	</testsuites>
 	<!--
 		Groups:
-		* unit            Pure-logic tests; the standalone CI default.
+		* unit            Pure-logic tests; the default for `phpunit`.
 		* needs-db        Requires a WordPress.org sandbox (init.php / hyperdb / Geonames / ip2location).
 		* e2e             Hits the live api.wordpress.org Events endpoint.
 		* data-freshness  Resolves regional wordcamp.org hosts to flag stale entries.
 
-		The unit-tests workflow excludes the needs-db, e2e, and data-freshness groups.
-		The events-api-live workflow runs only the e2e and data-freshness groups.
+		The excluded groups can be opted back in on the command line
+		(see the events-api-live workflow which passes `group e2e,data-freshness`).
 	-->
+	<groups>
+		<exclude>
+			<group>needs-db</group>
+			<group>e2e</group>
+			<group>data-freshness</group>
+		</exclude>
+	</groups>
 </phpunit>

--- a/api.wordpress.org/public_html/events/1.0/tests/Test_Events.php
+++ b/api.wordpress.org/public_html/events/1.0/tests/Test_Events.php
@@ -2,16 +2,15 @@
 
 namespace Dotorg\API\Events\Tests;
 use PHPUnit\Framework\TestCase;
-use Requests_Response;
+use PHPUnit\Framework\Attributes\{Group, DataProvider};
 
 use function Dotorg\API\Events\{
 	get_events, get_location, build_response, is_client_core, pin_one_off_events,
-	maybe_add_regional_wordcamps, get_iso_3166_2_country_codes, maybe_add_wp15_promo, remove_duplicate_events
+	maybe_add_regional_wordcamps, get_iso_3166_2_country_codes, maybe_add_wp15_promo, remove_duplicate_events,
+	get_regional_wordcamp_data
 };
 
-/**
- * @group events
- */
+#[Group( 'events' )]
 class Test_Events extends TestCase {
 	public static function setUpBeforeClass() : void {
 		require_once dirname( __DIR__ ) . '/index.php';
@@ -19,8 +18,6 @@ class Test_Events extends TestCase {
 
 	/**
 	 * Asserts that an HTTP response is valid and contains an event.
-	 *
-	 * @param Requests_Response $response
 	 */
 	public function assertResponseHasEvent( $response ) {
 		$body  = json_decode( $response->body );
@@ -42,11 +39,7 @@ class Test_Events extends TestCase {
 		$this->assertIsNumeric( $event->location->latitude );
 	}
 
-	/**
-	 * @covers ::main
-	 *
-	 * @group e2e
-	 */
+	#[Group( 'e2e' )]
 	public function test_get_events_e2e() : void {
 		$response = send_request( '/events/1.0/?location=seattle&locale=en_US&timezone=America/Los_Angeles' );
 		$body     = json_decode( $response->body );
@@ -55,14 +48,9 @@ class Test_Events extends TestCase {
 		$this->assertSame( 'Seattle', $body->location->description );
 	}
 
-	/**
-	 * @covers ::get_events
-	 *
-	 * @group unit
-	 *
-	 * @dataProvider data_get_events
-	 */
-	function test_get_events( array $input, array $expected ) : void {
+	#[Group( 'needs-db' )]
+	#[DataProvider( 'data_get_events' )]
+	public function test_get_events( array $input, array $expected ) : void {
 		$actual_result = get_events( $input );
 
 		$this->assertSame( $expected['count'], count( $actual_result ) );
@@ -71,7 +59,7 @@ class Test_Events extends TestCase {
 		$this->assertSame( $expected['country'], strtoupper( $actual_result[0]['location']['country'] ) );
 	}
 
-	function data_get_events() : array {
+	public static function data_get_events() : array {
 		$cases = array(
 			// This assumes there will always be at least 2 upcoming events, so it needs to be a very active community.
 			'2-near-seattle' => array(
@@ -104,14 +92,9 @@ class Test_Events extends TestCase {
 		return $cases;
 	}
 
-	/**
-	 * @covers ::get_events
-	 *
-	 * @group unit
-	 *
-	 * @dataProvider data_get_events_country_restriction
-	 */
-	function test_get_events_country_restriction( array $input, array $expected_countries ) : void {
+	#[Group( 'needs-db' )]
+	#[DataProvider( 'data_get_events_country_restriction' )]
+	public function test_get_events_country_restriction( array $input, array $expected_countries ) : void {
 		$actual_result    = get_events( $input );
 		$actual_countries = array_column( array_column( $actual_result, 'location' ), 'country' );
 		$actual_countries = array_unique( array_map( 'strtoupper', $actual_countries ) );
@@ -121,7 +104,7 @@ class Test_Events extends TestCase {
 		$this->assertSame( $expected_countries, $actual_countries );
 	}
 
-	function data_get_events_country_restriction() : array {
+	public static function data_get_events_country_restriction() : array {
 		return array(
 			'restricted-by-country' => array(
 				'input' => array(
@@ -167,21 +150,13 @@ class Test_Events extends TestCase {
 		);
 	}
 
-	/**
-	 * @covers ::maybe_add_regional_wordcamps
-	 * @covers ::get_iso_3166_2_country_codes
-	 *
-	 * @group unit
-	 */
+	#[Group( 'unit' )]
 	public function test_maybe_add_regional_wordcamps() : void {
-		$local_events = get_events( array(
-			'number' => '5',
-			'nearby' => array(
-				// Off the coast of Robben Island, South Africa.
-				'latitude'  => '-33.849951',
-				'longitude' => '18.426246',
-			),
-		) );
+		// Seed with a mock local event; the function under test only cares about
+		// what it merges into this array, not where it came from.
+		$local_events = array(
+			array( 'title' => 'Mock Local Event' ),
+		);
 
 		$region_data = array(
 			'us' => array(
@@ -229,11 +204,6 @@ class Test_Events extends TestCase {
 			'ip' => '8.8.8.8',
 		);
 
-		// Make sure there's at least one event, otherwise there could be false positives.
-		if ( ! $local_events ) {
-			$local_events[] = array( 'title' => 'Mock Event' );
-		}
-
 		$tests_expect_no_changes = array();
 		$tests_expect_changes    = array();
 
@@ -273,20 +243,15 @@ class Test_Events extends TestCase {
 		}
 	}
 
-	/**
-	 * @covers ::get_iso_3166_2_country_codes
-	 *
-	 * @dataProvider data_get_iso_3166_2_country_codes
-	 *
-	 * @group unit
-	 */
+	#[Group( 'unit' )]
+	#[DataProvider( 'data_get_iso_3166_2_country_codes' )]
 	public function test_get_iso_3166_2_country_codes( $continent, $sample_country ) : void {
 		$countries = get_iso_3166_2_country_codes( $continent );
 
 		$this->assertContains( $sample_country, $countries );
 	}
 
-	public function data_get_iso_3166_2_country_codes() : array {
+	public static function data_get_iso_3166_2_country_codes() : array {
 		return array(
 			array( 'antarctica',    'HM' ),
 			array( 'africa',        'KM' ),
@@ -298,11 +263,7 @@ class Test_Events extends TestCase {
 		);
 	}
 
-	/**
-	 * @covers ::maybe_add_wp15_promo
-	 *
-	 * @group unit
-	 */
+	#[Group( 'unit' )]
 	public function test_maybe_add_wp15_promo() : void {
 		$local_events_yes_wp15 = array(
 			array(
@@ -435,11 +396,7 @@ class Test_Events extends TestCase {
 		$this->assertSame( $local_events_no_wp15, $events_outside_date_range, 'outside-date-range' );
 	}
 
-	/**
-	 * @covers ::remove_duplicate_events
-	 *
-	 * @group unit
-	 */
+	#[Group( 'unit' )]
 	public function test_remove_duplicate_events() : void {
 		$duplicate_events = array(
 			// Each of these represents an event; extraneous fields have been removed for readability.
@@ -470,13 +427,8 @@ class Test_Events extends TestCase {
 		$this->assertSame( $unique_events, remove_duplicate_events( $duplicate_events ) );
 	}
 
-	/**
-	 * @covers ::get_location
-	 *
-	 * @group unit
-	 *
-	 * @dataProvider data_get_location
-	 */
+	#[Group( 'needs-db' )]
+	#[DataProvider( 'data_get_location' )]
 	public function test_get_location( array $input, $expected ) : void {
 		$actual_result = get_location( $input );
 
@@ -501,7 +453,7 @@ class Test_Events extends TestCase {
 		$this->assertSame( $expected, $actual_result );
 	}
 
-	public function data_get_location() : array {
+	public static function data_get_location() : array {
 		$cases = array(
 			/*
 			 * Only the country code is given
@@ -1416,17 +1368,9 @@ class Test_Events extends TestCase {
 		return $cases;
 	}
 
-	/**
-	 * @covers ::build_response
-	 *
-	 * @todo It might be better to do more abstracted tests of `main()`, or e2e tests, rather than coupling to the
-	 * internals of `build_request()`.
-	 *
-	 * @group unit
-	 *
-	 * @dataProvider data_build_response
-	 */
-	function test_build_response( array $input, array $expected ) : void {
+	#[Group( 'needs-db' )]
+	#[DataProvider( 'data_build_response' )]
+	public function test_build_response( array $input, array $expected ) : void {
 		$actual_result = build_response( $input['location'], $input['location_args'] );
 
 		$this->assertSame( $expected['location'], $actual_result['location'] );
@@ -1443,7 +1387,7 @@ class Test_Events extends TestCase {
 		}
 	}
 
-	function data_build_response() : array {
+	public static function data_build_response() : array {
 		return array(
 			'utrecht-ip' => array(
 				'input' => array(
@@ -1503,46 +1447,115 @@ class Test_Events extends TestCase {
 		);
 	}
 
-	/**
-	 * @covers ::pin_one_off_events
-	 *
-	 * @group unit
-	 */
-	function test_pin_one_off_events() {
+	#[Group( 'unit' )]
+	public function test_pin_one_off_events() : void {
 		$seed_events = array();
 
-		// Don't forget to update the values here when they're updated in the FUT.
-		$actual_events_before_start      = pin_one_off_events( $seed_events, strtotime( 'December 12, 2022' ) );
-		$actual_events_before_expiration = pin_one_off_events( $seed_events, strtotime( 'December 17, 2022' ) );
-		$actual_events_after_expiration  = pin_one_off_events( $seed_events, strtotime( 'December 19, 2022' ) );
+		// Keep in sync with the date window hardcoded in pin_one_off_events().
+		$actual_events_before_start      = pin_one_off_events( $seed_events, strtotime( 'December 10, 2024' ) );
+		$actual_events_before_expiration = pin_one_off_events( $seed_events, strtotime( 'December 13, 2024' ) );
+		$actual_events_after_expiration  = pin_one_off_events( $seed_events, strtotime( 'December 18, 2024' ) );
 
 		$this->assertEmpty( $actual_events_before_start );
 		$this->assertIsArray( $actual_events_after_expiration );
 		$this->assertEmpty( $actual_events_after_expiration );
 
 		$this->assertIsArray( $actual_events_before_expiration );
-		$this->assertSame( 'State of the Word', $actual_events_before_expiration[0]['title'] );
+		$this->assertStringStartsWith( 'State of the Word', $actual_events_before_expiration[0]['title'] );
 	}
 
-	/**
-	 * @covers ::is_client_core
-	 *
-	 * @group unit
-	 *
-	 * @dataProvider data_is_client_core
-	 */
-	function test_is_client_core( string $user_agent, bool $expected_result ) : void {
+	#[Group( 'unit' )]
+	#[DataProvider( 'data_is_client_core' )]
+	public function test_is_client_core( string $user_agent, bool $expected_result ) : void {
 		$actual_result = is_client_core( $user_agent );
 
 		$this->assertSame( $expected_result, $actual_result );
 	}
 
-	public function data_is_client_core() : array {
+	public static function data_is_client_core() : array {
 		return array(
 			'Empty string'                    => array( '', false ),
 			'Mentions WP but not Core format' => array( 'Contains WordPress but no slash', false ),
 			'Core old version'                => array( 'WordPress/4.9; https://example.org', true ),
 			'Core future version, no URL'     => array( 'WordPress/10.0', true ),
 		);
+	}
+
+	/**
+	 * Flag regional WordCamp entries that lag behind the latest edition published on wordcamp.org.
+	 *
+	 * For each entry, the bare host (e.g. https://us.wordcamp.org/) is resolved; the final URL
+	 * after redirects points to the latest published edition's year. If that year is newer than
+	 * the year in our hardcoded data, the entry needs updating.
+	 *
+	 * Intentionally does NOT flag entries whose event has passed without a successor —
+	 * a past entry with no newer edition is harmless dead data.
+	 */
+	#[Group( 'data-freshness' )]
+	public function test_regional_wordcamp_data_matches_latest_published_edition() : void {
+		foreach ( get_regional_wordcamp_data() as $region => $data ) {
+			$host = parse_url( $data['event']['url'], PHP_URL_HOST );
+			$this->assertNotEmpty( $host, "Region '$region' has no parseable host in event URL: " . $data['event']['url'] );
+
+			$final_url = $this->helper_resolve_url( "https://$host/" );
+			if ( ! $final_url ) {
+				// Network failure or non-redirecting host — skip without failing.
+				continue;
+			}
+
+			$hardcoded_year = $this->helper_extract_year( $data['event']['url'] );
+			$published_year = $this->helper_extract_year( $final_url );
+
+			if ( ! $hardcoded_year || ! $published_year ) {
+				continue;
+			}
+
+			$this->assertGreaterThanOrEqual(
+				$published_year,
+				$hardcoded_year,
+				sprintf(
+					'Regional WordCamp "%s" (region "%s"): hardcoded data is for %d, but %s now points to %d. Update get_regional_wordcamp_data() with the newer edition.',
+					$data['event']['title'],
+					$region,
+					$hardcoded_year,
+					$host,
+					$published_year
+				)
+			);
+		}
+	}
+
+	/**
+	 * Resolve a URL after redirects, returning the final effective URL.
+	 */
+	private function helper_resolve_url( string $url ) : ?string {
+		if ( ! function_exists( 'curl_init' ) ) {
+			return null;
+		}
+
+		$ch = curl_init( $url );
+		curl_setopt_array( $ch, array(
+			CURLOPT_FOLLOWLOCATION => true,
+			CURLOPT_RETURNTRANSFER => true,
+			CURLOPT_NOBODY         => true,
+			CURLOPT_TIMEOUT        => 10,
+			CURLOPT_USERAGENT      => 'Mozilla/5.0 (wordpress.org events-api-tests)',
+		) );
+		curl_exec( $ch );
+		$final = curl_getinfo( $ch, CURLINFO_EFFECTIVE_URL );
+		curl_close( $ch );
+
+		return $final ?: null;
+	}
+
+	/**
+	 * Extract a 4-digit year from a URL path segment, e.g. "/2026/" → 2026.
+	 */
+	private function helper_extract_year( string $url ) : ?int {
+		$path = parse_url( $url, PHP_URL_PATH ) ?? '';
+		if ( preg_match( '#/(\d{4})(?:-[\w-]+)?/?#', $path, $m ) ) {
+			return (int) $m[1];
+		}
+		return null;
 	}
 }

--- a/api.wordpress.org/public_html/events/1.0/tests/Test_Events.php
+++ b/api.wordpress.org/public_html/events/1.0/tests/Test_Events.php
@@ -13,10 +13,6 @@ use function Dotorg\API\Events\{
  * @group events
  */
 class Test_Events extends TestCase {
-	public static function setUpBeforeClass() : void {
-		require_once dirname( __DIR__ ) . '/index.php';
-	}
-
 	/**
 	 * Asserts that an HTTP response is valid and contains an event.
 	 */
@@ -36,7 +32,7 @@ class Test_Events extends TestCase {
 		$this->assertContains( $event->type, array( 'wordcamp', 'meetup' ) );
 		$this->assertIsString( $event->title );
 		$this->assertIsNumeric( $event->start_unix_timestamp );
-		$this->assertSame( $event->url, filter_var( $event->url, FILTER_VALIDATE_URL, FILTER_FLAG_PATH_REQUIRED & FILTER_FLAG_QUERY_REQUIRED ) );
+		$this->assertSame( $event->url, filter_var( $event->url, FILTER_VALIDATE_URL, FILTER_FLAG_PATH_REQUIRED ) );
 		$this->assertIsNumeric( $event->location->latitude );
 	}
 
@@ -1581,7 +1577,9 @@ class Test_Events extends TestCase {
 	}
 
 	/**
-	 * Resolve a URL after redirects, returning the final effective URL.
+	 * Resolve a URL after redirects, returning the final effective URL on a 200 response.
+	 * Returns null on cURL errors, non-2xx responses, or when cURL is unavailable, so the
+	 * caller can skip rather than treat a transport failure as a passing assertion.
 	 */
 	private function helper_resolve_url( string $url ) : ?string {
 		if ( ! function_exists( 'curl_init' ) ) {
@@ -1597,8 +1595,15 @@ class Test_Events extends TestCase {
 			CURLOPT_USERAGENT      => 'Mozilla/5.0 (wordpress.org events-api-tests)',
 		) );
 		curl_exec( $ch );
-		$final = curl_getinfo( $ch, CURLINFO_EFFECTIVE_URL );
+
+		$errno     = curl_errno( $ch );
+		$http_code = (int) curl_getinfo( $ch, CURLINFO_HTTP_CODE );
+		$final     = curl_getinfo( $ch, CURLINFO_EFFECTIVE_URL );
 		curl_close( $ch );
+
+		if ( $errno || $http_code < 200 || $http_code >= 300 ) {
+			return null;
+		}
 
 		return $final ?: null;
 	}

--- a/api.wordpress.org/public_html/events/1.0/tests/Test_Events.php
+++ b/api.wordpress.org/public_html/events/1.0/tests/Test_Events.php
@@ -2,7 +2,6 @@
 
 namespace Dotorg\API\Events\Tests;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\Attributes\{Group, DataProvider};
 
 use function Dotorg\API\Events\{
 	get_events, get_location, build_response, is_client_core, pin_one_off_events,
@@ -10,7 +9,9 @@ use function Dotorg\API\Events\{
 	get_regional_wordcamp_data
 };
 
-#[Group( 'events' )]
+/**
+ * @group events
+ */
 class Test_Events extends TestCase {
 	public static function setUpBeforeClass() : void {
 		require_once dirname( __DIR__ ) . '/index.php';
@@ -39,7 +40,11 @@ class Test_Events extends TestCase {
 		$this->assertIsNumeric( $event->location->latitude );
 	}
 
-	#[Group( 'e2e' )]
+	/**
+	 * @covers ::main
+	 *
+	 * @group e2e
+	 */
 	public function test_get_events_e2e() : void {
 		$response = send_request( '/events/1.0/?location=seattle&locale=en_US&timezone=America/Los_Angeles' );
 		$body     = json_decode( $response->body );
@@ -48,8 +53,13 @@ class Test_Events extends TestCase {
 		$this->assertSame( 'Seattle', $body->location->description );
 	}
 
-	#[Group( 'needs-db' )]
-	#[DataProvider( 'data_get_events' )]
+	/**
+	 * @covers ::get_events
+	 *
+	 * @group needs-db
+	 *
+	 * @dataProvider data_get_events
+	 */
 	public function test_get_events( array $input, array $expected ) : void {
 		$actual_result = get_events( $input );
 
@@ -92,8 +102,13 @@ class Test_Events extends TestCase {
 		return $cases;
 	}
 
-	#[Group( 'needs-db' )]
-	#[DataProvider( 'data_get_events_country_restriction' )]
+	/**
+	 * @covers ::get_events
+	 *
+	 * @group needs-db
+	 *
+	 * @dataProvider data_get_events_country_restriction
+	 */
 	public function test_get_events_country_restriction( array $input, array $expected_countries ) : void {
 		$actual_result    = get_events( $input );
 		$actual_countries = array_column( array_column( $actual_result, 'location' ), 'country' );
@@ -150,7 +165,12 @@ class Test_Events extends TestCase {
 		);
 	}
 
-	#[Group( 'unit' )]
+	/**
+	 * @covers ::maybe_add_regional_wordcamps
+	 * @covers ::get_iso_3166_2_country_codes
+	 *
+	 * @group unit
+	 */
 	public function test_maybe_add_regional_wordcamps() : void {
 		// Seed with a mock local event; the function under test only cares about
 		// what it merges into this array, not where it came from.
@@ -243,8 +263,13 @@ class Test_Events extends TestCase {
 		}
 	}
 
-	#[Group( 'unit' )]
-	#[DataProvider( 'data_get_iso_3166_2_country_codes' )]
+	/**
+	 * @covers ::get_iso_3166_2_country_codes
+	 *
+	 * @dataProvider data_get_iso_3166_2_country_codes
+	 *
+	 * @group unit
+	 */
 	public function test_get_iso_3166_2_country_codes( $continent, $sample_country ) : void {
 		$countries = get_iso_3166_2_country_codes( $continent );
 
@@ -263,7 +288,11 @@ class Test_Events extends TestCase {
 		);
 	}
 
-	#[Group( 'unit' )]
+	/**
+	 * @covers ::maybe_add_wp15_promo
+	 *
+	 * @group unit
+	 */
 	public function test_maybe_add_wp15_promo() : void {
 		$local_events_yes_wp15 = array(
 			array(
@@ -396,7 +425,11 @@ class Test_Events extends TestCase {
 		$this->assertSame( $local_events_no_wp15, $events_outside_date_range, 'outside-date-range' );
 	}
 
-	#[Group( 'unit' )]
+	/**
+	 * @covers ::remove_duplicate_events
+	 *
+	 * @group unit
+	 */
 	public function test_remove_duplicate_events() : void {
 		$duplicate_events = array(
 			// Each of these represents an event; extraneous fields have been removed for readability.
@@ -427,8 +460,13 @@ class Test_Events extends TestCase {
 		$this->assertSame( $unique_events, remove_duplicate_events( $duplicate_events ) );
 	}
 
-	#[Group( 'needs-db' )]
-	#[DataProvider( 'data_get_location' )]
+	/**
+	 * @covers ::get_location
+	 *
+	 * @group needs-db
+	 *
+	 * @dataProvider data_get_location
+	 */
 	public function test_get_location( array $input, $expected ) : void {
 		$actual_result = get_location( $input );
 
@@ -1368,8 +1406,13 @@ class Test_Events extends TestCase {
 		return $cases;
 	}
 
-	#[Group( 'needs-db' )]
-	#[DataProvider( 'data_build_response' )]
+	/**
+	 * @covers ::build_response
+	 *
+	 * @group needs-db
+	 *
+	 * @dataProvider data_build_response
+	 */
 	public function test_build_response( array $input, array $expected ) : void {
 		$actual_result = build_response( $input['location'], $input['location_args'] );
 
@@ -1447,7 +1490,11 @@ class Test_Events extends TestCase {
 		);
 	}
 
-	#[Group( 'unit' )]
+	/**
+	 * @covers ::pin_one_off_events
+	 *
+	 * @group unit
+	 */
 	public function test_pin_one_off_events() : void {
 		$seed_events = array();
 
@@ -1464,8 +1511,13 @@ class Test_Events extends TestCase {
 		$this->assertStringStartsWith( 'State of the Word', $actual_events_before_expiration[0]['title'] );
 	}
 
-	#[Group( 'unit' )]
-	#[DataProvider( 'data_is_client_core' )]
+	/**
+	 * @covers ::is_client_core
+	 *
+	 * @group unit
+	 *
+	 * @dataProvider data_is_client_core
+	 */
 	public function test_is_client_core( string $user_agent, bool $expected_result ) : void {
 		$actual_result = is_client_core( $user_agent );
 
@@ -1490,8 +1542,11 @@ class Test_Events extends TestCase {
 	 *
 	 * Intentionally does NOT flag entries whose event has passed without a successor —
 	 * a past entry with no newer edition is harmless dead data.
+	 *
+	 * @covers ::get_regional_wordcamp_data
+	 *
+	 * @group data-freshness
 	 */
-	#[Group( 'data-freshness' )]
 	public function test_regional_wordcamp_data_matches_latest_published_edition() : void {
 		foreach ( get_regional_wordcamp_data() as $region => $data ) {
 			$host = parse_url( $data['event']['url'], PHP_URL_HOST );

--- a/api.wordpress.org/public_html/events/1.0/tests/bootstrap.php
+++ b/api.wordpress.org/public_html/events/1.0/tests/bootstrap.php
@@ -1,6 +1,9 @@
 <?php
 namespace Dotorg\API\Events\Tests;
 
+// Load the project's composer autoloader (PHPUnit, yoast/phpunit-polyfills).
+require_once dirname( __DIR__, 5 ) . '/vendor/autoload.php';
+
 // Signal to index.php that we're running tests so it skips main() / bootstrap() / init.php.
 define( 'WPORG_RUNNING_TESTS', true );
 

--- a/api.wordpress.org/public_html/events/1.0/tests/bootstrap.php
+++ b/api.wordpress.org/public_html/events/1.0/tests/bootstrap.php
@@ -39,7 +39,7 @@ function send_request( $path ) {
 	$host      = $sandboxed ? $sandboxed . '.wordpress.org' : 'api.wordpress.org';
 	$url       = 'https://' . $host . $path;
 
-	$body = @file_get_contents(
+	$body = file_get_contents(
 		$url,
 		false,
 		stream_context_create( array(
@@ -54,6 +54,12 @@ function send_request( $path ) {
 			),
 		) )
 	);
+
+	if ( false === $body ) {
+		throw new \RuntimeException(
+			"Failed to fetch $url: " . ( error_get_last()['message'] ?? 'unknown error' )
+		);
+	}
 
 	$status_code = 0;
 	foreach ( $http_response_header ?? array() as $header ) {

--- a/api.wordpress.org/public_html/events/1.0/tests/bootstrap.php
+++ b/api.wordpress.org/public_html/events/1.0/tests/bootstrap.php
@@ -5,14 +5,14 @@ namespace Dotorg\API\Events\Tests;
 define( 'WPORG_RUNNING_TESTS', true );
 
 // Time constants normally defined inside main().
-defined( 'HOUR_IN_SECONDS' ) or define( 'HOUR_IN_SECONDS', 60 * 60 );
-defined( 'DAY_IN_SECONDS' )  or define( 'DAY_IN_SECONDS', HOUR_IN_SECONDS * 24 );
-defined( 'WEEK_IN_SECONDS' ) or define( 'WEEK_IN_SECONDS', 7 * DAY_IN_SECONDS );
+defined( 'HOUR_IN_SECONDS' ) || define( 'HOUR_IN_SECONDS', 60 * 60 );
+defined( 'DAY_IN_SECONDS' )  || define( 'DAY_IN_SECONDS', HOUR_IN_SECONDS * 24 );
+defined( 'WEEK_IN_SECONDS' ) || define( 'WEEK_IN_SECONDS', 7 * DAY_IN_SECONDS );
 
 // Throttle constants normally defined inside main(). Default to "off" for tests.
-defined( 'THROTTLE_STICKY_WORDCAMPS' ) or define( 'THROTTLE_STICKY_WORDCAMPS', false );
-defined( 'THROTTLE_GEONAMES' )         or define( 'THROTTLE_GEONAMES', 0 );
-defined( 'THROTTLE_IP2LOCATION' )      or define( 'THROTTLE_IP2LOCATION', 0 );
+defined( 'THROTTLE_STICKY_WORDCAMPS' ) || define( 'THROTTLE_STICKY_WORDCAMPS', false );
+defined( 'THROTTLE_GEONAMES' )         || define( 'THROTTLE_GEONAMES', 0 );
+defined( 'THROTTLE_IP2LOCATION' )      || define( 'THROTTLE_IP2LOCATION', 0 );
 
 // Pull in the global API config when running on a WordPress.org sandbox; absent locally / in standalone CI.
 $api_init_file = dirname( __DIR__, 3 ) . '/init.php';
@@ -33,6 +33,7 @@ require_once dirname( __DIR__ ) . '/index.php';
  *
  * @param string $path Request path including query string, e.g. "/events/1.0/?location=seattle".
  * @return object { body: string, status_code: int }
+ * @throws \RuntimeException When the request fails at the transport layer.
  */
 function send_request( $path ) {
 	$sandboxed = defined( 'WPORG_SANDBOXED' ) ? WPORG_SANDBOXED : false;
@@ -56,9 +57,9 @@ function send_request( $path ) {
 	);
 
 	if ( false === $body ) {
-		throw new \RuntimeException(
-			"Failed to fetch $url: " . ( error_get_last()['message'] ?? 'unknown error' )
-		);
+		$last_error = error_get_last();
+		// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Test bootstrap; message is CLI output for PHPUnit, not HTML.
+		throw new \RuntimeException( sprintf( 'Failed to fetch %s: %s', $url, $last_error['message'] ?? 'unknown error' ) );
 	}
 
 	$status_code = 0;

--- a/api.wordpress.org/public_html/events/1.0/tests/bootstrap.php
+++ b/api.wordpress.org/public_html/events/1.0/tests/bootstrap.php
@@ -1,0 +1,69 @@
+<?php
+namespace Dotorg\API\Events\Tests;
+
+// Signal to index.php that we're running tests so it skips main() / bootstrap() / init.php.
+define( 'WPORG_RUNNING_TESTS', true );
+
+// Time constants normally defined inside main().
+defined( 'HOUR_IN_SECONDS' ) or define( 'HOUR_IN_SECONDS', 60 * 60 );
+defined( 'DAY_IN_SECONDS' )  or define( 'DAY_IN_SECONDS', HOUR_IN_SECONDS * 24 );
+defined( 'WEEK_IN_SECONDS' ) or define( 'WEEK_IN_SECONDS', 7 * DAY_IN_SECONDS );
+
+// Throttle constants normally defined inside main(). Default to "off" for tests.
+defined( 'THROTTLE_STICKY_WORDCAMPS' ) or define( 'THROTTLE_STICKY_WORDCAMPS', false );
+defined( 'THROTTLE_GEONAMES' )         or define( 'THROTTLE_GEONAMES', 0 );
+defined( 'THROTTLE_IP2LOCATION' )      or define( 'THROTTLE_IP2LOCATION', 0 );
+
+// Pull in the global API config when running on a WordPress.org sandbox; absent locally / in standalone CI.
+$api_init_file = dirname( __DIR__, 3 ) . '/init.php';
+if ( file_exists( $api_init_file ) ) {
+	require_once $api_init_file;
+}
+
+// Load the API entry-point so its functions are defined. main() is gated by WPORG_RUNNING_TESTS.
+require_once dirname( __DIR__ ) . '/index.php';
+
+// Provide cache-function stubs (normally registered by disable_caching() inside main()).
+\Dotorg\API\Events\disable_caching();
+
+/**
+ * Make a real HTTP request to the live Events API.
+ *
+ * Used by the e2e group to detect production regressions and stale data.
+ *
+ * @param string $path Request path including query string, e.g. "/events/1.0/?location=seattle".
+ * @return object { body: string, status_code: int }
+ */
+function send_request( $path ) {
+	$sandboxed = defined( 'WPORG_SANDBOXED' ) ? WPORG_SANDBOXED : false;
+	$host      = $sandboxed ? $sandboxed . '.wordpress.org' : 'api.wordpress.org';
+	$url       = 'https://' . $host . $path;
+
+	$body = @file_get_contents(
+		$url,
+		false,
+		stream_context_create( array(
+			'http' => array(
+				'header'        => 'Host: api.wordpress.org',
+				'ignore_errors' => true,
+				'user_agent'    => 'WordPress/' . PHP_VERSION . '; https://example.org',
+				'timeout'       => 15,
+			),
+			'ssl'  => array(
+				'verify_peer_name' => ! $sandboxed,
+			),
+		) )
+	);
+
+	$status_code = 0;
+	foreach ( $http_response_header ?? array() as $header ) {
+		if ( preg_match( '#^HTTP/\S+\s+(\d+)#', $header, $m ) ) {
+			$status_code = (int) $m[1];
+		}
+	}
+
+	return (object) array(
+		'body'        => $body,
+		'status_code' => $status_code,
+	);
+}

--- a/api.wordpress.org/public_html/events/1.0/tests/bootstrap.php
+++ b/api.wordpress.org/public_html/events/1.0/tests/bootstrap.php
@@ -17,6 +17,15 @@ defined( 'THROTTLE_STICKY_WORDCAMPS' ) || define( 'THROTTLE_STICKY_WORDCAMPS', f
 defined( 'THROTTLE_GEONAMES' )         || define( 'THROTTLE_GEONAMES', 0 );
 defined( 'THROTTLE_IP2LOCATION' )      || define( 'THROTTLE_IP2LOCATION', 0 );
 
+// Other constants/globals normally initialised in main(); required when the
+// needs-db tests are exercised on a sandbox that provides init.php.
+defined( 'COVID_IMPACT_EXPIRATION' ) || define( 'COVID_IMPACT_EXPIRATION', strtotime( 'January 1 2022' ) );
+$GLOBALS['cache_group'] = 'events';
+$GLOBALS['cache_life']  = 12 * HOUR_IN_SECONDS;
+if ( ! isset( $_SERVER['HTTP_USER_AGENT'] ) ) {
+	$_SERVER['HTTP_USER_AGENT'] = '';
+}
+
 // Pull in the global API config when running on a WordPress.org sandbox; absent locally / in standalone CI.
 $api_init_file = dirname( __DIR__, 3 ) . '/init.php';
 if ( file_exists( $api_init_file ) ) {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		"wp-coding-standards/wpcs": "^3.3.0",
 		"phpcompatibility/phpcompatibility-wp": "*",
 		"sirbrillig/phpcs-changed": "^2.12.0",
-		"phpunit/phpunit": "^11.0",
+		"phpunit/phpunit": "^9.6",
 		"yoast/phpunit-polyfills": "^4.0"
 	},
 	"scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7762f52740f10097e62040d98d76542b",
+    "content-hash": "dedf0228fee79e3a3eb42e44069ac077",
     "packages": [],
     "packages-dev": [
         {
@@ -102,6 +102,75 @@
                 }
             ],
             "time": "2025-11-11T04:32:07+00:00"
+        },
+        {
+            "name": "doctrine/instantiator",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/23da848e1a2308728fe5fdddabf4be17ff9720c7",
+                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.4"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^14",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^10.5.58"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/2.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-05T06:47:08+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -729,35 +798,35 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "11.0.12",
+            "version": "9.2.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56"
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2c1ed04922802c15e1de5d7447b4856de949cf56",
-                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^5.7.0",
-                "php": ">=8.2",
-                "phpunit/php-file-iterator": "^5.1.0",
-                "phpunit/php-text-template": "^4.0.1",
-                "sebastian/code-unit-reverse-lookup": "^4.0.1",
-                "sebastian/complexity": "^4.0.1",
-                "sebastian/environment": "^7.2.1",
-                "sebastian/lines-of-code": "^3.0.1",
-                "sebastian/version": "^5.0.2",
-                "theseer/tokenizer": "^1.3.1"
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "sebastian/code-unit-reverse-lookup": "^2.0.3",
+                "sebastian/complexity": "^2.0.3",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/lines-of-code": "^1.0.4",
+                "sebastian/version": "^3.0.2",
+                "theseer/tokenizer": "^1.2.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.5.46"
+                "phpunit/phpunit": "^9.6"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -766,7 +835,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "11.0.x-dev"
+                    "dev-main": "9.2.x-dev"
                 }
             },
             "autoload": {
@@ -795,52 +864,40 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.12"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-code-coverage",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2025-12-24T07:01:01+00:00"
+            "time": "2024-08-22T04:23:01+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "5.1.1",
+            "version": "3.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903"
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/2f3a64888c814fc235386b7387dd5b5ed92ad903",
-                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.3"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.1-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -867,49 +924,36 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/5.1.1"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-file-iterator",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2026-02-02T13:52:54+00:00"
+            "time": "2021-12-02T12:48:52+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "5.0.1",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2"
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/c1ca3814734c07492b3d4c5f794f4b0995333da2",
-                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=7.3"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^9.3"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -917,7 +961,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
@@ -943,8 +987,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
-                "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/5.0.1"
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
             },
             "funding": [
                 {
@@ -952,32 +995,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T05:07:44+00:00"
+            "time": "2020-09-28T05:58:55+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "4.0.1",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964"
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
-                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1003,8 +1046,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/4.0.1"
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
             },
             "funding": [
                 {
@@ -1012,32 +1054,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T05:08:43+00:00"
+            "time": "2020-10-26T05:33:50+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "7.0.1",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3"
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
-                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "7.0-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -1063,8 +1105,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/7.0.1"
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
             },
             "funding": [
                 {
@@ -1072,23 +1113,24 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T05:09:35+00:00"
+            "time": "2020-10-26T13:16:10+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "11.5.55",
+            "version": "9.6.34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "adc7262fccc12de2b30f12a8aa0b33775d814f00"
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/adc7262fccc12de2b30f12a8aa0b33775d814f00",
-                "reference": "adc7262fccc12de2b30f12a8aa0b33775d814f00",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b36f02317466907a230d3aa1d34467041271ef4a",
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a",
                 "shasum": ""
             },
             "require": {
+                "doctrine/instantiator": "^1.5.0 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
@@ -1098,27 +1140,27 @@
                 "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
-                "php": ">=8.2",
-                "phpunit/php-code-coverage": "^11.0.12",
-                "phpunit/php-file-iterator": "^5.1.1",
-                "phpunit/php-invoker": "^5.0.1",
-                "phpunit/php-text-template": "^4.0.1",
-                "phpunit/php-timer": "^7.0.1",
-                "sebastian/cli-parser": "^3.0.2",
-                "sebastian/code-unit": "^3.0.3",
-                "sebastian/comparator": "^6.3.3",
-                "sebastian/diff": "^6.0.2",
-                "sebastian/environment": "^7.2.1",
-                "sebastian/exporter": "^6.3.2",
-                "sebastian/global-state": "^7.0.2",
-                "sebastian/object-enumerator": "^6.0.1",
-                "sebastian/recursion-context": "^6.0.3",
-                "sebastian/type": "^5.1.3",
-                "sebastian/version": "^5.0.2",
-                "staabm/side-effects-detector": "^1.0.5"
+                "php": ">=7.3",
+                "phpunit/php-code-coverage": "^9.2.32",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
+                "sebastian/comparator": "^4.0.10",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.8",
+                "sebastian/global-state": "^5.0.8",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
+                "sebastian/version": "^3.0.2"
             },
             "suggest": {
-                "ext-soap": "To be able to generate mocks based on WSDL files"
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "bin": [
                 "phpunit"
@@ -1126,7 +1168,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "11.5-dev"
+                    "dev-master": "9.6-dev"
                 }
             },
             "autoload": {
@@ -1158,7 +1200,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.55"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.34"
             },
             "funding": [
                 {
@@ -1182,32 +1224,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-18T12:37:06+00:00"
+            "time": "2026-01-27T05:45:00+00:00"
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "3.0.2",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180"
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/15c5dd40dc4f38794d383bb95465193f5e0ae180",
-                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-master": "1.0-dev"
                 }
             },
             "autoload": {
@@ -1230,8 +1272,7 @@
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/3.0.2"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
             },
             "funding": [
                 {
@@ -1239,32 +1280,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T04:41:36+00:00"
+            "time": "2024-03-02T06:27:43+00:00"
         },
         {
             "name": "sebastian/code-unit",
-            "version": "3.0.3",
+            "version": "1.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64"
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/54391c61e4af8078e5b276ab082b6d3c54c9ad64",
-                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.5"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-master": "1.0-dev"
                 }
             },
             "autoload": {
@@ -1287,8 +1328,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "security": "https://github.com/sebastianbergmann/code-unit/security/policy",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/3.0.3"
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
             },
             "funding": [
                 {
@@ -1296,32 +1336,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-19T07:56:08+00:00"
+            "time": "2020-10-26T13:08:54+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "4.0.1",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "183a9b2632194febd219bb9246eee421dad8d45e"
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/183a9b2632194febd219bb9246eee421dad8d45e",
-                "reference": "183a9b2632194febd219bb9246eee421dad8d45e",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1343,8 +1383,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "security": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/security/policy",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/4.0.1"
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
             },
             "funding": [
                 {
@@ -1352,39 +1391,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T04:45:54+00:00"
+            "time": "2020-09-28T05:30:19+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "6.3.3",
+            "version": "4.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9"
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
-                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d",
                 "shasum": ""
             },
             "require": {
-                "ext-dom": "*",
-                "ext-mbstring": "*",
-                "php": ">=8.2",
-                "sebastian/diff": "^6.0",
-                "sebastian/exporter": "^6.0"
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.4"
-            },
-            "suggest": {
-                "ext-bcmath": "For comparing BcMath\\Number objects"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.3-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1423,8 +1457,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/6.3.3"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.10"
             },
             "funding": [
                 {
@@ -1444,33 +1477,33 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-24T09:26:40+00:00"
+            "time": "2026-01-24T09:22:56+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "4.0.1",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0"
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/ee41d384ab1906c68852636b6de493846e13e5a0",
-                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^5.0",
-                "php": ">=8.2"
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1493,8 +1526,7 @@
             "homepage": "https://github.com/sebastianbergmann/complexity",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/4.0.1"
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
             },
             "funding": [
                 {
@@ -1502,33 +1534,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T04:49:50+00:00"
+            "time": "2023-12-22T06:19:30+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "6.0.2",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544"
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/b4ccd857127db5d41a5b676f24b51371d76d8544",
-                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0",
+                "phpunit/phpunit": "^9.3",
                 "symfony/process": "^4.2 || ^5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1560,8 +1592,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/6.0.2"
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
             },
             "funding": [
                 {
@@ -1569,27 +1600,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T04:53:05+00:00"
+            "time": "2024-03-02T06:30:58+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "7.2.1",
+            "version": "5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4"
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/a5c75038693ad2e8d4b6c15ba2403532647830c4",
-                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.3"
+                "phpunit/phpunit": "^9.3"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -1597,7 +1628,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "7.2-dev"
+                    "dev-master": "5.1-dev"
                 }
             },
             "autoload": {
@@ -1616,7 +1647,7 @@
                 }
             ],
             "description": "Provides functionality to handle HHVM/PHP environments",
-            "homepage": "https://github.com/sebastianbergmann/environment",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
             "keywords": [
                 "Xdebug",
                 "environment",
@@ -1624,55 +1655,42 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "security": "https://github.com/sebastianbergmann/environment/security/policy",
-                "source": "https://github.com/sebastianbergmann/environment/tree/7.2.1"
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/sebastian/environment",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2025-05-21T11:55:47+00:00"
+            "time": "2023-02-03T06:03:51+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "6.3.2",
+            "version": "4.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74"
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/70a298763b40b213ec087c51c739efcaa90bcd74",
-                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c",
                 "shasum": ""
             },
             "require": {
-                "ext-mbstring": "*",
-                "php": ">=8.2",
-                "sebastian/recursion-context": "^6.0"
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.3"
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.3-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1714,8 +1732,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/6.3.2"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.8"
             },
             "funding": [
                 {
@@ -1735,35 +1752,38 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-24T06:12:51+00:00"
+            "time": "2025-09-24T06:03:27+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "7.0.2",
+            "version": "5.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "3be331570a721f9a4b5917f4209773de17f747d7"
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/3be331570a721f9a4b5917f4209773de17f747d7",
-                "reference": "3be331570a721f9a4b5917f4209773de17f747d7",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "sebastian/object-reflector": "^4.0",
-                "sebastian/recursion-context": "^6.0"
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-uopz": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "7.0-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -1782,48 +1802,59 @@
                 }
             ],
             "description": "Snapshotting of global state",
-            "homepage": "https://www.github.com/sebastianbergmann/global-state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
             "keywords": [
                 "global state"
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/7.0.2"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-07-03T04:57:36+00:00"
+            "time": "2025-08-10T07:10:35+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "3.0.1",
+            "version": "1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a"
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d36ad0d782e5756913e42ad87cb2890f4ffe467a",
-                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^5.0",
-                "php": ">=8.2"
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-master": "1.0-dev"
                 }
             },
             "autoload": {
@@ -1846,8 +1877,7 @@
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/3.0.1"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
             },
             "funding": [
                 {
@@ -1855,34 +1885,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T04:58:38+00:00"
+            "time": "2023-12-22T06:20:34+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "6.0.1",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "f5b498e631a74204185071eb41f33f38d64608aa"
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/f5b498e631a74204185071eb41f33f38d64608aa",
-                "reference": "f5b498e631a74204185071eb41f33f38d64608aa",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "sebastian/object-reflector": "^4.0",
-                "sebastian/recursion-context": "^6.0"
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1904,8 +1934,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/6.0.1"
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
             },
             "funding": [
                 {
@@ -1913,32 +1942,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T05:00:13+00:00"
+            "time": "2020-10-26T13:12:34+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "4.0.1",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9"
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/6e1a43b411b2ad34146dee7524cb13a068bb35f9",
-                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1960,8 +1989,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/4.0.1"
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
             },
             "funding": [
                 {
@@ -1969,32 +1997,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T05:01:32+00:00"
+            "time": "2020-10-26T13:14:26+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "6.0.3",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc"
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/f6458abbf32a6c8174f8f26261475dc133b3d9dc",
-                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.3"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2024,8 +2052,7 @@
             "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/6.0.3"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
             },
             "funding": [
                 {
@@ -2045,32 +2072,86 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-13T04:42:22+00:00"
+            "time": "2025-08-10T06:57:39+00:00"
         },
         {
-            "name": "sebastian/type",
-            "version": "5.1.3",
+            "name": "sebastian/resource-operations",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449"
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
-                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.3"
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.1-dev"
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-14T16:00:52+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -2093,50 +2174,37 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "security": "https://github.com/sebastianbergmann/type/security/policy",
-                "source": "https://github.com/sebastianbergmann/type/tree/5.1.3"
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/sebastian/type",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2025-08-09T06:55:48+00:00"
+            "time": "2023-02-03T06:13:03+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "5.0.2",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874"
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c687e3387b99f5b03b6caa64c74b63e2936ff874",
-                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=7.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2159,8 +2227,7 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "security": "https://github.com/sebastianbergmann/version/security/policy",
-                "source": "https://github.com/sebastianbergmann/version/tree/5.0.2"
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
             },
             "funding": [
                 {
@@ -2168,7 +2235,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-10-09T05:16:32+00:00"
+            "time": "2020-09-28T06:39:44+00:00"
         },
         {
             "name": "sirbrillig/phpcs-changed",
@@ -2302,58 +2369,6 @@
                 }
             ],
             "time": "2025-11-04T16:30:35+00:00"
-        },
-        {
-            "name": "staabm/side-effects-detector",
-            "version": "1.0.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/staabm/side-effects-detector.git",
-                "reference": "d8334211a140ce329c13726d4a715adbddd0a163"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/staabm/side-effects-detector/zipball/d8334211a140ce329c13726d4a715adbddd0a163",
-                "reference": "d8334211a140ce329c13726d4a715adbddd0a163",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": "^7.4 || ^8.0"
-            },
-            "require-dev": {
-                "phpstan/extension-installer": "^1.4.3",
-                "phpstan/phpstan": "^1.12.6",
-                "phpunit/phpunit": "^9.6.21",
-                "symfony/var-dumper": "^5.4.43",
-                "tomasvotruba/type-coverage": "1.0.0",
-                "tomasvotruba/unused-public": "1.0.0"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "lib/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "A static analysis tool to detect side effects in PHP code",
-            "keywords": [
-                "static analysis"
-            ],
-            "support": {
-                "issues": "https://github.com/staabm/side-effects-detector/issues",
-                "source": "https://github.com/staabm/side-effects-detector/tree/1.0.5"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/staabm",
-                    "type": "github"
-                }
-            ],
-            "time": "2024-10-20T05:08:20+00:00"
         },
         {
             "name": "theseer/tokenizer",


### PR DESCRIPTION
Wires up the standalone PHPUnit test suites in the unit-tests workflow so they actually run, aligns them on the same toolchain WordPress Core uses, and adds an Events API freshness check to detect stale regional WordCamp entries.

Original scope was the events-api tests; expanded after discovering related issues in the existing standalone CI setup.

## What changed

### Toolchain alignment
- composer.json: phpunit/phpunit ^11.0 -> ^9.6, matching WordPress Core. yoast/phpunit-polyfills ^4.0 was already required and is now actually loaded.
- unit-tests.yml: drop the phpunit:^11 PHAR. composer install at the workspace root, then run vendor/bin/phpunit. WP-dependent jobs unchanged (already on PHPUnit 9 via wp-env).

### Existing suites unblocked
Both PHP: Serve Happy API and PHP: Browse Happy API were silently reporting "No tests executed!" in CI — PHPUnit 11.5+ refuses to discover files whose name does not match the class. Under PHPUnit 9 the original conventions work; phpunit.xml is now wired up with a bootstrap and a sensible group default.
- Serve Happy: 18 unit tests now run on PR (live group serve-happy-live-http kept excluded by default; available via --group on demand).
- Browse Happy: 705 tests now run on PR (new tests/bootstrap.php replaces the inline parse.php include).

### Events API tests
- index.php: trailing main() call gated on WPORG_RUNNING_TESTS so the file can be require-d by tests without booting init.php / hyperdb.
- tests/Test_Events.php (renamed from test-index.php for symmetry with the class): non-static data providers made static, decoupled test_maybe_add_regional_wordcamps from the DB, updated test_pin_one_off_events to the current SotW window.
- New tests/bootstrap.php: defines WPORG_RUNNING_TESTS plus the time/throttle/cache state main() normally sets up (HOUR_IN_SECONDS, COVID_IMPACT_EXPIRATION, $cache_group, HTTP_USER_AGENT default), conditionally loads init.php when on a sandbox, calls disable_caching() for wp_cache_* stubs, and exposes send_request() for e2e tests.
- New phpunit.xml.dist with bootstrap reference and default group exclusions for the three networked / DB-bound groups.
- New test_regional_wordcamp_data_matches_latest_published_edition: for each regional entry, resolves https://{host}/ via cURL and compares the year segment to the hardcoded data. Fails when wordcamp.org has published a newer edition than is in code.

### CI shape
- PR CI (unit-tests.yml): runs all three suites with their phpunit.xml defaults. No network calls, no DB. Total ~738 tests across the three suites.
- Daily cron (.github/workflows/events-api-live.yml, workflow_dispatch enabled): runs the events-api e2e + data-freshness groups against live api.wordpress.org and *.wordcamp.org. Failures here signal a production regression or a regional edition that needs updating.

## Test plan

- [x] Local: composer install, run each suite from its working directory.
  - Events API: 15 tests / 32 assertions (~15 ms)
  - Events API live: 2 tests / 22 assertions (~10 s; resolves all four regional hosts and hits api.wordpress.org)
  - Serve Happy: 18 tests / 18 assertions (was 0 in CI)
  - Browse Happy: 705 tests / 714 assertions (was 0 in CI)
- [x] CI: all green on 402a8b90b before this commit; the latest commit only changes XML defaults + a couple of bootstrap constants, no functional test changes.
- [x] Linting clean.

## Out of scope / follow-ups

- The Central API alternative for the freshness check (querying central.wordcamp.org for flagship/regional events) would be cleaner than redirect-sniffing, but needs the REST endpoint extended.
- The needs-db group in events tests still requires a WordPress.org sandbox (init.php / hyperdb / Geonames / ip2location). It is excluded by default; can be opted in on a sandbox with --group needs-db.

🤖 Generated with [Claude Code](https://claude.com/claude-code)