### PR TITLE
Translate: build language pack ZIPs via ZipArchive instead of exec('zip')

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/cli/class-language-pack.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/cli/class-language-pack.php
@@ -557,11 +557,6 @@ class Language_Pack extends WP_CLI_Command {
 	/**
 	 * Builds a ZIP archive from a list of files, junking paths (basename only).
 	 *
-	 * Replaces an earlier `exec( 'zip -9 -j ...' )` invocation that could fail
-	 * with "Unable to fork" under memory pressure as the parent CLI grew over
-	 * a long run, and that grew an unbounded shell argv as the number of JED
-	 * JSON files per language pack increased.
-	 *
 	 * Each entry is added by its basename (the `-j` equivalent) and must resolve
 	 * to a regular file inside the per-build working directory; anything else
 	 * is rejected to avoid pulling unrelated files into the archive.

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/cli/class-language-pack.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/cli/class-language-pack.php
@@ -555,6 +555,63 @@ class Language_Pack extends WP_CLI_Command {
 	}
 
 	/**
+	 * Builds a ZIP archive from a list of files, junking paths (basename only).
+	 *
+	 * Replaces an earlier `exec( 'zip -9 -j ...' )` invocation that could fail
+	 * with "Unable to fork" under memory pressure as the parent CLI grew over
+	 * a long run, and that grew an unbounded shell argv as the number of JED
+	 * JSON files per language pack increased.
+	 *
+	 * Each entry is added by its basename (the `-j` equivalent) and must resolve
+	 * to a regular file inside the per-build working directory; anything else
+	 * is rejected to avoid pulling unrelated files into the archive.
+	 *
+	 * @param string   $zip_path Destination ZIP path.
+	 * @param string[] $files    Files to add. Paths must be absolute and resolve
+	 *                           to regular files (no directories, no symlinks
+	 *                           pointing outside the working tree).
+	 * @return true|WP_Error
+	 */
+	private function build_zip_file( $zip_path, array $files ) {
+		if ( ! class_exists( 'ZipArchive' ) ) {
+			return new WP_Error( 'ziparchive_missing', 'ZipArchive PHP extension is not available.' );
+		}
+
+		$zip = new \ZipArchive();
+		$opened = $zip->open( $zip_path, \ZipArchive::CREATE | \ZipArchive::OVERWRITE );
+		if ( true !== $opened ) {
+			return new WP_Error( 'zip_open_failed', sprintf( 'ZipArchive::open() failed with code %d.', $opened ) );
+		}
+
+		$seen = [];
+		foreach ( $files as $file ) {
+			$real = realpath( $file );
+			if ( false === $real || ! is_file( $real ) || is_link( $file ) ) {
+				$zip->close();
+				return new WP_Error( 'zip_invalid_source', sprintf( 'Refusing to add non-regular or unresolved file: %s', $file ) );
+			}
+
+			$name = basename( $real );
+			if ( '' === $name || isset( $seen[ $name ] ) ) {
+				$zip->close();
+				return new WP_Error( 'zip_invalid_name', sprintf( 'Invalid or duplicate entry name for: %s', $file ) );
+			}
+			$seen[ $name ] = true;
+
+			if ( ! $zip->addFile( $real, $name ) ) {
+				$zip->close();
+				return new WP_Error( 'zip_add_failed', sprintf( 'ZipArchive::addFile() failed for: %s', $real ) );
+			}
+		}
+
+		if ( ! $zip->close() ) {
+			return new WP_Error( 'zip_close_failed', 'ZipArchive::close() failed.' );
+		}
+
+		return true;
+	}
+
+	/**
 	 * Inserts a language pack into database.
 	 *
 	 * @param string $type     Type of the language pack.
@@ -733,16 +790,10 @@ class Language_Pack extends WP_CLI_Command {
 			}
 
 			// Create ZIP file.
-			$result = $this->execute_command( sprintf(
-				'zip -9 -j %s %s %s %s 2>&1',
-				escapeshellarg( $zip_file ),
-				escapeshellarg( $po_file ),
-				escapeshellarg( $mo_file ),
-				implode( ' ', array_map( 'escapeshellarg', $additional_files ) )
-			) );
+			$result = $this->build_zip_file( $zip_file, array_merge( [ $po_file, $mo_file ], $additional_files ) );
 
 			if ( is_wp_error( $result ) ) {
-				WP_CLI::error_multi_line( $result->get_error_data() );
+				WP_CLI::error_multi_line( [ $result->get_error_message() ] );
 				WP_CLI::warning( "ZIP generation for {$wp_locale} failed." );
 
 				// Clean up.


### PR DESCRIPTION
## Summary

The language-pack CLI builder (`Language_Pack` WP-CLI command in `wporg-gp-customizations`) currently shells out to `zip -9 -j` once per pack via `exec()`. On long-running invocations this intermittently emits:

```
PHP Warning:  exec(): Unable to fork [zip -9 -j '…/foo.zip' '…/foo.po' '…/foo.mo' '…/foo-<hash>.json' …]
```

That specific PHP message originates from `popen()` returning `NULL`, i.e. a `fork(2)` failure — not an `execve` E2BIG. The realistic cause is **ENOMEM under memory overcommit**: the parent CLI process grows across many translation sets (each iteration loads all entries for a locale into memory and writes N JED JSON files), and eventually the kernel refuses to reserve commit charge for the forked child. A secondary concern is that the shell argv grows linearly with the number of JS-derived JSON files per pack and is unbounded in principle.

This PR replaces the `exec('zip …')` call with a small `ZipArchive` helper. No fork, no shell, no argv length to worry about.

## Why ZipArchive

- It's the same primitive WordPress core uses (`wp-admin/includes/file.php`, `wp-includes/block-template-utils.php`, `wp-admin/includes/privacy-tools.php`) and is already used elsewhere in this repo. The PHP `zip` extension is present in the CLI environment that runs the builder.
- The output is functionally equivalent: same set of files, junked paths (basename only — the `-j` equivalent), default deflate compression. `zip -9` vs. libzip's default deflate is unlikely to make a meaningful difference for these small text files; if size parity ever matters, `setCompressionName()` can be added.

## Security hardening (light)

On the way through, the helper tightens what it accepts as input:

- Each input path must resolve via `realpath()` to an existing **regular file**.
- Symlinks are rejected (`is_link($file)` check before adding) so a stray or hostile symlink in the working tree can't be followed into something unrelated.
- Duplicate basenames are rejected; junking paths means collisions would silently overwrite earlier entries inside the archive otherwise.
- All failure modes return a `WP_Error` and the caller's existing cleanup path (`rm -rf` of the working dir + `continue`) runs unchanged.

These are belt-and-braces — the caller already controls the paths it passes in — but they're cheap and make the helper safe to reuse later.

## Test plan

- [ ] Run the `wp wporg-translate language-pack generate` command against a representative project + locale and confirm the `.zip` is produced, contains `*.po`, `*.mo`, `*.l10n.php` (when present) and the per-JS `-<hash>.json` files, and that `unzip -l` shows basenames only (no leading paths).
- [ ] Confirm SHA/byte-for-byte equivalence isn't required (compression level differs from `zip -9`), but file list and contents match.
- [ ] Run a longer batch (many locales for a large project) and confirm the "Unable to fork" warnings stop appearing.
- [ ] Confirm the failure path still triggers cleanup: temporarily point one input at a missing file and verify `WP_CLI::warning( "ZIP generation for … failed." )` fires and the working directory is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)