### PR TITLE
[codex] Automate support badge awards

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-badges.php
+++ b/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-badges.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ * Support forum badge automation.
+ *
+ * @package wporg-forums
+ */
+
+declare( strict_types = 1 );
+
+namespace WordPressdotorg\Forums;
+
+use function WordPressdotorg\Profiles\assign_badge;
+use function WordPressdotorg\Profiles\has_badge;
+
+/**
+ * Awards Support badges based on forum role and reply activity.
+ */
+class Badges {
+
+	const CONTRIBUTOR_REPLY_THRESHOLD = 50;
+
+	/**
+	 * Badge assignments queued during the current request.
+	 *
+	 * @var array<string, bool>
+	 */
+	private $queued_assignments = array();
+
+	/**
+	 * Register badge assignment hooks.
+	 */
+	public function __construct() {
+		add_filter( 'bbp_set_user_role', array( $this, 'maybe_award_team_badge_for_bbp_role' ), 20, 2 );
+		add_action( 'add_user_role', array( $this, 'maybe_award_team_badge_for_role' ), 20, 2 );
+		add_action( 'set_user_role', array( $this, 'maybe_award_team_badge_for_role' ), 20, 2 );
+
+		add_action( 'bbp_new_reply', array( $this, 'maybe_award_contributor_badge_for_reply' ), 30 );
+		add_action( 'bbp_approved_reply', array( $this, 'maybe_award_contributor_badge_for_reply' ), 30 );
+		add_action( 'bbp_unspammed_reply', array( $this, 'maybe_award_contributor_badge_for_reply' ), 30 );
+		add_action( 'bbp_untrashed_reply', array( $this, 'maybe_award_contributor_badge_for_reply' ), 30 );
+		add_action( 'wporg_bbp_unarchived_reply', array( $this, 'maybe_award_contributor_badge_for_reply' ), 30 );
+	}
+
+	/**
+	 * Award the Support Team badge when bbPress assigns the moderator role.
+	 *
+	 * @param string $new_role New forum role.
+	 * @param int    $user_id  User ID.
+	 * @return string Unmodified role for the filter.
+	 */
+	public function maybe_award_team_badge_for_bbp_role( $new_role, $user_id ) {
+		$this->maybe_award_team_badge_for_role( $user_id, $new_role );
+
+		return $new_role;
+	}
+
+	/**
+	 * Award the Support Team badge when the moderator role is assigned.
+	 *
+	 * @param int    $user_id User ID.
+	 * @param string $role    Assigned role.
+	 */
+	public function maybe_award_team_badge_for_role( $user_id, $role ) {
+		if ( bbp_get_moderator_role() !== $role ) {
+			return;
+		}
+
+		$this->award_badge( 'support-team', $user_id );
+	}
+
+	/**
+	 * Award the Support Contributor badge if a reply pushes the author to the threshold.
+	 *
+	 * @param int $reply_id Reply ID.
+	 */
+	public function maybe_award_contributor_badge_for_reply( $reply_id ) {
+		if ( ! bbp_is_reply_published( $reply_id ) ) {
+			return;
+		}
+
+		$this->maybe_award_contributor_badge( bbp_get_reply_author_id( $reply_id ) );
+	}
+
+	/**
+	 * Award the Support Contributor badge to users at or above the reply threshold.
+	 *
+	 * @param int $user_id User ID.
+	 */
+	public function maybe_award_contributor_badge( $user_id ) {
+		$user_id = absint( $user_id );
+
+		if ( ! $user_id ) {
+			return;
+		}
+
+		if (
+			function_exists( 'WordPressdotorg\Profiles\has_badge' ) &&
+			has_badge( 'support-contributor', $user_id )
+		) {
+			return;
+		}
+
+		if ( $this->count_user_replies( $user_id ) < self::CONTRIBUTOR_REPLY_THRESHOLD ) {
+			return;
+		}
+
+		$this->award_badge( 'support-contributor', $user_id );
+	}
+
+	/**
+	 * Count a user's published forum replies.
+	 *
+	 * @param int $user_id User ID.
+	 * @param int $limit   Limit the count to the threshold needed for comparison.
+	 * @return int
+	 */
+	public function count_user_replies( $user_id, $limit = self::CONTRIBUTOR_REPLY_THRESHOLD ) {
+		global $wpdb;
+
+		$user_id       = absint( $user_id );
+		$limit         = max( 1, absint( $limit ) );
+		$post_type     = $this->get_reply_post_type();
+		$post_statuses = $this->get_counted_reply_statuses();
+		$placeholders  = implode( ', ', array_fill( 0, count( $post_statuses ), '%s' ) );
+
+		if ( ! $user_id || ! $post_statuses ) {
+			return 0;
+		}
+
+		$prepared_values = array_merge( array( $user_id, $post_type ), $post_statuses, array( $limit ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- $placeholders is generated from sanitized status values.
+		$query = $wpdb->prepare(
+			"SELECT COUNT(1)
+				FROM (
+					SELECT ID
+					FROM {$wpdb->posts}
+					WHERE post_author = %d
+						AND post_type = %s
+						AND post_status IN ( {$placeholders} )
+					LIMIT %d
+				) AS user_replies",
+			...$prepared_values
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- Runs on reply submission for a single author with a threshold-limited query.
+		return (int) $wpdb->get_var( $query );
+	}
+
+	/**
+	 * Get the bbPress reply post type.
+	 *
+	 * @return string
+	 */
+	private function get_reply_post_type() {
+		return function_exists( 'bbp_get_reply_post_type' ) ? bbp_get_reply_post_type() : 'reply';
+	}
+
+	/**
+	 * Get reply statuses that count toward the Support Contributor badge.
+	 *
+	 * @return string[]
+	 */
+	private function get_counted_reply_statuses() {
+		$post_statuses = function_exists( 'bbp_get_public_status_id' )
+			? array( bbp_get_public_status_id() )
+			: array( 'publish' );
+
+		/**
+		 * Filters the reply statuses that count toward Support Contributor badge eligibility.
+		 *
+		 * @param string[] $post_statuses Reply statuses to count.
+		 */
+		$post_statuses = (array) apply_filters( 'wporg_support_badges_counted_reply_statuses', $post_statuses );
+		$post_statuses = array_map( 'sanitize_key', $post_statuses );
+		$post_statuses = array_filter( $post_statuses );
+
+		return array_values( array_unique( $post_statuses ) );
+	}
+
+	/**
+	 * Assign a badge through the Profiles helper, once per request.
+	 *
+	 * @param string $badge   Badge slug.
+	 * @param int    $user_id User ID.
+	 * @return bool
+	 */
+	private function award_badge( $badge, $user_id ) {
+		$user_id = absint( $user_id );
+		$key     = "{$badge}:{$user_id}";
+
+		if (
+			! $user_id ||
+			isset( $this->queued_assignments[ $key ] ) ||
+			! function_exists( 'WordPressdotorg\Profiles\assign_badge' )
+		) {
+			return false;
+		}
+
+		$this->queued_assignments[ $key ] = true;
+
+		return assign_badge( $badge, $user_id );
+	}
+}

--- a/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-badges.php
+++ b/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-badges.php
@@ -20,13 +20,6 @@ class Badges {
 	const CONTRIBUTOR_REPLY_THRESHOLD = 50;
 
 	/**
-	 * Badge assignments queued during the current request.
-	 *
-	 * @var array<string, bool>
-	 */
-	private $queued_assignments = array();
-
-	/**
 	 * Register badge assignment hooks.
 	 */
 	public function __construct() {
@@ -188,17 +181,13 @@ class Badges {
 	 */
 	private function award_badge( $badge, $user_id ) {
 		$user_id = absint( $user_id );
-		$key     = "{$badge}:{$user_id}";
 
 		if (
 			! $user_id ||
-			isset( $this->queued_assignments[ $key ] ) ||
 			! function_exists( 'WordPressdotorg\Profiles\assign_badge' )
 		) {
 			return false;
 		}
-
-		$this->queued_assignments[ $key ] = true;
 
 		return assign_badge( $badge, $user_id );
 	}

--- a/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-plugin.php
@@ -24,6 +24,7 @@ class Plugin {
 	// Define the properties for all the Support Forum components.
 	public $users                = false;
 	public $user_notes           = false;
+	public $badges               = false;
 	public $moderators           = false;
 	public $hooks                = false;
 	public $report_topic         = false;
@@ -67,6 +68,7 @@ class Plugin {
 	private function __construct() {
 		$this->users        = new Users;
 		$this->user_notes   = new User_Notes;
+		$this->badges       = new Badges();
 		$this->moderators   = new Moderators;
 		$this->hooks        = new Hooks;
 		$this->report_topic = new Report_Topic;

--- a/wordpress.org/public_html/wp-content/plugins/support-forums/phpunit.xml
+++ b/wordpress.org/public_html/wp-content/plugins/support-forums/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<phpunit colors="true">
+	<testsuites>
+		<testsuite name="support-forums">
+			<directory suffix=".php">tests</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/wordpress.org/public_html/wp-content/plugins/support-forums/support-forums.php
+++ b/wordpress.org/public_html/wp-content/plugins/support-forums/support-forums.php
@@ -24,6 +24,7 @@ if ( ! class_exists( 'bbPress' ) ) {
 include( __DIR__ . '/inc/class-plugin.php' );
 include( __DIR__ . '/inc/class-users.php' );
 include( __DIR__ . '/inc/class-user-notes.php' );
+include __DIR__ . '/inc/class-badges.php';
 include( __DIR__ . '/inc/class-moderators.php' );
 include( __DIR__ . '/inc/class-hooks.php' );
 include( __DIR__ . '/inc/class-report-topic.php' );

--- a/wordpress.org/public_html/wp-content/plugins/support-forums/tests/Badges_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/support-forums/tests/Badges_Test.php
@@ -1,0 +1,187 @@
+<?php
+declare( strict_types=1 );
+
+// phpcs:ignoreFile -- Isolated tests intentionally define stub WordPress and bbPress functions across namespaces.
+
+namespace {
+	function sanitize_key( $key ) {
+		return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( $key ) );
+	}
+}
+
+namespace WordPressdotorg\Forums {
+	function add_filter( $hook_name, $callback, $priority = 10, $accepted_args = 1 ) {
+		Tests\Badges_Test::$hooks[] = compact( 'hook_name', 'callback', 'priority', 'accepted_args' );
+	}
+
+	function add_action( $hook_name, $callback, $priority = 10, $accepted_args = 1 ) {
+		add_filter( $hook_name, $callback, $priority, $accepted_args );
+	}
+
+	function apply_filters( $hook_name, $value ) {
+		return Tests\Badges_Test::$filters[ $hook_name ] ?? $value;
+	}
+
+	function absint( $maybeint ) {
+		return abs( (int) $maybeint );
+	}
+
+	function bbp_get_moderator_role() {
+		return 'bbp_moderator';
+	}
+
+	function bbp_get_reply_author_id( $reply_id ) {
+		return Tests\Badges_Test::$reply_authors[ $reply_id ] ?? 0;
+	}
+
+	function bbp_is_reply_published( $reply_id ) {
+		return Tests\Badges_Test::$published_replies[ $reply_id ] ?? false;
+	}
+
+	function bbp_get_reply_post_type() {
+		return 'reply';
+	}
+
+	function bbp_get_public_status_id() {
+		return 'publish';
+	}
+}
+
+namespace WordPressdotorg\Profiles {
+	function has_badge( $badge, $user_id ) {
+		return \WordPressdotorg\Forums\Tests\Badges_Test::$existing_badges[ "{$badge}:{$user_id}" ] ?? false;
+	}
+
+	function assign_badge( $badge, $user_id ) {
+		\WordPressdotorg\Forums\Tests\Badges_Test::$assigned_badges[] = compact( 'badge', 'user_id' );
+
+		return true;
+	}
+}
+
+namespace WordPressdotorg\Forums\Tests {
+	use PHPUnit\Framework\TestCase;
+	use WordPressdotorg\Forums\Badges;
+
+	require_once dirname( __DIR__ ) . '/inc/class-badges.php';
+
+	class Fake_WPDB {
+		public $posts = 'wp_posts';
+		public $reply_counts = array();
+		public $queries = array();
+
+		public function prepare( $query, ...$args ) {
+			if ( 1 === count( $args ) && is_array( $args[0] ) ) {
+				$args = $args[0];
+			}
+
+			$this->queries[] = compact( 'query', 'args' );
+
+			return array( $query, $args );
+		}
+
+		public function get_var( $prepared ) {
+			$user_id = $prepared[1][0] ?? 0;
+			$limit   = end( $prepared[1] );
+
+			return min( $this->reply_counts[ $user_id ] ?? 0, $limit );
+		}
+
+	}
+
+	class Badges_Test extends TestCase {
+		public static $assigned_badges = array();
+		public static $existing_badges = array();
+		public static $filters = array();
+		public static $hooks = array();
+		public static $published_replies = array();
+		public static $reply_authors = array();
+
+		protected function setUp(): void {
+			parent::setUp();
+
+			global $wpdb;
+
+			$wpdb                   = new Fake_WPDB();
+			self::$assigned_badges  = array();
+			self::$existing_badges  = array();
+			self::$filters          = array();
+			self::$hooks            = array();
+			self::$published_replies = array();
+			self::$reply_authors    = array();
+		}
+
+		public function test_moderator_role_assignment_awards_support_team_badge() {
+			$badges = new Badges();
+
+			$badges->maybe_award_team_badge_for_role( 123, 'bbp_moderator' );
+
+			$this->assertSame(
+				array(
+					array(
+						'badge'   => 'support-team',
+						'user_id' => 123,
+					),
+				),
+				self::$assigned_badges
+			);
+		}
+
+		public function test_non_moderator_role_assignment_does_not_award_support_team_badge() {
+			$badges = new Badges();
+
+			$badges->maybe_award_team_badge_for_role( 123, 'bbp_participant' );
+
+			$this->assertSame( array(), self::$assigned_badges );
+		}
+
+		public function test_published_reply_at_threshold_awards_support_contributor_badge() {
+			global $wpdb;
+
+			$wpdb->reply_counts[123] = 50;
+			self::$published_replies[456] = true;
+			self::$reply_authors[456] = 123;
+
+			$badges = new Badges();
+			$badges->maybe_award_contributor_badge_for_reply( 456 );
+
+			$this->assertSame(
+				array(
+					array(
+						'badge'   => 'support-contributor',
+						'user_id' => 123,
+					),
+				),
+				self::$assigned_badges
+			);
+		}
+
+		public function test_unpublished_reply_does_not_award_support_contributor_badge() {
+			global $wpdb;
+
+			$wpdb->reply_counts[123] = 50;
+			self::$published_replies[456] = false;
+			self::$reply_authors[456] = 123;
+
+			$badges = new Badges();
+			$badges->maybe_award_contributor_badge_for_reply( 456 );
+
+			$this->assertSame( array(), self::$assigned_badges );
+		}
+
+		public function test_existing_support_contributor_badge_skips_reply_count() {
+			global $wpdb;
+
+			$wpdb->reply_counts[123] = 50;
+			self::$existing_badges['support-contributor:123'] = true;
+			self::$published_replies[456] = true;
+			self::$reply_authors[456] = 123;
+
+			$badges = new Badges();
+			$badges->maybe_award_contributor_badge_for_reply( 456 );
+
+			$this->assertSame( array(), self::$assigned_badges );
+			$this->assertSame( array(), $wpdb->queries );
+		}
+	}
+}


### PR DESCRIPTION
Fixes https://meta.trac.wordpress.org/ticket/2214.

## What changed

Adds Support Forums badge automation for two earned badges:

- Awards the Support Team badge when a user is assigned the bbPress moderator role.
- Awards the Support Contributor badge when a user reaches 50 published forum replies.

The badge assignment uses the existing WordPress.org Profiles helper, so Profiles remains the system that applies badge group membership. The support-forums plugin only determines forum-specific eligibility.

## Notes

- Badge removal is intentionally not implemented; once earned, the badge remains.
- Existing Support Contributor badge holders are skipped before reply counting to avoid unnecessary reply-count queries on future replies.
- Reply statuses that count toward contributor eligibility are exposed through the documented `wporg_support_badges_counted_reply_statuses` filter.

## Validation

- `php -l wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-badges.php wordpress.org/public_html/wp-content/plugins/support-forums/tests/Badges_Test.php`
- `vendor/bin/phpunit -c wordpress.org/public_html/wp-content/plugins/support-forums/phpunit.xml`
- `vendor/bin/phpcs --standard=WordPress wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-badges.php wordpress.org/public_html/wp-content/plugins/support-forums/phpunit.xml wordpress.org/public_html/wp-content/plugins/support-forums/tests/Badges_Test.php`
- `BASE_REF=trunk php .github/bin/phpcs-branch.php`