### PR TITLE
Add aria-hidden to stars

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-template.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-template.php
@@ -715,7 +715,7 @@ class Template {
 		$args = is_numeric( $args ) ? array( 'rating' => $args ) : $args;
 		$args = wp_parse_args( $args, array(
 			'rating'   => 0,
-			'template' => '<span class="%1$s"></span>',
+			'template' => '<span class="%1$s" aria-hidden="true"></span>',
 		) );
 
 		$rating         = round( $args['rating'] / 0.5 ) * 0.5;


### PR DESCRIPTION
Partially fixes https://meta.trac.wordpress.org/ticket/8276 by adding `aria-hidden` to the ratings star output.

However, the container already has an `aria-label`. This is run through `wp_kses_post` at a few points, but I wouldn't have expected that to remove `aria-label`, so I'm not sure why it's gone.

In block contexts, this is rendered via `wporg/ratings-stars`, but I have no idea where that is.

