### PR TITLE
Environments: Add has_pending column to translate stats table

### DIFF
--- a/environments/translate/bin/after-start.sh
+++ b/environments/translate/bin/after-start.sh
@@ -161,17 +161,21 @@ $WP wp eval '
 		// into index-locales.php where current_count / all_count throws DivisionByZeroError.
 		$counts = $proj->get_project_translation_counts( $s->project_id, $s->locale, $s->slug );
 		if ( 0 === (int) $counts["all"] ) { continue; }
+		// has_pending mirrors production (denormalized "waiting > 0 OR fuzzy > 0").
+		// wporg-gp-routes/class-locale "needs attention" queries scan on it.
+		$has_pending = ( $counts["waiting"] > 0 || $counts["fuzzy"] > 0 ) ? 1 : 0;
 		$wpdb->query( $wpdb->prepare(
 			"INSERT INTO {$wpdb->prefix}gp_project_translation_status
-			 (project_id, locale, locale_slug, `all`, `current`, `waiting`, `fuzzy`, `warnings`, `untranslated`, date_added, date_modified)
-			 VALUES (%d, %s, %s, %d, %d, %d, %d, %d, %d, NOW(), NOW())
+			 (project_id, locale, locale_slug, `all`, `current`, `waiting`, `fuzzy`, `warnings`, `untranslated`, has_pending, date_added, date_modified)
+			 VALUES (%d, %s, %s, %d, %d, %d, %d, %d, %d, %d, NOW(), NOW())
 			 ON DUPLICATE KEY UPDATE
 			 `all`=VALUES(`all`), `current`=VALUES(`current`), `waiting`=VALUES(`waiting`),
 			 `fuzzy`=VALUES(`fuzzy`), `warnings`=VALUES(`warnings`), `untranslated`=VALUES(`untranslated`),
-			 date_modified=NOW()",
+			 has_pending=VALUES(has_pending), date_modified=NOW()",
 			$s->project_id, $s->locale, $s->slug,
 			(int) $counts["all"], (int) $counts["current"], (int) $counts["waiting"],
-			(int) $counts["fuzzy"], (int) $counts["warnings"], (int) $counts["untranslated"]
+			(int) $counts["fuzzy"], (int) $counts["warnings"], (int) $counts["untranslated"],
+			$has_pending
 		) );
 	}
 	$proj->cache_wp_themes_wp_plugins_strings();

--- a/environments/translate/bin/extra-tables.sql
+++ b/environments/translate/bin/extra-tables.sql
@@ -27,7 +27,7 @@ CREATE TABLE IF NOT EXISTS `wp_gp_user_projects` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS `wp_gp_project_translation_status` (
-  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
   `project_id` int(10) unsigned NOT NULL,
   `locale` varchar(10) NOT NULL,
   `locale_slug` varchar(255) NOT NULL,
@@ -37,14 +37,12 @@ CREATE TABLE IF NOT EXISTS `wp_gp_project_translation_status` (
   `fuzzy` int(10) unsigned NOT NULL DEFAULT '0',
   `warnings` int(10) unsigned NOT NULL DEFAULT '0',
   `untranslated` int(10) unsigned NOT NULL DEFAULT '0',
+  `has_pending` tinyint(1) NOT NULL DEFAULT 0,
   `date_added` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `date_modified` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   PRIMARY KEY (`id`),
   UNIQUE KEY `project_locale` (`project_id`,`locale`,`locale_slug`),
-  KEY `all` (`all`),
-  KEY `current` (`current`),
-  KEY `waiting` (`waiting`),
-  KEY `fuzzy` (`fuzzy`),
-  KEY `warnings` (`warnings`),
-  KEY `untranslated` (`untranslated`)
+  KEY `locale` (`locale`,`locale_slug`,`has_pending`),
+  KEY `date_added` (`date_added`),
+  KEY `date_modified` (`date_modified`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/environments/translate/bin/import-wp-core.php
+++ b/environments/translate/bin/import-wp-core.php
@@ -194,15 +194,18 @@ if ( ! isset( $wporg_gp_custom_stats ) ) {
 		if ( 0 === (int) $counts['all'] ) {
 			continue;
 		}
+		// has_pending mirrors production (denormalized "waiting > 0 OR fuzzy > 0").
+		// wporg-gp-routes/class-locale "needs attention" queries scan on it.
+		$has_pending = ( $counts['waiting'] > 0 || $counts['fuzzy'] > 0 ) ? 1 : 0;
 		$wpdb->query(
 			$wpdb->prepare(
 				"INSERT INTO {$wpdb->prefix}gp_project_translation_status
-				 (project_id, locale, locale_slug, `all`, `current`, `waiting`, `fuzzy`, `warnings`, `untranslated`, date_added, date_modified)
-				 VALUES (%d, %s, %s, %d, %d, %d, %d, %d, %d, NOW(), NOW())
+				 (project_id, locale, locale_slug, `all`, `current`, `waiting`, `fuzzy`, `warnings`, `untranslated`, has_pending, date_added, date_modified)
+				 VALUES (%d, %s, %s, %d, %d, %d, %d, %d, %d, %d, NOW(), NOW())
 				 ON DUPLICATE KEY UPDATE
 				 `all`=VALUES(`all`), `current`=VALUES(`current`), `waiting`=VALUES(`waiting`),
 				 `fuzzy`=VALUES(`fuzzy`), `warnings`=VALUES(`warnings`), `untranslated`=VALUES(`untranslated`),
-				 date_modified=NOW()",
+				 has_pending=VALUES(has_pending), date_modified=NOW()",
 				$set_row->project_id,
 				$set_row->locale,
 				$set_row->slug,
@@ -211,7 +214,8 @@ if ( ! isset( $wporg_gp_custom_stats ) ) {
 				(int) $counts['waiting'],
 				(int) $counts['fuzzy'],
 				(int) $counts['warnings'],
-				(int) $counts['untranslated']
+				(int) $counts['untranslated'],
+				$has_pending
 			)
 		);
 	}


### PR DESCRIPTION
## Summary
- Sync `wp_gp_project_translation_status` schema with production commit [`733b8ab`](https://github.com/WordPress/wordpress.org/commit/733b8ab511c69f81bf69c99c7062666362a21885): add denormalized `has_pending tinyint` + compound index `locale(locale, locale_slug, has_pending)`, drop the now-redundant single-column count indexes, bump `id` to `bigint`. Without it locale pages hit `WordPress database error: Unknown column 'stats.has_pending' in 'WHERE'` the moment a "needs attention" query runs.
- Teach both stats writers (`after-start.sh` rebuild loop, `import-wp-core.php` post-import refresh) to populate `has_pending = (waiting > 0 OR fuzzy > 0)` and include it in the `ON DUPLICATE KEY UPDATE` clause, so the new index actually points at the right rows.

Production maintains the table manually (no migration code in the plugin) — same approach as the existing extra-tables.sql.

## Test plan
- [x] `wp-env destroy && wp-env start` — fresh table created with the new column and indexes; `DESCRIBE` matches the production shape.
- [x] Live `ALTER TABLE` + backfill on an existing env — exactly the rows where `waiting > 0 OR fuzzy > 0` flipped to `has_pending = 1` (49 of 107).
- [x] `curl /locale/en-gb/default/` → HTTP 200, no DB error in the response.
- [x] phpcs clean (`vendor/bin/phpcs environments/translate/bin/import-wp-core.php -snq`).