### PR TITLE
Support Forums: Standardize loader and constructor style

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-plugin.php
@@ -66,17 +66,17 @@ class Plugin {
 	 * Instantiate a new Plugin object.
 	 */
 	private function __construct() {
-		$this->users            = new Users;
-		$this->user_notes       = new User_Notes;
-		$this->moderators       = new Moderators;
-		$this->hooks            = new Hooks;
-		$this->report_topic     = new Report_Topic;
-		$this->nsfw_handler     = new NSFW_Handler;
-		$this->stats            = new Stats;
-		$this->emails           = new Emails;
-		$this->audit_log        = new Audit_Log;
-		$this->badge_automation = new Badge_Automation;
-		$this->rest_api         = new REST_API;
+		$this->users            = new Users();
+		$this->user_notes       = new User_Notes();
+		$this->moderators       = new Moderators();
+		$this->hooks            = new Hooks();
+		$this->report_topic     = new Report_Topic();
+		$this->nsfw_handler     = new NSFW_Handler();
+		$this->stats            = new Stats();
+		$this->emails           = new Emails();
+		$this->audit_log        = new Audit_Log();
+		$this->badge_automation = new Badge_Automation();
+		$this->rest_api         = new REST_API();
 
 		// Set a flag to indicate whether this is the global forums, or a locale forum.
 		$this->is_main_forums = (
@@ -86,21 +86,21 @@ class Plugin {
 
 		// These modifications are specific to https://wordpress.org/support/
 		if ( $this->is_main_forums ) {
-			$this->dropin          = new Dropin;
-			$this->support_compat  = new Support_Compat;
+			$this->dropin          = new Dropin();
+			$this->support_compat  = new Support_Compat();
 
 			// Only load Performance_Optimizations if necessary.
-			$this->performance     = new Performance_Optimizations;
+			$this->performance     = new Performance_Optimizations();
 
 			// Ratings_Compat is loaded by Theme_Directory_Compat or
 			// Plugin_Directory_Compat depending on the request.
-			$this->themes          = new Theme_Directory_Compat;
-			$this->plugins         = new Plugin_Directory_Compat;
+			$this->themes          = new Theme_Directory_Compat();
+			$this->plugins         = new Plugin_Directory_Compat();
 		}
 
 		// Only load the Block Support if the Blocks Everywhere plugin is available.
 		if ( class_exists( 'Automattic\Blocks_Everywhere\Blocks_Everywhere' ) ) {
-			$this->blocks          = new Blocks;
+			$this->blocks          = new Blocks();
 		}
 
 		add_action( 'bbp_add_rewrite_rules', array( $this, 'maybe_flush_rewrite_rules' ) );

--- a/wordpress.org/public_html/wp-content/plugins/support-forums/support-forums.php
+++ b/wordpress.org/public_html/wp-content/plugins/support-forums/support-forums.php
@@ -21,29 +21,29 @@ if ( ! class_exists( 'bbPress' ) ) {
 }
 
 // General includes.
-include( __DIR__ . '/inc/class-plugin.php' );
-include( __DIR__ . '/inc/class-users.php' );
-include( __DIR__ . '/inc/class-user-notes.php' );
-include( __DIR__ . '/inc/class-moderators.php' );
-include( __DIR__ . '/inc/class-hooks.php' );
-include( __DIR__ . '/inc/class-report-topic.php' );
-include( __DIR__ . '/inc/class-nsfw-handler.php' );
-include( __DIR__ . '/inc/class-stats.php' );
-include( __DIR__ . '/inc/class-emails.php' );
-include( __DIR__ . '/inc/class-audit-log.php' );
-include( __DIR__ . '/inc/class-blocks.php' );
-include( __DIR__ . '/inc/class-rest-api.php' );
-include( __DIR__ . '/inc/class-badge-automation.php' );
+include __DIR__ . '/inc/class-plugin.php';
+include __DIR__ . '/inc/class-users.php';
+include __DIR__ . '/inc/class-user-notes.php';
+include __DIR__ . '/inc/class-moderators.php';
+include __DIR__ . '/inc/class-hooks.php';
+include __DIR__ . '/inc/class-report-topic.php';
+include __DIR__ . '/inc/class-nsfw-handler.php';
+include __DIR__ . '/inc/class-stats.php';
+include __DIR__ . '/inc/class-emails.php';
+include __DIR__ . '/inc/class-audit-log.php';
+include __DIR__ . '/inc/class-blocks.php';
+include __DIR__ . '/inc/class-rest-api.php';
+include __DIR__ . '/inc/class-badge-automation.php';
 
 // Compat-only includes.
-include( __DIR__ . '/inc/class-dropin.php' );
-include( __DIR__ . '/inc/class-support-compat.php' );
-include( __DIR__ . '/inc/class-directory-compat.php' );
-include( __DIR__ . '/inc/class-theme-directory-compat.php' );
-include( __DIR__ . '/inc/class-plugin-directory-compat.php' );
-include( __DIR__ . '/inc/class-ratings-compat.php' );
-include( __DIR__ . '/inc/class-stickies-compat.php' );
-include( __DIR__ . '/inc/class-performance-optimizations.php' );
+include __DIR__ . '/inc/class-dropin.php';
+include __DIR__ . '/inc/class-support-compat.php';
+include __DIR__ . '/inc/class-directory-compat.php';
+include __DIR__ . '/inc/class-theme-directory-compat.php';
+include __DIR__ . '/inc/class-plugin-directory-compat.php';
+include __DIR__ . '/inc/class-ratings-compat.php';
+include __DIR__ . '/inc/class-stickies-compat.php';
+include __DIR__ . '/inc/class-performance-optimizations.php';
 
 // Instantiate the plugin on load.
 Plugin::get_instance();


### PR DESCRIPTION
Follow-up to #677 / https://meta.trac.wordpress.org/ticket/2214.

This standardizes the support-forums loader and no-argument component instantiations so the active PHPCS rules pass without local suppressions:

- converts support-forums loader includes from parenthesized include calls to include statements
- converts support-forums no-argument component instantiations from bare new Foo to new Foo()

No behavior changes intended.