### PR TITLE
Environments: Add Browse Happy wp-env local development environment

### DIFF
--- a/environments/README.md
+++ b/environments/README.md
@@ -71,6 +71,18 @@ npm run jobs:env start
 npm run jobs:env -- run cli -- wp <command>
 ```
 
+### Browse Happy
+
+A local instance of [browsehappy.com](https://browsehappy.com) with the theme.
+
+**Start:**
+
+```bash
+npm run browsehappy:env start
+```
+
+**Access:** `http://localhost:8888`
+
 ### Handbook (in-plugin)
 
 The Handbook plugin has its own `.wp-env.json` in `wordpress.org/public_html/wp-content/plugins/handbook/`.

--- a/environments/browsehappy/.wp-env.json
+++ b/environments/browsehappy/.wp-env.json
@@ -1,0 +1,12 @@
+{
+  "core": "WordPress/WordPress#master",
+  "phpVersion": "8.4",
+  "testsEnvironment": false,
+  "themes": ["../browsehappy.com/public_html"],
+  "lifecycleScripts": {
+    "afterStart": "bash browsehappy/bin/after-start.sh"
+  },
+  "config": {
+    "WP_DEBUG": true
+  }
+}

--- a/environments/browsehappy/bin/after-start.sh
+++ b/environments/browsehappy/bin/after-start.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# Runs after wp-env start. Sets site name, description and activates the
+# Browse Happy theme.
+
+CONFIG="--config browsehappy/.wp-env.json"
+WP="npx wp-env $CONFIG run cli --"
+
+# Set site title and description to match the public site.
+$WP wp option update blogname 'Browse Happy'
+$WP wp option update blogdescription 'Online. Worry free. Upgrade your browser today!'
+
+# Activate the browsehappy theme.
+# wp-env uses the last path segment as the theme slug, so the slug is 'public_html'
+# rather than 'browsehappy' (from "themes": ["../browsehappy.com/public_html"]).
+# This theme is not pushed to the svn repo in wp-content/themes as per other sites.
+$WP wp theme activate public_html
+
+echo "Browse Happy environment ready!"

--- a/environments/package.json
+++ b/environments/package.json
@@ -11,7 +11,8 @@
 		"plugins:refresh": "npm run plugins:env -- run cli -- wp option delete wporg_env_imported && npm run plugins:env -- run cli wp eval-file wp-content/env-bin/import-plugins.php",
 		"plugins:test:env": "wp-env --config plugin-directory/.wp-env.test.json",
 		"plugins:test": "npm run plugins:test:env -- start && npm run plugins:test:env -- run tests-cli --env-cwd=wp-content/plugins/plugin-directory phpunit",
-		"jobs:env": "wp-env --config jobs/.wp-env.json"
+		"jobs:env": "wp-env --config jobs/.wp-env.json",
+		"browsehappy:env": "wp-env --config browsehappy/.wp-env.json"
 	},
 	"devDependencies": {
 		"@wordpress/env": "^11"


### PR DESCRIPTION
Adds a [wp-env](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/) configuration for the Browse Happy site (https://browsehappy.com), mirroring the existing `jobs` environment:

- `environments/browsehappy/.wp-env.json` — environment config (WordPress core, PHP 8.4, mounts the Browse Happy theme).
- `environments/browsehappy/bin/after-start.sh` — after-start script that sets the site title/description and activates the theme.
- `environments/package.json` — adds the `browsehappy:env` npm script.
- `environments/README.md` — documents how to start and access the environment.

**Start:** `npm run browsehappy:env start` (from `environments/`) → http://localhost:8888

I verified locally that a fresh `wp-env` start brings the site up with the Browse Happy theme correctly activated.

This recreates #666 so it can be merged from here. All of the work is Jamie's.

Props @JamieBradders.
