### PR TITLE
Translation Events: Make event end date optional

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/assets/css/translation-events.css
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/assets/css/translation-events.css
@@ -19,6 +19,18 @@
 	margin-top: 1em;
 }
 
+.translation-event-form .event-end-fields {
+	display: inline-block;
+	vertical-align: top;
+}
+
+.translation-event-form label.event-end-open-ended-toggle {
+	display: block;
+	width: auto;
+	margin-top: 0.5em;
+	font-weight: normal;
+}
+
 .translation-event-form #submit-event {
 	margin-left: 10%;
 	width: 30%;

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/assets/js/translation-events.js
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/assets/js/translation-events.js
@@ -8,6 +8,7 @@
 					selectUserTimezone();
 				}
 				validateEventDates();
+				bindOpenEndedToggle();
 				convertToUserLocalTime();
 				setInterval( convertToUserLocalTime, 10000 );
 
@@ -94,7 +95,9 @@
 						$( '#event-title' ).val( wordcamp.title.rendered );
 						$( '#event-description' ).val( wordcamp.content.rendered );
 						$( '#event-start' ).val( new Date( 1000 * wordcamp['Start Date (YYYY-mm-dd)'] ).toISOString().slice( 0,11 ) + '09:00' );
-						$( '#event-end' ).val( new Date( 1000 * wordcamp['End Date (YYYY-mm-dd)'] ).toISOString().slice( 0,11 ) + '18:00' );
+						if ( ! $( '#event-is-open-ended' ).is( ':checked' ) ) {
+							$( '#event-end' ).val( new Date( 1000 * wordcamp['End Date (YYYY-mm-dd)'] ).toISOString().slice( 0,11 ) + '18:00' );
+						}
 						$( '#event-timezone' ).val( wordcamp['Event Timezone'] );
 
 					}
@@ -123,13 +126,16 @@
 				$gp.notices.error( 'Event start date and time must be set.' );
 				return;
 			}
-			if ( '' === $( '#event-end' ).val() ) {
-				$gp.notices.error( 'Event end date and time must be set.' );
-				return;
-			}
-			if ( $( '#event-end' ).val() <= $( '#event-start' ).val() ) {
-				$gp.notices.error( 'Event end date and time must be later than event start date and time.' );
-				return;
+			const isOpenEnded = $( '#event-is-open-ended' ).is( ':checked' );
+			if ( ! isOpenEnded ) {
+				if ( '' === $( '#event-end' ).val() ) {
+					$gp.notices.error( 'Event end date and time must be set.' );
+					return;
+				}
+				if ( $( '#event-end' ).val() <= $( '#event-start' ).val() ) {
+					$gp.notices.error( 'Event end date and time must be later than event start date and time.' );
+					return;
+				}
 			}
 			if ( eventStatus === 'publish' && isDraft ) {
 				const submitPrompt = 'Are you sure you want to publish this event?';
@@ -193,6 +199,37 @@
 					error: function ( error ) {
 						$gp.notices.error( response.data.message );
 					},
+				}
+			);
+		}
+
+		function bindOpenEndedToggle() {
+			const $checkbox = $( '#event-is-open-ended' );
+			const $endInput = $( '#event-end' );
+			if ( ! $checkbox.length || ! $endInput.length ) {
+				return;
+			}
+
+			$checkbox.on(
+				'change',
+				function () {
+					if ( $checkbox.is( ':checked' ) ) {
+						$endInput.prop( 'disabled', true ).val( '' );
+						return;
+					}
+					$endInput.prop( 'disabled', false );
+					if ( '' === $endInput.val() ) {
+						const startVal = $( '#event-start' ).val();
+						if ( startVal ) {
+							const start = new Date( startVal );
+							start.setHours( start.getHours() + 1 );
+							const pad = ( n ) => String( n ).padStart( 2, '0' );
+							$endInput.val(
+								start.getFullYear() + '-' + pad( start.getMonth() + 1 ) + '-' + pad( start.getDate() )
+								+ 'T' + pad( start.getHours() ) + ':' + pad( start.getMinutes() )
+							);
+						}
+					}
 				}
 			);
 		}

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/includes/attendee/attendee-adder.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/includes/attendee/attendee-adder.php
@@ -5,6 +5,7 @@ namespace Wporg\TranslationEvents\Attendee;
 use Exception;
 use Wporg\TranslationEvents\Event\Event;
 use Wporg\TranslationEvents\Stats\Stats_Listener;
+use Wporg\TranslationEvents\Translation_Events;
 
 class Attendee_Adder {
 	private Attendee_Repository $attendee_repository;
@@ -37,6 +38,20 @@ class Attendee_Adder {
 
 	private function import_stats( Event $event, Attendee $attendee ): void {
 		global $wpdb, $gp_table_prefix;
+
+		$now   = Translation_Events::now();
+		$end   = $event->end() ? $event->end()->utc() : $now;
+		$start = $event->start()->utc();
+
+		// Open-ended events can span arbitrary durations. Cap the lookback to avoid
+		// a full table scan over `translations` when a new attendee joins.
+		if ( null === $event->end() ) {
+			$one_year_ago = $now->modify( '-1 year' );
+			if ( $start < $one_year_ago ) {
+				$start = $one_year_ago;
+			}
+		}
+
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
@@ -57,8 +72,8 @@ class Attendee_Adder {
 					'event_id'          => $event->id(),
 					'action'            => Stats_Listener::ACTION_CREATE,
 					'user_id'           => $attendee->user_id(),
-					'date_added_after'  => $event->start()->utc()->format( 'Y-m-d H:i:s' ),
-					'date_added_before' => $event->end()->utc()->format( 'Y-m-d H:i:s' ),
+					'date_added_after'  => $start->format( 'Y-m-d H:i:s' ),
+					'date_added_before' => $end->format( 'Y-m-d H:i:s' ),
 				),
 			),
 		);

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/includes/event/event-capabilities.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/includes/event/event-capabilities.php
@@ -266,8 +266,6 @@ class Event_Capabilities {
 	 * @return bool
 	 */
 	private function has_edit_field( WP_User $user, Event $event, $cap ): bool {
-		$event_end_plus_1_hr = $event->end()->modify( '+1 hour' );
-
 		if ( self::EDIT_DESCRIPTION === $cap ) {
 			return true;
 		}
@@ -284,10 +282,11 @@ class Event_Capabilities {
 			return ( self::EDIT_TITLE === $cap || self::EDIT_END === $cap );
 		}
 
-		if ( $event->end()->is_in_the_past() && $this->now < $event_end_plus_1_hr ) {
-			return ( self::EDIT_TITLE === $cap || self::EDIT_END === $cap );
-		}
-		if ( $event->end()->is_in_the_past() && $this->now > $event_end_plus_1_hr ) {
+		if ( $event->is_past() ) {
+			$event_end_plus_1_hr = $event->end()->modify( '+1 hour' );
+			if ( $this->now < $event_end_plus_1_hr ) {
+				return ( self::EDIT_TITLE === $cap || self::EDIT_END === $cap );
+			}
 			return ( self::EDIT_DESCRIPTION === $cap );
 		}
 

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/includes/event/event-form-handler.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/includes/event/event-form-handler.php
@@ -201,10 +201,11 @@ class Event_Form_Handler {
 		// This will be sanitized by sanitize_post which is called in wp_insert_post.
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$description     = isset( $data['event_description'] ) ? force_balance_tags( wp_unslash( $data['event_description'] ) ) : '';
-		$event_start     = isset( $data['event_start'] ) ? sanitize_text_field( wp_unslash( $data['event_start'] ) ) : '';
-		$event_end       = isset( $data['event_end'] ) ? sanitize_text_field( wp_unslash( $data['event_end'] ) ) : '';
-		$event_timezone  = isset( $data['event_timezone'] ) ? sanitize_text_field( wp_unslash( $data['event_timezone'] ) ) : '';
-		$attendance_mode = isset( $data['event_attendance_mode'] ) ? sanitize_text_field( wp_unslash( $data['event_attendance_mode'] ) ) : 'onsite';
+		$event_start         = isset( $data['event_start'] ) ? sanitize_text_field( wp_unslash( $data['event_start'] ) ) : '';
+		$event_end           = isset( $data['event_end'] ) ? sanitize_text_field( wp_unslash( $data['event_end'] ) ) : '';
+		$event_is_open_ended = ! empty( $data['event_is_open_ended'] );
+		$event_timezone      = isset( $data['event_timezone'] ) ? sanitize_text_field( wp_unslash( $data['event_timezone'] ) ) : '';
+		$attendance_mode     = isset( $data['event_attendance_mode'] ) ? sanitize_text_field( wp_unslash( $data['event_attendance_mode'] ) ) : 'onsite';
 
 		$event_status = '';
 		if ( isset( $data['event_form_action'] ) && in_array( $data['event_form_action'], array( 'draft', 'publish', 'trash' ), true ) ) {
@@ -223,16 +224,21 @@ class Event_Form_Handler {
 			throw new InvalidStart();
 		}
 
-		try {
-			$end = new Event_End_Date( $event_end, $timezone );
-		} catch ( Exception $e ) {
-			throw new InvalidEnd();
+		if ( $event_is_open_ended ) {
+			$end = null;
+		} else {
+			try {
+				$end = new Event_End_Date( $event_end, $timezone );
+			} catch ( Exception $e ) {
+				throw new InvalidEnd();
+			}
+			$end = $end->setTimezone( new DateTimeZone( 'UTC' ) );
 		}
 
 		$event = new Event(
 			get_current_user_id(),
 			$start->setTimezone( new DateTimeZone( 'UTC' ) ),
-			$end->setTimezone( new DateTimeZone( 'UTC' ) ),
+			$end,
 			$timezone,
 			$event_status,
 			$title,

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/includes/event/event-repository-cached.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/includes/event/event-repository-cached.php
@@ -61,7 +61,10 @@ class Event_Repository_Cached extends Event_Repository {
 			array_filter(
 				$events,
 				function ( $event ) {
-					return $event->start() <= $this->now && $this->now <= $event->end();
+					if ( $event->start() > $this->now ) {
+						return false;
+					}
+					return null === $event->end() || $this->now <= $event->end();
 				}
 			)
 		);

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/includes/event/event-repository.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/includes/event/event-repository.php
@@ -227,12 +227,7 @@ class Event_Repository implements Event_Repository_Interface {
 			$page_size,
 			array(
 				'meta_query' => array(
-					array(
-						'key'     => '_event_end',
-						'value'   => $this->now->format( 'Y-m-d H:i:s' ),
-						'compare' => '>',
-						'type'    => 'DATETIME',
-					),
+					$this->meta_query_end_after_or_unbounded( $this->now ),
 				),
 				'meta_key'   => '_event_start',
 				'orderby'    => array(
@@ -290,12 +285,7 @@ class Event_Repository implements Event_Repository_Interface {
 						'compare' => '<=',
 						'type'    => 'DATETIME',
 					),
-					array(
-						'key'     => '_event_end',
-						'value'   => $this->now->format( 'Y-m-d H:i:s' ),
-						'compare' => '>=',
-						'type'    => 'DATETIME',
-					),
+					$this->meta_query_end_after_or_unbounded( $this->now, '>=' ),
 				),
 				'meta_key'   => '_event_start',
 				'orderby'    => array(
@@ -318,12 +308,7 @@ class Event_Repository implements Event_Repository_Interface {
 			$page_size,
 			array(
 				'meta_query' => array(
-					array(
-						'key'     => '_event_end',
-						'value'   => $this->now->format( 'Y-m-d H:i:s' ),
-						'compare' => '>',
-						'type'    => 'DATETIME',
-					),
+					$this->meta_query_end_after_or_unbounded( $this->now ),
 				),
 				'meta_key'   => '_event_start',
 				'orderby'    => array(
@@ -454,12 +439,7 @@ class Event_Repository implements Event_Repository_Interface {
 					'compare' => '<=',
 					'type'    => 'DATETIME',
 				),
-				array(
-					'key'     => '_event_end',
-					'value'   => $boundary_start->format( 'Y-m-d H:i:s' ),
-					'compare' => '>',
-					'type'    => 'DATETIME',
-				),
+				$this->meta_query_end_after_or_unbounded( $boundary_start ),
 			),
 			'meta_key'   => '_event_start',
 			'meta_type'  => 'DATETIME',
@@ -604,15 +584,40 @@ class Event_Repository implements Event_Repository_Interface {
 		$meta = get_post_meta( $event_id );
 		$utc  = new DateTimeZone( 'UTC' );
 
-		if ( ! isset( $meta['_event_start'][0], $meta['_event_end'][0], $meta['_event_timezone'][0] ) ) {
+		if ( ! isset( $meta['_event_start'][0], $meta['_event_timezone'][0] ) ) {
 			return null;
+		}
+
+		$end = null;
+		if ( isset( $meta['_event_end'][0] ) && '' !== $meta['_event_end'][0] ) {
+			$end = new Event_End_Date( $meta['_event_end'][0], $utc );
 		}
 
 		return array(
 			'start'           => new Event_Start_Date( $meta['_event_start'][0], $utc ),
-			'end'             => new Event_End_Date( $meta['_event_end'][0], $utc ),
+			'end'             => $end,
 			'timezone'        => new DateTimeZone( $meta['_event_timezone'][0] ),
 			'attendance_mode' => ! isset( $meta['_event_attendance_mode'][0] ) ? 'onsite' : $meta['_event_attendance_mode'][0],
+		);
+	}
+
+	/**
+	 * Returns a meta_query fragment that matches events whose _event_end is after
+	 * the given boundary, OR which have no _event_end meta (open-ended events).
+	 */
+	private function meta_query_end_after_or_unbounded( DateTimeImmutable $boundary, string $compare = '>' ): array {
+		return array(
+			'relation' => 'OR',
+			array(
+				'key'     => '_event_end',
+				'value'   => $boundary->format( 'Y-m-d H:i:s' ),
+				'compare' => $compare,
+				'type'    => 'DATETIME',
+			),
+			array(
+				'key'     => '_event_end',
+				'compare' => 'NOT EXISTS',
+			),
 		);
 	}
 
@@ -626,7 +631,11 @@ class Event_Repository implements Event_Repository_Interface {
 		);
 		$hosts_ids = implode( ', ', $hosts_ids );
 		update_post_meta( $event->id(), '_event_start', $event->start()->utc()->format( 'Y-m-d H:i:s' ) );
-		update_post_meta( $event->id(), '_event_end', $event->end()->utc()->format( 'Y-m-d H:i:s' ) );
+		if ( null === $event->end() ) {
+			delete_post_meta( $event->id(), '_event_end' );
+		} else {
+			update_post_meta( $event->id(), '_event_end', $event->end()->utc()->format( 'Y-m-d H:i:s' ) );
+		}
 		update_post_meta( $event->id(), '_event_timezone', $event->timezone()->getName() );
 		update_post_meta( $event->id(), '_hosts', $hosts_ids );
 		update_post_meta( $event->id(), '_event_attendance_mode', $event->attendance_mode() );

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/includes/event/event.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/includes/event/event.php
@@ -36,7 +36,7 @@ class Event {
 	private int $id = 0;
 	private int $author_id;
 	private Event_Start_Date $start;
-	private Event_End_Date $end;
+	private ?Event_End_Date $end;
 	private DateTimeZone $timezone;
 	private string $slug = '';
 	private string $status;
@@ -53,7 +53,7 @@ class Event {
 	public function __construct(
 		int $author_id,
 		Event_Start_Date $start,
-		Event_End_Date $end,
+		?Event_End_Date $end,
 		DateTimeZone $timezone,
 		string $status,
 		string $title,
@@ -85,8 +85,12 @@ class Event {
 		return $this->start;
 	}
 
-	public function end(): Event_End_Date {
+	public function end(): ?Event_End_Date {
 		return $this->end;
+	}
+
+	public function is_open_ended(): bool {
+		return null === $this->end;
 	}
 
 	public function is_published(): bool {
@@ -103,11 +107,14 @@ class Event {
 
 	public function is_active(): bool {
 		$now = Translation_Events::now();
-		return $now >= $this->start->utc() && $now < $this->end->utc();
+		if ( $now < $this->start->utc() ) {
+			return false;
+		}
+		return null === $this->end || $now < $this->end->utc();
 	}
 
 	public function is_past(): bool {
-		return $this->end->is_in_the_past();
+		return null !== $this->end && $this->end->is_in_the_past();
 	}
 
 	public function is_remote(): bool {
@@ -154,7 +161,7 @@ class Event {
 		$this->start = $start;
 	}
 
-	public function set_end( Event_End_Date $end ): void {
+	public function set_end( ?Event_End_Date $end ): void {
 		$this->end = $end;
 	}
 
@@ -196,12 +203,15 @@ class Event {
 	 * @throws InvalidStart
 	 * @throws InvalidEnd
 	 */
-	public function validate_times( Event_Start_Date $start, Event_End_Date $end ) {
-		if ( $end <= $start ) {
-			throw new InvalidEnd();
-		}
+	public function validate_times( Event_Start_Date $start, ?Event_End_Date $end ) {
 		if ( ! $start->getTimezone() || 'UTC' !== $start->getTimezone()->getName() ) {
 			throw new InvalidStart();
+		}
+		if ( null === $end ) {
+			return;
+		}
+		if ( $end <= $start ) {
+			throw new InvalidEnd();
 		}
 		if ( ! $end->getTimezone() || 'UTC' !== $end->getTimezone()->getName() ) {
 			throw new InvalidEnd();

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/includes/routes/event/rss.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/includes/routes/event/rss.php
@@ -82,7 +82,9 @@ class Rss_Route extends Route {
 		$item .= '          <enclosure url="' . esc_url( Urls::event_image( $event->id() ) ) . '" type="image/png" length="1200" />';
 		$item .= '          <pubDate>' . esc_html( $event->updated_at()->format( DATE_RSS ) ) . '</pubDate>';
 		$item .= '          <ev:startdate>' . esc_html( $event->start()->format( DateTimeInterface::ATOM ) ) . '</ev:startdate>';
-		$item .= '          <ev:enddate>' . esc_html( $event->end()->format( DateTimeInterface::ATOM ) ) . '</ev:enddate>';
+		if ( null !== $event->end() ) {
+			$item .= '          <ev:enddate>' . esc_html( $event->end()->format( DateTimeInterface::ATOM ) ) . '</ev:enddate>';
+		}
 		$item .= '          <guid>' . esc_url( home_url( gp_url( gp_url_join( 'events', $event->slug() ) ) ) ) . '</guid>';
 		$item .= '      </item>';
 		return $item;

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/templates/event-details.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/templates/event-details.php
@@ -266,17 +266,22 @@ Templates::header(
 					<?php $event->start()->print_relative_time_html(); ?>
 				</span>
 				<?php $event->start()->print_time_html(); ?>
-				<span class="event-details-date-label">
-					<?php echo esc_html( $event->end()->is_in_the_past() ? __( 'Ended', 'gp-translation-events' ) : __( 'Ends', 'gp-translation-events' ) ); ?>:
-					<?php $event->end()->print_relative_time_html(); ?>
-
-				</span>
-				<?php $event->end()->print_time_html(); ?>
+				<?php if ( $event->is_open_ended() ) : ?>
+					<span class="event-details-date-label">
+						<?php esc_html_e( 'Ongoing event (no end date)', 'gp-translation-events' ); ?>
+					</span>
+				<?php else : ?>
+					<span class="event-details-date-label">
+						<?php echo esc_html( $event->end()->is_in_the_past() ? __( 'Ended', 'gp-translation-events' ) : __( 'Ends', 'gp-translation-events' ) ); ?>:
+						<?php $event->end()->print_relative_time_html(); ?>
+					</span>
+					<?php $event->end()->print_time_html(); ?>
+				<?php endif; ?>
 			</p>
 		</div>
 		<?php if ( is_user_logged_in() ) : ?>
 		<div class="event-details-join">
-			<?php if ( $event->end()->is_in_the_past() ) : ?>
+			<?php if ( $event->is_past() ) : ?>
 				<?php if ( $user_is_attending ) : ?>
 					<button disabled="disabled" class="button is-primary attend-btn"><?php esc_html_e( 'You attended', 'gp-translation-events' ); ?></button>
 				<?php endif; ?>
@@ -306,7 +311,7 @@ Templates::header(
 		<?php else : ?>
 		<div class="event-details-join">
 			<p>
-				<?php if ( ! $event->end()->is_in_the_past() ) : ?>
+				<?php if ( ! $event->is_past() ) : ?>
 					<a href="<?php echo esc_url( wp_login_url() ); ?>" class="button is-primary attend-btn"><?php esc_html_e( 'Login to attend', 'gp-translation-events' ); ?></a>
 				<?php else : ?>
 					<button disabled="disabled" class="button is-primary attend-btn"><?php esc_html_e( 'Event is over', 'gp-translation-events' ); ?></button>

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/templates/parts/event-form.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/templates/parts/event-form.php
@@ -52,7 +52,22 @@ use Wporg\TranslationEvents\Urls;
 		</div>
 		<div>
 			<label for="event-end"><?php esc_html_e( 'End Date', 'gp-translation-events' ); ?></label>
-			<input type="datetime-local" id="event-end" name="event_end" value="<?php echo esc_attr( $event->end()->format( 'Y-m-d H:i' ) ); ?>" required <?php echo esc_html( $is_create_form || current_user_can( 'edit_translation_event_end', $event->id() ) ?: 'readonly' ); ?>>
+			<?php
+			$is_open_ended   = $event->is_open_ended();
+			$end_value       = $is_open_ended ? '' : $event->end()->format( 'Y-m-d H:i' );
+			$can_edit_end    = $is_create_form || current_user_can( 'edit_translation_event_end', $event->id() );
+			$end_input_attrs = ! $can_edit_end ? 'readonly' : '';
+			if ( $is_open_ended ) {
+				$end_input_attrs .= ' disabled';
+			}
+			?>
+			<span class="event-end-fields">
+				<input type="datetime-local" id="event-end" name="event_end" value="<?php echo esc_attr( $end_value ); ?>" <?php echo esc_html( $end_input_attrs ); ?>>
+				<label for="event-is-open-ended" class="event-end-open-ended-toggle">
+					<input type="checkbox" id="event-is-open-ended" name="event_is_open_ended" value="1" <?php checked( $is_open_ended ); ?> <?php disabled( ! $can_edit_end ); ?>>
+					<?php esc_html_e( 'Ongoing event (no end date)', 'gp-translation-events' ); ?>
+				</label>
+			</span>
 		</div>
 		<div>
 			<label for="event-timezone"><?php esc_html_e( 'Event Timezone', 'gp-translation-events' ); ?></label>

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/templates/parts/event-list.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/templates/parts/event-list.php
@@ -102,12 +102,14 @@ $print_time = function ( $time ): void {
 					<span class="event-list-date"><?php $print_time( $event->start() ); ?></span>
 				<?php endif; ?>
 			<?php endif; ?>
-			<?php if ( $show_end ) : ?>
+			<?php if ( $show_end && ! $event->is_open_ended() ) : ?>
 				<?php if ( $event->end()->is_in_the_past() ) : ?>
 					<span class="event-list-date"><?php $print_time( $event->end() ); ?></span>
 				<?php else : ?>
 					<span class="event-list-date"><?php $print_time( $event->end() ); ?></time></span>
 				<?php endif; ?>
+			<?php elseif ( $show_end && $event->is_open_ended() ) : ?>
+				<span class="event-list-date"><?php esc_html_e( 'Ongoing', 'gp-translation-events' ); ?></span>
 			<?php endif; ?>
 
 			<?php // Excerpt. ?>

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/themes/wporg-translate-events-2024/blocks/event-date/index.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/themes/wporg-translate-events-2024/blocks/event-date/index.php
@@ -34,6 +34,9 @@ register_block_type(
 			if ( ! $event ) {
 				return '';
 			}
+			if ( $event->is_open_ended() ) {
+				return '<p>' . esc_html__( 'Ongoing', 'gp-translation-events' ) . '</p>';
+			}
 			$end = $event->end()->format( 'F j, Y' );
 			return '<p>' . esc_html( $end ) . '</p>';
 		},

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/wporg-gp-translation-events.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/wporg-gp-translation-events.php
@@ -211,8 +211,8 @@ class Translation_Events {
 		?>
 		<label for="event_start">Start Date (UTC): </label>
 		<input type="datetime-local" id="event_start" name="event_start" value="<?php echo esc_attr( $event->start() ); ?>" required><br>
-		<label for="event_end">End Date (UTC): </label>
-		<input type="datetime-local" id="event_end" name="event_end" value="<?php echo esc_attr( $event->end() ); ?>" required><br>
+		<label for="event_end">End Date (UTC, leave empty for ongoing event): </label>
+		<input type="datetime-local" id="event_end" name="event_end" value="<?php echo esc_attr( null === $event->end() ? '' : (string) $event->end() ); ?>"><br>
 		<label for="event-timezone">Timezone: </label>
 		<select id="event-timezone" name="event_timezone" required>
 			<?php
@@ -275,9 +275,15 @@ class Translation_Events {
 		}
 		$fields = array( 'event_start', 'event_end', 'event_timezone' );
 		foreach ( $fields as $field ) {
-			if ( isset( $_POST[ $field ] ) ) {
-				update_post_meta( $post_id, '_' . $field, sanitize_text_field( wp_unslash( $_POST[ $field ] ) ) );
+			if ( ! isset( $_POST[ $field ] ) ) {
+				continue;
 			}
+			$value = sanitize_text_field( wp_unslash( $_POST[ $field ] ) );
+			if ( 'event_end' === $field && '' === $value ) {
+				delete_post_meta( $post_id, '_' . $field );
+				continue;
+			}
+			update_post_meta( $post_id, '_' . $field, $value );
 		}
 	}
 


### PR DESCRIPTION
Generated with Claude Code, initially reviewed by myself.

---

## Summary

Makes the event end date optional, providing a semantically explicit way to model open-ended events (e.g. *WordPress Credits Contributions*) instead of relying on a fake far-future date.

This is an alternative to #676, which only hides the misleading "Ends: in 9 years" display when the configured end date is more than one year out — the underlying fake 2036 date persists. With this change, organizers can mark events as *Ongoing* via a checkbox; the end date meta is removed and the UI shows "Ongoing event" instead.

Fixes https://meta.trac.wordpress.org/ticket/8280

### Key changes

- **Domain (`Event`)**: `$end` is now `?Event_End_Date`; `is_active()`, `is_past()`, `validate_times()` are null-safe; new `is_open_ended()` helper.
- **Repository**: helper `meta_query_end_after_or_unbounded()` is applied to all current/upcoming queries so open-ended events (no `_event_end` meta) appear in current/upcoming lists. `update_event_meta()` deletes `_event_end` when null. `get_event_meta()` tolerates missing end.
- **Cached repository**: active-filter callback accepts null end.
- **Capabilities**: `has_edit_field` only modifies end when the event is past.
- **`Attendee_Adder`**: stats import clamps lookback to `max(start, now − 1 year)` for open-ended events to avoid unbounded SELECTs.
- **Form**: new "Ongoing event (no end date)" checkbox; the date input is disabled (so the browser doesn't POST a stale value) when ongoing.
- **JS**: checkbox toggles input state and skips end-date validation/WordCamp pre-fill when active.
- **Display**: details/list templates and the `event-end` theme block render an "Ongoing" label.
- **RSS**: `<ev:enddate>` is omitted for open-ended events.
- **Legacy admin metabox**: `required` removed and an empty value deletes the meta so admins can edit ongoing events from the WP Admin too.

### Backward compatibility

All existing events have `_event_end` set, so their behavior is unchanged. No migration required.

## Test plan

- [ ] Create a new event with the *Ongoing event* checkbox enabled — detail view shows "Ongoing event (no end date)"; `_event_end` meta is absent.
- [ ] Edit an existing event to open-ended — `_event_end` meta is deleted. Toggle back: meta is repopulated.
- [ ] An open-ended event with start in the future appears under *Upcoming*; with start in the past, under *Current*; never in *Past*.
- [ ] A bounded event with `end < now` continues to appear under *Past* (regression check).
- [ ] Host of an open-ended event can edit title/end after start.
- [ ] Attending an open-ended event with multi-year start does not run an unbounded translations scan.
- [ ] RSS feed (`/events/rss`) omits `<ev:enddate>` for open-ended events and remains well-formed.
- [ ] JS: toggling the checkbox enables/disables the end-date input and seeds a sensible default when unchecked.
- [ ] Cache: switching an active event between bounded and open-ended is reflected on the home page after the next request.