### PR TITLE
Plugin Directory: Add /browse/dashboard-widgets/ to the section URL whitelist

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-plugin-directory.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-plugin-directory.php
@@ -413,7 +413,7 @@ class Plugin_Directory {
 		API\Plugin_Fields::register();
 
 		// Add the browse/* views.
-		add_rewrite_tag( '%browse%', '(featured|popular|beta|blocks|block|new|favorites|adopt-me|updated|preview)' );
+		add_rewrite_tag( '%browse%', '(featured|popular|beta|blocks|block|new|favorites|adopt-me|updated|preview|dashboard-widgets)' );
 		add_permastruct( 'browse', 'browse/%browse%' );
 
 		// Create an archive for a users favorites too.
@@ -670,7 +670,7 @@ class Plugin_Directory {
 		// For any invalid values passed to browse, set it to featured instead
 		if (
 			! empty ( $wp_query->query['browse'] ) &&
-			! in_array( $wp_query->query['browse'], array( 'featured', 'popular', 'beta', 'blocks', 'block', 'new', 'favorites', 'adopt-me', 'updated', 'preview' ) )
+			! in_array( $wp_query->query['browse'], array( 'featured', 'popular', 'beta', 'blocks', 'block', 'new', 'favorites', 'adopt-me', 'updated', 'preview', 'dashboard-widgets' ) )
 		) {
 			 $wp_query->query['browse']      = 'featured';
 			 $wp_query->query_vars['browse'] = 'featured';


### PR DESCRIPTION
Follow-up to #625, which added backend detection of `wp_add_dashboard_widget()` calls and assigns the `dashboard-widgets` `plugin_section` term during plugin import. That landed in trunk (824702a0a, 9b8b91287), but `/plugins/browse/dashboard-widgets/` still 404'd-into-`/featured/` because the rewrite tag and validator both enumerate their accepted slugs.

## Summary

- `class-plugin-directory.php`: add `dashboard-widgets` to:
  - the `add_rewrite_tag( '%browse%', ... )` regex (line 416), and
  - the validation `in_array()` whitelist that falls invalid section names back to `featured` (line 673).

That is the entire change — two slug additions. The archive template, page title (`get_the_archive_title()` from the term name), and description (`get_the_archive_description()` from the term description) all flow through the existing shared `archive.html` template, so no theme changes are needed.

## Not in scope

Deliberately keeping this minimal per the request ("just the page"):

- Not adding `dashboard-widgets` to the front-page sections grid (`build/blocks/front-page/render.php`) — separate question of discovery / promotion.
- Not displaying `dashboard_widget_name` post meta on the plugin card.
- Not adding a translatable description string for the section in `class-i18n.php` (only the section name is currently registered — happy to add one if desired).

## Test plan

- [ ] Locally: `npx wp-env start` (which runs `after-start.sh` and seeds the `dashboard-widgets` term), then visit `/plugins/browse/dashboard-widgets/` and confirm the page renders with the term name as the title and lists plugins assigned to that section.
- [ ] Confirm `/plugins/browse/some-invalid-slug/` still falls back to `/browse/featured/`.
- [ ] Production: `dashboard-widgets` term needs to exist in the `plugin_section` taxonomy (same manual-creation assumption as the existing `featured`, `popular`, `block`, etc. sections — noted in #625).
