### PR TITLE
Plugin Directory: Skip the CSS source map in the production build

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/Gruntfile.js
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/Gruntfile.js
@@ -19,7 +19,7 @@ module.exports = function ( grunt ) {
 		sass: {
 			options: {
 				implementation: require( 'sass' ),
-				// Don't add source map & source mapURL in built version.
+				// Don't add source map & source map URL in built version.
 				sourceMap: 'build' !== process.argv[ 2 ],
 				omitSourceMapUrl: 'build' === process.argv[ 2 ],
 				outputStyle: 'expanded',

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/Gruntfile.js
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/Gruntfile.js
@@ -19,8 +19,8 @@ module.exports = function ( grunt ) {
 		sass: {
 			options: {
 				implementation: require( 'sass' ),
-				sourceMap: true,
-				// Don't add source map URL in built version.
+				// Don't add source map & source mapURL in built version.
+				sourceMap: 'build' !== process.argv[ 2 ],
 				omitSourceMapUrl: 'build' === process.argv[ 2 ],
 				outputStyle: 'expanded',
 				includePaths: [ './node_modules' ],


### PR DESCRIPTION
## What

The `grunt build` task (run via `npm run build:css`) was still writing a `css/style.css.map` file, even though source maps aren't intended for the built/production CSS.

This adjusts the `grunt-sass` `sourceMap` option so the map is generated only for the local development tasks (`grunt` / `grunt watch`) and is skipped during `grunt build`:

```js
sourceMap: 'build' !== process.argv[ 2 ],
omitSourceMapUrl: 'build' === process.argv[ 2 ],
```

## Why

`omitSourceMapUrl` only strips the `sourceMappingURL` comment from `style.css`; it doesn't stop `grunt-sass` from writing the `.map` file itself. The previous condition evaluated to `true` during `build`, so a `style.css.map` was emitted on every production build and could end up committed alongside the compiled CSS. Keeping source maps for local development while leaving them out of the build keeps the production output clean and avoids accidentally shipping/committing the map.

## Testing

- `npm run build:css` (i.e. `grunt build`) → no `css/style.css.map` is produced, and `style.css` contains no `sourceMappingURL` comment.
- `grunt` / `grunt watch` (local development) → source maps are still generated as before.

## Notes

Small, build-tooling-only change with no effect on the theme's runtime output. Feedback welcome — happy to adjust if there's a preferred pattern for detecting the build task in this Gruntfile.
