### PR TITLE
Plugin Directory: Adjust lightbox trigger icon z-index to prevent menu overlap

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/css/screenshots.css
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/css/screenshots.css
@@ -217,6 +217,7 @@
 
 #screenshots .wp-block-gallery.is-style-screenshots figure.wp-block-image button.lightbox-trigger {
 	cursor: zoom-in;
+	z-index: 5;
 }
 
 /**


### PR DESCRIPTION
This PR fixes a visual bug where the screenshot lightbox trigger icon was overlapping the menu, on hovering the screenshot.

## Fix
Added a z-index value for the trigger-icon, to override the inherited value.

## Screenshots
Before: 
<img width="643" height="244" alt="trigger-bug" src="https://github.com/user-attachments/assets/0b7d271b-6041-41ce-a7c9-a919fc7e109b" />

After: 

<img width="648" height="367" alt="fixed-trigger" src="https://github.com/user-attachments/assets/92042adc-6f15-42de-8599-b50144ab0238" />



## Refs
Closes: https://meta.trac.wordpress.org/ticket/8299