### PR TITLE
fix: typo in screen reader shadow color variable

### DIFF
--- a/buddypress.org/public_html/wp-content/themes/bb-base/style.css
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/style.css
@@ -70,7 +70,7 @@ a img { border: 1px solid transparent; }
 
 	/* Screen Reader */
 	--bbbase-screen-reader-color: rgba(33, 117, 155, 1);
-	--bbbase-screen-reader-shador-color: rgba(0, 0, 0, 0.6);
+	--bbbase-screen-reader-shadow-color: rgba(0, 0, 0, 0.6);
 
 	/* Common Colors */
 	--bbbase-brightest-white: rgba(255, 255, 255, 1);


### PR DESCRIPTION
Buddypress ticket: https://buddypress.trac.wordpress.org/ticket/9336

fix: typo in screen reader shadow color variable in below file:

`wordpress.org\buddypress.org\public_html\wp-content\themes\bb-base\style.css`

There is wrong variable name in the `style.css` file
Wrong: `--bbbase-screen-reader-shador-color: rgba(0, 0, 0, 0.6);`
Correct: `--bbbase-screen-reader-shadow-color: rgba(0, 0, 0, 0.6);`


