### PR TITLE
Plugin Directory: Fix malformed viewBox attribute on generated geopattern icons

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-plugin-geopattern-svg.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-plugin-geopattern-svg.php
@@ -34,7 +34,7 @@ class Plugin_Geopattern_SVG extends SVG {
 	 */
 	protected function getSvgHeader() {
 		if ( $this->viewbox ) {
-			return "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{$this->width}\" height=\"{$this->height}\" viewbox=\"{$this->viewbox}\" preserveAspectRatio=\"none\">";
+			return "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{$this->width}\" height=\"{$this->height}\" viewBox=\"{$this->viewbox}\" preserveAspectRatio=\"none\">";
 		} else {
 			return "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{$this->width}\" height=\"{$this->height}\">";
 		}


### PR DESCRIPTION
## Summary

Fixes [meta.trac #8270](https://meta.trac.wordpress.org/ticket/8270).

The auto-generated fallback "geopattern" plugin icons served from `https://s.w.org/plugins/geopattern-icon/<slug>_<hex>.svg` emitted the `viewBox` attribute in all-lowercase (`viewbox`). SVG attribute names are case-sensitive, so spec-compliant parsers treat it as an unknown attribute and the document effectively has **no** `viewBox`. Without a user coordinate system the icon cannot be scaled and renders garbled in native/strict renderers — notably Apple's CoreSVG (ImageIO, native iOS/macOS image loading) when the file is fetched directly as `image/svg+xml`.

It went unnoticed because, when an SVG is inlined into HTML, the parser's foreign-content attribute-adjustment step auto-corrects `viewbox` → `viewBox`, so it renders fine on the directory website. The standalone file fetched via `<img>` / CSS `background-image` / native loaders gets no such correction.

The fix is a single casing change in the generator template (`class-plugin-geopattern-svg.php`):

```diff
- viewbox="{$this->viewbox}"
+ viewBox="{$this->viewbox}"
```

The internal property name is left as `$viewbox` (private implementation detail); only the emitted attribute changes.

## Notes / scope decisions

- **`preserveAspectRatio="none"` was intentionally left as-is.** The ticket suggests `xMidYMid meet`, but `.plugin-icon` renders these in a fixed square box, and browsers already apply `viewBox` (auto-corrected) + `none`, i.e. stretch-to-fill — the established appearance on the directory today. Fixing only the casing makes native/CoreSVG renderers match that current behaviour; switching to `meet` would change rendering (letterboxing for non-square patterns). Happy to flip it if a stretch-vs-letterbox change is wanted.
- The ticket's other "secondary" items (excessive float precision on opacity values, comma-only `points` separators) are non-spec-violation polish living in the vendored `libs/geopattern-1.1.0/` library, so they are left out of this minimal, low-risk fix and can be a follow-up if desired.

## Test plan

- [ ] Request a generated icon (e.g. `/geopattern-icon/<slug>.svg`) and confirm the root element now contains `viewBox="0 0 W H"`.
- [ ] Confirm the file still passes `xmllint --noout` and renders identically in a browser.
- [ ] Confirm it now renders correctly when loaded as a standalone `image/svg+xml` in a strict/native renderer (e.g. macOS Quick Look / an `<img>` tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
