### PR TITLE
Plugin Directory: Guard against cron jobs without positional args

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/metabox/class-cron-logs.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/metabox/class-cron-logs.php
@@ -101,7 +101,7 @@ class Cron_Logs {
 				esc_html( $job->status ),
 				$task_desc,
 				$logs,
-				esc_html( json_encode( $job->args[0], JSON_PRETTY_PRINT ) )
+				esc_html( json_encode( $job->args[0] ?? $job->args, JSON_PRETTY_PRINT ) )
 			);
 		}
 


### PR DESCRIPTION
## Problem

The Cron Logs metabox on plugin edit screens throws:

```
E_WARNING: Undefined array key 0 in .../plugin-directory/admin/metabox/class-cron-logs.php:104
```

(observed on `post.php?action=edit&post=83940`).

## Root cause

`Cron_Logs::display()` renders a "Job Args" line via `json_encode( $job->args[0] )`. `$job->args` is the Cavalcade job's argument array, and for most plugin cron jobs index `0` holds an associative array of options — which is why the earlier field-insertion loop reads `$job->args[0][ $field ]`, but **guarded** with `! empty()`.

Line 104 has no such guard. A cron job scheduled without positional arguments has an empty `args` array, so `$job->args[0]` is undefined and the warning fires.

## Fix

Fall back to the full `args` array when index `0` isn't set, consistent with the guarded access already used elsewhere in the method:

```php
esc_html( json_encode( $job->args[0] ?? $job->args, JSON_PRETTY_PRINT ) )
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)