### PR TITLE
ServeHappy: Bump minimum WordPress supported PHP to 7.4

### DIFF
--- a/wordpress.org/public_html/wp-content/mu-plugins/pub/servehappy-config.php
+++ b/wordpress.org/public_html/wp-content/mu-plugins/pub/servehappy-config.php
@@ -13,7 +13,7 @@ namespace WordPressdotorg\API\Serve_Happy;
 define( 'RECOMMENDED_PHP', '8.3' );
 
 // The oldest branch of PHP which WordPress core still works with.
-define( 'MINIMUM_PHP', '7.2.24' );
+define( 'MINIMUM_PHP', '7.4' );
 
 // The lowest branch of PHP which is actively supported.
 define( 'SUPPORTED_PHP', '8.3' );


### PR DESCRIPTION
Ref: https://make.wordpress.org/core/2026/01/09/dropping-support-for-php-7-2-and-7-3/

Previously: https://meta.trac.wordpress.org/changeset/13936