### PR TITLE
Plugin Directory: Warn when the plugin Version header does not match its SVN tag

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
@@ -127,6 +127,16 @@ class Import {
 		// Validate various headers:
 
 		/*
+		 * Warn when the plugin's Version header has anything other than digits and dots.
+		 *
+		 * Catches things like `Version: Version: 1.7.0` (logistos), `v1.0`, `1.0-beta`, etc. —
+		 * cases where the header value isn't a plain dotted-numeric version.
+		 */
+		if ( $version && ! preg_match( '/^\d+(?:\.\d+)*$/', $version ) ) {
+			$this->warnings['version_header_unexpected_chars'] = $version;
+		}
+
+		/*
 		 * Warn when the plugin's Version header doesn't appear to match the tag it was released from.
 		 *
 		 * Trunk releases skip this check — there's no tag folder to compare against.
@@ -1270,9 +1280,10 @@ class Import {
 	 * Determine whether a plugin's Version header looks like a match for the SVN tag it was released from.
 	 *
 	 * Both sides are reduced to the leading dotted-numeric portion (e.g. `release-1.4.0` → `1.4.0`,
-	 * `1.4.0-beta` → `1.4.0`, `1.0 & beta` → `1.0`), then compared with `version_compare()`. Only the
-	 * "tag is ahead of the Version header" case is treated as a mismatch — equal values (so `1.0` vs
-	 * `1.0.0` is a match) and the unusual "Version header is ahead of tag" case are both allowed.
+	 * `1.4.0-beta` → `1.4.0`, `1.0 & beta` → `1.0`), then compared with `version_compare()`. Any
+	 * inequality is treated as a mismatch — including the unusual case where the Version header is
+	 * ahead of the tag, which is allowable but almost always unintended. `1.0` vs `1.0.0` is treated
+	 * as equal after trailing `.0` segments are stripped.
 	 *
 	 * @param string $version The plugin's Version header value.
 	 * @param string $tag     The SVN tag folder name (e.g. `1.4.1`, `v2.0`).
@@ -1297,9 +1308,9 @@ class Import {
 			return true;
 		}
 
-		// Only flag when the tag is strictly ahead of the Version header
-		// (the common "forgot to bump the header" mistake).
-		return version_compare( $normalized_tag, $normalized_version, '<=' );
+		// Flag any inequality. The common case is "forgot to bump the header" (tag ahead of
+		// version), but the inverse is also worth flagging — it's allowable yet usually unintended.
+		return version_compare( $normalized_tag, $normalized_version, '==' );
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
@@ -127,12 +127,12 @@ class Import {
 		// Validate various headers:
 
 		/*
-		 * Warn when the plugin's Version header has anything other than digits and dots.
+		 * Warn when the plugin's Version header has anything other than digits, dots, and an
+		 * optional `-rcN`, `-betaN`, or `-alphaN` pre-release suffix.
 		 *
-		 * Catches things like `Version: Version: 1.7.0` (logistos), `v1.0`, `1.0-beta`, etc. —
-		 * cases where the header value isn't a plain dotted-numeric version.
+		 * Catches things like `Version: Version: 1.7.0` (logistos), `v1.0`, `1.0 & beta`, etc.
 		 */
-		if ( $version && ! preg_match( '/^\d+(?:\.\d+)*$/', $version ) ) {
+		if ( $version && ! preg_match( '/^\d+(?:\.\d+)*(?:-(?:rc|beta|alpha)\d*)?$/', $version ) ) {
 			$this->warnings['version_header_unexpected_chars'] = $version;
 		}
 
@@ -1291,14 +1291,15 @@ class Import {
 	 */
 	public static function version_matches_tag( $version, $tag ) {
 		$normalize = static function ( $v ) {
-			// Capture the leading dotted-numeric portion after any non-digit prefix
-			// (e.g. `v`, `Version: `, `release-`, `tag-`, `hover-`) and ignoring trailing
-			// non-version junk (e.g. `1.0-beta`, `1.0 & beta`).
-			if ( ! preg_match( '/^[^0-9]*(\d+(?:\.\d+)*)/', (string) $v, $m ) ) {
+			// Capture the leading dotted-numeric portion (plus an optional `-rcN` / `-betaN` /
+			// `-alphaN` pre-release suffix) after any non-digit prefix such as `v`, `Version: `,
+			// `release-`, `tag-`, or `hover-`.
+			if ( ! preg_match( '/^[^0-9]*(\d+(?:\.\d+)*(?:-(?:rc|beta|alpha)\d*)?)/', (string) $v, $m ) ) {
 				return '';
 			}
 			// Strip trailing `.0` segments so version_compare() treats `1.0` and `1.0.0` as equal.
-			return preg_replace( '/(\.0+)+$/', '', $m[1] );
+			// Only applies to the dotted-numeric portion; a pre-release suffix is left alone.
+			return preg_replace( '/(\.0+)+(?=(?:-(?:rc|beta|alpha)\d*)?$)/', '', $m[1] );
 		};
 
 		$normalized_version = $normalize( $version );

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
@@ -127,6 +127,18 @@ class Import {
 		// Validate various headers:
 
 		/*
+		 * Warn when the plugin's Version header doesn't appear to match the tag it was released from.
+		 *
+		 * Trunk releases skip this check — there's no tag folder to compare against.
+		 */
+		if ( 'trunk' !== $stable_tag && $version && ! self::version_matches_tag( $version, $stable_tag ) ) {
+			$this->warnings['version_tag_mismatch'] = [
+				'version' => $version,
+				'tag'     => $stable_tag,
+			];
+		}
+
+		/*
 		 * Check to see if the plugin is using the `Update URI` header.
 		 *
 		 * Plugins on WordPress.org should NOT use this header, but we do accept some URI formats for it in the API,
@@ -1252,6 +1264,40 @@ class Import {
 		}
 
 		return (object) $headers;
+	}
+
+	/**
+	 * Determine whether a plugin's Version header looks like a match for the SVN tag it was released from.
+	 *
+	 * Strips a leading "Version" word or 'v' prefix from both sides, then uses a containment check
+	 * so that minor format differences (e.g. `1.4` vs `1.4.0`) are still treated as a match. Empty
+	 * inputs are treated as a match because there's nothing useful to compare.
+	 *
+	 * @param string $version The plugin's Version header value.
+	 * @param string $tag     The SVN tag folder name (e.g. `1.4.1`, `v2.0`).
+	 * @return bool True when the values appear to match, false when they look mismatched.
+	 */
+	public static function version_matches_tag( $version, $tag ) {
+		$normalize = static function ( $v ) {
+			$v = trim( (string) $v );
+			// Strip a leading "Version" word, with optional ':' or '-' separator.
+			$v = preg_replace( '/^version\b\s*[:\-]?\s*/i', '', $v );
+			// Strip a leading 'v' when followed by a digit (e.g. v1.0 → 1.0).
+			$v = preg_replace( '/^v(?=\d)/i', '', $v );
+			return trim( $v );
+		};
+
+		$normalized_version = $normalize( $version );
+		$normalized_tag     = $normalize( $tag );
+
+		if ( '' === $normalized_version || '' === $normalized_tag ) {
+			return true;
+		}
+
+		return (
+			false !== stripos( $normalized_version, $normalized_tag ) ||
+			false !== stripos( $normalized_tag, $normalized_version )
+		);
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
@@ -130,7 +130,8 @@ class Import {
 		 * Warn when the plugin's Version header has anything other than digits, dots, and an
 		 * optional `-rcN`, `-betaN`, or `-alphaN` pre-release suffix.
 		 *
-		 * Catches things like `Version: Version: 1.7.0` (logistos), `v1.0`, `1.0 & beta`, etc.
+		 * Catches headers that include an accidental duplicate `Version:` prefix, stray
+		 * letters or punctuation, or other free-form text mixed in with the version number.
 		 */
 		if ( $version && ! preg_match( '/^\d+(?:\.\d+)*(?:-(?:rc|beta|alpha)\d*)?$/', $version ) ) {
 			$this->warnings['version_header_unexpected_chars'] = $version;

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
@@ -1273,6 +1273,10 @@ class Import {
 	 * so that minor format differences (e.g. `1.4` vs `1.4.0`) are still treated as a match. Empty
 	 * inputs are treated as a match because there's nothing useful to compare.
 	 *
+	 * Note: this does NOT re-apply the legacy `.X` → `0.X` normalization that
+	 * `Readme_Parser::sanitize_stable_tag()` performs — by the time this is reached, the
+	 * stable tag has already been sanitized, and that form should not be supported for new releases.
+	 *
 	 * @param string $version The plugin's Version header value.
 	 * @param string $tag     The SVN tag folder name (e.g. `1.4.1`, `v2.0`).
 	 * @return bool True when the values appear to match, false when they look mismatched.

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
@@ -128,12 +128,16 @@ class Import {
 
 		/*
 		 * Warn when the plugin's Version header has anything other than digits, dots, and an
-		 * optional `-rcN`, `-betaN`, or `-alphaN` pre-release suffix.
+		 * optional `-rc` / `-beta` / `-alpha` pre-release suffix (with optional digits).
 		 *
 		 * Catches headers that include an accidental duplicate `Version:` prefix, stray
 		 * letters or punctuation, or other free-form text mixed in with the version number.
+		 *
+		 * The strict format matters because WordPress core uses `version_compare()` to decide
+		 * whether to offer an update — a malformed header can silently give the wrong answer
+		 * for users running an older release.
 		 */
-		if ( $version && ! preg_match( '/^\d+(?:\.\d+)*(?:-(?:rc|beta|alpha)\d*)?$/', $version ) ) {
+		if ( $version && ! preg_match( '/^\d+(?:\.\d+)*(?:-(?:rc|beta|alpha)(?:\.?\d+)?)?$/i', $version ) ) {
 			$this->warnings['version_header_unexpected_chars'] = $version;
 		}
 
@@ -1292,15 +1296,18 @@ class Import {
 	 */
 	public static function version_matches_tag( $version, $tag ) {
 		$normalize = static function ( $v ) {
-			// Capture the leading dotted-numeric portion (plus an optional `-rcN` / `-betaN` /
-			// `-alphaN` pre-release suffix) after any non-digit prefix such as `v`, `Version: `,
-			// `release-`, `tag-`, or `hover-`.
-			if ( ! preg_match( '/^[^0-9]*(\d+(?:\.\d+)*(?:-(?:rc|beta|alpha)\d*)?)/', (string) $v, $m ) ) {
+			// Capture the leading dotted-numeric portion (plus an optional `-rc` / `-beta` /
+			// `-alpha` pre-release suffix, case-insensitive, with optional `.`/no-separator digits)
+			// after any non-digit prefix such as `v`, `Version: `, `release-`, `tag-`, or `hover-`.
+			if ( ! preg_match( '/^[^0-9]*(\d+(?:\.\d+)*(?:-(?:rc|beta|alpha)(?:\.?\d+)?)?)/i', (string) $v, $m ) ) {
 				return '';
 			}
+			// Lowercase the suffix — version_compare() is not consistently case-insensitive
+			// (e.g. `1.0-Beta` < `1.0-beta`), so normalize before comparing.
+			$captured = strtolower( $m[1] );
 			// Strip trailing `.0` segments so version_compare() treats `1.0` and `1.0.0` as equal.
 			// Only applies to the dotted-numeric portion; a pre-release suffix is left alone.
-			return preg_replace( '/(\.0+)+(?=(?:-(?:rc|beta|alpha)\d*)?$)/', '', $m[1] );
+			return preg_replace( '/(\.0+)+(?=(?:-(?:rc|beta|alpha)(?:\.?\d+)?)?$)/', '', $captured );
 		};
 
 		$normalized_version = $normalize( $version );

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
@@ -1269,9 +1269,10 @@ class Import {
 	/**
 	 * Determine whether a plugin's Version header looks like a match for the SVN tag it was released from.
 	 *
-	 * Strips a leading "Version" word or 'v' prefix from both sides, then uses a containment check
-	 * so that minor format differences (e.g. `1.4` vs `1.4.0`) are still treated as a match. Empty
-	 * inputs are treated as a match because there's nothing useful to compare.
+	 * Both sides are reduced to the leading dotted-numeric portion (e.g. `release-1.4.0` → `1.4.0`,
+	 * `1.4.0-beta` → `1.4.0`, `1.0 & beta` → `1.0`), then compared with `version_compare()`. Only the
+	 * "tag is ahead of the Version header" case is treated as a mismatch — equal values (so `1.0` vs
+	 * `1.0.0` is a match) and the unusual "Version header is ahead of tag" case are both allowed.
 	 *
 	 * Note: this does NOT re-apply the legacy `.X` → `0.X` normalization that
 	 * `Readme_Parser::sanitize_stable_tag()` performs — by the time this is reached, the
@@ -1283,12 +1284,14 @@ class Import {
 	 */
 	public static function version_matches_tag( $version, $tag ) {
 		$normalize = static function ( $v ) {
-			$v = trim( (string) $v );
-			// Strip a leading "Version" word, with optional ':' or '-' separator.
-			$v = preg_replace( '/^version\b\s*[:\-]?\s*/i', '', $v );
-			// Strip a leading 'v' when followed by a digit (e.g. v1.0 → 1.0).
-			$v = preg_replace( '/^v(?=\d)/i', '', $v );
-			return trim( $v );
+			// Capture the leading dotted-numeric portion after any non-digit prefix
+			// (e.g. `v`, `Version: `, `release-`, `tag-`, `hover-`) and ignoring trailing
+			// non-version junk (e.g. `1.0-beta`, `1.0 & beta`).
+			if ( ! preg_match( '/^[^0-9]*(\d+(?:\.\d+)*)/', (string) $v, $m ) ) {
+				return '';
+			}
+			// Strip trailing `.0` segments so version_compare() treats `1.0` and `1.0.0` as equal.
+			return preg_replace( '/(\.0+)+$/', '', $m[1] );
 		};
 
 		$normalized_version = $normalize( $version );
@@ -1298,10 +1301,9 @@ class Import {
 			return true;
 		}
 
-		return (
-			false !== stripos( $normalized_version, $normalized_tag ) ||
-			false !== stripos( $normalized_tag, $normalized_version )
-		);
+		// Only flag when the tag is strictly ahead of the Version header
+		// (the common "forgot to bump the header" mistake).
+		return version_compare( $normalized_tag, $normalized_version, '<=' );
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
@@ -1274,10 +1274,6 @@ class Import {
 	 * "tag is ahead of the Version header" case is treated as a mismatch — equal values (so `1.0` vs
 	 * `1.0.0` is a match) and the unusual "Version header is ahead of tag" case are both allowed.
 	 *
-	 * Note: this does NOT re-apply the legacy `.X` → `0.X` normalization that
-	 * `Readme_Parser::sanitize_stable_tag()` performs — by the time this is reached, the
-	 * stable tag has already been sanitized, and that form should not be supported for new releases.
-	 *
 	 * @param string $version The plugin's Version header value.
 	 * @param string $tag     The SVN tag folder name (e.g. `1.4.1`, `v2.0`).
 	 * @return bool True when the values appear to match, false when they look mismatched.

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/readme/class-validator.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/readme/class-validator.php
@@ -312,7 +312,7 @@ class Validator {
 				$tag     = is_array( $data ) ? ( $data['tag']     ?? '' ) : '';
 				return sprintf(
 					/* translators: 1: 'Version' plugin header, 2: the Version header value, 3: the SVN tag path */
-					__( 'The %1$s header (%2$s) does not match the SVN tag this release was imported from (%3$s). Update the %1$s header in your main plugin file so it matches the tag.', 'wporg-plugins' ),
+					__( 'The %1$s header (%2$s) is older than the SVN tag this release was imported from (%3$s). Update the %1$s header in your main plugin file so it matches the tag.', 'wporg-plugins' ),
 					'<code>Version</code>',
 					'<code>' . esc_html( $version ) . '</code>',
 					'<code>/tags/' . esc_html( $tag ) . '/</code>'

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/readme/class-validator.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/readme/class-validator.php
@@ -307,6 +307,16 @@ class Validator {
 					'<code>/tags/' . esc_html( $data ) . '/</code>',
 					'<code>/trunk/</code>'
 				);
+			case 'version_tag_mismatch':
+				$version = is_array( $data ) ? ( $data['version'] ?? '' ) : '';
+				$tag     = is_array( $data ) ? ( $data['tag']     ?? '' ) : '';
+				return sprintf(
+					/* translators: 1: 'Version' plugin header, 2: the Version header value, 3: the SVN tag path */
+					__( 'The %1$s header (%2$s) does not match the SVN tag this release was imported from (%3$s). Update the %1$s header in your main plugin file so it matches the tag.', 'wporg-plugins' ),
+					'<code>Version</code>',
+					'<code>' . esc_html( $version ) . '</code>',
+					'<code>/tags/' . esc_html( $tag ) . '/</code>'
+				);
 			case 'contributor_ignored':
 				if ( ! $data ) {
 					return sprintf(

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/readme/class-validator.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/readme/class-validator.php
@@ -307,12 +307,20 @@ class Validator {
 					'<code>/tags/' . esc_html( $data ) . '/</code>',
 					'<code>/trunk/</code>'
 				);
+			case 'version_header_unexpected_chars':
+				return sprintf(
+					/* translators: 1: 'Version' plugin header, 2: the Version header value */
+					__( 'The %1$s header (%2$s) contains unexpected characters. Use only digits and dots, for example %3$s.', 'wporg-plugins' ),
+					'<code>Version</code>',
+					'<code>' . esc_html( $data ) . '</code>',
+					'<code>1.2.3</code>'
+				);
 			case 'version_tag_mismatch':
 				$version = is_array( $data ) ? ( $data['version'] ?? '' ) : '';
 				$tag     = is_array( $data ) ? ( $data['tag']     ?? '' ) : '';
 				return sprintf(
 					/* translators: 1: 'Version' plugin header, 2: the Version header value, 3: the SVN tag path */
-					__( 'The %1$s header (%2$s) is older than the SVN tag this release was imported from (%3$s). Update the %1$s header in your main plugin file so it matches the tag.', 'wporg-plugins' ),
+					__( 'The %1$s header (%2$s) does not match the SVN tag this release was imported from (%3$s). Update the %1$s header in your main plugin file so it matches the tag.', 'wporg-plugins' ),
 					'<code>Version</code>',
 					'<code>' . esc_html( $version ) . '</code>',
 					'<code>/tags/' . esc_html( $tag ) . '/</code>'

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/readme/class-validator.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/readme/class-validator.php
@@ -309,10 +309,9 @@ class Validator {
 				);
 			case 'version_header_unexpected_chars':
 				return sprintf(
-					/* translators: 1: 'Version' plugin header, 2: the Version header value */
-					__( 'The %1$s header (%2$s) contains unexpected characters. Use only digits and dots, for example %3$s.', 'wporg-plugins' ),
-					'<code>Version</code>',
-					'<code>' . esc_html( $data ) . '</code>',
+					/* translators: 1: the full 'Version: X' header line, 2: an example version */
+					__( 'The %1$s header contains unexpected characters. Use only digits and dots, for example %2$s.', 'wporg-plugins' ),
+					'<code>Version: ' . esc_html( $data ) . '</code>',
 					'<code>1.2.3</code>'
 				);
 			case 'version_tag_mismatch':

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Import_Version_Matches_Tag_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Import_Version_Matches_Tag_Test.php
@@ -49,7 +49,6 @@ class Import_Version_Matches_Tag_Test extends TestCase {
 			'hover- prefix on tag'      => array( '1.0', 'hover-1.0' ),
 			'-beta trailing on version' => array( '1.0-beta', '1.0' ),
 			'space-&-beta trailing'     => array( '1.0 & beta', '1.0' ),
-			'header ahead of tag'       => array( '2.0', '1.0' ),
 			'empty version'             => array( '', '1.0' ),
 			'empty tag'                 => array( '1.0', '' ),
 			'both empty'                => array( '', '' ),
@@ -65,6 +64,7 @@ class Import_Version_Matches_Tag_Test extends TestCase {
 			'tag has trailing digit' => array( '1.4.0', '1.4.10' ),
 			'release- prefix on tag' => array( '1.0', 'release-2.0' ),
 			'tag-beta still ahead'   => array( '1.4.0', '1.4.1-beta' ),
+			'header ahead of tag'    => array( '2.0', '1.0' ),
 		);
 	}
 }

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Import_Version_Matches_Tag_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Import_Version_Matches_Tag_Test.php
@@ -36,23 +36,25 @@ class Import_Version_Matches_Tag_Test extends TestCase {
 	public static function matches_provider() {
 		return array(
 			// Format: [ $version, $tag ].
-			'exact match'               => array( '1.0', '1.0' ),
-			'short tag, long version'   => array( '1.0.0', '1.0' ),
-			'short version, long tag'   => array( '1.0', '1.0.0' ),
-			'leading v on tag'          => array( '1.0', 'v1.0' ),
-			'leading v on version'      => array( 'v1.0', '1.0' ),
-			'capital V prefix'          => array( 'V1.0', '1.0' ),
-			'Version word prefix'       => array( 'Version 1.0', '1.0' ),
-			'Version: prefix'           => array( 'Version: 1.0', '1.0' ),
-			'release- prefix on tag'    => array( '1.4.0', 'release-1.4.0' ),
-			'tag- prefix on tag'        => array( '2.0', 'tag-2.0' ),
-			'hover- prefix on tag'      => array( '1.0', 'hover-1.0' ),
-			'-beta trailing on version' => array( '1.0-beta', '1.0' ),
-			'space-&-beta trailing'     => array( '1.0 & beta', '1.0' ),
-			'empty version'             => array( '', '1.0' ),
-			'empty tag'                 => array( '1.0', '' ),
-			'both empty'                => array( '', '' ),
-			'no digits'                 => array( 'abc', '1.0' ),
+			'exact match'             => array( '1.0', '1.0' ),
+			'short tag, long version' => array( '1.0.0', '1.0' ),
+			'short version, long tag' => array( '1.0', '1.0.0' ),
+			'leading v on tag'        => array( '1.0', 'v1.0' ),
+			'leading v on version'    => array( 'v1.0', '1.0' ),
+			'capital V prefix'        => array( 'V1.0', '1.0' ),
+			'Version word prefix'     => array( 'Version 1.0', '1.0' ),
+			'Version: prefix'         => array( 'Version: 1.0', '1.0' ),
+			'release- prefix on tag'  => array( '1.4.0', 'release-1.4.0' ),
+			'tag- prefix on tag'      => array( '2.0', 'tag-2.0' ),
+			'hover- prefix on tag'    => array( '1.0', 'hover-1.0' ),
+			'space-&-beta trailing'   => array( '1.0 & beta', '1.0' ),
+			'matching -beta'          => array( '1.0-beta', '1.0-beta' ),
+			'matching -rc1'           => array( '1.4.0-rc1', '1.4.0-rc1' ),
+			'matching -alpha'         => array( '1.0-alpha', '1.0-alpha' ),
+			'empty version'           => array( '', '1.0' ),
+			'empty tag'               => array( '1.0', '' ),
+			'both empty'              => array( '', '' ),
+			'no digits'               => array( 'abc', '1.0' ),
 		);
 	}
 
@@ -65,6 +67,9 @@ class Import_Version_Matches_Tag_Test extends TestCase {
 			'release- prefix on tag' => array( '1.0', 'release-2.0' ),
 			'tag-beta still ahead'   => array( '1.4.0', '1.4.1-beta' ),
 			'header ahead of tag'    => array( '2.0', '1.0' ),
+			'beta vs final'          => array( '1.0-beta', '1.0' ),
+			'final vs beta'          => array( '1.0', '1.0-beta' ),
+			'different rc numbers'   => array( '1.4.0-rc1', '1.4.0-rc2' ),
 		);
 	}
 }

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Import_Version_Matches_Tag_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Import_Version_Matches_Tag_Test.php
@@ -35,28 +35,36 @@ class Import_Version_Matches_Tag_Test extends TestCase {
 
 	public static function matches_provider() {
 		return array(
-			'exact match'                     => array( '1.0', '1.0' ),
-			'leading v on tag'                => array( '1.0', 'v1.0' ),
-			'leading v on version'            => array( 'v1.0', '1.0' ),
-			'leading v on both'               => array( 'v1.0', 'v1.0' ),
-			'Version word prefix on version'  => array( 'Version 1.0', '1.0' ),
-			'Version: prefix on version'      => array( 'Version: 1.0', '1.0' ),
-			'tag is shorter version'          => array( '1.4.0', '1.4' ),
-			'tag is longer version'           => array( '1.4', '1.4.0' ),
-			'version with build suffix'       => array( '1.0-beta', '1.0' ),
-			'empty version'                   => array( '', '1.0' ),
-			'empty tag'                       => array( '1.0', '' ),
-			'both empty'                      => array( '', '' ),
-			'capital V prefix'                => array( 'V1.0', '1.0' ),
+			// Format: [ $version, $tag ].
+			'exact match'               => array( '1.0', '1.0' ),
+			'short tag, long version'   => array( '1.0.0', '1.0' ),
+			'short version, long tag'   => array( '1.0', '1.0.0' ),
+			'leading v on tag'          => array( '1.0', 'v1.0' ),
+			'leading v on version'      => array( 'v1.0', '1.0' ),
+			'capital V prefix'          => array( 'V1.0', '1.0' ),
+			'Version word prefix'       => array( 'Version 1.0', '1.0' ),
+			'Version: prefix'           => array( 'Version: 1.0', '1.0' ),
+			'release- prefix on tag'    => array( '1.4.0', 'release-1.4.0' ),
+			'tag- prefix on tag'        => array( '2.0', 'tag-2.0' ),
+			'hover- prefix on tag'      => array( '1.0', 'hover-1.0' ),
+			'-beta trailing on version' => array( '1.0-beta', '1.0' ),
+			'space-&-beta trailing'     => array( '1.0 & beta', '1.0' ),
+			'header ahead of tag'       => array( '2.0', '1.0' ),
+			'empty version'             => array( '', '1.0' ),
+			'empty tag'                 => array( '1.0', '' ),
+			'both empty'                => array( '', '' ),
+			'no digits'                 => array( 'abc', '1.0' ),
 		);
 	}
 
 	public static function mismatches_provider() {
 		return array(
-			'bandsintown case'        => array( '1.4.0', '1.4.1' ),
-			'different major'         => array( '1.0', '2.0' ),
-			'unrelated version'       => array( '3.2.1', '1.0' ),
-			'partial overlap by char' => array( '1.4.0', '1.4.10' ), // 1.4.0 not in 1.4.10, 1.4.10 not in 1.4.0.
+			// Format: [ $version, $tag ].
+			'bandsintown case'       => array( '1.4.0', '1.4.1' ),
+			'different major'        => array( '1.0', '2.0' ),
+			'tag has trailing digit' => array( '1.4.0', '1.4.10' ),
+			'release- prefix on tag' => array( '1.0', 'release-2.0' ),
+			'tag-beta still ahead'   => array( '1.4.0', '1.4.1-beta' ),
 		);
 	}
 }

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Import_Version_Matches_Tag_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Import_Version_Matches_Tag_Test.php
@@ -51,6 +51,9 @@ class Import_Version_Matches_Tag_Test extends TestCase {
 			'matching -beta'          => array( '1.0-beta', '1.0-beta' ),
 			'matching -rc1'           => array( '1.4.0-rc1', '1.4.0-rc1' ),
 			'matching -alpha'         => array( '1.0-alpha', '1.0-alpha' ),
+			'case-insensitive -Beta'  => array( '1.0-Beta', '1.0-beta' ),
+			'case-insensitive -RC1'   => array( '1.0-RC1', '1.0-rc1' ),
+			'dot vs no-dot suffix'    => array( '1.0-beta.1', '1.0-beta1' ),
 			'empty version'           => array( '', '1.0' ),
 			'empty tag'               => array( '1.0', '' ),
 			'both empty'              => array( '', '' ),
@@ -70,6 +73,7 @@ class Import_Version_Matches_Tag_Test extends TestCase {
 			'beta vs final'          => array( '1.0-beta', '1.0' ),
 			'final vs beta'          => array( '1.0', '1.0-beta' ),
 			'different rc numbers'   => array( '1.4.0-rc1', '1.4.0-rc2' ),
+			'dot-separated suffixes' => array( '1.0-beta.1', '1.0-beta.2' ),
 		);
 	}
 }

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Import_Version_Matches_Tag_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Import_Version_Matches_Tag_Test.php
@@ -33,7 +33,7 @@ class Import_Version_Matches_Tag_Test extends TestCase {
 		);
 	}
 
-	public function matches_provider() {
+	public static function matches_provider() {
 		return array(
 			'exact match'                     => array( '1.0', '1.0' ),
 			'leading v on tag'                => array( '1.0', 'v1.0' ),
@@ -51,7 +51,7 @@ class Import_Version_Matches_Tag_Test extends TestCase {
 		);
 	}
 
-	public function mismatches_provider() {
+	public static function mismatches_provider() {
 		return array(
 			'bandsintown case'        => array( '1.4.0', '1.4.1' ),
 			'different major'         => array( '1.0', '2.0' ),

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Import_Version_Matches_Tag_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Import_Version_Matches_Tag_Test.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Tests for Import::version_matches_tag().
+ *
+ * @package WordPressdotorg\Plugin_Directory\Tests
+ */
+
+use PHPUnit\Framework\TestCase;
+use WordPressdotorg\Plugin_Directory\CLI\Import;
+
+/**
+ * @group import
+ */
+class Import_Version_Matches_Tag_Test extends TestCase {
+
+	/**
+	 * @dataProvider matches_provider
+	 */
+	public function test_matches( $version, $tag ) {
+		$this->assertTrue(
+			Import::version_matches_tag( $version, $tag ),
+			"Expected '{$version}' to match tag '{$tag}'"
+		);
+	}
+
+	/**
+	 * @dataProvider mismatches_provider
+	 */
+	public function test_mismatches( $version, $tag ) {
+		$this->assertFalse(
+			Import::version_matches_tag( $version, $tag ),
+			"Expected '{$version}' to be flagged as a mismatch with tag '{$tag}'"
+		);
+	}
+
+	public function matches_provider() {
+		return array(
+			'exact match'                     => array( '1.0', '1.0' ),
+			'leading v on tag'                => array( '1.0', 'v1.0' ),
+			'leading v on version'            => array( 'v1.0', '1.0' ),
+			'leading v on both'               => array( 'v1.0', 'v1.0' ),
+			'Version word prefix on version'  => array( 'Version 1.0', '1.0' ),
+			'Version: prefix on version'      => array( 'Version: 1.0', '1.0' ),
+			'tag is shorter version'          => array( '1.4.0', '1.4' ),
+			'tag is longer version'           => array( '1.4', '1.4.0' ),
+			'version with build suffix'       => array( '1.0-beta', '1.0' ),
+			'empty version'                   => array( '', '1.0' ),
+			'empty tag'                       => array( '1.0', '' ),
+			'both empty'                      => array( '', '' ),
+			'capital V prefix'                => array( 'V1.0', '1.0' ),
+		);
+	}
+
+	public function mismatches_provider() {
+		return array(
+			'bandsintown case'        => array( '1.4.0', '1.4.1' ),
+			'different major'         => array( '1.0', '2.0' ),
+			'unrelated version'       => array( '3.2.1', '1.0' ),
+			'partial overlap by char' => array( '1.4.0', '1.4.10' ), // 1.4.0 not in 1.4.10, 1.4.10 not in 1.4.0.
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Adds two new import warnings for the plugin directory, both surfaced on the existing committer-only notice block on each plugin page.

### `version_tag_mismatch`

Flags when the `Version` header in the imported main plugin file does not match the SVN tag the release came from. Skipped for trunk-stable releases.

Comparison logic (`Import::version_matches_tag()`):

- Both sides are normalised: the leading dotted-numeric portion is captured, ignoring common prefixes (`v`, `Version:`, `release-`, `tag-`, `hover-`, etc.) and trailing junk (anything after the version-y part). An optional `-rcN`, `-betaN`, or `-alphaN` pre-release suffix is preserved.
- Trailing `.0` segments are stripped from the dotted-numeric portion so `1.0` and `1.0.0` compare equal.
- The values are compared with `version_compare( $tag, $version, '==' )`. Any inequality is flagged — including the unusual "header is ahead of the tag" direction, which is allowable but almost always unintended.

### `version_header_unexpected_chars`

Flags when the `Version` header value is not a clean dotted-numeric value (with the same optional `-rc` / `-beta` / `-alpha` suffix). Catches headers that include an accidental duplicate `Version:` prefix, stray letters or punctuation, or other free-form text mixed in with the version number.

Renders the literal header line in the message, e.g. *"The `Version: <value>` header contains unexpected characters. Use only digits and dots, for example `1.2.3`."*

### Plumbing

Both warnings are captured into `$importer->warnings` and persisted to the existing `_import_warnings` post meta by the cron-job wrapper, alongside the existing `stable_tag_invalid` family. The committer-visible notice on each plugin's page renders them via the existing `translate_code_to_message()` path.

## Test plan

- [x] PHPUnit coverage in `tests/Import_Version_Matches_Tag_Test.php` for the match/mismatch matrix — exact match, `v` / `Version:` / `release-` / `tag-` / `hover-` prefixes, trailing junk, tag-shorter / tag-longer, pre-release suffix matching/mismatching, char-level non-overlap, header-ahead-of-tag, and empty inputs.
- [x] Verified in the local plugin-directory wp-env that the rendered admin notice reads as expected for: a tag mismatch where the header is older than the tag, a tag mismatch where the header is newer than the tag, and a Version header containing unexpected characters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
