### PR TITLE
Plugin Directory: Search: Only boost whole-slug matches, to prevent slug squatting. See #8225.

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-plugin-search.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-plugin-search.php
@@ -274,15 +274,42 @@ class Plugin_Search {
 			],
 		];
 
-		// A direct slug match
+		// Boost on a title match.
 		$should_match[] = [
 			'multi_match' => [
 				'query'  => $search_phrase,
-				'fields' => $this->localise_es_fields( [ 'title', 'slug_text' ] ),
+				'fields' => $this->localise_es_fields( [ 'title' ] ),
 				'type'   => 'most_fields',
 				'boost'  => 5,
 			],
 		];
+
+		// A direct slug match.
+		//
+		// The slug boost is meant to reward searches that are looking for a
+		// specific plugin by its slug (e.g. `wordpress-seo`, `wp-google-maps`),
+		// not searches for a topic that happens to appear as one word of a slug.
+		//
+		// Previously `slug_text` was included in the title `most_fields` match
+		// above. Because `slug_text` is word-tokenized (`wp-google-maps` becomes
+		// `wp`, `google`, `maps`), a generic single-word query like `map` matched
+		// a fragment of every `*-map(s)` slug and collected the full slug boost.
+		// That let plugins squat on common terms by stuffing them into the slug.
+		//
+		// Instead we match the query against the whole-slug `slug` keyword field,
+		// normalised the same way the slug itself was generated. `sanitize_title()`
+		// turns `WP Google Maps` into `wp-google-maps`, so an actual slug search
+		// still scores a decisive, constant boost, while a single common word
+		// only matches a plugin whose entire slug is that word.
+		$slug_candidate = sanitize_title( $search_phrase );
+		if ( $slug_candidate ) {
+			$should_match[] = [
+				'constant_score' => [
+					'filter' => [ 'term' => [ 'slug' => $slug_candidate ] ],
+					'boost'  => 8,
+				],
+			];
+		}
 
 		$should_match[] = [
 			'multi_match' => [


### PR DESCRIPTION
Fixes the slug boost in plugin search so it rewards _searching for a plugin by its slug_ without letting plugins **squat on common keywords** via their slug. See https://meta.trac.wordpress.org/ticket/8225.

### Problem

`slug_text` was part of the high-weight (`boost: 5`) `most_fields` title clause. `slug_text` is word-tokenized — `wp-google-maps` → `wp`, `google`, `maps` — so a generic single-word query like `map` matched a _fragment_ of every `*-map(s)` slug and collected the full slug boost. This is a **slug-squatting** vector: stuffing a popular term into a slug buys ranking on that term.

Concretely, for the query `map`, every plugin with `map` as one slug word got the boost, and the only top results _without_ it (`wp-google-maps`, `google-maps-widget`, whose slugs contain `maps`, not `map`) were the ones penalised — the opposite of intent.

### Fix

Match the query against the whole-slug `slug` keyword field, normalised with `sanitize_title()` (the same function that generated the slug), via a `constant_score` clause. The slug boost now fires only when the query _is_ the plugin's identifier, not when it shares one word with it. `slug_text` is removed from the title `most_fields` clause; title matching is unchanged.

### Behaviour — slug-searches still match the expected plugin

| Search query | Normalised | Result |
|---|---|---|
| `map` | `map` | **no slug boost** (no plugin's whole slug is `map`) — squatting prevented |
| `maps` | `maps` | **no slug boost** — squatting prevented |
| `wp-google-maps` | `wp-google-maps` | boosts `wp-google-maps` ✓ |
| `WP Google Maps` (spaces) | `wp-google-maps` | boosts `wp-google-maps` ✓ |
| `wordpress-seo` | `wordpress-seo` | boosts `wordpress-seo` ✓ |
| `leaflet-map` | `leaflet-map` | boosts `leaflet-map` ✓ |
| `contact-form-7` | `contact-form-7` | boosts `contact-form-7` ✓ |
| `woocommerce` | `woocommerce` | boosts `woocommerce` ✓ (single-word brand slugs still match) |

Verified against the live index: single common words (`map`/`maps`) match zero whole-slugs, while every real slug search returns exactly its plugin with a flat, predictable score.
