### PR TITLE
Plugin Directory: Skip Gandalf scans for missing-tag trunk fallbacks

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan-gandalf.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan-gandalf.php
@@ -43,10 +43,11 @@ class Plugin_Scan_Gandalf {
 		}
 
 		if (
-			! isset( $import_context['stable_tag'], $import_context['old_stable_tag'], $import_context['changed_svn_tags'] ) ||
+			! isset( $import_context['stable_tag'], $import_context['old_stable_tag'], $import_context['changed_svn_tags'], $import_context['warnings'] ) ||
 			! is_string( $import_context['stable_tag'] ) ||
 			! is_string( $import_context['old_stable_tag'] ) ||
-			! is_array( $import_context['changed_svn_tags'] )
+			! is_array( $import_context['changed_svn_tags'] ) ||
+			! is_array( $import_context['warnings'] )
 		) {
 			return false;
 		}
@@ -54,7 +55,13 @@ class Plugin_Scan_Gandalf {
 		$stable_tag       = $import_context['stable_tag'];
 		$old_stable_tag   = $import_context['old_stable_tag'];
 		$changed_svn_tags = array_map( 'strval', $import_context['changed_svn_tags'] );
+		$warnings         = $import_context['warnings'];
 		$release_ref      = trim( $stable_tag ) ?: 'trunk';
+
+		// The importer records this when the readme points to a missing tag and falls back to trunk.
+		if ( 'trunk' === $release_ref && isset( $warnings['stable_tag_invalid_trunk_fallback'] ) ) {
+			return false;
+		}
 
 		// Trunk-only commits should not rescan a tag-based stable ZIP that was not rebuilt.
 		if ( $stable_tag === $old_stable_tag && ! in_array( $release_ref, $changed_svn_tags, true ) ) {

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan-gandalf.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan-gandalf.php
@@ -58,13 +58,7 @@ class Plugin_Scan_Gandalf {
 		$warnings         = $import_context['warnings'];
 		$release_ref      = trim( $stable_tag ) ?: 'trunk';
 
-		// The importer records this when the readme points to a missing tag and falls back to trunk.
-		if ( 'trunk' === $release_ref && isset( $warnings['stable_tag_invalid_trunk_fallback'] ) ) {
-			return false;
-		}
-
-		// Trunk-only commits should not rescan a tag-based stable ZIP that wasn't rebuilt.
-		if ( $stable_tag === $old_stable_tag && ! in_array( $release_ref, $changed_svn_tags, true ) ) {
+		if ( ! self::should_scan_import_context( $stable_tag, $old_stable_tag, $changed_svn_tags, $warnings ) ) {
 			return false;
 		}
 
@@ -98,6 +92,34 @@ class Plugin_Scan_Gandalf {
 				'requested_at'         => time(),
 			]
 		);
+	}
+
+	/**
+	 * Determine whether importer context should trigger a Gandalf scan.
+	 *
+	 * @param string $stable_tag       The new stable tag.
+	 * @param string $old_stable_tag   The previous stable tag.
+	 * @param array  $changed_svn_tags The SVN tags that changed.
+	 * @param array  $warnings         The import warnings.
+	 * @return bool Whether the context should be scanned.
+	 */
+	protected static function should_scan_import_context( $stable_tag, $old_stable_tag, $changed_svn_tags, $warnings ) {
+		$release_ref = trim( $stable_tag );
+		if ( '' === $release_ref ) {
+			$release_ref = 'trunk';
+		}
+
+		// The importer records this when the readme points to a missing tag and falls back to trunk.
+		if ( 'trunk' === $release_ref && isset( $warnings['stable_tag_invalid_trunk_fallback'] ) ) {
+			return false;
+		}
+
+		// Trunk-only commits should not rescan a tag-based stable ZIP that wasn't rebuilt.
+		if ( $stable_tag === $old_stable_tag && ! in_array( $release_ref, $changed_svn_tags, true ) ) {
+			return false;
+		}
+
+		return true;
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan-gandalf.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan-gandalf.php
@@ -63,7 +63,7 @@ class Plugin_Scan_Gandalf {
 			return false;
 		}
 
-		// Trunk-only commits should not rescan a tag-based stable ZIP that was not rebuilt.
+		// Trunk-only commits should not rescan a tag-based stable ZIP that wasn't rebuilt.
 		if ( $stable_tag === $old_stable_tag && ! in_array( $release_ref, $changed_svn_tags, true ) ) {
 			return false;
 		}

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Plugin_Scan_Gandalf_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Plugin_Scan_Gandalf_Test.php
@@ -5,288 +5,104 @@
  * @package WordPressdotorg\Plugin_Directory\Tests
  */
 
-use WordPressdotorg\Plugin_Directory\Jobs\Plugin_Scan_Gandalf;
 use PHPUnit\Framework\TestCase;
+use WordPressdotorg\Plugin_Directory\Jobs\Plugin_Scan_Gandalf;
 
 /**
- * Tests Gandalf dispatch eligibility from importer context.
+ * Tests Gandalf scan eligibility from importer context.
  *
  * @group gandalf
  */
 class Plugin_Scan_Gandalf_Test extends TestCase {
 
 	/**
-	 * Captured Gandalf dispatch requests.
+	 * Invoke Plugin_Scan_Gandalf::should_scan_import_context().
 	 *
-	 * @var array
+	 * @param string $stable_tag       The new stable tag.
+	 * @param string $old_stable_tag   The previous stable tag.
+	 * @param array  $changed_svn_tags The SVN tags that changed.
+	 * @param array  $warnings         The import warnings.
+	 * @return bool
 	 */
-	private $requests = array();
+	private function should_scan_import_context( $stable_tag, $old_stable_tag, $changed_svn_tags, $warnings ) {
+		$reflection = new ReflectionClass( Plugin_Scan_Gandalf::class );
+		$method     = $reflection->getMethod( 'should_scan_import_context' );
+		$method->setAccessible( true );
 
-	/**
-	 * Plugin posts created during a test.
-	 *
-	 * @var array
-	 */
-	private $plugin_ids = array();
-
-	/**
-	 * Define the Gandalf shared secret used by the integration guard.
-	 */
-	public static function setUpBeforeClass(): void {
-		parent::setUpBeforeClass();
-
-		if ( ! defined( 'WP_GANDALF_SCAN_SHARED_SECRET' ) ) {
-			define( 'WP_GANDALF_SCAN_SHARED_SECRET', 'test-secret' );
-		}
-	}
-
-	/**
-	 * Capture Gandalf HTTP dispatches for each test.
-	 */
-	protected function setUp(): void {
-		parent::setUp();
-
-		$this->requests   = array();
-		$this->plugin_ids = array();
-
-		add_filter( 'pre_http_request', array( $this, 'capture_gandalf_request' ), 10, 3 );
-	}
-
-	/**
-	 * Remove the HTTP capture filter.
-	 */
-	protected function tearDown(): void {
-		remove_filter( 'pre_http_request', array( $this, 'capture_gandalf_request' ), 10 );
-
-		foreach ( $this->plugin_ids as $post_id ) {
-			wp_delete_post( $post_id, true );
-		}
-
-		parent::tearDown();
-	}
-
-	/**
-	 * Capture the Gandalf HTTP request and return a matching accepted response.
-	 *
-	 * @param false|array|WP_Error $preempt     Whether to preempt the request.
-	 * @param array                $parsed_args Request arguments.
-	 * @param string               $url         Request URL.
-	 * @return array
-	 */
-	public function capture_gandalf_request( $preempt, $parsed_args, $url ) {
-		if ( Plugin_Scan_Gandalf::ENDPOINT !== $url ) {
-			return $preempt;
-		}
-
-		$body             = json_decode( $parsed_args['body'], true );
-		$this->requests[] = array(
-			'url'  => $url,
-			'args' => $parsed_args,
-			'body' => $body,
-		);
-
-		return array(
-			'headers'  => array(),
-			'body'     => wp_json_encode(
-				array(
-					'scan_id' => $body['scan_id'],
-				)
-			),
-			'response' => array(
-				'code'    => 202,
-				'message' => 'Accepted',
-			),
-			'cookies'  => array(),
-		);
+		return $method->invoke( null, $stable_tag, $old_stable_tag, $changed_svn_tags, $warnings );
 	}
 
 	/**
 	 * A missing-tag trunk fallback should not dispatch to Gandalf.
 	 */
 	public function test_missing_tag_trunk_fallback_does_not_dispatch() {
-		$plugin = $this->create_plugin(
-			'gandalf-missing-tag-fallback',
-			array(
-				'version' => '1.0.1',
-			)
-		);
-
-		$result = Plugin_Scan_Gandalf::dispatch_from_import_context(
-			$plugin,
-			array(
-				'stable_tag'       => 'trunk',
-				'old_stable_tag'   => '1.0.0',
-				'changed_svn_tags' => array( 'trunk' ),
-				'warnings'         => array(
+		$this->assertFalse(
+			$this->should_scan_import_context(
+				'trunk',
+				'1.0.0',
+				array( 'trunk' ),
+				array(
 					'stable_tag_invalid_trunk_fallback' => '1.0.1',
-				),
+				)
 			)
 		);
-
-		$this->assertFalse( $result );
-		$this->assertSame( array(), $this->requests );
-		$pending = get_post_meta( $plugin->ID, Plugin_Scan_Gandalf::PENDING_META_KEY, true );
-		$this->assertSame( array(), $pending ? $pending : array() );
 	}
 
 	/**
 	 * An intentional trunk release should still dispatch.
 	 */
 	public function test_intentional_trunk_release_dispatches() {
-		$plugin = $this->create_plugin(
-			'gandalf-intentional-trunk',
-			array(
-				'version' => '1.0.1',
+		$this->assertTrue(
+			$this->should_scan_import_context(
+				'trunk',
+				'trunk',
+				array( 'trunk' ),
+				array()
 			)
 		);
-
-		$result = Plugin_Scan_Gandalf::dispatch_from_import_context(
-			$plugin,
-			array(
-				'stable_tag'       => 'trunk',
-				'old_stable_tag'   => 'trunk',
-				'changed_svn_tags' => array( 'trunk' ),
-				'warnings'         => array(),
-			)
-		);
-
-		$this->assertTrue( $result );
-		$this->assertCount( 1, $this->requests );
-		$this->assertSame( 'trunk', $this->requests[0]['body']['release_ref'] );
-		$this->assertSame( 'https://downloads.wordpress.org/plugin/gandalf-intentional-trunk.zip', $this->requests[0]['body']['current_zip_url'] );
 	}
 
 	/**
-	 * A normal tagged release should dispatch and include previous ZIP context.
+	 * A normal tagged release should still dispatch.
 	 */
 	public function test_tagged_release_dispatches_with_empty_warnings() {
-		$plugin = $this->create_plugin(
-			'gandalf-tagged-release',
-			array(
-				'version'         => '1.0.1',
-				'last_version'    => '1.0.0',
-				'last_stable_tag' => '1.0.0',
+		$this->assertTrue(
+			$this->should_scan_import_context(
+				'1.0.1',
+				'1.0.0',
+				array( '1.0.1' ),
+				array()
 			)
 		);
-
-		$result = Plugin_Scan_Gandalf::dispatch_from_import_context(
-			$plugin,
-			array(
-				'stable_tag'       => '1.0.1',
-				'old_stable_tag'   => '1.0.0',
-				'changed_svn_tags' => array( '1.0.1' ),
-				'warnings'         => array(),
-			)
-		);
-
-		$this->assertTrue( $result );
-		$this->assertCount( 1, $this->requests );
-		$this->assertSame( '1.0.1', $this->requests[0]['body']['release_ref'] );
-		$this->assertSame( 'https://downloads.wordpress.org/plugin/gandalf-tagged-release.1.0.1.zip', $this->requests[0]['body']['current_zip_url'] );
-		$this->assertSame( '1.0.0', $this->requests[0]['body']['previous_release_ref'] );
-		$this->assertSame( 'https://downloads.wordpress.org/plugin/gandalf-tagged-release.1.0.0.zip', $this->requests[0]['body']['previous_zip_url'] );
 	}
 
 	/**
 	 * The fallback warning alone should not skip a non-trunk release ref.
 	 */
 	public function test_fallback_warning_does_not_skip_non_trunk_release_ref() {
-		$plugin = $this->create_plugin(
-			'gandalf-tagged-warning',
-			array(
-				'version' => '1.0.1',
-			)
-		);
-
-		$result = Plugin_Scan_Gandalf::dispatch_from_import_context(
-			$plugin,
-			array(
-				'stable_tag'       => '1.0.1',
-				'old_stable_tag'   => '1.0.0',
-				'changed_svn_tags' => array( '1.0.1' ),
-				'warnings'         => array(
+		$this->assertTrue(
+			$this->should_scan_import_context(
+				'1.0.1',
+				'1.0.0',
+				array( '1.0.1' ),
+				array(
 					'stable_tag_invalid_trunk_fallback' => '1.0.1',
-				),
+				)
 			)
 		);
-
-		$this->assertTrue( $result );
-		$this->assertCount( 1, $this->requests );
-		$this->assertSame( '1.0.1', $this->requests[0]['body']['release_ref'] );
 	}
 
 	/**
 	 * Development-only trunk changes should not rescan an unchanged tagged stable release.
 	 */
 	public function test_trunk_only_change_with_existing_stable_tag_does_not_dispatch() {
-		$plugin = $this->create_plugin(
-			'gandalf-dev-trunk',
-			array(
-				'version' => '1.0.1',
+		$this->assertFalse(
+			$this->should_scan_import_context(
+				'1.0.1',
+				'1.0.1',
+				array( 'trunk' ),
+				array()
 			)
 		);
-
-		$result = Plugin_Scan_Gandalf::dispatch_from_import_context(
-			$plugin,
-			array(
-				'stable_tag'       => '1.0.1',
-				'old_stable_tag'   => '1.0.1',
-				'changed_svn_tags' => array( 'trunk' ),
-				'warnings'         => array(),
-			)
-		);
-
-		$this->assertFalse( $result );
-		$this->assertSame( array(), $this->requests );
-	}
-
-	/**
-	 * Direct calls with incomplete importer context should not dispatch.
-	 */
-	public function test_malformed_import_context_does_not_dispatch() {
-		$plugin = $this->create_plugin(
-			'gandalf-malformed-context',
-			array(
-				'version' => '1.0.1',
-			)
-		);
-
-		$result = Plugin_Scan_Gandalf::dispatch_from_import_context(
-			$plugin,
-			array(
-				'stable_tag'       => 'trunk',
-				'old_stable_tag'   => 'trunk',
-				'changed_svn_tags' => array( 'trunk' ),
-			)
-		);
-
-		$this->assertFalse( $result );
-		$this->assertSame( array(), $this->requests );
-	}
-
-	/**
-	 * Create a minimal plugin post with the post meta Gandalf reads.
-	 *
-	 * @param string $slug Plugin slug.
-	 * @param array  $meta Plugin post meta.
-	 * @return WP_Post
-	 */
-	private function create_plugin( $slug, $meta = array() ) {
-		$post_id = wp_insert_post(
-			array(
-				'post_name'   => $slug,
-				'post_title'  => $slug,
-				'post_type'   => 'plugin',
-				'post_status' => 'publish',
-			)
-		);
-
-		$this->plugin_ids[] = $post_id;
-
-		foreach ( $meta as $key => $value ) {
-			update_post_meta( $post_id, $key, $value );
-		}
-
-		return get_post( $post_id );
 	}
 }

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Plugin_Scan_Gandalf_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Plugin_Scan_Gandalf_Test.php
@@ -6,13 +6,14 @@
  */
 
 use WordPressdotorg\Plugin_Directory\Jobs\Plugin_Scan_Gandalf;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests Gandalf dispatch eligibility from importer context.
  *
  * @group gandalf
  */
-class Plugin_Scan_Gandalf_Test extends WP_UnitTestCase {
+class Plugin_Scan_Gandalf_Test extends TestCase {
 
 	/**
 	 * Captured Gandalf dispatch requests.
@@ -20,6 +21,13 @@ class Plugin_Scan_Gandalf_Test extends WP_UnitTestCase {
 	 * @var array
 	 */
 	private $requests = array();
+
+	/**
+	 * Plugin posts created during a test.
+	 *
+	 * @var array
+	 */
+	private $plugin_ids = array();
 
 	/**
 	 * Define the Gandalf shared secret used by the integration guard.
@@ -38,7 +46,8 @@ class Plugin_Scan_Gandalf_Test extends WP_UnitTestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->requests = array();
+		$this->requests   = array();
+		$this->plugin_ids = array();
 
 		add_filter( 'pre_http_request', array( $this, 'capture_gandalf_request' ), 10, 3 );
 	}
@@ -48,6 +57,10 @@ class Plugin_Scan_Gandalf_Test extends WP_UnitTestCase {
 	 */
 	protected function tearDown(): void {
 		remove_filter( 'pre_http_request', array( $this, 'capture_gandalf_request' ), 10 );
+
+		foreach ( $this->plugin_ids as $post_id ) {
+			wp_delete_post( $post_id, true );
+		}
 
 		parent::tearDown();
 	}
@@ -259,7 +272,7 @@ class Plugin_Scan_Gandalf_Test extends WP_UnitTestCase {
 	 * @return WP_Post
 	 */
 	private function create_plugin( $slug, $meta = array() ) {
-		$post_id = self::factory()->post->create(
+		$post_id = wp_insert_post(
 			array(
 				'post_name'   => $slug,
 				'post_title'  => $slug,
@@ -267,6 +280,8 @@ class Plugin_Scan_Gandalf_Test extends WP_UnitTestCase {
 				'post_status' => 'publish',
 			)
 		);
+
+		$this->plugin_ids[] = $post_id;
 
 		foreach ( $meta as $key => $value ) {
 			update_post_meta( $post_id, $key, $value );

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Plugin_Scan_Gandalf_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Plugin_Scan_Gandalf_Test.php
@@ -1,0 +1,277 @@
+<?php
+/**
+ * Tests for Jobs\Plugin_Scan_Gandalf.
+ *
+ * @package WordPressdotorg\Plugin_Directory\Tests
+ */
+
+use WordPressdotorg\Plugin_Directory\Jobs\Plugin_Scan_Gandalf;
+
+/**
+ * Tests Gandalf dispatch eligibility from importer context.
+ *
+ * @group gandalf
+ */
+class Plugin_Scan_Gandalf_Test extends WP_UnitTestCase {
+
+	/**
+	 * Captured Gandalf dispatch requests.
+	 *
+	 * @var array
+	 */
+	private $requests = array();
+
+	/**
+	 * Define the Gandalf shared secret used by the integration guard.
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
+		if ( ! defined( 'WP_GANDALF_SCAN_SHARED_SECRET' ) ) {
+			define( 'WP_GANDALF_SCAN_SHARED_SECRET', 'test-secret' );
+		}
+	}
+
+	/**
+	 * Capture Gandalf HTTP dispatches for each test.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->requests = array();
+
+		add_filter( 'pre_http_request', array( $this, 'capture_gandalf_request' ), 10, 3 );
+	}
+
+	/**
+	 * Remove the HTTP capture filter.
+	 */
+	protected function tearDown(): void {
+		remove_filter( 'pre_http_request', array( $this, 'capture_gandalf_request' ), 10 );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Capture the Gandalf HTTP request and return a matching accepted response.
+	 *
+	 * @param false|array|WP_Error $preempt     Whether to preempt the request.
+	 * @param array                $parsed_args Request arguments.
+	 * @param string               $url         Request URL.
+	 * @return array
+	 */
+	public function capture_gandalf_request( $preempt, $parsed_args, $url ) {
+		if ( Plugin_Scan_Gandalf::ENDPOINT !== $url ) {
+			return $preempt;
+		}
+
+		$body             = json_decode( $parsed_args['body'], true );
+		$this->requests[] = array(
+			'url'  => $url,
+			'args' => $parsed_args,
+			'body' => $body,
+		);
+
+		return array(
+			'headers'  => array(),
+			'body'     => wp_json_encode(
+				array(
+					'scan_id' => $body['scan_id'],
+				)
+			),
+			'response' => array(
+				'code'    => 202,
+				'message' => 'Accepted',
+			),
+			'cookies'  => array(),
+		);
+	}
+
+	/**
+	 * A missing-tag trunk fallback should not dispatch to Gandalf.
+	 */
+	public function test_missing_tag_trunk_fallback_does_not_dispatch() {
+		$plugin = $this->create_plugin(
+			'gandalf-missing-tag-fallback',
+			array(
+				'version' => '1.0.1',
+			)
+		);
+
+		$result = Plugin_Scan_Gandalf::dispatch_from_import_context(
+			$plugin,
+			array(
+				'stable_tag'       => 'trunk',
+				'old_stable_tag'   => '1.0.0',
+				'changed_svn_tags' => array( 'trunk' ),
+				'warnings'         => array(
+					'stable_tag_invalid_trunk_fallback' => '1.0.1',
+				),
+			)
+		);
+
+		$this->assertFalse( $result );
+		$this->assertSame( array(), $this->requests );
+		$pending = get_post_meta( $plugin->ID, Plugin_Scan_Gandalf::PENDING_META_KEY, true );
+		$this->assertSame( array(), $pending ? $pending : array() );
+	}
+
+	/**
+	 * An intentional trunk release should still dispatch.
+	 */
+	public function test_intentional_trunk_release_dispatches() {
+		$plugin = $this->create_plugin(
+			'gandalf-intentional-trunk',
+			array(
+				'version' => '1.0.1',
+			)
+		);
+
+		$result = Plugin_Scan_Gandalf::dispatch_from_import_context(
+			$plugin,
+			array(
+				'stable_tag'       => 'trunk',
+				'old_stable_tag'   => 'trunk',
+				'changed_svn_tags' => array( 'trunk' ),
+				'warnings'         => array(),
+			)
+		);
+
+		$this->assertTrue( $result );
+		$this->assertCount( 1, $this->requests );
+		$this->assertSame( 'trunk', $this->requests[0]['body']['release_ref'] );
+		$this->assertSame( 'https://downloads.wordpress.org/plugin/gandalf-intentional-trunk.zip', $this->requests[0]['body']['current_zip_url'] );
+	}
+
+	/**
+	 * A normal tagged release should dispatch and include previous ZIP context.
+	 */
+	public function test_tagged_release_dispatches_with_empty_warnings() {
+		$plugin = $this->create_plugin(
+			'gandalf-tagged-release',
+			array(
+				'version'         => '1.0.1',
+				'last_version'    => '1.0.0',
+				'last_stable_tag' => '1.0.0',
+			)
+		);
+
+		$result = Plugin_Scan_Gandalf::dispatch_from_import_context(
+			$plugin,
+			array(
+				'stable_tag'       => '1.0.1',
+				'old_stable_tag'   => '1.0.0',
+				'changed_svn_tags' => array( '1.0.1' ),
+				'warnings'         => array(),
+			)
+		);
+
+		$this->assertTrue( $result );
+		$this->assertCount( 1, $this->requests );
+		$this->assertSame( '1.0.1', $this->requests[0]['body']['release_ref'] );
+		$this->assertSame( 'https://downloads.wordpress.org/plugin/gandalf-tagged-release.1.0.1.zip', $this->requests[0]['body']['current_zip_url'] );
+		$this->assertSame( '1.0.0', $this->requests[0]['body']['previous_release_ref'] );
+		$this->assertSame( 'https://downloads.wordpress.org/plugin/gandalf-tagged-release.1.0.0.zip', $this->requests[0]['body']['previous_zip_url'] );
+	}
+
+	/**
+	 * The fallback warning alone should not skip a non-trunk release ref.
+	 */
+	public function test_fallback_warning_does_not_skip_non_trunk_release_ref() {
+		$plugin = $this->create_plugin(
+			'gandalf-tagged-warning',
+			array(
+				'version' => '1.0.1',
+			)
+		);
+
+		$result = Plugin_Scan_Gandalf::dispatch_from_import_context(
+			$plugin,
+			array(
+				'stable_tag'       => '1.0.1',
+				'old_stable_tag'   => '1.0.0',
+				'changed_svn_tags' => array( '1.0.1' ),
+				'warnings'         => array(
+					'stable_tag_invalid_trunk_fallback' => '1.0.1',
+				),
+			)
+		);
+
+		$this->assertTrue( $result );
+		$this->assertCount( 1, $this->requests );
+		$this->assertSame( '1.0.1', $this->requests[0]['body']['release_ref'] );
+	}
+
+	/**
+	 * Development-only trunk changes should not rescan an unchanged tagged stable release.
+	 */
+	public function test_trunk_only_change_with_existing_stable_tag_does_not_dispatch() {
+		$plugin = $this->create_plugin(
+			'gandalf-dev-trunk',
+			array(
+				'version' => '1.0.1',
+			)
+		);
+
+		$result = Plugin_Scan_Gandalf::dispatch_from_import_context(
+			$plugin,
+			array(
+				'stable_tag'       => '1.0.1',
+				'old_stable_tag'   => '1.0.1',
+				'changed_svn_tags' => array( 'trunk' ),
+				'warnings'         => array(),
+			)
+		);
+
+		$this->assertFalse( $result );
+		$this->assertSame( array(), $this->requests );
+	}
+
+	/**
+	 * Direct calls with incomplete importer context should not dispatch.
+	 */
+	public function test_malformed_import_context_does_not_dispatch() {
+		$plugin = $this->create_plugin(
+			'gandalf-malformed-context',
+			array(
+				'version' => '1.0.1',
+			)
+		);
+
+		$result = Plugin_Scan_Gandalf::dispatch_from_import_context(
+			$plugin,
+			array(
+				'stable_tag'       => 'trunk',
+				'old_stable_tag'   => 'trunk',
+				'changed_svn_tags' => array( 'trunk' ),
+			)
+		);
+
+		$this->assertFalse( $result );
+		$this->assertSame( array(), $this->requests );
+	}
+
+	/**
+	 * Create a minimal plugin post with the post meta Gandalf reads.
+	 *
+	 * @param string $slug Plugin slug.
+	 * @param array  $meta Plugin post meta.
+	 * @return WP_Post
+	 */
+	private function create_plugin( $slug, $meta = array() ) {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_name'   => $slug,
+				'post_title'  => $slug,
+				'post_type'   => 'plugin',
+				'post_status' => 'publish',
+			)
+		);
+
+		foreach ( $meta as $key => $value ) {
+			update_post_meta( $post_id, $key, $value );
+		}
+
+		return get_post( $post_id );
+	}
+}


### PR DESCRIPTION
A common plugin release sequence is:

1. commit release work to `trunk`;
2. update `trunk/readme.txt` to point `Stable Tag` at the next version;
3. create the matching SVN tag shortly after.

When the importer sees step 2 before step 3, the named tag does not exist yet. The importer falls back to `trunk` and records `stable_tag_invalid_trunk_fallback`.

That fallback can produce a real public ZIP. In the common case, though, it is a short-lived trunk package followed seconds or minutes later by the intended tagged release.

- the fallback trunk ZIP, usually as a whole-package scan; and
- the intended tagged ZIP, usually as the more useful release/diff scan.

This patch skips Gandalf dispatch only for that importer-known fallback case:

- `release_ref` is `trunk`; and
- importer warnings include `stable_tag_invalid_trunk_fallback`.

This is not a general trunk skip. Normal tagged releases, intentional trunk releases, current-tag rebuilds, and trunk releases without the missing-tag fallback warning still scan normally.

### Replay notes

I replayed the last 7 days of trunk-touching SVN revisions statically to measure. The replay saw 5,014 trunk-touching revisions.

Breakdown:

- 2,715 were trunk-touching revisions where a non-trunk `Stable Tag` resolved to an existing SVN tag. _(Already skipped today: trunk activity where `Stable Tag` points to an existing tag.)_
- 1,357 were trunk-touching revisions where a non-trunk `Stable Tag` pointed to a missing SVN tag, causing the importer to fall back to `trunk` and record `stable_tag_invalid_trunk_fallback`. _(Newly skipped by this PR.)_
- 853 were not classified due to replay script limitation. _(Not relevant here)_
- 88 had an empty or trunk-style `Stable Tag`. _(Intentional trunk-style releases; this PR does not skip those.)_

For the 1,357 missing-tag fallback cases this patch would skip, 1,048 created the intended tag within the next hour, the vast majority within 10 minutes.

276 had no exact matching tag creation in the replay window, and this is the trade-off that this PR proposes. Of those, 63 were later followed by a different tagged release for the same plugin, which remains eligible for Gandalf. The remaining 213 had no later tag in the replay window.

The replay shows the intended win: most skipped fallback trunk scans are followed shortly by the intended tagged release scan.

It also shows the limitation: the skip is not lossless. Some fallback trunk packages do not get the matching tag.

Policy changes or deferred scans can be addressed separately. This immediate change gets most of the observed benefit by avoiding duplicate whole-package scans for short-lived fallback trunk artifacts.