### PR TITLE
Translation Events: Hide end date when more than 1 year in the future

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/includes/event/event-date.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/includes/event/event-date.php
@@ -63,7 +63,8 @@ abstract class Event_Date extends DateTimeImmutable {
 	}
 
 	public function is_more_than_one_year_in_the_future(): bool {
-		return $this->utc() > Translation_Events::now()->modify( '+1 year' );
+		$now = Translation_Events::now();
+		return $this->utc() > $now->modify( '+1 year' );
 	}
 
 	public function print_relative_time_html() {

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/includes/event/event-date.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/includes/event/event-date.php
@@ -62,6 +62,10 @@ abstract class Event_Date extends DateTimeImmutable {
 		return $this->utc() < Translation_Events::now();
 	}
 
+	public function is_more_than_one_year_in_the_future(): bool {
+		return $this->utc() > Translation_Events::now()->modify( '+1 year' );
+	}
+
 	public function print_relative_time_html() {
 		echo wp_kses(
 			'<time

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/templates/event-details.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/templates/event-details.php
@@ -266,12 +266,13 @@ Templates::header(
 					<?php $event->start()->print_relative_time_html(); ?>
 				</span>
 				<?php $event->start()->print_time_html(); ?>
+				<?php if ( $event->end()->is_in_the_past() || ! $event->end()->is_more_than_one_year_in_the_future() ) : ?>
 				<span class="event-details-date-label">
 					<?php echo esc_html( $event->end()->is_in_the_past() ? __( 'Ended', 'gp-translation-events' ) : __( 'Ends', 'gp-translation-events' ) ); ?>:
 					<?php $event->end()->print_relative_time_html(); ?>
-
 				</span>
 				<?php $event->end()->print_time_html(); ?>
+				<?php endif; ?>
 			</p>
 		</div>
 		<?php if ( is_user_logged_in() ) : ?>

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/templates/event-details.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/templates/event-details.php
@@ -266,12 +266,13 @@ Templates::header(
 					<?php $event->start()->print_relative_time_html(); ?>
 				</span>
 				<?php $event->start()->print_time_html(); ?>
-				<?php if ( $event->end()->is_in_the_past() || ! $event->end()->is_more_than_one_year_in_the_future() ) : ?>
+				<?php $end = $event->end(); ?>
+				<?php if ( $end->is_in_the_past() || ! $end->is_more_than_one_year_in_the_future() ) : ?>
 				<span class="event-details-date-label">
-					<?php echo esc_html( $event->end()->is_in_the_past() ? __( 'Ended', 'gp-translation-events' ) : __( 'Ends', 'gp-translation-events' ) ); ?>:
-					<?php $event->end()->print_relative_time_html(); ?>
+					<?php echo esc_html( $end->is_in_the_past() ? __( 'Ended', 'gp-translation-events' ) : __( 'Ends', 'gp-translation-events' ) ); ?>:
+					<?php $end->print_relative_time_html(); ?>
 				</span>
-				<?php $event->end()->print_time_html(); ?>
+					<?php $end->print_time_html(); ?>
 				<?php endif; ?>
 			</p>
 		</div>


### PR DESCRIPTION
On the event details page, the end date and relative time (e.g. "Ends: in 9 years") are now hidden when the end date is more than one year in the future. Past end dates and near-future ones are unaffected.

Fixes https://meta.trac.wordpress.org/ticket/8280