### PR TITLE
Five for the Future: Add Find Me to the /pledges/ directory

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/content-pledge.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/content-pledge.php
@@ -25,6 +25,16 @@ $medium      = (int) ( $contributor['_metrics_medium'] ?? 0 );
 $top_repos   = $contributor['_metrics_top_repos'] ?? array();
 $window_days = (int) ( $contributor['_metrics_window_days'] ?? ContributionMetrics\WINDOW_DAYS_DEFAULT );
 
+// _is_you is set by page-pledges.php on the row matching get_current_user_id().
+// JS uses #pledges-card-you to locate the in-list card for IntersectionObserver,
+// and CSS applies the "you are here" treatment (ribbon, ring, badge).
+// _is_standing is set only when this card is being rendered inside the
+// "Your standing" hero block at the top of the page — same visual treatment,
+// but it must NOT carry the unique id (that's reserved for the in-list copy
+// so the jump pill anchor resolves to one element).
+$is_you      = ! empty( $contributor['_is_you'] );
+$is_standing = ! empty( $contributor['_is_standing'] );
+
 // Data attributes used by client-side filter. `data-active` lets the JS exclude
 // inactive cards from the "active contributors" result count and toggle the
 // inactive divider when filters empty its section.
@@ -35,6 +45,7 @@ $row_attrs = array(
 	'data-name'        => strtolower( $contributor['name'] ?? '' ),
 	'data-sponsorship' => $status_class,
 	'data-active'      => $weighted > 0 ? '1' : '0',
+	'data-you'         => $is_you ? '1' : '0',
 );
 
 $attrs_html = '';
@@ -52,7 +63,13 @@ $is_initially_hidden = 'all' !== $active_sponsorship && $active_sponsorship !== 
 
 ?>
 
-<article class="pledges-card"<?php echo $is_initially_hidden ? ' hidden' : ''; ?> <?php echo $attrs_html; // phpcs:ignore WordPress.Security.EscapeOutput ?>>
+<article<?php echo $is_you && ! $is_standing ? ' id="pledges-card-you"' : ''; ?> class="pledges-card<?php echo $is_you ? ' is-you' : ''; ?>"<?php echo $is_initially_hidden ? ' hidden' : ''; ?> <?php echo $attrs_html; // phpcs:ignore WordPress.Security.EscapeOutput ?>>
+	<?php if ( $is_you ) : ?>
+		<span class="pledges-card-you-badge">
+			<span class="pledges-card-you-dot" aria-hidden="true"></span>
+			<?php esc_html_e( 'You are here', 'wporg-5ftf' ); ?>
+		</span>
+	<?php endif; ?>
 	<span class="pledges-card-rank" aria-hidden="true"><?php echo esc_html( str_pad( (string) $contributor['_rank'], 2, '0', STR_PAD_LEFT ) ); ?></span>
 
 	<div class="pledges-card-avatar">

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/content-pledge.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/content-pledge.php
@@ -58,8 +58,15 @@ foreach ( $row_attrs as $k => $v ) {
 // otherwise the footer-loaded JS hides them after first paint, producing a visible
 // flash of every card. $sponsorship is inherited from the parent template scope via
 // `require`; default to 'independent' if this file is ever included standalone.
+//
+// Standing-card twins are never sponsorship-hidden at this layer — the outer
+// .pledges-standing-card-ranked wrapper owns visibility (PHP renders it with
+// [hidden] in filtered-out state, JS swaps on filter change). If the inner
+// article were ALSO hidden, JS un-hiding the wrapper would leave the ranked
+// standing card visually blank because apply() never touches cards outside
+// #pledges-grid.
 $active_sponsorship  = $sponsorship ?? 'independent';
-$is_initially_hidden = 'all' !== $active_sponsorship && $active_sponsorship !== $status_class;
+$is_initially_hidden = ! $is_standing && 'all' !== $active_sponsorship && $active_sponsorship !== $status_class;
 
 ?>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/css/page-pledges.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/css/page-pledges.css
@@ -540,6 +540,261 @@
 }
 
 /* ------------------------------------------------------------------ */
+/* Your standing (find me)                                            */
+/*                                                                    */
+/* Hoisted user card at the top + floating jump-to-card pill. Both    */
+/* hide via body.is-on-me when the user is scrolled to their in-list  */
+/* card (IntersectionObserver, see js/page-pledges.js).               */
+/* ------------------------------------------------------------------ */
+
+.pledges-standing {
+	margin: 0 0 24px;
+}
+
+.pledges-standing-eyebrow {
+	font-family: var(--wp--preset--font-family--inter, system-ui, sans-serif);
+	font-size: 11px;
+	font-weight: 700;
+	letter-spacing: 0.7px;
+	text-transform: uppercase;
+	color: var(--wp--preset--color--charcoal-3, #5d6166);
+	margin: 0 0 10px;
+	display: flex;
+	align-items: center;
+	gap: 6px;
+}
+
+.pledges-standing-ranked .pledges-standing-eyebrow,
+.pledges-standing-ranked .pledges-standing-eyebrow::before {
+	color: var(--wp--preset--color--blueberry-1, #3858e9);
+}
+
+.pledges-standing-ranked .pledges-standing-eyebrow::before {
+	content: "";
+	width: 6px;
+	height: 6px;
+	border-radius: 3px;
+	background: currentColor;
+}
+
+.pledges-standing-filtered-out .pledges-standing-eyebrow {
+	color: #7a4a00;
+}
+
+/* Sign-in / not-ranked / filtered-out — non-card variants */
+.pledges-standing-card-signin,
+.pledges-standing-card-not-ranked {
+	background: var(--wp--preset--color--light-grey-2, #f6f7f7);
+	border: 1px dashed var(--wp--preset--color--light-grey-1, #c3c4c7);
+	border-radius: 8px;
+	padding: 18px 22px;
+	font-family: var(--wp--preset--font-family--inter, system-ui, sans-serif);
+	display: flex;
+	align-items: center;
+	gap: 16px;
+}
+
+.pledges-standing-card-filtered {
+	background: #fff3da;
+	border: 1px solid #e9c890;
+	border-radius: 8px;
+	padding: 18px 22px;
+	font-family: var(--wp--preset--font-family--inter, system-ui, sans-serif);
+	display: flex;
+	align-items: center;
+	gap: 16px;
+}
+
+.pledges-standing-avatar {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 48px;
+	height: 48px;
+	flex-shrink: 0;
+}
+
+.pledges-standing-avatar img {
+	width: 48px;
+	height: 48px;
+	border-radius: 50%;
+	display: block;
+}
+
+.pledges-standing-avatar-placeholder {
+	background: #fff;
+	border: 1px dashed var(--wp--preset--color--light-grey-1, #c3c4c7);
+	border-radius: 50%;
+	color: var(--wp--preset--color--charcoal-4, #787c82);
+}
+
+.pledges-standing-body {
+	flex: 1;
+	min-width: 0;
+}
+
+.pledges-standing-title {
+	display: block;
+	font-size: 16px;
+	font-weight: 600;
+	color: var(--wp--preset--color--charcoal-1, #1d2327);
+	line-height: 1.3;
+}
+
+.pledges-standing-card-filtered .pledges-standing-title {
+	color: #5e3700;
+}
+
+.pledges-standing-sub {
+	font-size: 13px;
+	color: var(--wp--preset--color--charcoal-3, #5d6166);
+	margin: 4px 0 0;
+	line-height: 1.45;
+}
+
+.pledges-standing-card-filtered .pledges-standing-sub {
+	color: #7a4a00;
+}
+
+.pledges-standing-action {
+	flex-shrink: 0;
+	background: var(--wp--preset--color--charcoal-1, #1d2327);
+	color: #fff;
+	font-size: 14px;
+	font-weight: 600;
+	text-decoration: none;
+	padding: 10px 16px;
+	border-radius: 999px;
+	white-space: nowrap;
+}
+
+.pledges-standing-action:hover,
+.pledges-standing-action:focus {
+	color: #fff;
+	text-decoration: none;
+	background: #000;
+}
+
+.pledges-standing-action-link {
+	background: transparent;
+	color: var(--wp--preset--color--blueberry-1, #3858e9);
+	padding: 10px 4px;
+}
+
+.pledges-standing-action-link:hover,
+.pledges-standing-action-link:focus {
+	background: transparent;
+	color: var(--wp--preset--color--blueberry-1, #3858e9);
+	text-decoration: underline;
+}
+
+/* "You are here" treatment shared by the standing card and the in-list card */
+.pledges-card.is-you {
+	position: relative;
+	border-color: var(--wp--preset--color--blueberry-1, #3858e9);
+	box-shadow: inset 4px 0 0 var(--wp--preset--color--blueberry-1, #3858e9);
+}
+
+.pledges-card.is-you .pledges-card-rank {
+	color: var(--wp--preset--color--blueberry-1, #3858e9);
+}
+
+.pledges-card.is-you .pledges-card-avatar img {
+	box-shadow: 0 0 0 2px #fff, 0 0 0 4px var(--wp--preset--color--blueberry-1, #3858e9);
+}
+
+.pledges-card.is-you .pledges-card-weight strong {
+	color: var(--wp--preset--color--blueberry-1, #3858e9);
+}
+
+.pledges-card-you-badge {
+	position: absolute;
+	top: 10px;
+	right: 14px;
+	font-size: 10px;
+	font-weight: 700;
+	letter-spacing: 0.8px;
+	text-transform: uppercase;
+	color: var(--wp--preset--color--blueberry-1, #3858e9);
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	line-height: 1;
+}
+
+.pledges-card-you-dot {
+	width: 6px;
+	height: 6px;
+	border-radius: 3px;
+	background: currentColor;
+}
+
+/* Floating "Jump to your card" pill — bottom-right of the viewport. */
+.pledges-jump-pill {
+	position: fixed;
+	right: 24px;
+	bottom: 24px;
+	z-index: 20;
+	background: var(--wp--preset--color--charcoal-1, #1d2327);
+	color: #fff;
+	border-radius: 999px;
+	padding: 8px 14px 8px 8px;
+	display: inline-flex;
+	align-items: center;
+	gap: 10px;
+	font-family: var(--wp--preset--font-family--inter, system-ui, sans-serif);
+	font-size: 13px;
+	font-weight: 600;
+	text-decoration: none;
+	box-shadow: 0 12px 32px -6px rgba(0, 0, 0, .45), 0 2px 6px rgba(0, 0, 0, .1);
+	transition: transform .18s, opacity .18s, box-shadow .18s;
+}
+
+.pledges-jump-pill:hover,
+.pledges-jump-pill:focus {
+	color: #fff;
+	text-decoration: none;
+	transform: translateY(-1px);
+	box-shadow: 0 14px 36px -6px rgba(0, 0, 0, .50), 0 2px 6px rgba(0, 0, 0, .12);
+}
+
+.pledges-jump-avatar img {
+	width: 26px;
+	height: 26px;
+	border-radius: 50%;
+	display: block;
+}
+
+.pledges-jump-rank {
+	color: rgba(255, 255, 255, 0.6);
+	font-weight: 500;
+	font-variant-numeric: tabular-nums;
+}
+
+.pledges-jump-icon {
+	background: rgba(255, 255, 255, 0.12);
+	border-radius: 999px;
+	width: 24px;
+	height: 24px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	margin-left: 2px;
+}
+
+/* Option-1 hide-on-overlap. `is-on-me` fires from IntersectionObserver
+   when the in-list user card is in the viewport. `is-find-me-hidden`
+   fires when the in-list card is filter-hidden (no layout for the
+   observer to react to). Both states recede the standing card and pill
+   so the page never shows the same identity twice at once. */
+body.is-on-me .pledges-standing-card-ranked,
+body.is-on-me .pledges-jump-pill,
+body.is-find-me-hidden .pledges-standing,
+body.is-find-me-hidden .pledges-jump-pill {
+	display: none;
+}
+
+/* ------------------------------------------------------------------ */
 /* Narrow (< 720px) layout — collapse card columns                     */
 /* ------------------------------------------------------------------ */
 
@@ -638,6 +893,48 @@
 	.pledges-howitworks-body p {
 		font-size: 14px;
 		line-height: 1.5;
+	}
+
+	/* Standing block: stack action below body so the card doesn't
+	   overflow on narrow screens. */
+	.pledges-standing-card-signin,
+	.pledges-standing-card-not-ranked,
+	.pledges-standing-card-filtered {
+		flex-wrap: wrap;
+		padding: 14px 16px;
+		gap: 12px;
+	}
+
+	.pledges-standing-action {
+		margin-left: auto;
+	}
+
+	/* "You are here" badge needs more breathing room when the rank
+	   becomes a corner pill (see .pledges-card-rank override above). */
+	.pledges-card.is-you .pledges-card-you-badge {
+		top: auto;
+		bottom: 10px;
+		right: 12px;
+		left: auto;
+	}
+
+	.pledges-card.is-you .pledges-card-rank {
+		background: var(--wp--preset--color--blueberry-2, #e8edff);
+		color: var(--wp--preset--color--blueberry-1, #3858e9);
+	}
+
+	/* Floating pill: tuck into thumb-zone corner, drop the visible label
+	   to save horizontal real estate. The aria-label still names the
+	   action for screen readers. */
+	.pledges-jump-pill {
+		right: 12px;
+		bottom: 16px;
+		padding: 6px 10px 6px 6px;
+		gap: 6px;
+	}
+
+	.pledges-jump-label {
+		display: none;
 	}
 }
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/css/page-pledges.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/css/page-pledges.css
@@ -605,6 +605,16 @@
 	gap: 16px;
 }
 
+/* Both standing-card twins set display:flex unconditionally above, which
+   overrides the browser-default [hidden] { display:none } UA rule. Same
+   issue on the jump pill (display:inline-flex). Make [hidden] win again
+   so server-side and JS can both toggle visibility by flipping it. */
+.pledges-standing-card-ranked[hidden],
+.pledges-standing-card-filtered[hidden],
+.pledges-jump-pill[hidden] {
+	display: none !important;
+}
+
 .pledges-standing-avatar {
 	display: flex;
 	align-items: center;
@@ -783,14 +793,19 @@
 }
 
 /* Option-1 hide-on-overlap. `is-on-me` fires from IntersectionObserver
-   when the in-list user card is in the viewport. `is-find-me-hidden`
-   fires when the in-list card is filter-hidden (no layout for the
-   observer to react to). Both states recede the standing card and pill
-   so the page never shows the same identity twice at once. */
+   when the in-list user card is in the viewport — both standing-card
+   twins and the floating pill recede so the page never shows the same
+   identity twice at once.
+
+   `is-find-me-filtered` fires when the sponsorship filter has hidden
+   the in-list card. The standing block stays on the page (JS toggles
+   [hidden] between the ranked and filtered-out twins so the Clear
+   filters affordance is always reachable); only the jump pill goes
+   away, since clicking it would scroll to an invisible target. */
 body.is-on-me .pledges-standing-card-ranked,
+body.is-on-me .pledges-standing-card-filtered,
 body.is-on-me .pledges-jump-pill,
-body.is-find-me-hidden .pledges-standing,
-body.is-find-me-hidden .pledges-jump-pill {
+body.is-find-me-filtered .pledges-jump-pill {
 	display: none;
 }
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/css/page-pledges.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/css/page-pledges.css
@@ -693,19 +693,6 @@
 	background: #000;
 }
 
-.pledges-standing-action-link {
-	background: transparent;
-	color: var(--wp--preset--color--blueberry-1, #3858e9);
-	padding: 10px 4px;
-}
-
-.pledges-standing-action-link:hover,
-.pledges-standing-action-link:focus {
-	background: transparent;
-	color: var(--wp--preset--color--blueberry-1, #3858e9);
-	text-decoration: underline;
-}
-
 /* "You are here" treatment shared by the standing card and the in-list card */
 .pledges-card.is-you {
 	position: relative;

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/css/page-pledges.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/css/page-pledges.css
@@ -802,8 +802,7 @@
    [hidden] between the ranked and filtered-out twins so the Clear
    filters affordance is always reachable); only the jump pill goes
    away, since clicking it would scroll to an invisible target. */
-body.is-on-me .pledges-standing-card-ranked,
-body.is-on-me .pledges-standing-card-filtered,
+body.is-on-me .pledges-standing,
 body.is-on-me .pledges-jump-pill,
 body.is-find-me-filtered .pledges-jump-pill {
 	display: none;

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/css/page-pledges.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/css/page-pledges.css
@@ -547,11 +547,17 @@
 /* card (IntersectionObserver, see js/page-pledges.js).               */
 /* ------------------------------------------------------------------ */
 
-.pledges-standing {
+/* margin-top: 0 wins against `.entry-content > * { margin-top: ... }` from
+   the theme; without it the standing section gets a big gap below the
+   page header. */
+.entry-content .pledges-standing {
 	margin: 0 0 24px;
 }
 
-.pledges-standing-eyebrow {
+/* Theme typography (`.entry-content p`, `.entry-content h2`) was bumping
+   the eyebrow into a giant heading — bump our specificity high enough
+   to win, and reset margins so it sits tight under the page header. */
+.entry-content .pledges-standing-eyebrow {
 	font-family: var(--wp--preset--font-family--inter, system-ui, sans-serif);
 	font-size: 11px;
 	font-weight: 700;
@@ -559,6 +565,8 @@
 	text-transform: uppercase;
 	color: var(--wp--preset--color--charcoal-3, #5d6166);
 	margin: 0 0 10px;
+	padding: 0;
+	line-height: 1.2;
 	display: flex;
 	align-items: center;
 	gap: 6px;
@@ -923,13 +931,21 @@ body.is-find-me-filtered .pledges-jump-pill {
 		margin-left: auto;
 	}
 
-	/* "You are here" badge needs more breathing room when the rank
-	   becomes a corner pill (see .pledges-card-rank override above). */
+	/* On narrow viewports the rank pill takes the top-right corner and the
+	   impact footer takes the bottom-right, so there's no clean place for
+	   the "You are here" badge. The blueberry ribbon, avatar ring, rank
+	   pill, and impact number already mark the card visually — keep the
+	   text in the DOM for screen readers, drop it from the visual layout. */
 	.pledges-card.is-you .pledges-card-you-badge {
-		top: auto;
-		bottom: 10px;
-		right: 12px;
-		left: auto;
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		white-space: nowrap;
+		border: 0;
 	}
 
 	.pledges-card.is-you .pledges-card-rank {

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/js/page-pledges.js
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/js/page-pledges.js
@@ -328,7 +328,15 @@
 		// class. Without this toggle the eyebrow would stay blueberry over
 		// the gold filtered-out twin (or gold + missing-dot over the ranked
 		// twin) when JS swaps which twin is visible.
-		if ( standingSect ) {
+		//
+		// Gated on both twins existing: in the 'not-ranked' / 'logged-out'
+		// server states the section is rendered with its own modifier
+		// (e.g. .pledges-standing-not-ranked) and neither twin is in the
+		// DOM. The user's in-list card can still trigger this code path
+		// (their inactive card has id="pledges-card-you" when
+		// show_inactive=1), so without the gate we'd stack a second state
+		// modifier onto the section and the eyebrow color would conflict.
+		if ( standingSect && standingRank && standingFiltd ) {
 			standingSect.classList.toggle( 'pledges-standing-ranked', ! hiddenByFilter );
 			standingSect.classList.toggle( 'pledges-standing-filtered-out', hiddenByFilter );
 		}

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/js/page-pledges.js
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/js/page-pledges.js
@@ -131,6 +131,48 @@
 				resultPhrase.textContent = template.replace( '%d', String( total ) );
 			}
 		}
+
+		// Propagate the user's visible-relative rank to the standing card and
+		// pill so all three "your rank" labels agree. Server initial render
+		// uses the absolute rank (the user's position in the unfiltered active
+		// list); the renumber loop above rewrites the in-list card to the
+		// visible-relative rank under the current filter — mirror that here.
+		syncFindMeRank();
+	}
+
+	function syncFindMeRank() {
+		var card = document.getElementById( 'pledges-card-you' );
+		if ( ! card || card.hidden ) {
+			return;
+		}
+		var rankEl = card.querySelector( '.pledges-card-rank' );
+		if ( ! rankEl ) {
+			return;
+		}
+		var visibleRankText = rankEl.textContent;
+		var visibleRankNum  = parseInt( visibleRankText, 10 );
+
+		var standing = document.querySelector( '.pledges-standing-card-ranked' );
+		if ( standing ) {
+			var standingRankEl = standing.querySelector( '.pledges-card-rank' );
+			if ( standingRankEl ) {
+				standingRankEl.textContent = visibleRankText;
+			}
+		}
+
+		var pill = document.querySelector( '.pledges-jump-pill' );
+		if ( pill && ! isNaN( visibleRankNum ) ) {
+			var pillRankEl = pill.querySelector( '.pledges-jump-rank' );
+			if ( pillRankEl ) {
+				pillRankEl.textContent = '#' + visibleRankNum;
+			}
+			// Server-provided localized template — JS rebuilds the aria-label
+			// so screen readers also hear the updated rank.
+			var ariaTpl = pill.dataset.ariaTemplate;
+			if ( ariaTpl ) {
+				pill.setAttribute( 'aria-label', ariaTpl.replace( '%d', String( visibleRankNum ) ) );
+			}
+		}
 	}
 
 	/**
@@ -252,6 +294,7 @@
 	 */
 	var youCard       = document.getElementById( 'pledges-card-you' );
 	var jumpPill      = document.querySelector( '.pledges-jump-pill' );
+	var standingSect  = document.querySelector( '.pledges-standing' );
 	var standingRank  = document.querySelector( '.pledges-standing-card-ranked' );
 	var standingFiltd = document.querySelector( '.pledges-standing-card-filtered' );
 
@@ -280,6 +323,14 @@
 		}
 		if ( standingFiltd ) {
 			standingFiltd.hidden = ! hiddenByFilter;
+		}
+		// CSS keys the eyebrow color + dot off the section's state modifier
+		// class. Without this toggle the eyebrow would stay blueberry over
+		// the gold filtered-out twin (or gold + missing-dot over the ranked
+		// twin) when JS swaps which twin is visible.
+		if ( standingSect ) {
+			standingSect.classList.toggle( 'pledges-standing-ranked', ! hiddenByFilter );
+			standingSect.classList.toggle( 'pledges-standing-filtered-out', hiddenByFilter );
 		}
 		// Pill mirrors the ranked-twin visibility — JS owns the [hidden] flag
 		// so the server's initial render survives a client-side filter swap.

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/js/page-pledges.js
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/js/page-pledges.js
@@ -264,6 +264,14 @@
 		// Body class is the cross-cutting state flag (used by other rules too).
 		document.body.classList.toggle( 'is-find-me-filtered', hiddenByFilter );
 
+		// When the card flips to display:none, IntersectionObserver never
+		// fires isIntersecting=false on it (there's no layout to observe), so
+		// is-on-me can persist from before the filter change and continue
+		// hiding the standing block. Clear it explicitly here.
+		if ( hiddenByFilter ) {
+			document.body.classList.remove( 'is-on-me' );
+		}
+
 		// Both twins live in the DOM. Toggle [hidden] on both so swaps work
 		// in either direction (ranked → filtered AND filtered → ranked when
 		// the user clears the filter through the toolbar).

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/js/page-pledges.js
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/js/page-pledges.js
@@ -242,27 +242,50 @@
 	 * #pledges-card-you), both indicators recede via the body class
 	 * `is-on-me` so the page isn't showing the same identity three times.
 	 *
-	 * Also: if the sponsorship filter has hidden the user's card (filter
-	 * changed client-side after server render), the in-list card has no
-	 * layout, so IntersectionObserver won't fire and the pill would link to
-	 * an invisible target. Body class `is-find-me-hidden` covers that case.
+	 * The 'ranked' server state renders two standing-card twins side by side:
+	 * one ranked + one filtered-out, with the filtered-out twin hidden by
+	 * default. When the sponsorship filter changes client-side to one that
+	 * excludes the user, the in-list card's `hidden` attribute flips on, and
+	 * this code swaps which standing-card twin is visible — so the user
+	 * always has a "Clear filters" recovery affordance on the page instead
+	 * of the whole block disappearing.
 	 */
-	var youCard = document.getElementById( 'pledges-card-you' );
-	var jumpPill = document.querySelector( '.pledges-jump-pill' );
+	var youCard       = document.getElementById( 'pledges-card-you' );
+	var jumpPill      = document.querySelector( '.pledges-jump-pill' );
+	var standingRank  = document.querySelector( '.pledges-standing-card-ranked' );
+	var standingFiltd = document.querySelector( '.pledges-standing-card-filtered' );
 
-	function updateFindMeHidden() {
+	function refreshStandingVariant() {
 		if ( ! youCard ) {
 			return;
 		}
-		document.body.classList.toggle( 'is-find-me-hidden', !! youCard.hidden );
+		var hiddenByFilter = !! youCard.hidden;
+
+		// Body class is the cross-cutting state flag (used by other rules too).
+		document.body.classList.toggle( 'is-find-me-filtered', hiddenByFilter );
+
+		// Both twins live in the DOM. Toggle [hidden] on both so swaps work
+		// in either direction (ranked → filtered AND filtered → ranked when
+		// the user clears the filter through the toolbar).
+		if ( standingRank ) {
+			standingRank.hidden = hiddenByFilter;
+		}
+		if ( standingFiltd ) {
+			standingFiltd.hidden = ! hiddenByFilter;
+		}
+		// Pill mirrors the ranked-twin visibility — JS owns the [hidden] flag
+		// so the server's initial render survives a client-side filter swap.
+		if ( jumpPill ) {
+			jumpPill.hidden = hiddenByFilter;
+		}
 	}
 
-	// Re-evaluate the find-me-hidden state after every filter change. The
-	// original apply() updates card visibility; we layer on the find-me check.
+	// Re-evaluate after every filter change. The original apply() updates
+	// card visibility; we layer the standing-variant swap on top.
 	var originalApply = apply;
 	apply = function () {
 		originalApply.apply( this, arguments );
-		updateFindMeHidden();
+		refreshStandingVariant();
 	};
 
 	if ( youCard && 'IntersectionObserver' in window ) {

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/js/page-pledges.js
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/js/page-pledges.js
@@ -232,6 +232,86 @@
 		} );
 	}
 
+	/**
+	 * Find Me — Option 1 (hide-on-overlap).
+	 *
+	 * The page renders, server-side, a "Your standing" card at the top and a
+	 * floating "Jump to your card" pill at the bottom. Both indicate where
+	 * the logged-in user sits in the ranking. When the user is *actually
+	 * looking at* their in-list card (IntersectionObserver fires for
+	 * #pledges-card-you), both indicators recede via the body class
+	 * `is-on-me` so the page isn't showing the same identity three times.
+	 *
+	 * Also: if the sponsorship filter has hidden the user's card (filter
+	 * changed client-side after server render), the in-list card has no
+	 * layout, so IntersectionObserver won't fire and the pill would link to
+	 * an invisible target. Body class `is-find-me-hidden` covers that case.
+	 */
+	var youCard = document.getElementById( 'pledges-card-you' );
+	var jumpPill = document.querySelector( '.pledges-jump-pill' );
+
+	function updateFindMeHidden() {
+		if ( ! youCard ) {
+			return;
+		}
+		document.body.classList.toggle( 'is-find-me-hidden', !! youCard.hidden );
+	}
+
+	// Re-evaluate the find-me-hidden state after every filter change. The
+	// original apply() updates card visibility; we layer on the find-me check.
+	var originalApply = apply;
+	apply = function () {
+		originalApply.apply( this, arguments );
+		updateFindMeHidden();
+	};
+
+	if ( youCard && 'IntersectionObserver' in window ) {
+		var io = new IntersectionObserver( function ( entries ) {
+			entries.forEach( function ( entry ) {
+				document.body.classList.toggle( 'is-on-me', entry.isIntersecting );
+			} );
+		}, {
+			// Trigger before the card is fully on-screen so the standing card
+			// fades out as the user approaches their row, not after they're
+			// already staring at the duplicate.
+			rootMargin: '-15% 0px -15% 0px',
+			threshold: 0,
+		} );
+		io.observe( youCard );
+	}
+
+	if ( jumpPill && youCard ) {
+		jumpPill.addEventListener( 'click', function ( e ) {
+			// Let modified clicks (cmd/ctrl/shift/middle) navigate normally so
+			// users can open the deep link in a new tab.
+			if ( e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey ) {
+				return;
+			}
+			e.preventDefault();
+			// Smooth-scroll the card to the middle of the viewport. block:'center'
+			// matches the design — the card lands with neighbors visible above
+			// and below for context, not flush against the top of the viewport.
+			try {
+				youCard.scrollIntoView( { behavior: 'smooth', block: 'center' } );
+			} catch ( err ) {
+				youCard.scrollIntoView();
+			}
+			// Move focus into the card so screen readers announce it. Cards
+			// aren't naturally focusable, so set tabindex on demand and clear
+			// it on blur to keep the tab order untouched for keyboard users.
+			youCard.setAttribute( 'tabindex', '-1' );
+			try {
+				youCard.focus( { preventScroll: true } );
+			} catch ( err ) {
+				youCard.focus();
+			}
+			youCard.addEventListener( 'blur', function onBlur() {
+				youCard.removeAttribute( 'tabindex' );
+				youCard.removeEventListener( 'blur', onBlur );
+			} );
+		} );
+	}
+
 	// Initial paint: sync the carry-forward hrefs once even when the user
 	// hasn't toggled anything, so links rendered with no sponsorship query arg
 	// inherit one if the page was loaded with ?sponsorship= in the URL.

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/js/page-pledges.js
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/js/page-pledges.js
@@ -381,16 +381,20 @@
 			// Move focus into the card so screen readers announce it. Cards
 			// aren't naturally focusable, so set tabindex on demand and clear
 			// it on blur to keep the tab order untouched for keyboard users.
-			youCard.setAttribute( 'tabindex', '-1' );
-			try {
-				youCard.focus( { preventScroll: true } );
-			} catch ( err ) {
-				youCard.focus();
+			// Guard on hasAttribute so repeated pill clicks (before the card
+			// blurs) don't accumulate orphan blur listeners — each addEvent-
+			// Listener call creates a new closure even with { once: true }.
+			if ( ! youCard.hasAttribute( 'tabindex' ) ) {
+				youCard.setAttribute( 'tabindex', '-1' );
+				try {
+					youCard.focus( { preventScroll: true } );
+				} catch ( err ) {
+					youCard.focus();
+				}
+				youCard.addEventListener( 'blur', function () {
+					youCard.removeAttribute( 'tabindex' );
+				}, { once: true } );
 			}
-			youCard.addEventListener( 'blur', function onBlur() {
-				youCard.removeAttribute( 'tabindex' );
-				youCard.removeEventListener( 'blur', onBlur );
-			} );
 		} );
 	}
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
@@ -322,9 +322,9 @@ if ( ! $current_user_id ) {
 
 					<?php if ( $standing_state ) : ?>
 						<section class="pledges-standing pledges-standing-<?php echo esc_attr( $standing_state ); ?>" aria-labelledby="pledges-standing-eyebrow">
-							<h2 id="pledges-standing-eyebrow" class="pledges-standing-eyebrow">
+							<p id="pledges-standing-eyebrow" class="pledges-standing-eyebrow">
 								<?php esc_html_e( 'Your standing', 'wporg-5ftf' ); ?>
-							</h2>
+							</p>
 
 							<?php if ( 'logged-out' === $standing_state ) : ?>
 								<?php
@@ -368,7 +368,6 @@ if ( ! $current_user_id ) {
 											?>
 										</p>
 									</div>
-									<a class="pledges-standing-action pledges-standing-action-link" href="#pledges-howitworks"><?php esc_html_e( 'How impact is scored', 'wporg-5ftf' ); ?> &rarr;</a>
 								</div>
 
 							<?php elseif ( 'ranked' === $standing_state || 'filtered-out' === $standing_state ) : ?>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
@@ -278,7 +278,6 @@ $current_user_id = get_current_user_id();
 $standing_state  = '';         // logged-out | ranked | filtered-out | not-ranked | '' (hide block)
 $standing_rank   = 0;
 $standing_user   = null;
-$standing_label  = '';         // For filtered-out: the chip label that's hiding the user.
 
 if ( ! $current_user_id ) {
 	$standing_state = 'logged-out';
@@ -292,14 +291,9 @@ if ( ! $current_user_id ) {
 		$standing_rank = array_search( $current_user_id, array_keys( $active_contributors ), true );
 		$standing_rank = false === $standing_rank ? 0 : $standing_rank + 1;
 
-		if ( 'all' === $sponsorship || $user_row_sponsorship === $sponsorship ) {
-			$standing_state = 'ranked';
-		} else {
-			$standing_state = 'filtered-out';
-			$standing_label = 'sponsored' === $sponsorship
-				? __( 'Sponsored', 'wporg-5ftf' )
-				: __( 'Independent', 'wporg-5ftf' );
-		}
+		$standing_state = ( 'all' === $sponsorship || $user_row_sponsorship === $sponsorship )
+			? 'ranked'
+			: 'filtered-out';
 	} else {
 		$standing_state = 'not-ranked';
 	}
@@ -333,7 +327,14 @@ if ( ! $current_user_id ) {
 							</h2>
 
 							<?php if ( 'logged-out' === $standing_state ) : ?>
-								<?php $login_url = wp_login_url( ( is_ssl() ? 'https://' : 'http://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] ); ?>
+								<?php
+								// Anchor the redirect target to home_url() so the canonical site
+								// URL controls the host. Concatenating $_SERVER['HTTP_HOST'] would
+								// be attacker-controlled (forged Host header behind misconfigured
+								// proxies) and could turn the login redirect into an open redirect.
+								$login_redirect = home_url( wp_unslash( $_SERVER['REQUEST_URI'] ?? '/pledges/' ) );
+								$login_url      = wp_login_url( $login_redirect );
+								?>
 								<div class="pledges-standing-card pledges-standing-card-signin">
 									<span class="pledges-standing-avatar pledges-standing-avatar-placeholder" aria-hidden="true">
 										<svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" focusable="false">
@@ -347,28 +348,6 @@ if ( ! $current_user_id ) {
 										<p class="pledges-standing-sub"><?php esc_html_e( 'Your rank, recent impact, and a jump-to-card link will appear here.', 'wporg-5ftf' ); ?></p>
 									</div>
 									<a class="pledges-standing-action" href="<?php echo esc_url( $login_url ); ?>"><?php esc_html_e( 'Sign in', 'wporg-5ftf' ); ?> &rarr;</a>
-								</div>
-
-							<?php elseif ( 'filtered-out' === $standing_state ) : ?>
-								<div class="pledges-standing-card pledges-standing-card-filtered">
-									<span class="pledges-standing-avatar">
-										<?php echo wp_kses_post( get_avatar( $standing_user['email'], 56 ) ); ?>
-									</span>
-									<div class="pledges-standing-body">
-										<strong class="pledges-standing-title"><?php esc_html_e( 'You\'re hidden by current filters.', 'wporg-5ftf' ); ?></strong>
-										<p class="pledges-standing-sub">
-											<?php
-											echo wp_kses_data( sprintf(
-												/* translators: 1: contributor name, 2: sponsorship filter label */
-												__( '%1$s &mdash; %2$s contributor. The <strong>%3$s</strong> filter is excluding you.', 'wporg-5ftf' ),
-												esc_html( $standing_user['name'] ),
-												empty( $standing_user['sponsored'] ) ? esc_html__( 'independent', 'wporg-5ftf' ) : esc_html__( 'sponsored', 'wporg-5ftf' ),
-												esc_html( $standing_label )
-											) );
-											?>
-										</p>
-									</div>
-									<a class="pledges-standing-action" href="<?php echo esc_url( $build_pledges_url( $window_days, 'all' ) ); ?>"><?php esc_html_e( 'Clear filters', 'wporg-5ftf' ); ?> &rarr;</a>
 								</div>
 
 							<?php elseif ( 'not-ranked' === $standing_state ) : ?>
@@ -392,15 +371,48 @@ if ( ! $current_user_id ) {
 									<a class="pledges-standing-action pledges-standing-action-link" href="#pledges-howitworks"><?php esc_html_e( 'How impact is scored', 'wporg-5ftf' ); ?> &rarr;</a>
 								</div>
 
-							<?php elseif ( 'ranked' === $standing_state ) : ?>
+							<?php elseif ( 'ranked' === $standing_state || 'filtered-out' === $standing_state ) : ?>
 								<?php
+								// Both twins always render whenever the user has impact. JS
+								// flips [hidden] between them on every client-side sponsorship
+								// change so the user always has a "Clear filters" affordance
+								// even when their card gets filtered out mid-session, and so
+								// the swap also covers the inverse path (lands filtered-out,
+								// clears the filter via the toolbar, ranked twin un-hides).
 								$contributor                 = $standing_user;
 								$contributor['_rank']        = $standing_rank;
 								$contributor['_is_you']      = true;
 								$contributor['_is_standing'] = true;
+								// The only chip that can exclude the user is the one opposite
+								// their sponsorship — so the label is deterministic regardless
+								// of which twin is initially visible.
+								$exclusion_label = empty( $standing_user['sponsored'] )
+									? __( 'Sponsored', 'wporg-5ftf' )
+									: __( 'Independent', 'wporg-5ftf' );
+								$is_filtered    = ( 'filtered-out' === $standing_state );
 								?>
-								<div class="pledges-standing-card pledges-standing-card-ranked">
+								<div class="pledges-standing-card pledges-standing-card-ranked"<?php echo $is_filtered ? ' hidden' : ''; ?>>
 									<?php require __DIR__ . '/content-pledge.php'; ?>
+								</div>
+								<div class="pledges-standing-card pledges-standing-card-filtered"<?php echo $is_filtered ? '' : ' hidden'; ?>>
+									<span class="pledges-standing-avatar">
+										<?php echo wp_kses_post( get_avatar( $standing_user['email'], 56 ) ); ?>
+									</span>
+									<div class="pledges-standing-body">
+										<strong class="pledges-standing-title"><?php esc_html_e( 'You\'re hidden by current filters.', 'wporg-5ftf' ); ?></strong>
+										<p class="pledges-standing-sub">
+											<?php
+											echo wp_kses_data( sprintf(
+												/* translators: 1: contributor name, 2: sponsorship status word (independent/sponsored), 3: name of the chip currently excluding the user */
+												__( '%1$s &mdash; %2$s contributor. The <strong>%3$s</strong> filter is excluding you.', 'wporg-5ftf' ),
+												esc_html( $standing_user['name'] ),
+												empty( $standing_user['sponsored'] ) ? esc_html__( 'independent', 'wporg-5ftf' ) : esc_html__( 'sponsored', 'wporg-5ftf' ),
+												esc_html( $exclusion_label )
+											) );
+											?>
+										</p>
+									</div>
+									<a class="pledges-standing-action" href="<?php echo esc_url( $build_pledges_url( $window_days, 'all' ) ); ?>"><?php esc_html_e( 'Clear filters', 'wporg-5ftf' ); ?> &rarr;</a>
 								</div>
 							<?php endif; ?>
 						</section>
@@ -609,17 +621,22 @@ if ( ! $current_user_id ) {
 
 				<?php endif; ?>
 
-				<?php if ( 'ranked' === $standing_state ) : ?>
+				<?php if ( 'ranked' === $standing_state || 'filtered-out' === $standing_state ) : ?>
 					<?php
 					// Floating jump-to pill. Server-side render is a real anchor link
 					// pointing at #pledges-card-you, so JS-disabled and middle-clicks
 					// still navigate correctly. JS upgrades to smooth-scroll + focus
 					// and hides the pill while the in-list card is in the viewport
 					// (Option-1 hide-on-overlap, see js/page-pledges.js).
+					//
+					// In 'filtered-out' state the pill is rendered with [hidden] so
+					// it stays in the DOM (JS un-hides on filter-toggle-to-matching)
+					// but doesn't briefly flash visible before JS runs.
 					/* translators: 1: rank number */
 					$pill_label = sprintf( __( 'Jump to your card, ranked #%d', 'wporg-5ftf' ), $standing_rank );
+					$pill_hidden = ( 'filtered-out' === $standing_state );
 					?>
-					<a class="pledges-jump-pill" href="#pledges-card-you" aria-label="<?php echo esc_attr( $pill_label ); ?>">
+					<a class="pledges-jump-pill" href="#pledges-card-you" aria-label="<?php echo esc_attr( $pill_label ); ?>"<?php echo $pill_hidden ? ' hidden' : ''; ?>>
 						<span class="pledges-jump-avatar" aria-hidden="true">
 							<?php echo wp_kses_post( get_avatar( $standing_user['email'], 26 ) ); ?>
 						</span>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
@@ -286,10 +286,17 @@ if ( ! $current_user_id ) {
 	$user_row_sponsorship = empty( $standing_user['sponsored'] ) ? 'independent' : 'sponsored';
 
 	if ( isset( $active_contributors[ $current_user_id ] ) ) {
-		// The user has tracked impact in the window. array_search() against the
-		// already-sorted keys is the rank — cheaper than iterating with a counter.
-		$standing_rank = array_search( $current_user_id, array_keys( $active_contributors ), true );
-		$standing_rank = false === $standing_rank ? 0 : $standing_rank + 1;
+		// Single-pass rank lookup. array_search() against array_keys() built a
+		// full keys array first and then scanned it — two passes' worth of
+		// work for the same answer when foreach can short-circuit on match.
+		$position = 0;
+		foreach ( $active_contributors as $uid => $_unused_contributor ) {
+			$position++;
+			if ( (int) $uid === (int) $current_user_id ) {
+				$standing_rank = $position;
+				break;
+			}
+		}
 
 		$standing_state = ( 'all' === $sponsorship || $user_row_sponsorship === $sponsorship )
 			? 'ranked'

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
@@ -328,11 +328,23 @@ if ( ! $current_user_id ) {
 
 							<?php if ( 'logged-out' === $standing_state ) : ?>
 								<?php
-								// Anchor the redirect target to home_url() so the canonical site
-								// URL controls the host. Concatenating $_SERVER['HTTP_HOST'] would
-								// be attacker-controlled (forged Host header behind misconfigured
-								// proxies) and could turn the login redirect into an open redirect.
-								$login_redirect = home_url( wp_unslash( $_SERVER['REQUEST_URI'] ?? '/pledges/' ) );
+								// /pledges/ is a virtual route registered by the team-pledges
+								// mu-plugin and is the only URL this template renders. Use the
+								// static path so home_url() doesn't re-prepend the subsite path:
+								// home_url('/themes/pledges/') on the themes subsite would emit
+								// /themes/themes/pledges/ because home_url() appends the path
+								// argument verbatim onto get_option('home'). Re-add the three
+								// filter args explicitly so login round-trips don't drop the
+								// active window/sponsorship/show-inactive view.
+								$login_redirect_args = array();
+								foreach ( array( 'window', 'sponsorship', 'show_inactive' ) as $login_redirect_arg ) {
+									if ( isset( $_GET[ $login_redirect_arg ] ) && is_string( $_GET[ $login_redirect_arg ] ) ) {
+										$login_redirect_args[ $login_redirect_arg ] = sanitize_text_field( wp_unslash( $_GET[ $login_redirect_arg ] ) );
+									}
+								}
+								$login_redirect = $login_redirect_args
+									? add_query_arg( $login_redirect_args, home_url( '/pledges/' ) )
+									: home_url( '/pledges/' );
 								$login_url      = wp_login_url( $login_redirect );
 								?>
 								<div class="pledges-standing-card pledges-standing-card-signin">
@@ -632,10 +644,11 @@ if ( ! $current_user_id ) {
 					// it stays in the DOM (JS un-hides on filter-toggle-to-matching)
 					// but doesn't briefly flash visible before JS runs.
 					/* translators: 1: rank number */
-					$pill_label = sprintf( __( 'Jump to your card, ranked #%d', 'wporg-5ftf' ), $standing_rank );
-					$pill_hidden = ( 'filtered-out' === $standing_state );
+					$pill_aria_template = __( 'Jump to your card, ranked #%d', 'wporg-5ftf' );
+					$pill_label         = sprintf( $pill_aria_template, $standing_rank );
+					$pill_hidden        = ( 'filtered-out' === $standing_state );
 					?>
-					<a class="pledges-jump-pill" href="#pledges-card-you" aria-label="<?php echo esc_attr( $pill_label ); ?>"<?php echo $pill_hidden ? ' hidden' : ''; ?>>
+					<a class="pledges-jump-pill" href="#pledges-card-you" aria-label="<?php echo esc_attr( $pill_label ); ?>" data-aria-template="<?php echo esc_attr( $pill_aria_template ); ?>"<?php echo $pill_hidden ? ' hidden' : ''; ?>>
 						<span class="pledges-jump-avatar" aria-hidden="true">
 							<?php echo wp_kses_post( get_avatar( $standing_user['email'], 26 ) ); ?>
 						</span>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
@@ -267,6 +267,46 @@ $build_pledges_url = function ( $window, $sponsorship_value ) use ( $pledges_url
 	return $args ? add_query_arg( $args, $pledges_url ) : $pledges_url;
 };
 
+// ------------------------------------------------------------------
+// Your standing: pre-compute the logged-in viewer's state so the
+// "Your standing" block + jump-to-card pill can render server-side.
+// Anonymous visitors usually hit a cached response — they always get
+// the same "Sign in" card. Logged-in visitors bypass page cache and
+// get a per-user render.
+// ------------------------------------------------------------------
+$current_user_id = get_current_user_id();
+$standing_state  = '';         // logged-out | ranked | filtered-out | not-ranked | '' (hide block)
+$standing_rank   = 0;
+$standing_user   = null;
+$standing_label  = '';         // For filtered-out: the chip label that's hiding the user.
+
+if ( ! $current_user_id ) {
+	$standing_state = 'logged-out';
+} elseif ( isset( $contributors[ $current_user_id ] ) ) {
+	$standing_user        = $contributors[ $current_user_id ];
+	$user_row_sponsorship = empty( $standing_user['sponsored'] ) ? 'independent' : 'sponsored';
+
+	if ( isset( $active_contributors[ $current_user_id ] ) ) {
+		// The user has tracked impact in the window. array_search() against the
+		// already-sorted keys is the rank — cheaper than iterating with a counter.
+		$standing_rank = array_search( $current_user_id, array_keys( $active_contributors ), true );
+		$standing_rank = false === $standing_rank ? 0 : $standing_rank + 1;
+
+		if ( 'all' === $sponsorship || $user_row_sponsorship === $sponsorship ) {
+			$standing_state = 'ranked';
+		} else {
+			$standing_state = 'filtered-out';
+			$standing_label = 'sponsored' === $sponsorship
+				? __( 'Sponsored', 'wporg-5ftf' )
+				: __( 'Independent', 'wporg-5ftf' );
+		}
+	} else {
+		$standing_state = 'not-ranked';
+	}
+}
+// If the viewer is logged in but not on this team's opt-in roster, leave
+// $standing_state empty so the block is hidden entirely (no useful info to show).
+
 ?>
 
 <div id="primary" class="content-area">
@@ -285,6 +325,86 @@ $build_pledges_url = function ( $window, $sponsorship_value ) use ( $pledges_url
 			<div class="entry-content">
 
 				<?php if ( $contributors ) : ?>
+
+					<?php if ( $standing_state ) : ?>
+						<section class="pledges-standing pledges-standing-<?php echo esc_attr( $standing_state ); ?>" aria-labelledby="pledges-standing-eyebrow">
+							<h2 id="pledges-standing-eyebrow" class="pledges-standing-eyebrow">
+								<?php esc_html_e( 'Your standing', 'wporg-5ftf' ); ?>
+							</h2>
+
+							<?php if ( 'logged-out' === $standing_state ) : ?>
+								<?php $login_url = wp_login_url( ( is_ssl() ? 'https://' : 'http://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] ); ?>
+								<div class="pledges-standing-card pledges-standing-card-signin">
+									<span class="pledges-standing-avatar pledges-standing-avatar-placeholder" aria-hidden="true">
+										<svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" focusable="false">
+											<path d="M5.5 8.5v-2a4.5 4.5 0 019 0v2"/>
+											<rect x="4" y="8.5" width="12" height="8" rx="1.5"/>
+											<path d="M10 12v2"/>
+										</svg>
+									</span>
+									<div class="pledges-standing-body">
+										<strong class="pledges-standing-title"><?php esc_html_e( 'Sign in to see where you stand.', 'wporg-5ftf' ); ?></strong>
+										<p class="pledges-standing-sub"><?php esc_html_e( 'Your rank, recent impact, and a jump-to-card link will appear here.', 'wporg-5ftf' ); ?></p>
+									</div>
+									<a class="pledges-standing-action" href="<?php echo esc_url( $login_url ); ?>"><?php esc_html_e( 'Sign in', 'wporg-5ftf' ); ?> &rarr;</a>
+								</div>
+
+							<?php elseif ( 'filtered-out' === $standing_state ) : ?>
+								<div class="pledges-standing-card pledges-standing-card-filtered">
+									<span class="pledges-standing-avatar">
+										<?php echo wp_kses_post( get_avatar( $standing_user['email'], 56 ) ); ?>
+									</span>
+									<div class="pledges-standing-body">
+										<strong class="pledges-standing-title"><?php esc_html_e( 'You\'re hidden by current filters.', 'wporg-5ftf' ); ?></strong>
+										<p class="pledges-standing-sub">
+											<?php
+											echo wp_kses_data( sprintf(
+												/* translators: 1: contributor name, 2: sponsorship filter label */
+												__( '%1$s &mdash; %2$s contributor. The <strong>%3$s</strong> filter is excluding you.', 'wporg-5ftf' ),
+												esc_html( $standing_user['name'] ),
+												empty( $standing_user['sponsored'] ) ? esc_html__( 'independent', 'wporg-5ftf' ) : esc_html__( 'sponsored', 'wporg-5ftf' ),
+												esc_html( $standing_label )
+											) );
+											?>
+										</p>
+									</div>
+									<a class="pledges-standing-action" href="<?php echo esc_url( $build_pledges_url( $window_days, 'all' ) ); ?>"><?php esc_html_e( 'Clear filters', 'wporg-5ftf' ); ?> &rarr;</a>
+								</div>
+
+							<?php elseif ( 'not-ranked' === $standing_state ) : ?>
+								<div class="pledges-standing-card pledges-standing-card-not-ranked">
+									<span class="pledges-standing-avatar">
+										<?php echo wp_kses_post( get_avatar( $standing_user['email'], 56 ) ); ?>
+									</span>
+									<div class="pledges-standing-body">
+										<strong class="pledges-standing-title"><?php esc_html_e( 'You are not ranked in this team.', 'wporg-5ftf' ); ?></strong>
+										<p class="pledges-standing-sub">
+											<?php
+											echo esc_html( sprintf(
+												/* translators: 1: team name, 2: window in days */
+												__( 'Land a high- or medium-impact contribution to %1$s in the last %2$d days to appear here.', 'wporg-5ftf' ),
+												$current_team->post_title,
+												$window_days
+											) );
+											?>
+										</p>
+									</div>
+									<a class="pledges-standing-action pledges-standing-action-link" href="#pledges-howitworks"><?php esc_html_e( 'How impact is scored', 'wporg-5ftf' ); ?> &rarr;</a>
+								</div>
+
+							<?php elseif ( 'ranked' === $standing_state ) : ?>
+								<?php
+								$contributor                 = $standing_user;
+								$contributor['_rank']        = $standing_rank;
+								$contributor['_is_you']      = true;
+								$contributor['_is_standing'] = true;
+								?>
+								<div class="pledges-standing-card pledges-standing-card-ranked">
+									<?php require __DIR__ . '/content-pledge.php'; ?>
+								</div>
+							<?php endif; ?>
+						</section>
+					<?php endif; ?>
 
 					<div class="pledges-howitworks" id="pledges-howitworks" role="note">
 						<div class="pledges-howitworks-icon" aria-hidden="true">i</div>
@@ -368,9 +488,10 @@ $build_pledges_url = function ( $window, $sponsorship_value ) use ( $pledges_url
 					<div class="pledges-grid" id="pledges-grid">
 						<?php
 						$rank = 0;
-						foreach ( $active_contributors as $contributor ) {
+						foreach ( $active_contributors as $uid => $contributor ) {
 							$rank++;
-							$contributor['_rank'] = $rank;
+							$contributor['_rank']   = $rank;
+							$contributor['_is_you'] = ( (int) $uid === (int) $current_user_id );
 							require __DIR__ . '/content-pledge.php';
 						}
 
@@ -392,9 +513,10 @@ $build_pledges_url = function ( $window, $sponsorship_value ) use ( $pledges_url
 								<span><?php echo esc_html( $inactive_label ); ?></span>
 							</div>
 							<?php
-							foreach ( $inactive_contributors as $contributor ) {
+							foreach ( $inactive_contributors as $uid => $contributor ) {
 								$rank++;
-								$contributor['_rank'] = $rank;
+								$contributor['_rank']   = $rank;
+								$contributor['_is_you'] = ( (int) $uid === (int) $current_user_id );
 								require __DIR__ . '/content-pledge.php';
 							}
 						endif;
@@ -485,6 +607,28 @@ $build_pledges_url = function ( $window, $sponsorship_value ) use ( $pledges_url
 						?>
 					</p>
 
+				<?php endif; ?>
+
+				<?php if ( 'ranked' === $standing_state ) : ?>
+					<?php
+					// Floating jump-to pill. Server-side render is a real anchor link
+					// pointing at #pledges-card-you, so JS-disabled and middle-clicks
+					// still navigate correctly. JS upgrades to smooth-scroll + focus
+					// and hides the pill while the in-list card is in the viewport
+					// (Option-1 hide-on-overlap, see js/page-pledges.js).
+					/* translators: 1: rank number */
+					$pill_label = sprintf( __( 'Jump to your card, ranked #%d', 'wporg-5ftf' ), $standing_rank );
+					?>
+					<a class="pledges-jump-pill" href="#pledges-card-you" aria-label="<?php echo esc_attr( $pill_label ); ?>">
+						<span class="pledges-jump-avatar" aria-hidden="true">
+							<?php echo wp_kses_post( get_avatar( $standing_user['email'], 26 ) ); ?>
+						</span>
+						<span class="pledges-jump-label"><?php esc_html_e( 'Jump to your card', 'wporg-5ftf' ); ?></span>
+						<span class="pledges-jump-rank" aria-hidden="true">#<?php echo esc_html( $standing_rank ); ?></span>
+						<span class="pledges-jump-icon" aria-hidden="true">
+							<svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" focusable="false"><path d="M6 2v8M3 7l3 3 3-3"/></svg>
+						</span>
+					</a>
 				<?php endif; ?>
 
 			</div>


### PR DESCRIPTION
## Summary

Adds a **Find Me** feature to the redesigned `/pledges/` contributor directory so logged-in contributors can see where they stand and jump to their card from anywhere on the page. Implements the *Option 1: hide-on-overlap* behavior agreed in design review.

## What it does

When a logged-in contributor lands on `/pledges/`, the page now shows:

- A **Your standing** card at the top of the page that mirrors the user's ranked contributor row.
- A floating **Jump to your card** pill in the bottom-right corner that deep-links to the exact in-list card.

When the user scrolls down to their in-list card (or clicks the pill and lands on it), both indicators recede via `body.is-on-me` — the page never shows the same identity twice at once. As soon as the user scrolls back up past their row, the indicators return.

## States

The Your-standing block covers five conditions:

1. **Logged out** — dashed sign-in card pointing at `wp_login_url()`, no floater.
2. **Ranked and off-screen** — card mirrors the in-list row, floater visible.
3. **Ranked and in viewport** — `IntersectionObserver` adds `is-on-me`; card + floater hidden by CSS. Re-shows on scroll-away. `rootMargin: -15% 0px -15% 0px` so the fade happens as the row approaches, not after the duplication is visible.
4. **Filtered out** — warn-tone card naming the chip excluding the user (e.g. "The **Sponsored** filter is excluding you"), with a one-tap **Clear filters →** action.
5. **Not ranked on this team** — dashed card pointing at "How impact is scored". Logged-in users not on the team's opt-in roster see no standing block.

## Why server-side rendering for a per-user feature

The Your-standing state is computed in `page-pledges.php` from `get_current_user_id()`, then handed to `content-pledge.php` via two new flags (`_is_you`, `_is_standing`). This gives JS-disabled and slow-network visitors the right initial paint — the jump-to pill is a real `<a href="#pledges-card-you">`, the standing card is real markup, no JS needed for the basic feature to work.

Anonymous visitors hit the existing page cache and all see the same dashed "Sign in" card. Logged-in visitors already bypass the page cache, so per-user rendering doesn't introduce a cache-poisoning surface.

## Accessibility

- The pill is a proper anchor with an `aria-label` that names both the action and the user's rank, so screen readers announce *"Jump to your card, ranked #47"*.
- Click handler sets `tabindex="-1"` on the in-list card just before focusing it, then strips it on blur — focus lands on the card so screen readers announce it, but tab order stays untouched for keyboard users.
- Modifier-clicks (cmd/ctrl/shift/middle) on the pill fall through to native navigation so *open in new tab* still produces a shareable deep link.
- `block: 'center'` on `scrollIntoView` lands the card with neighbors visible above and below for context.

## Responsive

Three breakpoints handled in `css/page-pledges.css` at the existing 720px media query:

- The standing card's action button wraps below the body text instead of overflowing.
- The "You are here" badge moves from top-right to bottom-right of the card (the rank pill takes the top-right corner on narrow viewports).
- The floating pill drops its visible label (aria-label still names it), shrinks to a fab-style avatar + rank + arrow, and tucks into the thumb-zone corner.

## Test plan

- [ ] Logged out: load `/core/pledges/` → dashed sign-in card at top, no floating pill, sign-in button links to `wp_login_url()` with redirect back to `/pledges/`.
- [ ] Logged in on team, ranked: see your standing card at top + floating pill bottom-right. Click pill → smooth-scrolls to your in-list card, both indicators fade out. Scroll back up → indicators return. The in-list card and standing card show identical content.
- [ ] Logged in on team, ranked, filter to a sponsorship that excludes you: standing card switches to warn-tone naming the filter. Click "Clear filters →" → lands on `?sponsorship=all`, you reappear in the list.
- [ ] Logged in on team, no impact in window: dashed "You are not ranked in this team" card with "How impact is scored →" link to the existing how-this-page-works section.
- [ ] Logged in but not on this team: no standing block renders.
- [ ] JS disabled: clicking the pill jumps (non-smooth) to `#pledges-card-you`. Hide-on-overlap doesn't fire — both indicators stay visible. Sign-in button still works.
- [ ] Mobile (375px wide): standing card stacks, floating pill shrinks to avatar + rank + arrow with no visible label, "you are here" badge sits at the bottom of the card.
- [ ] Middle-click / cmd-click the pill: opens `#pledges-card-you` in a new tab. The new tab loads cleanly with no JS hijack.
- [ ] Screen reader: announce "Jump to your card, ranked #47" on the pill. Focus lands on the card after click.

## Files

- `page-pledges.php` — state computation, Your-standing markup, floating pill, `_is_you` + `_is_standing` flags on the contributor loops.
- `content-pledge.php` — `data-you="1"` attribute, "You are here" badge, `id="pledges-card-you"` gated by `! _is_standing`.
- `js/page-pledges.js` — `IntersectionObserver` for `is-on-me`, `apply()` extension for `is-find-me-hidden`, pill click handler with smooth-scroll + focus management + modifier-key guards.
- `css/page-pledges.css` — `.pledges-standing` variants (signin / not-ranked / filtered-out / ranked), `.pledges-card.is-you` ribbon + ring + badge, `.pledges-jump-pill` floating action with hover/focus elevation, responsive overrides at 720px.