### PR TITLE
Plugin Directory: fix screenshot lightbox showing a tiny, duplicated image

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/gallery-lightbox-enhancements/assets/lightbox-captions.css
+++ b/wordpress.org/public_html/wp-content/plugins/gallery-lightbox-enhancements/assets/lightbox-captions.css
@@ -12,22 +12,30 @@
  */
 
 /**
- * The core zoom-mode `.scrim` is white at 0.9 opacity by default, but
- * core CSS doesn't pin it (no `top`/`left` declared). With the two
- * `.lightbox-image-container` siblings each `position: relative; top:
- * 450px`, the absolute scrim falls through to its normal-flow position
- * and lands somewhere around `y: 1444px` — visually below the viewport
- * fold. Pin it to the overlay's top-left so the dimmer actually covers
- * the page as intended.
+ * Defensive pin for the core zoom-mode `.scrim` (white, 0.9 opacity).
+ * Core leaves it `position: absolute` with no `top`/`left`, relying on
+ * its two `.lightbox-image-container` siblings being out of normal flow
+ * so the scrim's static position resolves to the overlay's top-left.
+ * We keep those containers on core's own positioning (see note below),
+ * so this is belt-and-braces — harmless if core already covers the page.
  */
 .wp-lightbox-overlay .scrim {
 	top: 0 !important;
 	left: 0 !important;
 }
 
-.wp-lightbox-overlay .lightbox-image-container {
-	position: relative;
-}
+/*
+ * Do NOT override `.lightbox-image-container` positioning. Core stacks
+ * its two containers — the zoom-thumbnail and the full-resolution image
+ * — as absolutely positioned, center-overlapping siblings, with the
+ * full-resolution one painted on top. Forcing them to `position:
+ * relative` drops both into normal flow and stacks the images
+ * vertically, rendering the picture twice the moment both containers
+ * hold a real image (e.g. plugin screenshots, whose lightbox source is
+ * wired up server-side). The caption is mounted into the top container
+ * and pins to its frame, using that absolute container as its
+ * containing block — no positioning override required here.
+ */
 
 .wp-lightbox-overlay .lightbox-image-container > figcaption.wp-lightbox-caption {
 	position: absolute;

--- a/wordpress.org/public_html/wp-content/plugins/gallery-lightbox-enhancements/assets/lightbox-captions.js
+++ b/wordpress.org/public_html/wp-content/plugins/gallery-lightbox-enhancements/assets/lightbox-captions.js
@@ -4,13 +4,13 @@
  * against the bottom edge of the picture frame — exactly the visual
  * contract of https://github.com/WordPress/gutenberg/pull/77477.
  *
- * Why "visible": core renders two `.lightbox-image-container` siblings.
- * One holds the small thumbnail used for the zoom animation hand-off,
- * the other holds the full-resolution image. Which one is on screen
- * depends on the lifecycle stage (opening, navigating, closing). We
- * pick the container whose <img> is actually inside the viewport at
- * sync time, mount the caption there, and let CSS pin it to its
- * parent's bottom — which is the bottom of the displayed picture.
+ * Why "visible": core renders two center-overlapping
+ * `.lightbox-image-container` siblings. One holds the small thumbnail
+ * used for the zoom animation hand-off, the other the full-resolution
+ * image, which paints on top. We mount the caption into that top
+ * container — the last one on screen — so it pins to the bottom of the
+ * displayed picture and is not occluded by the enlarged image, then let
+ * CSS anchor it to the absolutely-positioned container frame.
  *
  * `data-wp-text` / `data-wp-bind` attributes added after the
  * Interactivity runtime parsed the page do not bind, so the caption is
@@ -48,14 +48,17 @@
 	 */
 	function getVisibleContainer( overlay ) {
 		var containers = overlay.querySelectorAll( '.lightbox-image-container' );
-		for ( var i = 0; i < containers.length; i++ ) {
+		// Iterate from the end: core's containers center-overlap and the
+		// last one (the full-resolution image) paints on top, so the
+		// caption must live there or it renders behind the enlarged image.
+		for ( var i = containers.length - 1; i >= 0; i-- ) {
 			var img = containers[ i ].querySelector( 'img' );
 			if ( img && isInViewport( img ) ) {
 				return containers[ i ];
 			}
 		}
-		// Fallback: first container — wrong-spot caption beats no caption at all.
-		return containers[ 0 ] || null;
+		// Fallback: last container — wrong-spot caption beats no caption at all.
+		return containers[ containers.length - 1 ] || null;
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-screenshots.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-screenshots.php
@@ -60,6 +60,18 @@ class Screenshots {
 	const SYNTHETIC_ID_OFFSET = 9000000;
 
 	/**
+	 * Per-request lightbox metadata, keyed by synthetic attachment id.
+	 *
+	 * Each entry holds the full-resolution `ps.w.org` URL and intrinsic
+	 * width / height for one screenshot. {@see self::fix_lightbox_metadata()}
+	 * reads this map to repair the core Image block's lightbox state — see
+	 * that method for why the repair is necessary.
+	 *
+	 * @var array<int, array{url:string,width:(int|string),height:(int|string)}>
+	 */
+	protected static $lightbox_meta = array();
+
+	/**
 	 * Renders the shortcode output.
 	 *
 	 * @return string
@@ -100,9 +112,19 @@ class Screenshots {
 		// force every layout rule to use `!important`. The filter
 		// scopes the change to galleries that carry our marker class,
 		// so other Gallery blocks on the page render unchanged.
+		//
+		// Pair the layout filter with the lightbox-metadata repair. Our
+		// screenshots are external `ps.w.org` assets with synthetic
+		// attachment ids, so core cannot resolve the full-resolution
+		// source or dimensions the lightbox needs; fix_lightbox_metadata()
+		// supplies them once core has assigned each image its render-time
+		// state key. It hooks at priority 20 so it runs after core's own
+		// lightbox filter (priority 15) and overrides the broken values.
 		add_filter( 'render_block_core/gallery', array( __CLASS__, 'strip_layout_classes' ), 20, 1 );
+		add_filter( 'render_block_core/image', array( __CLASS__, 'fix_lightbox_metadata' ), 20, 2 );
 		$markup   = self::build_gallery_markup( $screenshots, $count, $dimensions );
 		$rendered = do_blocks( $markup );
+		remove_filter( 'render_block_core/image', array( __CLASS__, 'fix_lightbox_metadata' ), 20 );
 		remove_filter( 'render_block_core/gallery', array( __CLASS__, 'strip_layout_classes' ), 20 );
 
 		if ( $use_reveal ) {
@@ -228,6 +250,10 @@ class Screenshots {
 		$inner = '';
 		$index = 0;
 
+		// Reset the lightbox metadata map for this render — build_image_block()
+		// fills it as it mints each synthetic id.
+		self::$lightbox_meta = array();
+
 		foreach ( $screenshots as $screenshot_num => $screenshot ) {
 			// Every figure loads eagerly — this is a detail page, not
 			// a list, so users land here already committed to seeing
@@ -340,6 +366,17 @@ class Screenshots {
 		$srcset = self::photon_srcset( $src );
 		$class  = 'wp-block-image size-large';
 
+		// Record the full-resolution source and intrinsic dimensions for the
+		// lightbox-state repair in fix_lightbox_metadata(). The grid thumbnail
+		// loads a Photon-shrunk srcset candidate, so core (which has no real
+		// attachment to query) would otherwise enlarge that small image; this
+		// hands the lightbox the lossless original at its true size.
+		self::$lightbox_meta[ (int) $id ] = array(
+			'url'    => $src,
+			'width'  => ( is_array( $dimensions ) && ! empty( $dimensions[0] ) ) ? (int) $dimensions[0] : 'none',
+			'height' => ( is_array( $dimensions ) && ! empty( $dimensions[1] ) ) ? (int) $dimensions[1] : 'none',
+		);
+
 		// `width` and `height` ship the screenshot's intrinsic
 		// dimensions so the browser reserves layout space from the
 		// aspect ratio at parse time. Without them every figure
@@ -397,6 +434,85 @@ class Screenshots {
 	}
 
 	/**
+	 * Repairs the core Image block lightbox state for screenshot images.
+	 *
+	 * Plugin screenshots are external `ps.w.org` assets with no real
+	 * attachment, so each block carries a *synthetic* id (see
+	 * {@see self::SYNTHETIC_ID_OFFSET}). Core's lightbox renderer
+	 * (`block_core_image_render_lightbox()`, priority 15 on this same
+	 * filter) treats that id as a genuine attachment:
+	 *
+	 *   $uploadedSrc = wp_get_attachment_url( $id );        // → false
+	 *   $meta        = wp_get_attachment_metadata( $id );   // → false
+	 *   $targetWidth = $meta['width']  ?? 'none';           // → 'none'
+	 *   $targetHeight= $meta['height'] ?? 'none';           // → 'none'
+	 *
+	 * The empty `uploadedSrc` leaves the lightbox with no full-resolution
+	 * image to enlarge, and the `'none'` dimensions make core's view
+	 * script fall back to the *thumbnail's* natural size — which on
+	 * production is a Photon-shrunk srcset candidate (≤900px, often the
+	 * 300px tile). The enlarged view therefore renders tiny. On
+	 * environments without Photon the thumbnail is the full-resolution
+	 * original, which is why the bug is invisible on local / staging.
+	 *
+	 * Core keys its lightbox metadata by a per-render `uniqid()` (exposed
+	 * on the figure's `data-wp-context`), not by the attachment id, so the
+	 * only way to correct it is to read that generated key back out of the
+	 * rendered markup and re-set the affected fields. `wp_interactivity_state()`
+	 * merges with `array_replace_recursive()` (later call wins), and this
+	 * filter runs at priority 20 — after core's priority-15 pass — so the
+	 * corrected values override the broken ones. `lightboxSrcset` is
+	 * cleared so the enlarged image loads the lossless original rather than
+	 * a capped Photon candidate.
+	 *
+	 * @param string $block_content Rendered Image block markup.
+	 * @param array  $parsed_block  Parsed block, including `attrs['id']`.
+	 * @return string The unmodified markup (only interactivity state is changed).
+	 */
+	public static function fix_lightbox_metadata( $block_content, $parsed_block ) {
+		$id = isset( $parsed_block['attrs']['id'] ) ? (int) $parsed_block['attrs']['id'] : 0;
+		if ( $id < self::SYNTHETIC_ID_OFFSET || ! isset( self::$lightbox_meta[ $id ] ) ) {
+			return $block_content;
+		}
+
+		if ( ! function_exists( 'wp_interactivity_state' ) ) {
+			return $block_content;
+		}
+
+		// Recover the render-time state key core assigned to this image.
+		$processor = new \WP_HTML_Tag_Processor( $block_content );
+		if ( ! $processor->next_tag( 'figure' ) ) {
+			return $block_content;
+		}
+		$context = $processor->get_attribute( 'data-wp-context' );
+		if ( ! is_string( $context ) ) {
+			return $block_content;
+		}
+		$decoded  = json_decode( $context, true );
+		$image_id = ( is_array( $decoded ) && isset( $decoded['imageId'] ) ) ? $decoded['imageId'] : '';
+		if ( '' === $image_id ) {
+			return $block_content;
+		}
+
+		$meta = self::$lightbox_meta[ $id ];
+		wp_interactivity_state(
+			'core/image',
+			array(
+				'metadata' => array(
+					$image_id => array(
+						'uploadedSrc'    => $meta['url'],
+						'targetWidth'    => $meta['width'],
+						'targetHeight'   => $meta['height'],
+						'lightboxSrcset' => false,
+					),
+				),
+			)
+		);
+
+		return $block_content;
+	}
+
+	/**
 	 * Wraps the rendered gallery in a reveal container with a single
 	 * "Show all N screenshots" button below it. Click reveals every
 	 * hidden figure with a per-tile staggered fade-in and removes the
@@ -449,9 +565,10 @@ class Screenshots {
 	 * Routing the URL through `i0.wp.com` (Photon) returns a re-encoded,
 	 * width-bound copy at ~10× smaller payload — see
 	 * https://developer.wordpress.com/docs/photon/ for the resize/optim
-	 * options. The lightbox `src` (the unprefixed `ps.w.org` URL) stays the
-	 * full-resolution original so users get the lossless image when they
-	 * enlarge a screenshot.
+	 * options. The grid thumbnail therefore loads a small Photon candidate;
+	 * the lightbox is pointed back at the full-resolution `ps.w.org` original
+	 * separately by {@see self::fix_lightbox_metadata()} so users still get
+	 * the lossless image when they enlarge a screenshot.
 	 *
 	 * @param string $src Original asset URL.
 	 * @return string Attribute fragment ready to interpolate into `<img>`,


### PR DESCRIPTION

## Summary

The screenshot gallery lightbox (added in #622) had two production-only bugs:

1. **Image too small** — the enlarged image was capped at the 900px Photon
   thumbnail instead of showing the full-resolution screenshot.
2. **Image duplicated** — the screenshot rendered twice, stacked vertically.

Both are fixed here. They were related: fixing (1) is what surfaced (2).

## Background

Plugin screenshots are external `ps.w.org` assets with no real attachment, so each `core/image` block is given a *synthetic* attachment ID. Core's lightbox renderer treats that ID as a genuine attachment:

So the lightbox had no full-resolution source to enlarge and no real dimensions, falling back to the thumbnail's Photon-shrunk size.

This was not surfaced during sandbox testing because the Photon srcset is gated to production only  photon_srcset() bails on non-production environments.

With no srcset on the sandbox, the thumbnail <img> loads the full-resolution ps.w.org original, so the thumbnail's natural size is the full image and the lightbox looked correct. Only on production, where Photon caps the thumbnail at ≤900px, did the bug appear — and the duplicate-image bug below was likewise masked because the enlarged container had no source to render.

## Fix

1. Repair the lightbox metadata (class-screenshots.php)

A new render_block_core/image filter (priority 20, after core's priority-15 lightbox pass) overrides the interactivity state for our screenshot blocks with the real uploadedSrc, targetWidth/targetHeight, and clears lightboxSrcset so the enlarged view loads the lossless original instead of a capped Photon candidate. Core keys this state by a per-render uniqid(), so the filter reads that key back out of the rendered markup. wp_interactivity_state() merges later-call-wins, so the corrected values replace the broken ones. Applied on all environments so sandbox and production behave identically.

2. Stop stacking the lightbox's two image containers (gallery-lightbox-enhancements)

The caption polyfill forced core's two center-overlapping .lightbox-image-container siblings to position: relative, dropping them into normal flow and stacking them vertically. This only ever looked correct because the enlarged container was empty (bug 1 above). Once that container held a real image, the screenshot rendered twice.

- CSS: removed the position: relative override so core's absolute center-overlap is restored.
- JS: the caption is now mounted into the top (full-resolution) container so it isn't occluded by the enlarged image.

## Testing

- Before startign to test, comment out this line: http://github.com/WordPress/wordpress.org/blob/53180a2d8dec3ab9ad4acc5dea5d732e667b9e1c/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-screenshots.php#L588
- Visit a plugin page e.g: https://wordpress.org/plugins/woocommerce/
- The enlarged image is shown on lightbox.
- The image renders once, not stacked/duplicated.
- Captions still pin to the bottom of the picture. (e.g: https://wordpress.org/plugins/wordpress-seo/)


## Screenshots

Before:

<img width="1706" height="915" alt="production-lightbox" src="https://github.com/user-attachments/assets/7e72b4eb-d65a-4328-a557-6e6f6ba1e8e6" />

After:

<img width="1701" height="902" alt="Screenshot 2026-06-08 at 22 37 34" src="https://github.com/user-attachments/assets/05a8eac1-8ff7-4e9e-a084-67168213415e" />

<img width="1481" height="862" alt="Screenshot 2026-06-08 at 22 43 51" src="https://github.com/user-attachments/assets/98863060-e94a-4163-a2ff-ca4ef703baba" />

