### PR TITLE
Five for the Future: Use _n() for the /pledges/ ranked-by-impact label

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/page-pledges.php
@@ -488,7 +488,7 @@ if ( ! $current_user_id ) {
 							<?php
 							echo esc_html( sprintf(
 								/* translators: %d: window in days */
-								__( 'Ranked by impact, last %d days.', 'wporg-5ftf' ),
+								_n( 'Ranked by impact, last %d day.', 'Ranked by impact, last %d days.', $window_days, 'wporg-5ftf' ),
 								$window_days
 							) );
 							?>


### PR DESCRIPTION
## Summary

The `Ranked by impact, last %d days.` label on `/pledges/` was wrapped in `__()`, which forces every translation to treat the day count as plural. Switch to `_n()` with a singular form (`Ranked by impact, last %d day.`) so locales that distinguish 1 vs N can render the singular when `\$window_days` is 1, and existing plural-aware locales keep the plural for 30/90/180.

Props iworks, dd32.

Fixes https://meta.trac.wordpress.org/ticket/8251.

## Test plan

- [ ] On `/pledges/?window=30` (or 90 / 180): label reads "Ranked by impact, last 30 days." — unchanged.
- [ ] If `WINDOW_DAYS_ALLOWED` ever adds 1 (or any locale renders different plural forms for these counts): the singular form is now available to translators.