### PR TITLE
Five for the Future: wire the Test team into the contributor directory

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/inc/contribution-metrics.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/inc/contribution-metrics.php
@@ -37,7 +37,7 @@ const CACHE_PREFIX        = '5ftf_contrib_metrics_v1_';
  *   2. Wire the data source into get_team_contribution_metrics().
  *   3. Add the team's post_name slug to this list.
  */
-const TEAMS_WITH_DATA = array( 'core', 'meta' );
+const TEAMS_WITH_DATA = array( 'core', 'meta', 'test' );
 
 /**
  * Whether the given team has wired-up contribution tracking.
@@ -93,6 +93,7 @@ function team_to_github_repos( string $slug ): array {
 	$map = array(
 		'core' => array( 'WordPress/wordpress-develop', 'WordPress/gutenberg' ),
 		'meta' => array( 'WordPress/wporg-main', 'WordPress/wporg-mu-plugins' ),
+		'test' => array( 'WordPress/test-handbook' ),
 	);
 	return isset( $map[ $slug ] ) ? $map[ $slug ] : array();
 }


### PR DESCRIPTION
- Adds `test` to `TEAMS_WITH_DATA` so `/pledges/` on the Test make site renders the directory instead of the
  bring-tracking-to-this-team guide.
- Maps `test` to `WordPress/test-handbook` in `team_to_github_repos()` so GitHub activity is scoped to the team's repo.

  No Trac mapping — the Test team has no Trac source, so the Trac branch in `get_team_contribution_metrics()` is skipped and rankings come entirely from `wporg_github_activity`.