### PR TITLE
Five for the Future: Make sponsorship filter URL-driven and persist it across time-window changes

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/content-pledge.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/content-pledge.php
@@ -96,8 +96,8 @@ $is_initially_hidden = 'all' !== $active_sponsorship && $active_sponsorship !== 
 				$parts = array();
 				if ( $high > 0 ) {
 					$parts[] = sprintf(
-						/* translators: 1: <strong> tag, 2: number of high-weight contributions, 3: </strong> tag */
-						_n( '%1$s%2$d high-weight%3$s contribution', '%1$s%2$d high-weight%3$s contributions', $high, 'wporg-5ftf' ),
+						/* translators: 1: <strong> tag, 2: number of high-impact contributions, 3: </strong> tag */
+						_n( '%1$s%2$d high-impact%3$s contribution', '%1$s%2$d high-impact%3$s contributions', $high, 'wporg-5ftf' ),
 						'<strong>',
 						$high,
 						'</strong>'
@@ -105,8 +105,8 @@ $is_initially_hidden = 'all' !== $active_sponsorship && $active_sponsorship !== 
 				}
 				if ( $medium > 0 ) {
 					$parts[] = sprintf(
-						/* translators: 1: <strong> tag, 2: number of medium-weight contributions, 3: </strong> tag */
-						_n( '%1$s%2$d medium%3$s contribution', '%1$s%2$d medium%3$s contributions', $medium, 'wporg-5ftf' ),
+						/* translators: 1: <strong> tag, 2: number of medium-impact contributions, 3: </strong> tag */
+						_n( '%1$s%2$d medium-impact%3$s contribution', '%1$s%2$d medium-impact%3$s contributions', $medium, 'wporg-5ftf' ),
 						'<strong>',
 						$medium,
 						'</strong>'
@@ -145,7 +145,7 @@ $is_initially_hidden = 'all' !== $active_sponsorship && $active_sponsorship !== 
 			} else {
 				echo esc_html( sprintf(
 					/* translators: %d: window in days */
-					__( 'No verified contributions in the last %d days.', 'wporg-5ftf' ),
+					__( 'No tracked contributions in the last %d days.', 'wporg-5ftf' ),
 					$window_days
 				) );
 			}
@@ -156,7 +156,7 @@ $is_initially_hidden = 'all' !== $active_sponsorship && $active_sponsorship !== 
 	<aside class="pledges-card-meta">
 		<span class="pledges-card-weight">
 			<strong><?php echo esc_html( number_format_i18n( $weighted ) ); ?></strong>
-			<span class="pledges-card-weight-label"><?php esc_html_e( 'weighted', 'wporg-5ftf' ); ?></span>
+			<span class="pledges-card-weight-label"><?php esc_html_e( 'impact', 'wporg-5ftf' ); ?></span>
 		</span>
 	</aside>
 </article>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/content-pledge.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/content-pledge.php
@@ -42,11 +42,13 @@ foreach ( $row_attrs as $k => $v ) {
 	$attrs_html .= sprintf( ' %s="%s"', esc_attr( $k ), esc_attr( $v ) );
 }
 
-// Default sponsorship filter is "Independent" (matches the JS state and the
-// is-on chip in page-pledges.php). Pre-hide sponsored cards so the browser
-// paints the filtered view immediately; otherwise the footer-loaded JS hides
-// them after first paint, producing a visible flash of every card.
-$is_initially_hidden = 'independent' !== $status_class;
+// Sponsorship filter is URL-driven (see ?sponsorship= handling in page-pledges.php).
+// Pre-hide non-matching cards so the browser paints the filtered view immediately;
+// otherwise the footer-loaded JS hides them after first paint, producing a visible
+// flash of every card. $sponsorship is inherited from the parent template scope via
+// `require`; default to 'independent' if this file is ever included standalone.
+$active_sponsorship  = $sponsorship ?? 'independent';
+$is_initially_hidden = 'all' !== $active_sponsorship && $active_sponsorship !== $status_class;
 
 ?>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/css/page-pledges.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/css/page-pledges.css
@@ -522,6 +522,23 @@
 	text-decoration: none;
 }
 
+.pledges-empty-extra {
+	margin: 14px 0 0;
+	font-size: 14px;
+	line-height: 1.5;
+}
+
+.pledges-empty-extra a {
+	color: var(--wp--preset--color--blueberry-1, #3858e9);
+	text-decoration: none;
+	font-weight: 500;
+}
+
+.pledges-empty-extra a:hover,
+.pledges-empty-extra a:focus {
+	text-decoration: underline;
+}
+
 /* ------------------------------------------------------------------ */
 /* Narrow (< 720px) layout — collapse card columns                     */
 /* ------------------------------------------------------------------ */

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/css/page-pledges.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/css/page-pledges.css
@@ -503,6 +503,7 @@
 }
 
 .pledges-empty-reset {
+	display: inline-block;
 	margin-top: 10px;
 	background: var(--wp--preset--color--charcoal-1, #1d2327);
 	color: #fff;
@@ -512,6 +513,13 @@
 	font-size: 14px;
 	line-height: 1.4;
 	cursor: pointer;
+	text-decoration: none;
+}
+
+.pledges-empty-reset:hover,
+.pledges-empty-reset:focus {
+	color: #fff;
+	text-decoration: none;
 }
 
 /* ------------------------------------------------------------------ */

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/js/page-pledges.js
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/js/page-pledges.js
@@ -2,9 +2,11 @@
  * Page Pledges — Five for the Future redesign Page 1.
  * Client-side filter over the cards already rendered server-side.
  *
- * Filters: sponsorship (all/independent/sponsored). The time window is server-side
- * (?window=30|90|180); chips are <a> links that reload the page so the aggregator
- * runs against the new window.
+ * Filters: sponsorship (all/independent/sponsored) and time window (30/90/180).
+ * Both groups are URL-driven (?sponsorship=, ?window=) so the view is
+ * bookmarkable. The time-window chips reload the page so the aggregator runs
+ * against the new window; the sponsorship chips are intercepted here for an
+ * instant in-place re-filter and the URL is kept in sync via replaceState.
  *
  * Visibility is non-destructive — all cards stay in DOM, hidden via the `hidden`
  * attribute, and visible cards are re-ranked from 01 on every state change.
@@ -29,8 +31,22 @@
 	var hiwDismiss = hiwBanner && hiwBanner.querySelector( '.pledges-howitworks-dismiss' );
 	var hiwKey = 'wporg-pledges-hiw-dismissed';
 
+	var SPONSORSHIP_DEFAULT = 'independent';
+	var SPONSORSHIP_ALLOWED = [ 'all', 'independent', 'sponsored' ];
+
+	// Seed state from the server-rendered is-on chip so PHP stays the single
+	// source of truth for the default. Allow-list the value so malformed markup
+	// (missing data-value, injected chip) can't put state into an undefined
+	// limbo that hides every card.
+	var initialChip = document.querySelector(
+		'.pledges-chip.is-on[data-filter="sponsorship"]'
+	);
+	var initialValue = initialChip ? initialChip.dataset.value : SPONSORSHIP_DEFAULT;
+	if ( SPONSORSHIP_ALLOWED.indexOf( initialValue ) === -1 ) {
+		initialValue = SPONSORSHIP_DEFAULT;
+	}
 	var state = {
-		sponsorship: 'independent',
+		sponsorship: initialValue,
 	};
 
 	/**
@@ -118,26 +134,86 @@
 	}
 
 	/**
-	 * Wire BUTTON chips for client-side filtering. <a> chips (time window)
-	 * navigate via URL and reload — handled by the browser, not JS.
+	 * Keep the URL in sync with the current sponsorship filter, and carry the
+	 * value forward into sibling navigational links (time-window chips, the
+	 * show_inactive toggle) so a subsequent full-page reload preserves it.
 	 */
-	document.querySelectorAll( 'button.pledges-chip' ).forEach( function ( chip ) {
-		chip.addEventListener( 'click', function () {
-			var filter = chip.dataset.filter;
-			var value = chip.dataset.value;
-			if ( ! filter ) {
-				return;
+	function syncUrl() {
+		try {
+			var current = new URL( window.location.href );
+			if ( state.sponsorship && state.sponsorship !== SPONSORSHIP_DEFAULT ) {
+				current.searchParams.set( 'sponsorship', state.sponsorship );
+			} else {
+				current.searchParams.delete( 'sponsorship' );
 			}
-			document
-				.querySelectorAll( 'button.pledges-chip[data-filter="' + filter + '"]' )
-				.forEach( function ( c ) {
-					c.classList.remove( 'is-on' );
-				} );
-			chip.classList.add( 'is-on' );
-			state[ filter ] = value;
-			apply();
+			window.history.replaceState( null, '', current.toString() );
+		} catch ( e ) {
+			/* ignore; URL hygiene is best-effort */
+		}
+
+		// Rewrite hrefs on full-page-reload links so the next navigation keeps
+		// the sponsorship state. CSS-only chips (sponsorship) re-route through
+		// our click handler and don't need rewriting here.
+		var carryLinks = document.querySelectorAll(
+			'a.pledges-chip[data-filter="window"], .pledges-inactive-toggle a[href]'
+		);
+		carryLinks.forEach( function ( link ) {
+			try {
+				var u = new URL( link.href, window.location.origin );
+				if ( state.sponsorship && state.sponsorship !== SPONSORSHIP_DEFAULT ) {
+					u.searchParams.set( 'sponsorship', state.sponsorship );
+				} else {
+					u.searchParams.delete( 'sponsorship' );
+				}
+				link.href = u.toString();
+			} catch ( e ) {
+				/* ignore malformed hrefs */
+			}
 		} );
-	} );
+	}
+
+	/**
+	 * Set the active sponsorship value, refresh chip state, sync the URL, and
+	 * re-apply the visibility filter.
+	 */
+	function setSponsorship( value ) {
+		if ( SPONSORSHIP_ALLOWED.indexOf( value ) === -1 ) {
+			value = SPONSORSHIP_DEFAULT;
+		}
+		state.sponsorship = value;
+		document
+			.querySelectorAll( '.pledges-chip[data-filter="sponsorship"]' )
+			.forEach( function ( c ) {
+				var isActive = c.dataset.value === value;
+				c.classList.toggle( 'is-on', isActive );
+				if ( isActive ) {
+					c.setAttribute( 'aria-current', 'true' );
+				} else {
+					c.removeAttribute( 'aria-current' );
+				}
+			} );
+		syncUrl();
+		apply();
+	}
+
+	/**
+	 * Intercept sponsorship anchor chips so the filter applies instantly
+	 * without a full page reload. The href stays correct so middle-click and
+	 * "open in new tab" still produce a shareable URL.
+	 */
+	document
+		.querySelectorAll( 'a.pledges-chip[data-filter="sponsorship"]' )
+		.forEach( function ( chip ) {
+			chip.addEventListener( 'click', function ( e ) {
+				// Let modified clicks (cmd/ctrl/shift/middle) navigate normally
+				// so users can open the filtered view in a new tab.
+				if ( e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey ) {
+					return;
+				}
+				e.preventDefault();
+				setSponsorship( chip.dataset.value );
+			} );
+		} );
 
 	/**
 	 * Empty-state reset.
@@ -145,15 +221,13 @@
 	var resetBtn = document.querySelector( '.pledges-empty-reset' );
 	if ( resetBtn ) {
 		resetBtn.addEventListener( 'click', function () {
-			document
-				.querySelectorAll( '.pledges-chip[data-filter="sponsorship"]' )
-				.forEach( function ( c ) {
-					c.classList.toggle( 'is-on', c.dataset.value === 'all' );
-				} );
-			state.sponsorship = 'all';
-			apply();
+			setSponsorship( 'all' );
 		} );
 	}
 
+	// Initial paint: sync the carry-forward hrefs once even when the user
+	// hasn't toggled anything, so links rendered with no sponsorship query arg
+	// inherit one if the page was loaded with ?sponsorship= in the URL.
+	syncUrl();
 	apply();
 } )();

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/js/page-pledges.js
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/js/page-pledges.js
@@ -216,11 +216,18 @@
 		} );
 
 	/**
-	 * Empty-state reset.
+	 * Empty-state reset. Rendered as an anchor pointing at the cleared-filter URL
+	 * so JS-disabled visitors get a working escape hatch; intercept here for the
+	 * instant in-place re-filter when JS is available. Modifier clicks fall
+	 * through so "open in new tab" still produces a shareable URL.
 	 */
-	var resetBtn = document.querySelector( '.pledges-empty-reset' );
-	if ( resetBtn ) {
-		resetBtn.addEventListener( 'click', function () {
+	var resetLink = document.querySelector( '.pledges-empty-reset' );
+	if ( resetLink ) {
+		resetLink.addEventListener( 'click', function ( e ) {
+			if ( e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey ) {
+				return;
+			}
+			e.preventDefault();
 			setSponsorship( 'all' );
 		} );
 	}

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/js/page-pledges.js
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/js/page-pledges.js
@@ -155,7 +155,7 @@
 		// the sponsorship state. CSS-only chips (sponsorship) re-route through
 		// our click handler and don't need rewriting here.
 		var carryLinks = document.querySelectorAll(
-			'a.pledges-chip[data-filter="window"], .pledges-inactive-toggle a[href]'
+			'a.pledges-chip[data-filter="window"], .pledges-inactive-toggle a[href], .pledges-empty-extra a[href]'
 		);
 		carryLinks.forEach( function ( link ) {
 			try {

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
@@ -267,13 +267,6 @@ $build_pledges_url = function ( $window, $sponsorship_value ) use ( $pledges_url
 	return $args ? add_query_arg( $args, $pledges_url ) : $pledges_url;
 };
 
-// aria-current="true" on the active chip restores the semantic the <button>
-// chips used to carry implicitly; without it, screen readers announce three
-// indistinguishable links instead of "current page" on the selected filter.
-$aria_current_attr = function ( $is_active ) {
-	return $is_active ? ' aria-current="true"' : '';
-};
-
 ?>
 
 <div id="primary" class="content-area">
@@ -327,15 +320,15 @@ $aria_current_attr = function ( $is_active ) {
 						<div class="pledges-filters" role="group" aria-label="<?php esc_attr_e( 'Filter contributors', 'wporg-5ftf' ); ?>">
 							<div class="pledges-filter-group">
 								<span class="pledges-filter-label"><?php esc_html_e( 'Time window', 'wporg-5ftf' ); ?></span>
-								<a class="pledges-chip<?php echo 30 === $window_days ? ' is-on' : ''; ?>"<?php echo $aria_current_attr( 30 === $window_days ); // phpcs:ignore WordPress.Security.EscapeOutput ?> data-filter="window" data-value="30" href="<?php echo esc_url( $build_pledges_url( 30, $sponsorship ) ); ?>"><?php esc_html_e( '30 days', 'wporg-5ftf' ); ?></a>
-								<a class="pledges-chip<?php echo 90 === $window_days ? ' is-on' : ''; ?>"<?php echo $aria_current_attr( 90 === $window_days ); // phpcs:ignore WordPress.Security.EscapeOutput ?> data-filter="window" data-value="90" href="<?php echo esc_url( $build_pledges_url( 90, $sponsorship ) ); ?>"><?php esc_html_e( '90 days', 'wporg-5ftf' ); ?></a>
-								<a class="pledges-chip<?php echo 180 === $window_days ? ' is-on' : ''; ?>"<?php echo $aria_current_attr( 180 === $window_days ); // phpcs:ignore WordPress.Security.EscapeOutput ?> data-filter="window" data-value="180" href="<?php echo esc_url( $build_pledges_url( 180, $sponsorship ) ); ?>"><?php esc_html_e( '6 months', 'wporg-5ftf' ); ?></a>
+								<a class="pledges-chip<?php echo 30 === $window_days ? ' is-on' : ''; ?>"<?php echo 30 === $window_days ? ' aria-current="true"' : ''; ?> data-filter="window" data-value="30" href="<?php echo esc_url( $build_pledges_url( 30, $sponsorship ) ); ?>"><?php esc_html_e( '30 days', 'wporg-5ftf' ); ?></a>
+								<a class="pledges-chip<?php echo 90 === $window_days ? ' is-on' : ''; ?>"<?php echo 90 === $window_days ? ' aria-current="true"' : ''; ?> data-filter="window" data-value="90" href="<?php echo esc_url( $build_pledges_url( 90, $sponsorship ) ); ?>"><?php esc_html_e( '90 days', 'wporg-5ftf' ); ?></a>
+								<a class="pledges-chip<?php echo 180 === $window_days ? ' is-on' : ''; ?>"<?php echo 180 === $window_days ? ' aria-current="true"' : ''; ?> data-filter="window" data-value="180" href="<?php echo esc_url( $build_pledges_url( 180, $sponsorship ) ); ?>"><?php esc_html_e( '6 months', 'wporg-5ftf' ); ?></a>
 							</div>
 							<div class="pledges-filter-group">
 								<span class="pledges-filter-label"><?php esc_html_e( 'Sponsorship', 'wporg-5ftf' ); ?></span>
-								<a class="pledges-chip<?php echo 'all' === $sponsorship ? ' is-on' : ''; ?>"<?php echo $aria_current_attr( 'all' === $sponsorship ); // phpcs:ignore WordPress.Security.EscapeOutput ?> data-filter="sponsorship" data-value="all" href="<?php echo esc_url( $build_pledges_url( $window_days, 'all' ) ); ?>"><?php esc_html_e( 'All', 'wporg-5ftf' ); ?></a>
-								<a class="pledges-chip<?php echo 'independent' === $sponsorship ? ' is-on' : ''; ?>"<?php echo $aria_current_attr( 'independent' === $sponsorship ); // phpcs:ignore WordPress.Security.EscapeOutput ?> data-filter="sponsorship" data-value="independent" href="<?php echo esc_url( $build_pledges_url( $window_days, 'independent' ) ); ?>"><?php esc_html_e( 'Independent', 'wporg-5ftf' ); ?></a>
-								<a class="pledges-chip<?php echo 'sponsored' === $sponsorship ? ' is-on' : ''; ?>"<?php echo $aria_current_attr( 'sponsored' === $sponsorship ); // phpcs:ignore WordPress.Security.EscapeOutput ?> data-filter="sponsorship" data-value="sponsored" href="<?php echo esc_url( $build_pledges_url( $window_days, 'sponsored' ) ); ?>"><?php esc_html_e( 'Sponsored', 'wporg-5ftf' ); ?></a>
+								<a class="pledges-chip<?php echo 'all' === $sponsorship ? ' is-on' : ''; ?>"<?php echo 'all' === $sponsorship ? ' aria-current="true"' : ''; ?> data-filter="sponsorship" data-value="all" href="<?php echo esc_url( $build_pledges_url( $window_days, 'all' ) ); ?>"><?php esc_html_e( 'All', 'wporg-5ftf' ); ?></a>
+								<a class="pledges-chip<?php echo 'independent' === $sponsorship ? ' is-on' : ''; ?>"<?php echo 'independent' === $sponsorship ? ' aria-current="true"' : ''; ?> data-filter="sponsorship" data-value="independent" href="<?php echo esc_url( $build_pledges_url( $window_days, 'independent' ) ); ?>"><?php esc_html_e( 'Independent', 'wporg-5ftf' ); ?></a>
+								<a class="pledges-chip<?php echo 'sponsored' === $sponsorship ? ' is-on' : ''; ?>"<?php echo 'sponsored' === $sponsorship ? ' aria-current="true"' : ''; ?> data-filter="sponsorship" data-value="sponsored" href="<?php echo esc_url( $build_pledges_url( $window_days, 'sponsored' ) ); ?>"><?php esc_html_e( 'Sponsored', 'wporg-5ftf' ); ?></a>
 							</div>
 						</div>
 					</div>
@@ -381,25 +374,27 @@ $aria_current_attr = function ( $is_active ) {
 							require __DIR__ . '/content-pledge.php';
 						}
 
-						if ( $show_inactive && $inactive_contributors ) {
-							// Hide the divider when the sponsorship filter has emptied its
-							// section so JS-disabled visitors don't see an orphan label above
-							// nothing. JS apply() will toggle this back on if the filter changes.
-							$divider_hidden = 0 === $visible_inactive_count ? ' hidden' : '';
+						if ( $show_inactive && $inactive_contributors ) :
 							$inactive_label = sprintf(
 								/* translators: 1: count, 2: window in days */
 								_n( '%1$d contributor with no verified contributions in the last %2$d days', '%1$d contributors with no verified contributions in the last %2$d days', $inactive_count, 'wporg-5ftf' ),
 								$inactive_count,
 								$window_days
 							);
-							echo '<div class="pledges-inactive-divider"' . esc_attr( $divider_hidden ) . '><span>' . esc_html( $inactive_label ) . '</span></div>';
-
+							// Hide the divider when the sponsorship filter has emptied its
+							// section so JS-disabled visitors don't see an orphan label above
+							// nothing. JS apply() will toggle this back on if the filter changes.
+							?>
+							<div class="pledges-inactive-divider"<?php echo 0 === $visible_inactive_count ? ' hidden' : ''; ?>>
+								<span><?php echo esc_html( $inactive_label ); ?></span>
+							</div>
+							<?php
 							foreach ( $inactive_contributors as $contributor ) {
 								$rank++;
 								$contributor['_rank'] = $rank;
 								require __DIR__ . '/content-pledge.php';
 							}
-						}
+						endif;
 						?>
 					</div>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
@@ -202,8 +202,21 @@ foreach ( $contributors as $uid => $c ) {
 // `?show_inactive=1` opt-in to render inactive ones too (still beneath the active list).
 $show_inactive = ! empty( $_GET['show_inactive'] );
 
+// Sponsorship filter is URL-driven so the view is bookmarkable and survives
+// time-window navigations (the window chips are full-page reloads). Default
+// matches the historical JS default so existing links don't shift meaning.
+$sponsorship_default = 'independent';
+$sponsorship_allowed = array( 'all', 'independent', 'sponsored' );
+// is_string() guard before sanitize_key(): a URL like ?sponsorship[]=foo makes
+// $_GET['sponsorship'] an array, which would TypeError sanitize_key() on PHP 8
+// and 500 the page.
+$sponsorship_raw = isset( $_GET['sponsorship'] ) ? wp_unslash( $_GET['sponsorship'] ) : '';
+$sponsorship     = is_string( $sponsorship_raw ) ? sanitize_key( $sponsorship_raw ) : '';
+if ( ! in_array( $sponsorship, $sponsorship_allowed, true ) ) {
+	$sponsorship = $sponsorship_default;
+}
+
 $total_count       = count( $contributors );
-$active_count      = count( $active_contributors );
 $inactive_count    = count( $inactive_contributors );
 $independent_count = 0;
 $sponsored_count   = 0;
@@ -212,6 +225,17 @@ foreach ( $contributors as $c ) {
 		$sponsored_count++;
 	} else {
 		$independent_count++;
+	}
+}
+
+// Visible active count under the current sponsorship filter, so the initial
+// render's "N active contributors" matches what the user actually sees and
+// doesn't twitch when the JS recomputes after hydration.
+$visible_active_count = 0;
+foreach ( $active_contributors as $c ) {
+	$row_sponsorship = empty( $c['sponsored'] ) ? 'independent' : 'sponsored';
+	if ( 'all' === $sponsorship || $row_sponsorship === $sponsorship ) {
+		$visible_active_count++;
 	}
 }
 
@@ -266,27 +290,46 @@ foreach ( $contributors as $c ) {
 
 					<div class="pledges-toolbar">
 						<div class="pledges-filters" role="group" aria-label="<?php esc_attr_e( 'Filter contributors', 'wporg-5ftf' ); ?>">
+							<?php
+							// home_url('/pledges/') already includes the team site path, so no REQUEST_URI concat needed.
+							// Each filter group's links carry the *other* groups' state forward so switching one
+							// dimension doesn't silently reset the others (see issue #374).
+							$pledges_url = home_url( '/pledges/' );
+							$default_w   = ContributionMetrics\WINDOW_DAYS_DEFAULT;
+
+							$build_pledges_url = function ( $window, $sponsorship_value ) use ( $pledges_url, $default_w, $show_inactive, $sponsorship_default ) {
+								$args = array();
+								if ( $window !== $default_w ) {
+									$args['window'] = $window;
+								}
+								if ( $sponsorship_value !== $sponsorship_default ) {
+									$args['sponsorship'] = $sponsorship_value;
+								}
+								if ( $show_inactive ) {
+									$args['show_inactive'] = 1;
+								}
+								return $args ? add_query_arg( $args, $pledges_url ) : $pledges_url;
+							};
+							?>
+							<?php
+							// aria-current="true" on the active chip restores the semantic the <button>
+							// chips used to carry implicitly; without it, screen readers announce three
+							// indistinguishable links instead of "current page" on the selected filter.
+							$aria_current = function ( $is_active ) {
+								return $is_active ? ' aria-current="true"' : '';
+							};
+							?>
 							<div class="pledges-filter-group">
 								<span class="pledges-filter-label"><?php esc_html_e( 'Time window', 'wporg-5ftf' ); ?></span>
-								<?php
-								// home_url('/pledges/') already includes the team site path, so no REQUEST_URI concat needed.
-								// Carry show_inactive forward so changing the window doesn't silently collapse the inactive list.
-								$pledges_url   = home_url( '/pledges/' );
-								$base_url      = $show_inactive ? add_query_arg( 'show_inactive', '1', $pledges_url ) : $pledges_url;
-								$default_w     = ContributionMetrics\WINDOW_DAYS_DEFAULT;
-								$url_for_30    = 30 === $default_w ? $base_url : add_query_arg( 'window', 30, $base_url );
-								$url_for_90    = 90 === $default_w ? $base_url : add_query_arg( 'window', 90, $base_url );
-								$url_for_180   = 180 === $default_w ? $base_url : add_query_arg( 'window', 180, $base_url );
-								?>
-								<a class="pledges-chip<?php echo 30 === $window_days ? ' is-on' : ''; ?>" href="<?php echo esc_url( $url_for_30 ); ?>"><?php esc_html_e( '30 days', 'wporg-5ftf' ); ?></a>
-								<a class="pledges-chip<?php echo 90 === $window_days ? ' is-on' : ''; ?>" href="<?php echo esc_url( $url_for_90 ); ?>"><?php esc_html_e( '90 days', 'wporg-5ftf' ); ?></a>
-								<a class="pledges-chip<?php echo 180 === $window_days ? ' is-on' : ''; ?>" href="<?php echo esc_url( $url_for_180 ); ?>"><?php esc_html_e( '6 months', 'wporg-5ftf' ); ?></a>
+								<a class="pledges-chip<?php echo 30 === $window_days ? ' is-on' : ''; ?>"<?php echo $aria_current( 30 === $window_days ); // phpcs:ignore WordPress.Security.EscapeOutput ?> data-filter="window" data-value="30" href="<?php echo esc_url( $build_pledges_url( 30, $sponsorship ) ); ?>"><?php esc_html_e( '30 days', 'wporg-5ftf' ); ?></a>
+								<a class="pledges-chip<?php echo 90 === $window_days ? ' is-on' : ''; ?>"<?php echo $aria_current( 90 === $window_days ); // phpcs:ignore WordPress.Security.EscapeOutput ?> data-filter="window" data-value="90" href="<?php echo esc_url( $build_pledges_url( 90, $sponsorship ) ); ?>"><?php esc_html_e( '90 days', 'wporg-5ftf' ); ?></a>
+								<a class="pledges-chip<?php echo 180 === $window_days ? ' is-on' : ''; ?>"<?php echo $aria_current( 180 === $window_days ); // phpcs:ignore WordPress.Security.EscapeOutput ?> data-filter="window" data-value="180" href="<?php echo esc_url( $build_pledges_url( 180, $sponsorship ) ); ?>"><?php esc_html_e( '6 months', 'wporg-5ftf' ); ?></a>
 							</div>
 							<div class="pledges-filter-group">
 								<span class="pledges-filter-label"><?php esc_html_e( 'Sponsorship', 'wporg-5ftf' ); ?></span>
-								<button type="button" class="pledges-chip" data-filter="sponsorship" data-value="all"><?php esc_html_e( 'All', 'wporg-5ftf' ); ?></button>
-								<button type="button" class="pledges-chip is-on" data-filter="sponsorship" data-value="independent"><?php esc_html_e( 'Independent', 'wporg-5ftf' ); ?></button>
-								<button type="button" class="pledges-chip" data-filter="sponsorship" data-value="sponsored"><?php esc_html_e( 'Sponsored', 'wporg-5ftf' ); ?></button>
+								<a class="pledges-chip<?php echo 'all' === $sponsorship ? ' is-on' : ''; ?>"<?php echo $aria_current( 'all' === $sponsorship ); // phpcs:ignore WordPress.Security.EscapeOutput ?> data-filter="sponsorship" data-value="all" href="<?php echo esc_url( $build_pledges_url( $window_days, 'all' ) ); ?>"><?php esc_html_e( 'All', 'wporg-5ftf' ); ?></a>
+								<a class="pledges-chip<?php echo 'independent' === $sponsorship ? ' is-on' : ''; ?>"<?php echo $aria_current( 'independent' === $sponsorship ); // phpcs:ignore WordPress.Security.EscapeOutput ?> data-filter="sponsorship" data-value="independent" href="<?php echo esc_url( $build_pledges_url( $window_days, 'independent' ) ); ?>"><?php esc_html_e( 'Independent', 'wporg-5ftf' ); ?></a>
+								<a class="pledges-chip<?php echo 'sponsored' === $sponsorship ? ' is-on' : ''; ?>"<?php echo $aria_current( 'sponsored' === $sponsorship ); // phpcs:ignore WordPress.Security.EscapeOutput ?> data-filter="sponsorship" data-value="sponsored" href="<?php echo esc_url( $build_pledges_url( $window_days, 'sponsored' ) ); ?>"><?php esc_html_e( 'Sponsored', 'wporg-5ftf' ); ?></a>
 							</div>
 						</div>
 					</div>
@@ -304,11 +347,10 @@ foreach ( $contributors as $c ) {
 						<?php
 						// The result phrase is a JS-controlled template so the singular/plural
 						// form follows the visible-card count after client-side filtering, instead
-						// of being baked at render time against $active_count and drifting (e.g.
-						// "1 active contributors").
+						// of being baked at render time and drifting (e.g. "1 active contributors").
 						?>
-						<span class="pledges-result-count">
-							<span id="pledges-result-count"><?php echo esc_html( $active_count ); ?></span>
+						<span class="pledges-result-count" aria-live="polite">
+							<span id="pledges-result-count"><?php echo esc_html( $visible_active_count ); ?></span>
 							<span
 								id="pledges-result-phrase"
 								data-singular="<?php echo esc_attr__( 'active contributor (of %d total)', 'wporg-5ftf' ); ?>"
@@ -317,7 +359,7 @@ foreach ( $contributors as $c ) {
 							><?php
 								echo esc_html( sprintf(
 									/* translators: %d: total count */
-									_n( 'active contributor (of %d total)', 'active contributors (of %d total)', $active_count, 'wporg-5ftf' ),
+									_n( 'active contributor (of %d total)', 'active contributors (of %d total)', $visible_active_count, 'wporg-5ftf' ),
 									$total_count
 								) );
 								?></span>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
@@ -409,7 +409,7 @@ $build_pledges_url = function ( $window, $sponsorship_value ) use ( $pledges_url
 					?>
 					<div class="pledges-empty" id="pledges-empty"<?php echo $empty_initially_visible ? '' : ' hidden'; ?>>
 						<p><?php esc_html_e( 'No contributors match the selected filters.', 'wporg-5ftf' ); ?></p>
-						<button type="button" class="pledges-empty-reset"><?php esc_html_e( 'Clear filters', 'wporg-5ftf' ); ?></button>
+						<a class="pledges-empty-reset" href="<?php echo esc_url( $build_pledges_url( $window_days, 'all' ) ); ?>"><?php esc_html_e( 'Clear filters', 'wporg-5ftf' ); ?></a>
 					</div>
 
 					<?php if ( $inactive_contributors ) : ?>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
@@ -231,13 +231,48 @@ foreach ( $contributors as $c ) {
 // Visible active count under the current sponsorship filter, so the initial
 // render's "N active contributors" matches what the user actually sees and
 // doesn't twitch when the JS recomputes after hydration.
-$visible_active_count = 0;
+$visible_active_count   = 0;
+$visible_inactive_count = 0;
 foreach ( $active_contributors as $c ) {
 	$row_sponsorship = empty( $c['sponsored'] ) ? 'independent' : 'sponsored';
 	if ( 'all' === $sponsorship || $row_sponsorship === $sponsorship ) {
 		$visible_active_count++;
 	}
 }
+foreach ( $inactive_contributors as $c ) {
+	$row_sponsorship = empty( $c['sponsored'] ) ? 'independent' : 'sponsored';
+	if ( 'all' === $sponsorship || $row_sponsorship === $sponsorship ) {
+		$visible_inactive_count++;
+	}
+}
+
+// Chip URL builder. home_url('/pledges/') already includes the team site path,
+// so no REQUEST_URI concat needed. Each filter group's links carry the *other*
+// groups' state forward so switching one dimension doesn't silently reset the
+// others (see issue #374).
+$pledges_url = home_url( '/pledges/' );
+$default_w   = ContributionMetrics\WINDOW_DAYS_DEFAULT;
+
+$build_pledges_url = function ( $window, $sponsorship_value ) use ( $pledges_url, $default_w, $show_inactive, $sponsorship_default ) {
+	$args = array();
+	if ( $window !== $default_w ) {
+		$args['window'] = $window;
+	}
+	if ( $sponsorship_value !== $sponsorship_default ) {
+		$args['sponsorship'] = $sponsorship_value;
+	}
+	if ( $show_inactive ) {
+		$args['show_inactive'] = 1;
+	}
+	return $args ? add_query_arg( $args, $pledges_url ) : $pledges_url;
+};
+
+// aria-current="true" on the active chip restores the semantic the <button>
+// chips used to carry implicitly; without it, screen readers announce three
+// indistinguishable links instead of "current page" on the selected filter.
+$aria_current_attr = function ( $is_active ) {
+	return $is_active ? ' aria-current="true"' : '';
+};
 
 ?>
 
@@ -290,46 +325,17 @@ foreach ( $active_contributors as $c ) {
 
 					<div class="pledges-toolbar">
 						<div class="pledges-filters" role="group" aria-label="<?php esc_attr_e( 'Filter contributors', 'wporg-5ftf' ); ?>">
-							<?php
-							// home_url('/pledges/') already includes the team site path, so no REQUEST_URI concat needed.
-							// Each filter group's links carry the *other* groups' state forward so switching one
-							// dimension doesn't silently reset the others (see issue #374).
-							$pledges_url = home_url( '/pledges/' );
-							$default_w   = ContributionMetrics\WINDOW_DAYS_DEFAULT;
-
-							$build_pledges_url = function ( $window, $sponsorship_value ) use ( $pledges_url, $default_w, $show_inactive, $sponsorship_default ) {
-								$args = array();
-								if ( $window !== $default_w ) {
-									$args['window'] = $window;
-								}
-								if ( $sponsorship_value !== $sponsorship_default ) {
-									$args['sponsorship'] = $sponsorship_value;
-								}
-								if ( $show_inactive ) {
-									$args['show_inactive'] = 1;
-								}
-								return $args ? add_query_arg( $args, $pledges_url ) : $pledges_url;
-							};
-							?>
-							<?php
-							// aria-current="true" on the active chip restores the semantic the <button>
-							// chips used to carry implicitly; without it, screen readers announce three
-							// indistinguishable links instead of "current page" on the selected filter.
-							$aria_current = function ( $is_active ) {
-								return $is_active ? ' aria-current="true"' : '';
-							};
-							?>
 							<div class="pledges-filter-group">
 								<span class="pledges-filter-label"><?php esc_html_e( 'Time window', 'wporg-5ftf' ); ?></span>
-								<a class="pledges-chip<?php echo 30 === $window_days ? ' is-on' : ''; ?>"<?php echo $aria_current( 30 === $window_days ); // phpcs:ignore WordPress.Security.EscapeOutput ?> data-filter="window" data-value="30" href="<?php echo esc_url( $build_pledges_url( 30, $sponsorship ) ); ?>"><?php esc_html_e( '30 days', 'wporg-5ftf' ); ?></a>
-								<a class="pledges-chip<?php echo 90 === $window_days ? ' is-on' : ''; ?>"<?php echo $aria_current( 90 === $window_days ); // phpcs:ignore WordPress.Security.EscapeOutput ?> data-filter="window" data-value="90" href="<?php echo esc_url( $build_pledges_url( 90, $sponsorship ) ); ?>"><?php esc_html_e( '90 days', 'wporg-5ftf' ); ?></a>
-								<a class="pledges-chip<?php echo 180 === $window_days ? ' is-on' : ''; ?>"<?php echo $aria_current( 180 === $window_days ); // phpcs:ignore WordPress.Security.EscapeOutput ?> data-filter="window" data-value="180" href="<?php echo esc_url( $build_pledges_url( 180, $sponsorship ) ); ?>"><?php esc_html_e( '6 months', 'wporg-5ftf' ); ?></a>
+								<a class="pledges-chip<?php echo 30 === $window_days ? ' is-on' : ''; ?>"<?php echo $aria_current_attr( 30 === $window_days ); // phpcs:ignore WordPress.Security.EscapeOutput ?> data-filter="window" data-value="30" href="<?php echo esc_url( $build_pledges_url( 30, $sponsorship ) ); ?>"><?php esc_html_e( '30 days', 'wporg-5ftf' ); ?></a>
+								<a class="pledges-chip<?php echo 90 === $window_days ? ' is-on' : ''; ?>"<?php echo $aria_current_attr( 90 === $window_days ); // phpcs:ignore WordPress.Security.EscapeOutput ?> data-filter="window" data-value="90" href="<?php echo esc_url( $build_pledges_url( 90, $sponsorship ) ); ?>"><?php esc_html_e( '90 days', 'wporg-5ftf' ); ?></a>
+								<a class="pledges-chip<?php echo 180 === $window_days ? ' is-on' : ''; ?>"<?php echo $aria_current_attr( 180 === $window_days ); // phpcs:ignore WordPress.Security.EscapeOutput ?> data-filter="window" data-value="180" href="<?php echo esc_url( $build_pledges_url( 180, $sponsorship ) ); ?>"><?php esc_html_e( '6 months', 'wporg-5ftf' ); ?></a>
 							</div>
 							<div class="pledges-filter-group">
 								<span class="pledges-filter-label"><?php esc_html_e( 'Sponsorship', 'wporg-5ftf' ); ?></span>
-								<a class="pledges-chip<?php echo 'all' === $sponsorship ? ' is-on' : ''; ?>"<?php echo $aria_current( 'all' === $sponsorship ); // phpcs:ignore WordPress.Security.EscapeOutput ?> data-filter="sponsorship" data-value="all" href="<?php echo esc_url( $build_pledges_url( $window_days, 'all' ) ); ?>"><?php esc_html_e( 'All', 'wporg-5ftf' ); ?></a>
-								<a class="pledges-chip<?php echo 'independent' === $sponsorship ? ' is-on' : ''; ?>"<?php echo $aria_current( 'independent' === $sponsorship ); // phpcs:ignore WordPress.Security.EscapeOutput ?> data-filter="sponsorship" data-value="independent" href="<?php echo esc_url( $build_pledges_url( $window_days, 'independent' ) ); ?>"><?php esc_html_e( 'Independent', 'wporg-5ftf' ); ?></a>
-								<a class="pledges-chip<?php echo 'sponsored' === $sponsorship ? ' is-on' : ''; ?>"<?php echo $aria_current( 'sponsored' === $sponsorship ); // phpcs:ignore WordPress.Security.EscapeOutput ?> data-filter="sponsorship" data-value="sponsored" href="<?php echo esc_url( $build_pledges_url( $window_days, 'sponsored' ) ); ?>"><?php esc_html_e( 'Sponsored', 'wporg-5ftf' ); ?></a>
+								<a class="pledges-chip<?php echo 'all' === $sponsorship ? ' is-on' : ''; ?>"<?php echo $aria_current_attr( 'all' === $sponsorship ); // phpcs:ignore WordPress.Security.EscapeOutput ?> data-filter="sponsorship" data-value="all" href="<?php echo esc_url( $build_pledges_url( $window_days, 'all' ) ); ?>"><?php esc_html_e( 'All', 'wporg-5ftf' ); ?></a>
+								<a class="pledges-chip<?php echo 'independent' === $sponsorship ? ' is-on' : ''; ?>"<?php echo $aria_current_attr( 'independent' === $sponsorship ); // phpcs:ignore WordPress.Security.EscapeOutput ?> data-filter="sponsorship" data-value="independent" href="<?php echo esc_url( $build_pledges_url( $window_days, 'independent' ) ); ?>"><?php esc_html_e( 'Independent', 'wporg-5ftf' ); ?></a>
+								<a class="pledges-chip<?php echo 'sponsored' === $sponsorship ? ' is-on' : ''; ?>"<?php echo $aria_current_attr( 'sponsored' === $sponsorship ); // phpcs:ignore WordPress.Security.EscapeOutput ?> data-filter="sponsorship" data-value="sponsored" href="<?php echo esc_url( $build_pledges_url( $window_days, 'sponsored' ) ); ?>"><?php esc_html_e( 'Sponsored', 'wporg-5ftf' ); ?></a>
 							</div>
 						</div>
 					</div>
@@ -376,13 +382,17 @@ foreach ( $active_contributors as $c ) {
 						}
 
 						if ( $show_inactive && $inactive_contributors ) {
+							// Hide the divider when the sponsorship filter has emptied its
+							// section so JS-disabled visitors don't see an orphan label above
+							// nothing. JS apply() will toggle this back on if the filter changes.
+							$divider_hidden = 0 === $visible_inactive_count ? ' hidden' : '';
 							$inactive_label = sprintf(
 								/* translators: 1: count, 2: window in days */
 								_n( '%1$d contributor with no verified contributions in the last %2$d days', '%1$d contributors with no verified contributions in the last %2$d days', $inactive_count, 'wporg-5ftf' ),
 								$inactive_count,
 								$window_days
 							);
-							echo '<div class="pledges-inactive-divider"><span>' . esc_html( $inactive_label ) . '</span></div>';
+							echo '<div class="pledges-inactive-divider"' . esc_attr( $divider_hidden ) . '><span>' . esc_html( $inactive_label ) . '</span></div>';
 
 							foreach ( $inactive_contributors as $contributor ) {
 								$rank++;
@@ -393,7 +403,16 @@ foreach ( $active_contributors as $c ) {
 						?>
 					</div>
 
-					<div class="pledges-empty" id="pledges-empty" hidden>
+					<?php
+					// Pre-show the empty state when the sponsorship filter has hidden every
+					// card the server would have rendered. Otherwise a JS-disabled visitor
+					// with ?sponsorship=sponsored on an all-independent team would see a
+					// blank grid and no explanation. JS apply() will hide this again if a
+					// later filter change brings cards back.
+					$visible_inactive_for_empty = $show_inactive ? $visible_inactive_count : 0;
+					$empty_initially_visible    = 0 === ( $visible_active_count + $visible_inactive_for_empty );
+					?>
+					<div class="pledges-empty" id="pledges-empty"<?php echo $empty_initially_visible ? '' : ' hidden'; ?>>
 						<p><?php esc_html_e( 'No contributors match the selected filters.', 'wporg-5ftf' ); ?></p>
 						<button type="button" class="pledges-empty-reset"><?php esc_html_e( 'Clear filters', 'wporg-5ftf' ); ?></button>
 					</div>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
@@ -73,7 +73,7 @@ if ( ! ContributionMetrics\team_has_tracking_data( $current_team->post_name ) ) 
 							<?php
 							echo wp_kses_data( sprintf(
 								/* translators: %s: team name */
-								__( 'We don\'t yet have automated contribution tracking for the <strong>%s</strong> team. Sponsors, recruiters, and team reps can\'t see who is shipping verified work — only a list of people who opted in.', 'wporg-5ftf' ),
+								__( 'We don\'t yet have automated contribution tracking for the <strong>%s</strong> team. Sponsors, recruiters, and team reps can\'t see who is shipping tracked work — only a list of people who opted in.', 'wporg-5ftf' ),
 								esc_html( $current_team->post_title )
 							) );
 							?>
@@ -111,7 +111,7 @@ if ( ! ContributionMetrics\team_has_tracking_data( $current_team->post_name ) ) 
 
 						<li class="pledges-guide-step">
 							<h3><?php esc_html_e( 'Propose a metrics discussion', 'wporg-5ftf' ); ?></h3>
-							<p><?php esc_html_e( 'Once you have earned standing in the team, propose a discussion (in a meeting or async) to define what counts as a verified contribution. What types of work? What weights? Which signals should be tracked, and which intentionally ignored?', 'wporg-5ftf' ); ?></p>
+							<p><?php esc_html_e( 'Once you have earned standing in the team, propose a discussion (in a meeting or async) to define what counts as a tracked contribution. What types of work? What impact levels? Which signals should be tracked, and which intentionally ignored?', 'wporg-5ftf' ); ?></p>
 						</li>
 
 						<li class="pledges-guide-step">
@@ -291,7 +291,7 @@ $build_pledges_url = function ( $window, $sponsorship_value ) use ( $pledges_url
 						<div class="pledges-howitworks-body">
 							<strong><?php esc_html_e( 'How this page works', 'wporg-5ftf' ); ?></strong>
 							<p>
-								<?php esc_html_e( 'Contributors are ranked by weighted recent activity, not by pledged hours. Signals come from Trac props (release credits) and GitHub activity (merged PRs, pushes, closed issues), bucketed into high, medium, and low weight. Low-weight contributions (typo fixes, whitespace) don\'t factor into the ranking. Inactive contributors decay down the list automatically.', 'wporg-5ftf' ); ?>
+								<?php esc_html_e( 'Contributors are ranked by recent contribution impact, not by pledged hours. Activity is tracked from release credits in Trac and GitHub work (merged PRs, pushes, closed issues), sorted into high, medium, and low impact. Low-impact contributions (typo fixes, whitespace) don\'t factor into the ranking. Inactive contributors gradually drop down the list.', 'wporg-5ftf' ); ?>
 							</p>
 						</div>
 						<button type="button" class="pledges-howitworks-dismiss" aria-label="<?php esc_attr_e( 'Dismiss', 'wporg-5ftf' ); ?>">&times;</button>
@@ -305,7 +305,7 @@ $build_pledges_url = function ( $window, $sponsorship_value ) use ( $pledges_url
 							// scopes the rank line below, not this banner. Don't conflate the two.
 							echo wp_kses_data( sprintf(
 								/* translators: %s: team name */
-								__( 'opted-in contributors to %s.', 'wporg-5ftf' ),
+								__( 'contributors to %s.', 'wporg-5ftf' ),
 								'<strong>' . esc_html( $current_team->post_title ) . '</strong>'
 							) );
 							?>
@@ -338,7 +338,7 @@ $build_pledges_url = function ( $window, $sponsorship_value ) use ( $pledges_url
 							<?php
 							echo esc_html( sprintf(
 								/* translators: %d: window in days */
-								__( 'Ranked by weighted volume, last %d days.', 'wporg-5ftf' ),
+								__( 'Ranked by impact, last %d days.', 'wporg-5ftf' ),
 								$window_days
 							) );
 							?>
@@ -377,7 +377,7 @@ $build_pledges_url = function ( $window, $sponsorship_value ) use ( $pledges_url
 						if ( $show_inactive && $inactive_contributors ) :
 							$inactive_label = sprintf(
 								/* translators: 1: count, 2: window in days */
-								_n( '%1$d contributor with no verified contributions in the last %2$d days', '%1$d contributors with no verified contributions in the last %2$d days', $inactive_count, 'wporg-5ftf' ),
+								_n( '%1$d contributor with no tracked contributions in the last %2$d days', '%1$d contributors with no tracked contributions in the last %2$d days', $inactive_count, 'wporg-5ftf' ),
 								$inactive_count,
 								$window_days
 							);
@@ -412,7 +412,30 @@ $build_pledges_url = function ( $window, $sponsorship_value ) use ( $pledges_url
 						<a class="pledges-empty-reset" href="<?php echo esc_url( $build_pledges_url( $window_days, 'all' ) ); ?>"><?php esc_html_e( 'Clear filters', 'wporg-5ftf' ); ?></a>
 					</div>
 
-					<?php if ( $inactive_contributors ) : ?>
+					<?php if ( $inactive_contributors && ! $show_inactive ) : ?>
+						<p class="pledges-empty-extra">
+							<a href="<?php echo esc_url( add_query_arg( 'show_inactive', '1' ) ); ?>">
+								<?php
+								echo esc_html( sprintf(
+									/* translators: 1: count, 2: window in days */
+									_n( 'Show %1$d contributor with no tracked contributions in the last %2$d days', 'Show %1$d contributors with no tracked contributions in the last %2$d days', $inactive_count, 'wporg-5ftf' ),
+									$inactive_count,
+									$window_days
+								) );
+								?>
+							</a>
+						</p>
+					<?php endif; ?>
+
+					<?php
+					// Standalone inactive toggle: only renders when there's a visible active
+					// section to anchor it to (or when inactive is already shown, so the user
+					// can hide it). When the visible active count is 0 the empty state above
+					// already carries the "Show inactive" suggestion via pledges-empty-extra,
+					// so showing the standalone toggle below would just duplicate the CTA.
+					$show_standalone_toggle = $inactive_contributors && ( $visible_active_count > 0 || $show_inactive );
+					?>
+					<?php if ( $show_standalone_toggle ) : ?>
 						<p class="pledges-inactive-toggle">
 							<?php if ( $show_inactive ) : ?>
 								<a href="<?php echo esc_url( remove_query_arg( 'show_inactive' ) ); ?>">
@@ -429,7 +452,7 @@ $build_pledges_url = function ( $window, $sponsorship_value ) use ( $pledges_url
 									<?php
 									echo esc_html( sprintf(
 										/* translators: 1: count, 2: window in days */
-										_n( 'Show %1$d contributor with no verified contributions in the last %2$d days', 'Show %1$d contributors with no verified contributions in the last %2$d days', $inactive_count, 'wporg-5ftf' ),
+										_n( 'Show %1$d contributor with no tracked contributions in the last %2$d days', 'Show %1$d contributors with no tracked contributions in the last %2$d days', $inactive_count, 'wporg-5ftf' ),
 										$inactive_count,
 										$window_days
 									) );

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
@@ -375,10 +375,13 @@ $build_pledges_url = function ( $window, $sponsorship_value ) use ( $pledges_url
 						}
 
 						if ( $show_inactive && $inactive_contributors ) :
+							// Label reflects the *visible* inactive count under the current
+							// sponsorship filter, otherwise "10 contributors with no tracked
+							// contributions" sits above 2 cards when the filter hides the rest.
 							$inactive_label = sprintf(
 								/* translators: 1: count, 2: window in days */
-								_n( '%1$d contributor with no tracked contributions in the last %2$d days', '%1$d contributors with no tracked contributions in the last %2$d days', $inactive_count, 'wporg-5ftf' ),
-								$inactive_count,
+								_n( '%1$d contributor with no tracked contributions in the last %2$d days', '%1$d contributors with no tracked contributions in the last %2$d days', $visible_inactive_count, 'wporg-5ftf' ),
+								$visible_inactive_count,
 								$window_days
 							);
 							// Hide the divider when the sponsorship filter has emptied its
@@ -412,7 +415,15 @@ $build_pledges_url = function ( $window, $sponsorship_value ) use ( $pledges_url
 						<a class="pledges-empty-reset" href="<?php echo esc_url( $build_pledges_url( $window_days, 'all' ) ); ?>"><?php esc_html_e( 'Clear filters', 'wporg-5ftf' ); ?></a>
 					</div>
 
-					<?php if ( $inactive_contributors && ! $show_inactive ) : ?>
+					<?php
+					// Empty-state companion CTA: only render when the empty state itself is
+					// showing (visible_active_count === 0 && !show_inactive). Without the
+					// visible_active_count gate this would also render alongside the
+					// standalone inactive toggle below when the grid has visible cards,
+					// producing two "Show inactive" CTAs on the same page.
+					$show_empty_extra = $inactive_contributors && ! $show_inactive && 0 === $visible_active_count;
+					?>
+					<?php if ( $show_empty_extra ) : ?>
 						<p class="pledges-empty-extra">
 							<a href="<?php echo esc_url( add_query_arg( 'show_inactive', '1' ) ); ?>">
 								<?php


### PR DESCRIPTION
## Summary

Fixes [WordPress/five-for-the-future#374](https://github.com/WordPress/five-for-the-future/issues/374).

On the redesigned `/pledges/` directory (introduced in #616), the two filter groups behaved inconsistently:

- **Time window** chips (30 / 90 / 180 days) were `<a>` links — selection lived in the URL (`?window=`).
- **Sponsorship** chips (All / Independent / Sponsored) were `<button>` toggles — selection was JS-only, not bookmarkable, and snapped back to the default "Independent" on every time-window navigation.

## What changed

- `?sponsorship=all|independent|sponsored` is now read server-side in `page-pledges.php` (with an `is_string()` guard before `sanitize_key()` so an array-typed `$_GET` can't 500 the page on PHP 8) and validated against an allow-list.
- A single `$build_pledges_url($window, $sponsorship)` closure builds every chip URL. Each filter group's links carry the *other* group's state forward (plus `show_inactive`), so switching window keeps sponsorship and vice versa.
- Sponsorship chips render as `<a>` links with the right `is-on` class and `aria-current="true"` on the active chip in both groups. Cards get the `hidden` attribute server-side from `$sponsorship`, eliminating the JS flash on initial paint. The initial "N active contributors" count is computed against the URL filter so it doesn't twitch after hydration.
- `js/page-pledges.js` seeds `state.sponsorship` from the server-rendered `is-on` chip (PHP is the single source of truth), intercepts sponsorship anchor clicks for an instant in-place re-filter, uses `history.replaceState` to keep the URL in sync, and rewrites the hrefs of sibling links (time-window chips, `show_inactive` toggle) so a subsequent full-page reload preserves sponsorship. Modified clicks (cmd/ctrl/shift/middle) fall through so "open in new tab" lands on a real shareable URL. State value is allow-listed on read and on every set. Result-count region gets `aria-live="polite"`.

## Acceptance criteria (from the issue)

- [x] Visiting `/pledges/?window=90&sponsorship=sponsored` lands directly on that view.
- [x] Clicking 30 days while Sponsored is selected keeps Sponsored selected.
- [x] Clicking Independent while viewing 90 days keeps 90 days selected.
- [x] The active chip in each group matches the query string on initial render, with no client-side flash.

## Test plan

- [ ] Load `/pledges/?window=180&sponsorship=sponsored` on a team with tracking (e.g. `/core/pledges/`) — verify the 180-days and Sponsored chips are active and only sponsored cards render on first paint with JS disabled.
- [ ] With JS enabled, toggle each sponsorship chip — verify URL updates to `?sponsorship=…` via `replaceState` (or drops the arg when "Independent"), card visibility re-filters instantly, and re-rank starts at 01.
- [ ] After toggling sponsorship via JS, click a time-window chip — verify the sponsorship value is preserved across the reload.
- [ ] Verify the `Show N inactive contributors` toggle carries both `?window=` and `?sponsorship=` forward.
- [ ] Confirm screen reader announces the active chip (aria-current) and the visible count change (aria-live).
- [ ] Send `?sponsorship[]=foo` and `?sponsorship=garbage` — both should coerce to the default and render normally (no 500).