### PR TITLE
Plugin Directory: Extract asset image dimensions during plugin import

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/bin/backfill-asset-dimensions.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/bin/backfill-asset-dimensions.php
@@ -102,10 +102,9 @@ foreach ( $post_ids as $i => $post_id ) {
 				continue;
 			}
 
-			$ext        = strtolower( pathinfo( $record['filename'], PATHINFO_EXTENSION ) );
-			$is_raster  = in_array( $ext, array( 'png', 'jpg', 'jpeg', 'gif' ), true );
-			$has_dims   = ! empty( $record['width'] ) && ! empty( $record['height'] );
-			$tried_fail = ! empty( $record['dimensions_failed'] );
+			$ext       = strtolower( pathinfo( $record['filename'], PATHINFO_EXTENSION ) );
+			$is_raster = in_array( $ext, array( 'png', 'jpg', 'jpeg', 'gif' ), true );
+			$has_dims  = ! empty( $record['width'] ) && ! empty( $record['height'] );
 
 			if ( ! $is_raster ) {
 				++$counts['skipped'];
@@ -113,11 +112,6 @@ foreach ( $post_ids as $i => $post_id ) {
 			}
 			if ( $has_dims ) {
 				++$counts['reused'];
-				continue;
-			}
-			if ( $tried_fail ) {
-				++$counts['failed'];
-				$failed_files[] = "{$slug} {$type} {$record['filename']}";
 				continue;
 			}
 

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/bin/backfill-asset-dimensions.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/bin/backfill-asset-dimensions.php
@@ -38,6 +38,17 @@ if ( ! class_exists( '\WordPressdotorg\Plugin_Directory\Plugin_Directory' ) ) {
 
 global $wpdb;
 
+// Be more patient with slow SVN responses during a bulk run than the
+// per-request import path is. Uses http_request_args (not the timeout
+// filter) so the helper's explicit `timeout => 15` is overridden.
+add_filter(
+	'http_request_args',
+	function ( $args ) {
+		$args['timeout'] = 30;
+		return $args;
+	}
+);
+
 $meta_keys = array(
 	'screenshot' => 'assets_screenshots',
 	'banner'     => 'assets_banners',

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/bin/backfill-asset-dimensions.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/bin/backfill-asset-dimensions.php
@@ -86,7 +86,7 @@ foreach ( $post_ids as $i => $post_id ) {
 		continue;
 	}
 
-	$slug         = $plugin->post_name;
+	$slug         = $plugin->post_name; // Only used for the failure list.
 	$plugin_dirty = false;
 
 	foreach ( $meta_keys as $type => $meta_key ) {
@@ -117,7 +117,7 @@ foreach ( $post_ids as $i => $post_id ) {
 
 			// Pass the existing record as the prior so the helper short-circuits
 			// for cases it already knows the answer for.
-			$updated = Import::enrich_asset_dimensions( $record, $record, $slug );
+			$updated = Import::enrich_asset_dimensions( $record, $record, $plugin );
 
 			if ( ! empty( $updated['width'] ) && ! empty( $updated['height'] ) ) {
 				++$counts['extracted'];

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/bin/backfill-asset-dimensions.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/bin/backfill-asset-dimensions.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile — CLI script: output not escaped, loop vars shadow WP globals.
 namespace WordPressdotorg\Plugin_Directory;
 
 use WordPressdotorg\Plugin_Directory\CLI\Import;

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/bin/backfill-asset-dimensions.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/bin/backfill-asset-dimensions.php
@@ -86,7 +86,6 @@ $counts          = array(
 	'reused'    => 0,
 	'extracted' => 0,
 	'failed'    => 0,
-	'skipped'   => 0, // SVG / non-raster.
 );
 $failed_files    = array();
 
@@ -114,15 +113,7 @@ foreach ( $post_ids as $i => $post_id ) {
 				continue;
 			}
 
-			$ext       = strtolower( pathinfo( $record['filename'], PATHINFO_EXTENSION ) );
-			$is_raster = in_array( $ext, array( 'png', 'jpg', 'jpeg', 'gif' ), true );
-			$has_dims  = ! empty( $record['width'] ) && ! empty( $record['height'] );
-
-			if ( ! $is_raster ) {
-				++$counts['skipped'];
-				continue;
-			}
-			if ( $has_dims ) {
+			if ( ! empty( $record['width'] ) && ! empty( $record['height'] ) ) {
 				++$counts['reused'];
 				continue;
 			}
@@ -158,13 +149,12 @@ foreach ( $post_ids as $i => $post_id ) {
 
 	if ( ( $i + 1 ) % 100 === 0 ) {
 		echo sprintf(
-			"  [%d/%d] reused=%d extracted=%d failed=%d skipped=%d\n",
+			"  [%d/%d] reused=%d extracted=%d failed=%d\n",
 			$i + 1,
 			$total_plugins,
 			$counts['reused'],
 			$counts['extracted'],
-			$counts['failed'],
-			$counts['skipped']
+			$counts['failed']
 		);
 	}
 }
@@ -173,9 +163,8 @@ echo "\nDone.\n";
 echo "  Plugins scanned: {$total_plugins}\n";
 echo "  Plugins updated: {$plugins_updated}" . ( $opts['dry-run'] ? ' (would update)' : '' ) . "\n";
 echo "  Assets with cached dimensions reused: {$counts['reused']}\n";
-echo "  Assets newly extracted:                {$counts['extracted']}\n";
-echo "  Assets failed extraction:              {$counts['failed']}\n";
-echo "  Non-raster assets skipped (SVG/etc.):  {$counts['skipped']}\n";
+echo "  Assets newly extracted:               {$counts['extracted']}\n";
+echo "  Assets failed extraction:             {$counts['failed']}\n";
 
 if ( $failed_files ) {
 	echo "\nFailed assets:\n  " . implode( "\n  ", $failed_files ) . "\n";

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/bin/backfill-asset-dimensions.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/bin/backfill-asset-dimensions.php
@@ -1,0 +1,176 @@
+<?php
+namespace WordPressdotorg\Plugin_Directory;
+
+use WordPressdotorg\Plugin_Directory\CLI\Import;
+
+// This script should only be called in a CLI environment.
+if ( 'cli' != php_sapi_name() ) {
+	die();
+}
+
+$opts = getopt( '', array( 'url:', 'abspath:', 'plugin:', 'limit:', 'dry-run' ) );
+
+if ( empty( $opts['url'] ) ) {
+	$opts['url'] = 'https://wordpress.org/plugins/';
+}
+if ( empty( $opts['abspath'] ) && false !== strpos( __DIR__, 'wp-content' ) ) {
+	$opts['abspath'] = substr( __DIR__, 0, strpos( __DIR__, 'wp-content' ) );
+}
+
+$opts['dry-run'] = isset( $opts['dry-run'] );
+$opts['limit']   = isset( $opts['limit'] ) ? (int) $opts['limit'] : 0;
+
+// Bootstrap WordPress.
+$_SERVER['HTTP_HOST']   = parse_url( $opts['url'], PHP_URL_HOST );
+$_SERVER['REQUEST_URI'] = parse_url( $opts['url'], PHP_URL_PATH );
+
+require rtrim( $opts['abspath'], '/' ) . '/wp-load.php';
+
+if ( ! class_exists( '\WordPressdotorg\Plugin_Directory\Plugin_Directory' ) ) {
+	fwrite( STDERR, "Error! This site doesn't have the Plugin Directory plugin enabled.\n" );
+	if ( defined( 'WPORG_PLUGIN_DIRECTORY_BLOGID' ) ) {
+		fwrite( STDERR, "Run the following command instead:\n" );
+		fwrite( STDERR, "\tphp " . implode( ' ', $argv ) . ' --url ' . get_site_url( WPORG_PLUGIN_DIRECTORY_BLOGID, '/' ) . "\n" );
+	}
+	die();
+}
+
+global $wpdb;
+
+$meta_keys = array(
+	'screenshot' => 'assets_screenshots',
+	'banner'     => 'assets_banners',
+	'icon'       => 'assets_icons',
+);
+
+if ( ! empty( $opts['plugin'] ) ) {
+	$plugin = Plugin_Directory::get_plugin_post( $opts['plugin'] );
+	if ( ! $plugin ) {
+		fwrite( STDERR, "Plugin '{$opts['plugin']}' not found.\n" );
+		exit( 1 );
+	}
+	$post_ids = array( $plugin->ID );
+} else {
+	$post_ids = $wpdb->get_col( $wpdb->prepare(
+		"SELECT DISTINCT post_id
+		   FROM {$wpdb->postmeta}
+		  WHERE meta_key IN ( %s, %s, %s )
+		    AND meta_value != ''
+		    AND meta_value != 'a:0:{}'
+		  ORDER BY post_id ASC",
+		$meta_keys['screenshot'],
+		$meta_keys['banner'],
+		$meta_keys['icon']
+	) );
+
+	if ( $opts['limit'] > 0 ) {
+		$post_ids = array_slice( $post_ids, 0, $opts['limit'] );
+	}
+}
+
+$total_plugins   = count( $post_ids );
+$plugins_updated = 0;
+$counts          = array(
+	'reused'    => 0,
+	'extracted' => 0,
+	'failed'    => 0,
+	'skipped'   => 0, // SVG / non-raster.
+);
+$failed_files    = array();
+
+echo "Scanning {$total_plugins} plugins" . ( $opts['dry-run'] ? ' (dry-run)' : '' ) . "...\n";
+
+foreach ( $post_ids as $i => $post_id ) {
+	$plugin = get_post( $post_id );
+	if ( ! $plugin || 'plugin' !== $plugin->post_type ) {
+		continue;
+	}
+
+	$slug         = $plugin->post_name;
+	$plugin_dirty = false;
+
+	foreach ( $meta_keys as $type => $meta_key ) {
+		$records = get_post_meta( $post_id, $meta_key, true );
+		if ( ! is_array( $records ) || ! $records ) {
+			continue;
+		}
+
+		$meta_dirty = false;
+
+		foreach ( $records as $filename => $record ) {
+			if ( ! is_array( $record ) || empty( $record['filename'] ) || ! isset( $record['revision'] ) ) {
+				continue;
+			}
+
+			$ext        = strtolower( pathinfo( $record['filename'], PATHINFO_EXTENSION ) );
+			$is_raster  = in_array( $ext, array( 'png', 'jpg', 'jpeg', 'gif' ), true );
+			$has_dims   = ! empty( $record['width'] ) && ! empty( $record['height'] );
+			$tried_fail = ! empty( $record['dimensions_failed'] );
+
+			if ( ! $is_raster ) {
+				++$counts['skipped'];
+				continue;
+			}
+			if ( $has_dims ) {
+				++$counts['reused'];
+				continue;
+			}
+			if ( $tried_fail ) {
+				++$counts['failed'];
+				$failed_files[] = "{$slug} {$type} {$record['filename']}";
+				continue;
+			}
+
+			// Pass the existing record as the prior so the helper short-circuits
+			// for cases it already knows the answer for.
+			$updated = Import::enrich_asset_dimensions( $record, $record, $slug );
+
+			if ( ! empty( $updated['width'] ) && ! empty( $updated['height'] ) ) {
+				++$counts['extracted'];
+			} else {
+				++$counts['failed'];
+				$failed_files[] = "{$slug} {$type} {$record['filename']}";
+			}
+
+			if ( $updated !== $record ) {
+				$records[ $filename ] = $updated;
+				$meta_dirty           = true;
+			}
+		}
+
+		if ( $meta_dirty ) {
+			$plugin_dirty = true;
+			if ( ! $opts['dry-run'] ) {
+				update_post_meta( $post_id, $meta_key, wp_slash( $records ) );
+			}
+		}
+	}
+
+	if ( $plugin_dirty ) {
+		++$plugins_updated;
+	}
+
+	if ( ( $i + 1 ) % 100 === 0 ) {
+		echo sprintf(
+			"  [%d/%d] reused=%d extracted=%d failed=%d skipped=%d\n",
+			$i + 1,
+			$total_plugins,
+			$counts['reused'],
+			$counts['extracted'],
+			$counts['failed'],
+			$counts['skipped']
+		);
+	}
+}
+
+echo "\nDone.\n";
+echo "  Plugins scanned: {$total_plugins}\n";
+echo "  Plugins updated: {$plugins_updated}" . ( $opts['dry-run'] ? ' (would update)' : '' ) . "\n";
+echo "  Assets with cached dimensions reused: {$counts['reused']}\n";
+echo "  Assets newly extracted:                {$counts['extracted']}\n";
+echo "  Assets failed extraction:              {$counts['failed']}\n";
+echo "  Non-raster assets skipped (SVG/etc.):  {$counts['skipped']}\n";
+
+if ( $failed_files ) {
+	echo "\nFailed assets:\n  " . implode( "\n  ", $failed_files ) . "\n";
+}

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
@@ -1103,10 +1103,10 @@ class Import {
 	 * Populate `width` and `height` on an asset record, reusing the prior
 	 * import's values when the SVN revision hasn't changed.
 	 *
-	 * @param array             $record The asset record.
-	 * @param array|null        $prior  Matching record from the prior import.
-	 * @param int|\WP_Post|null $post   The plugin post.
-	 * @param string|null       $local  Optional local path to read instead of fetching from SVN.
+	 * @param array        $record The asset record.
+	 * @param array|null   $prior  Matching record from the prior import.
+	 * @param int|\WP_Post $post   The plugin post.
+	 * @param string|null  $local  Optional local path to read instead of fetching from SVN.
 	 * @return array
 	 */
 	public static function enrich_asset_dimensions( $record, $prior, $post, $local = null ) {

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
@@ -828,18 +828,12 @@ class Import {
 		);
 
 		// Previously-imported asset metadata, used to skip re-reading any file whose
-		// SVN revision hasn't changed. The cached `width`/`height` from the prior
-		// import is reused as-is when the revision matches.
+		// SVN revision hasn't changed.
 		$prior_assets = array(
-			'screenshot' => array(),
-			'banner'     => array(),
-			'icon'       => array(),
+			'screenshot' => get_post_meta( $this->plugin->ID, 'assets_screenshots', true ) ?: array(),
+			'banner'     => get_post_meta( $this->plugin->ID, 'assets_banners',     true ) ?: array(),
+			'icon'       => get_post_meta( $this->plugin->ID, 'assets_icons',       true ) ?: array(),
 		);
-		if ( $this->plugin ) {
-			$prior_assets['screenshot'] = get_post_meta( $this->plugin->ID, 'assets_screenshots', true ) ?: array();
-			$prior_assets['banner']     = get_post_meta( $this->plugin->ID, 'assets_banners',     true ) ?: array();
-			$prior_assets['icon']       = get_post_meta( $this->plugin->ID, 'assets_icons',       true ) ?: array();
-		}
 
 		$svn_blueprints_folder = null;
 		$svn_assets_folder = SVN::ls( self::PLUGIN_SVN_BASE . "/{$plugin_slug}/assets/", true /* verbose */ );

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
@@ -1112,9 +1112,7 @@ class Import {
 	 * stream).
 	 *
 	 * SVG and unknown formats are left untouched — they have no fixed
-	 * pixel dimensions to record. When extraction fails for a raster
-	 * format, `dimensions_failed` is set on the record so a later run
-	 * can identify the offenders without re-fetching every file.
+	 * pixel dimensions to record.
 	 *
 	 * @param array       $record The asset record (`filename`, `revision`, …).
 	 * @param array|null  $prior  Matching record from the prior import, or null.
@@ -1124,20 +1122,16 @@ class Import {
 	 * @return array The record, with `width` and `height` added when known.
 	 */
 	public static function enrich_asset_dimensions( $record, $prior, $slug, $local = null ) {
-		if ( is_array( $prior ) && isset( $prior['revision'] ) && (string) $prior['revision'] === (string) $record['revision'] ) {
-			if ( isset( $prior['width'], $prior['height'] ) && $prior['width'] > 0 && $prior['height'] > 0 ) {
-				$record['width']  = (int) $prior['width'];
-				$record['height'] = (int) $prior['height'];
+		if (
+			is_array( $prior ) &&
+			isset( $prior['revision'], $prior['width'], $prior['height'] ) &&
+			(string) $prior['revision'] === (string) $record['revision'] &&
+			$prior['width'] > 0 && $prior['height'] > 0
+		) {
+			$record['width']  = (int) $prior['width'];
+			$record['height'] = (int) $prior['height'];
 
-				return $record;
-			}
-
-			// Same revision and we already tried — don't re-fetch only to fail again.
-			if ( ! empty( $prior['dimensions_failed'] ) ) {
-				$record['dimensions_failed'] = true;
-
-				return $record;
-			}
+			return $record;
 		}
 
 		$ext = strtolower( pathinfo( $record['filename'], PATHINFO_EXTENSION ) );
@@ -1185,8 +1179,6 @@ class Import {
 		if ( $size && ! empty( $size[0] ) && ! empty( $size[1] ) ) {
 			$record['width']  = (int) $size[0];
 			$record['height'] = (int) $size[1];
-		} else {
-			$record['dimensions_failed'] = true;
 		}
 
 		return $record;

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
@@ -1132,7 +1132,12 @@ class Import {
 
 			// Range the first read to 128 KB — enough for the headers of
 			// PNG/GIF and most JPEGs. Fall back to a full read only when
-			// the prefix isn't enough to decode the header.
+			// the prefix isn't enough to decode the header — the falsy
+			// `$size` at the bottom of the loop is the implicit retry.
+			// Transport errors / non-2xx / empty body intentionally bail
+			// out via `break`: those failure modes (network down, 4xx,
+			// 5xx, empty file) won't be helped by re-requesting the same
+			// URL without Range.
 			foreach ( array( 128 * KB_IN_BYTES, 0 ) as $limit ) {
 				$args = array( 'timeout' => 15 );
 				if ( $limit > 0 ) {

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
@@ -1103,10 +1103,10 @@ class Import {
 	 * Populate `width` and `height` on an asset record, reusing the prior
 	 * import's values when the SVN revision hasn't changed.
 	 *
-	 * @param array              $record The asset record.
-	 * @param array|null         $prior  Matching record from the prior import.
-	 * @param int|\WP_Post|null  $post   The plugin post.
-	 * @param string|null        $local  Optional local path to read instead of fetching from SVN.
+	 * @param array             $record The asset record.
+	 * @param array|null        $prior  Matching record from the prior import.
+	 * @param int|\WP_Post|null $post   The plugin post.
+	 * @param string|null       $local  Optional local path to read instead of fetching from SVN.
 	 * @return array
 	 */
 	public static function enrich_asset_dimensions( $record, $prior, $post, $local = null ) {
@@ -1131,7 +1131,9 @@ class Import {
 
 		if ( $local && file_exists( $local ) ) {
 			$size = @getimagesize( $local );
-		} else {
+		}
+
+		if ( ! $size ) {
 			// Fetch direct from SVN rather than the CDN, so the byte
 			// stream is always the revision we just listed.
 			$url = Template::get_asset_url( $post, $record, false /* no CDN */ );

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
@@ -827,6 +827,20 @@ class Import {
 			'blueprint'  => 100 * KB_IN_BYTES,
 		);
 
+		// Previously-imported asset metadata, used to skip re-reading any file whose
+		// SVN revision hasn't changed. The cached `width`/`height` from the prior
+		// import is reused as-is when the revision matches.
+		$prior_assets = array(
+			'screenshot' => array(),
+			'banner'     => array(),
+			'icon'       => array(),
+		);
+		if ( $this->plugin ) {
+			$prior_assets['screenshot'] = get_post_meta( $this->plugin->ID, 'assets_screenshots', true ) ?: array();
+			$prior_assets['banner']     = get_post_meta( $this->plugin->ID, 'assets_banners',     true ) ?: array();
+			$prior_assets['icon']       = get_post_meta( $this->plugin->ID, 'assets_icons',       true ) ?: array();
+		}
+
 		$svn_blueprints_folder = null;
 		$svn_assets_folder = SVN::ls( self::PLUGIN_SVN_BASE . "/{$plugin_slug}/assets/", true /* verbose */ );
 		if ( $svn_assets_folder ) { // /assets/ may not exist.
@@ -862,7 +876,15 @@ class Import {
 					$resolution = preg_replace( '/[^0-9]/u', 'x', $resolution );
 				}
 
-				$assets[ $type ][ $asset['filename'] ] = compact( 'filename', 'revision', 'resolution', 'location', 'locale' );
+				$record = compact( 'filename', 'revision', 'resolution', 'location', 'locale' );
+
+				$record = self::enrich_asset_dimensions(
+					$record,
+					$prior_assets[ $type ][ $filename ] ?? null,
+					$plugin_slug
+				);
+
+				$assets[ $type ][ $asset['filename'] ] = $record;
 			}
 		}
 
@@ -921,12 +943,21 @@ class Import {
 				continue;
 			}
 
-			$assets['screenshot'][ $filename ] = array(
+			$record = array(
 				'filename'   => $filename,
 				'revision'   => $svn_export['revision'],
 				'resolution' => $screenshot_id,
 				'location'   => 'plugin',
 			);
+
+			$record = self::enrich_asset_dimensions(
+				$record,
+				$prior_assets['screenshot'][ $filename ] ?? null,
+				$plugin_slug,
+				$plugin_screenshot
+			);
+
+			$assets['screenshot'][ $filename ] = $record;
 		}
 
 		if ( 'trunk' === $stable_tag ) {
@@ -1066,6 +1097,129 @@ class Import {
 			$plugin_slug,
 			$this,
 		);
+	}
+
+	/**
+	 * Populate `width` and `height` on an asset record.
+	 *
+	 * Reuses the cached values from the prior import when the SVN revision
+	 * hasn't changed; otherwise reads the image (from a local path if one is
+	 * supplied, or by fetching the file from SVN) and parses dimensions via
+	 * `getimagesize()`. To keep import bandwidth in check, the remote path
+	 * first tries the leading 128 KB via a Range request and only falls
+	 * back to the full body when that prefix isn't enough to decode the
+	 * header (e.g. progressive JPEGs with the SOF segment deep in the
+	 * stream).
+	 *
+	 * SVG and unknown formats are left untouched — they have no fixed
+	 * pixel dimensions to record. When extraction fails for a raster
+	 * format, `dimensions_failed` is set on the record so a later run
+	 * can identify the offenders without re-fetching every file.
+	 *
+	 * @param array       $record The asset record (`filename`, `revision`, …).
+	 * @param array|null  $prior  Matching record from the prior import, or null.
+	 * @param string      $slug   Plugin slug, used to construct the SVN URL.
+	 * @param string|null $local  Optional local path; preferred over a remote
+	 *                            fetch when the file is already on disk.
+	 * @return array The record, with `width` and `height` added when known.
+	 */
+	public static function enrich_asset_dimensions( $record, $prior, $slug, $local = null ) {
+		if ( is_array( $prior ) && isset( $prior['revision'] ) && (string) $prior['revision'] === (string) $record['revision'] ) {
+			if ( isset( $prior['width'], $prior['height'] ) && $prior['width'] > 0 && $prior['height'] > 0 ) {
+				$record['width']  = (int) $prior['width'];
+				$record['height'] = (int) $prior['height'];
+
+				return $record;
+			}
+
+			// Same revision and we already tried — don't re-fetch only to fail again.
+			if ( ! empty( $prior['dimensions_failed'] ) ) {
+				$record['dimensions_failed'] = true;
+
+				return $record;
+			}
+		}
+
+		$ext = strtolower( pathinfo( $record['filename'], PATHINFO_EXTENSION ) );
+		if ( ! in_array( $ext, array( 'png', 'jpg', 'jpeg', 'gif' ), true ) ) {
+			return $record;
+		}
+
+		$size = false;
+
+		if ( $local && file_exists( $local ) ) {
+			$size = @getimagesize( $local );
+		} else {
+			// 'plugin'-located screenshots live in /trunk/; everything
+			// else (banners, icons, /assets/-located screenshots) lives
+			// in /assets/.
+			$folder = ( isset( $record['location'] ) && 'plugin' === $record['location'] ) ? 'trunk' : 'assets';
+			$url    = add_query_arg(
+				'rev',
+				$record['revision'],
+				sprintf(
+					'%s/%s/%s/%s',
+					self::PLUGIN_SVN_BASE,
+					$slug,
+					$folder,
+					rawurlencode( $record['filename'] )
+				)
+			);
+
+			// Try the first 128 KB first; it covers all PNG/GIF and the
+			// overwhelming majority of JPEGs without paying for the full
+			// download of multi-megabyte screenshots.
+			$prefix = self::fetch_asset_bytes( $url, 131072 );
+			if ( '' !== $prefix ) {
+				$size = @getimagesizefromstring( $prefix );
+			}
+
+			if ( ! $size ) {
+				$full = self::fetch_asset_bytes( $url );
+				if ( '' !== $full ) {
+					$size = @getimagesizefromstring( $full );
+				}
+			}
+		}
+
+		if ( $size && ! empty( $size[0] ) && ! empty( $size[1] ) ) {
+			$record['width']  = (int) $size[0];
+			$record['height'] = (int) $size[1];
+		} else {
+			$record['dimensions_failed'] = true;
+		}
+
+		return $record;
+	}
+
+	/**
+	 * Fetch the bytes of an asset over HTTP.
+	 *
+	 * Pass `$range` to request only a prefix via a `Range` header. The body
+	 * is returned for both 200 and 206 responses; an empty string indicates
+	 * the request failed or returned no usable bytes.
+	 *
+	 * @param string $url   The asset URL.
+	 * @param int    $range Optional. The number of leading bytes to request.
+	 * @return string The response body, or an empty string on failure.
+	 */
+	protected static function fetch_asset_bytes( $url, $range = 0 ) {
+		$args = array( 'timeout' => 15 );
+		if ( $range > 0 ) {
+			$args['headers'] = array( 'Range' => 'bytes=0-' . ( $range - 1 ) );
+		}
+
+		$response = wp_remote_get( $url, $args );
+		if ( is_wp_error( $response ) ) {
+			return '';
+		}
+
+		$code = wp_remote_retrieve_response_code( $response );
+		if ( 200 !== $code && 206 !== $code ) {
+			return '';
+		}
+
+		return (string) wp_remote_retrieve_body( $response );
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
@@ -1100,26 +1100,14 @@ class Import {
 	}
 
 	/**
-	 * Populate `width` and `height` on an asset record.
+	 * Populate `width` and `height` on an asset record, reusing the prior
+	 * import's values when the SVN revision hasn't changed.
 	 *
-	 * Reuses the cached values from the prior import when the SVN revision
-	 * hasn't changed; otherwise reads the image (from a local path if one is
-	 * supplied, or by fetching the file from SVN) and parses dimensions via
-	 * `getimagesize()`. To keep import bandwidth in check, the remote path
-	 * first tries the leading 128 KB via a Range request and only falls
-	 * back to the full body when that prefix isn't enough to decode the
-	 * header (e.g. progressive JPEGs with the SOF segment deep in the
-	 * stream).
-	 *
-	 * SVG and unknown formats are left untouched — they have no fixed
-	 * pixel dimensions to record.
-	 *
-	 * @param array              $record The asset record (`filename`, `revision`, …).
-	 * @param array|null         $prior  Matching record from the prior import, or null.
-	 * @param int|\WP_Post|null  $post   The plugin post, used to construct the SVN URL.
-	 * @param string|null        $local  Optional local path; preferred over a remote
-	 *                                   fetch when the file is already on disk.
-	 * @return array The record, with `width` and `height` added when known.
+	 * @param array              $record The asset record.
+	 * @param array|null         $prior  Matching record from the prior import.
+	 * @param int|\WP_Post|null  $post   The plugin post.
+	 * @param string|null        $local  Optional local path to read instead of fetching from SVN.
+	 * @return array
 	 */
 	public static function enrich_asset_dimensions( $record, $prior, $post, $local = null ) {
 		if (

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
@@ -1134,7 +1134,7 @@ class Import {
 		}
 
 		if ( ! $size ) {
-			$url = Template::get_asset_url( $post, $record, false );
+			$url = Template::get_asset_url( $post, $record, false /* no CDN */ );
 
 			// Range the first read to 128 KB — enough for the headers of
 			// PNG/GIF and most JPEGs. Fall back to a full read only when

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
@@ -881,7 +881,7 @@ class Import {
 				$record = self::enrich_asset_dimensions(
 					$record,
 					$prior_assets[ $type ][ $filename ] ?? null,
-					$plugin_slug
+					$this->plugin
 				);
 
 				$assets[ $type ][ $asset['filename'] ] = $record;
@@ -953,7 +953,7 @@ class Import {
 			$record = self::enrich_asset_dimensions(
 				$record,
 				$prior_assets['screenshot'][ $filename ] ?? null,
-				$plugin_slug,
+				$this->plugin,
 				$plugin_screenshot
 			);
 
@@ -1114,14 +1114,14 @@ class Import {
 	 * SVG and unknown formats are left untouched — they have no fixed
 	 * pixel dimensions to record.
 	 *
-	 * @param array       $record The asset record (`filename`, `revision`, …).
-	 * @param array|null  $prior  Matching record from the prior import, or null.
-	 * @param string      $slug   Plugin slug, used to construct the SVN URL.
-	 * @param string|null $local  Optional local path; preferred over a remote
-	 *                            fetch when the file is already on disk.
+	 * @param array              $record The asset record (`filename`, `revision`, …).
+	 * @param array|null         $prior  Matching record from the prior import, or null.
+	 * @param int|\WP_Post|null  $post   The plugin post, used to construct the SVN URL.
+	 * @param string|null        $local  Optional local path; preferred over a remote
+	 *                                   fetch when the file is already on disk.
 	 * @return array The record, with `width` and `height` added when known.
 	 */
-	public static function enrich_asset_dimensions( $record, $prior, $slug, $local = null ) {
+	public static function enrich_asset_dimensions( $record, $prior, $post, $local = null ) {
 		if (
 			is_array( $prior ) &&
 			isset( $prior['revision'], $prior['width'], $prior['height'] ) &&
@@ -1144,21 +1144,9 @@ class Import {
 		if ( $local && file_exists( $local ) ) {
 			$size = @getimagesize( $local );
 		} else {
-			// 'plugin'-located screenshots live in /trunk/; everything
-			// else (banners, icons, /assets/-located screenshots) lives
-			// in /assets/.
-			$folder = ( isset( $record['location'] ) && 'plugin' === $record['location'] ) ? 'trunk' : 'assets';
-			$url    = add_query_arg(
-				'rev',
-				$record['revision'],
-				sprintf(
-					'%s/%s/%s/%s',
-					self::PLUGIN_SVN_BASE,
-					$slug,
-					$folder,
-					rawurlencode( $record['filename'] )
-				)
-			);
+			// Fetch direct from SVN rather than the CDN, so the byte
+			// stream is always the revision we just listed.
+			$url = Template::get_asset_url( $post, $record, false /* no CDN */ );
 
 			// Cap the first read at 128 KB — covers all PNG/GIF and the
 			// overwhelming majority of JPEGs without paying for the full

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
@@ -1139,7 +1139,7 @@ class Import {
 			// Range the first read to 128 KB — enough for the headers of
 			// PNG/GIF and most JPEGs. Fall back to a full read only when
 			// the prefix isn't enough to decode the header.
-			foreach ( array( 131072, 0 ) as $limit ) {
+			foreach ( array( 128 * KB_IN_BYTES, 0 ) as $limit ) {
 				$args = array( 'timeout' => 15 );
 				if ( $limit > 0 ) {
 					$args['headers']             = array( 'Range' => 'bytes=0-' . ( $limit - 1 ) );

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
@@ -1138,18 +1138,23 @@ class Import {
 			// stream is always the revision we just listed.
 			$url = Template::get_asset_url( $post, $record, false /* no CDN */ );
 
-			// Cap the first read at 128 KB — covers all PNG/GIF and the
-			// overwhelming majority of JPEGs without paying for the full
-			// download of multi-megabyte screenshots. Fall back to a full
-			// read only when the prefix isn't enough to decode the header.
+			// Ask for just the first 128 KB via Range — enough for all
+			// PNG/GIF and the overwhelming majority of JPEGs, saving the
+			// bandwidth of downloading multi-megabyte screenshots. Fall
+			// back to a full read when the prefix isn't enough to decode
+			// the header (e.g. JPEGs with the SOF marker past 128 KB).
+			// `limit_response_size` is a memory backstop in case the
+			// server ignores Range and streams the whole body.
 			foreach ( array( 131072, 0 ) as $limit ) {
 				$args = array( 'timeout' => 15 );
 				if ( $limit > 0 ) {
+					$args['headers']             = array( 'Range' => 'bytes=0-' . ( $limit - 1 ) );
 					$args['limit_response_size'] = $limit;
 				}
 
 				$response = wp_remote_get( $url, $args );
-				if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+				$code     = wp_remote_retrieve_response_code( $response );
+				if ( is_wp_error( $response ) || ( 200 !== $code && 206 !== $code ) ) {
 					break;
 				}
 

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
@@ -1103,10 +1103,10 @@ class Import {
 	 * Populate `width` and `height` on an asset record, reusing the prior
 	 * import's values when the SVN revision hasn't changed.
 	 *
-	 * @param array        $record The asset record.
-	 * @param array|null   $prior  Matching record from the prior import.
-	 * @param int|\WP_Post $post   The plugin post.
-	 * @param string|null  $local  Optional local path to read instead of fetching from SVN.
+	 * @param array       $record The asset record.
+	 * @param array|null  $prior  Matching record from the prior import.
+	 * @param \WP_Post    $post   The plugin post.
+	 * @param string|null $local  Optional local path to read instead of fetching from SVN.
 	 * @return array
 	 */
 	public static function enrich_asset_dimensions( $record, $prior, $post, $local = null ) {

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
@@ -1160,18 +1160,29 @@ class Import {
 				)
 			);
 
-			// Try the first 128 KB first; it covers all PNG/GIF and the
+			// Cap the first read at 128 KB — covers all PNG/GIF and the
 			// overwhelming majority of JPEGs without paying for the full
-			// download of multi-megabyte screenshots.
-			$prefix = self::fetch_asset_bytes( $url, 131072 );
-			if ( '' !== $prefix ) {
-				$size = @getimagesizefromstring( $prefix );
-			}
+			// download of multi-megabyte screenshots. Fall back to a full
+			// read only when the prefix isn't enough to decode the header.
+			foreach ( array( 131072, 0 ) as $limit ) {
+				$args = array( 'timeout' => 15 );
+				if ( $limit > 0 ) {
+					$args['limit_response_size'] = $limit;
+				}
 
-			if ( ! $size ) {
-				$full = self::fetch_asset_bytes( $url );
-				if ( '' !== $full ) {
-					$size = @getimagesizefromstring( $full );
+				$response = wp_remote_get( $url, $args );
+				if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+					break;
+				}
+
+				$body = wp_remote_retrieve_body( $response );
+				if ( '' === $body ) {
+					break;
+				}
+
+				$size = @getimagesizefromstring( $body );
+				if ( $size ) {
+					break;
 				}
 			}
 		}
@@ -1182,36 +1193,6 @@ class Import {
 		}
 
 		return $record;
-	}
-
-	/**
-	 * Fetch the bytes of an asset over HTTP.
-	 *
-	 * Pass `$range` to request only a prefix via a `Range` header. The body
-	 * is returned for both 200 and 206 responses; an empty string indicates
-	 * the request failed or returned no usable bytes.
-	 *
-	 * @param string $url   The asset URL.
-	 * @param int    $range Optional. The number of leading bytes to request.
-	 * @return string The response body, or an empty string on failure.
-	 */
-	protected static function fetch_asset_bytes( $url, $range = 0 ) {
-		$args = array( 'timeout' => 15 );
-		if ( $range > 0 ) {
-			$args['headers'] = array( 'Range' => 'bytes=0-' . ( $range - 1 ) );
-		}
-
-		$response = wp_remote_get( $url, $args );
-		if ( is_wp_error( $response ) ) {
-			return '';
-		}
-
-		$code = wp_remote_retrieve_response_code( $response );
-		if ( 200 !== $code && 206 !== $code ) {
-			return '';
-		}
-
-		return (string) wp_remote_retrieve_body( $response );
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
@@ -1134,17 +1134,11 @@ class Import {
 		}
 
 		if ( ! $size ) {
-			// Fetch direct from SVN rather than the CDN, so the byte
-			// stream is always the revision we just listed.
-			$url = Template::get_asset_url( $post, $record, false /* no CDN */ );
+			$url = Template::get_asset_url( $post, $record, false );
 
-			// Ask for just the first 128 KB via Range — enough for all
-			// PNG/GIF and the overwhelming majority of JPEGs, saving the
-			// bandwidth of downloading multi-megabyte screenshots. Fall
-			// back to a full read when the prefix isn't enough to decode
-			// the header (e.g. JPEGs with the SOF marker past 128 KB).
-			// `limit_response_size` is a memory backstop in case the
-			// server ignores Range and streams the whole body.
+			// Range the first read to 128 KB — enough for the headers of
+			// PNG/GIF and most JPEGs. Fall back to a full read only when
+			// the prefix isn't enough to decode the header.
 			foreach ( array( 131072, 0 ) as $limit ) {
 				$args = array( 'timeout' => 15 );
 				if ( $limit > 0 ) {

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
@@ -1116,51 +1116,51 @@ class Import {
 			return $record;
 		}
 
-		$ext = strtolower( pathinfo( $record['filename'], PATHINFO_EXTENSION ) );
-		if ( ! in_array( $ext, array( 'png', 'jpg', 'jpeg', 'gif' ), true ) ) {
-			return $record;
-		}
-
 		$size = false;
 
 		if ( $local && file_exists( $local ) ) {
-			$size = getimagesize( $local );
+			$size = wp_getimagesize( $local );
 		}
 
 		if ( ! $size ) {
-			$url = Template::get_asset_url( $post, $record, false /* no CDN */ );
+			$url       = Template::get_asset_url( $post, $record, false /* no CDN */ );
+			$temp_file = wp_tempnam( $record['filename'] );
 
 			// Range the first read to 128 KB — enough for the headers of
-			// PNG/GIF and most JPEGs. Fall back to a full read only when
-			// the prefix isn't enough to decode the header — the falsy
-			// `$size` at the bottom of the loop is the implicit retry.
-			// Transport errors / non-2xx / empty body intentionally bail
-			// out via `break`: those failure modes (network down, 4xx,
-			// 5xx, empty file) won't be helped by re-requesting the same
+			// most images. Fall back to a full read only when the prefix
+			// isn't enough to decode the header — the falsy `$size` at
+			// the bottom of the loop is the implicit retry. Transport
+			// errors / non-2xx intentionally bail out via `break`: those
+			// failure modes won't be helped by re-requesting the same
 			// URL without Range.
 			foreach ( array( 128 * KB_IN_BYTES, 0 ) as $limit ) {
-				$args = array( 'timeout' => 15 );
+				$args = array(
+					'timeout'  => 15,
+					'stream'   => true,
+					'filename' => $temp_file,
+				);
 				if ( $limit > 0 ) {
 					$args['headers']             = array( 'Range' => 'bytes=0-' . ( $limit - 1 ) );
 					$args['limit_response_size'] = $limit;
 				}
 
-				$response = wp_remote_get( $url, $args );
+				$response = wp_safe_remote_get( $url, $args );
 				$code     = wp_remote_retrieve_response_code( $response );
 				if ( is_wp_error( $response ) || ( 200 !== $code && 206 !== $code ) ) {
 					break;
 				}
 
-				$body = wp_remote_retrieve_body( $response );
-				if ( '' === $body ) {
+				if ( ! file_exists( $temp_file ) || 0 === filesize( $temp_file ) ) {
 					break;
 				}
 
-				$size = getimagesizefromstring( $body );
+				$size = wp_getimagesize( $temp_file );
 				if ( $size ) {
 					break;
 				}
 			}
+
+			unlink( $temp_file );
 		}
 
 		if ( $size && ! empty( $size[0] ) && ! empty( $size[1] ) ) {

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
@@ -1124,7 +1124,7 @@ class Import {
 		$size = false;
 
 		if ( $local && file_exists( $local ) ) {
-			$size = @getimagesize( $local );
+			$size = getimagesize( $local );
 		}
 
 		if ( ! $size ) {
@@ -1151,7 +1151,7 @@ class Import {
 					break;
 				}
 
-				$size = @getimagesizefromstring( $body );
+				$size = getimagesizefromstring( $body );
 				if ( $size ) {
 					break;
 				}


### PR DESCRIPTION
Reads `width` / `height` from each plugin asset (screenshots, banners, icons) at import time and stores them alongside the existing per-asset metadata, so callers can read dimensions straight from post meta instead of fetching and decoding the image at request time.

Primarily intended to make #622 easier — that PR currently has to probe screenshot dimensions on every page render. With this in place, the shortcode can just read `width` / `height` from the asset record.

## What changes

- `cli/class-import.php`: `export_and_parse_plugin()` now runs each asset record through a new `Import::enrich_asset_dimensions()` helper. The helper reuses cached values when the SVN revision is unchanged, otherwise reads dimensions via `getimagesize()` (from disk for `/trunk/` screenshots that are already exported, or from `Template::get_asset_url()` for `/assets/`-located files). Remote fetches use `wp_remote_get()` with `limit_response_size` capped at 128 KB, falling back to a full read only when the prefix is not enough.
- `bin/backfill-asset-dimensions.php` (new): walks every plugin with non-empty asset meta and fills in missing dimensions. Flags: `--plugin=slug`, `--limit=N`, `--dry-run`. Prints per-100 progress and a summary of failures.

## Notes

- The new `width` / `height` keys ride along inside the existing `assets_*` records — no schema change.
- SVG and other non-raster formats are left untouched.