### PR TITLE
Credits Shortcode: Remove trailing double slash from profile URLs

### DIFF
--- a/api.wordpress.org/public_html/core/credits/shortcode.php
+++ b/api.wordpress.org/public_html/core/credits/shortcode.php
@@ -54,7 +54,7 @@ function wporg_wordpress_credits_shortcode( $attrs ) {
 	asort( $props, SORT_FLAG_CASE | SORT_STRING );
 	$output = array();
 	foreach ( $props as $username => $name ) {
-		$output[] = '<a href="' . sprintf( $results['data']['profiles'], $username ) . '/">' . $name . '</a>';
+		$output[] = '<a href="' . sprintf( $results['data']['profiles'], $username ) . '">' . $name . '</a>';
 	}
 
 	$container_atts = '';


### PR DESCRIPTION
## Summary
- The `[wpcredits]` shortcode was generating profile URLs with a double trailing slash (`//`), e.g. `https://profiles.wordpress.org/username//`
- The profiles URL template in `wp-credits.php` already includes a trailing slash (`%s/`), so the extra `/` appended in `shortcode.php` was redundant
- Removed the unnecessary `/` concatenation from the anchor `href` output

<img width="3176" height="1504" alt="Huzaifa-20260521231217" src="https://github.com/user-attachments/assets/5777d6a2-a6a3-4ef6-a1af-fe2cef692e51" />

## Test plan
- [ ] Use the shortcode `[wpcredits 7.0 class="has-small-font-size" exclude="ideag"]` on a page
- [ ] Verify that profile links now render as `https://profiles.wordpress.org/{username}/` (single trailing slash)
- [ ] Verify links still work and redirect correctly to user profiles

