### PR TITLE
Five for the Future: Fix /pledges/ Find Me Clear-filters button color and mobile filtered-out card layout

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/css/page-pledges.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/css/page-pledges.css
@@ -502,7 +502,10 @@
 	display: none;
 }
 
-.pledges-empty-reset {
+/* Specificity bumped against .entry-content's typography rules — without the
+   prefix, `.entry-content a { color: #3858e9 }` from the theme wins and the
+   white text on the dark pill ends up rendering as dark-blue-on-black. */
+.entry-content .pledges-empty-reset {
 	display: inline-block;
 	margin-top: 10px;
 	background: var(--wp--preset--color--charcoal-1, #1d2327);
@@ -516,8 +519,8 @@
 	text-decoration: none;
 }
 
-.pledges-empty-reset:hover,
-.pledges-empty-reset:focus {
+.entry-content .pledges-empty-reset:hover,
+.entry-content .pledges-empty-reset:focus {
 	color: #fff;
 	text-decoration: none;
 }
@@ -674,7 +677,10 @@
 	color: #7a4a00;
 }
 
-.pledges-standing-action {
+/* Specificity bumped against .entry-content's typography rules — without the
+   prefix, `.entry-content a { color: #3858e9 }` from the theme wins and the
+   white text on the dark pill ends up rendering as dark-blue-on-black. */
+.entry-content .pledges-standing-action {
 	flex-shrink: 0;
 	background: var(--wp--preset--color--charcoal-1, #1d2327);
 	color: #fff;
@@ -686,8 +692,8 @@
 	white-space: nowrap;
 }
 
-.pledges-standing-action:hover,
-.pledges-standing-action:focus {
+.entry-content .pledges-standing-action:hover,
+.entry-content .pledges-standing-action:focus {
 	color: #fff;
 	text-decoration: none;
 	background: #000;
@@ -904,18 +910,26 @@ body.is-find-me-filtered .pledges-jump-pill {
 		line-height: 1.5;
 	}
 
-	/* Standing block: stack action below body so the card doesn't
-	   overflow on narrow screens. */
+	/* Standing block: switch to a column layout so the title can breathe
+	   instead of getting squeezed between the avatar and the action button.
+	   flex-wrap alone wasn't enough — the body had flex:1 and the action
+	   pulled to the right, so the title compressed to ~10 chars wide
+	   ("You're hidden by current filters." wrapped to four lines on /meta/
+	   in production). Stacking the action below the body and stretching it
+	   full-width keeps both readable and lands the CTA in the thumb zone. */
 	.pledges-standing-card-signin,
 	.pledges-standing-card-not-ranked,
 	.pledges-standing-card-filtered {
-		flex-wrap: wrap;
+		flex-direction: column;
+		align-items: flex-start;
 		padding: 14px 16px;
 		gap: 12px;
 	}
 
-	.pledges-standing-action {
-		margin-left: auto;
+	.entry-content .pledges-standing-action {
+		margin-left: 0;
+		align-self: stretch;
+		text-align: center;
 	}
 
 	/* On narrow viewports the rank pill takes the top-right corner and the


### PR DESCRIPTION
## Summary

Two post-deploy polish fixes on the /pledges/ Find Me feature shipped in #646, found via live design review on make.wordpress.org/meta/pledges/.

### 1. Clear-filters button: dark-blue text on near-black pill

The Clear filters button — used both inside the filtered-out standing card ("You're hidden by current filters." card) and inside the empty-state card — was rendering as dark-blue text on a charcoal-1 pill. The theme's `.entry-content a { color: #3858e9 }` rule (specificity 0,2,0) was beating `.pledges-standing-action { color: #fff }` and `.pledges-empty-reset { color: #fff }` (both at 0,1,0).

Bump both buttons' specificity to `.entry-content .pledges-standing-action` and `.entry-content .pledges-empty-reset` so the white-on-charcoal pill survives the theme's typography reset. Same prefix pattern already used to win the typography fight on the `.pledges-standing-eyebrow` label in #646.

### 2. Mobile filtered-out card: title wrapping to four lines

On mobile (verified live at 375px), the filtered-out standing card was packing avatar + body + Clear-filters action onto a single row with `flex-wrap`. The Clear filters button held its width on the right while the body shrank to about 10 characters wide, fragmenting "You're hidden by current filters." into four lines and compressing the explanatory sub-line into a column of two-word stubs.

Switch the mobile layout to `flex-direction: column` with `align-items: flex-start`, and stretch the action button full-width. The title gets full row to breathe, the sub-line wraps naturally, and the CTA lands in the thumb zone instead of competing for horizontal space.

Same fix automatically applies to the sign-in twin (logged-out state) which shares the same flex pattern with its own Sign-in action button.

## Test plan

- [ ] On a team where you're sponsored (e.g. `make.wordpress.org/meta/pledges/`) at mobile width (375): verify the "You're hidden by current filters" card title is on one line, the sub-line reads naturally, and the Clear filters button spans full width below.
- [ ] Same page on desktop: layout unchanged (avatar + body + button still on one row, action right-aligned).
- [ ] Logged-out on any team subsite at mobile width: verify the sign-in card layout — title not fragmenting, "Sign in →" button full-width.
- [ ] Filtered-out standing card's Clear filters button: text is white, not dark-blue.
- [ ] Empty-state card's Clear filters button (e.g. `/meta/pledges/?sponsorship=independent` for a sponsored user): text is white, not dark-blue.

## Files

- `wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/css/page-pledges.css` only — CSS-only change, no PHP/JS touched.