### PR TITLE
Hold changed lines and new files to the full WordPress standard

### DIFF
--- a/.github/bin/phpcs-branch.php
+++ b/.github/bin/phpcs-branch.php
@@ -12,7 +12,7 @@
 namespace WordPressOrg\Bin\PHPCS_Changed;
 
 function run_phpcs( $file, $bin_dir ) {
-	exec( "$bin_dir/phpcs $file -snq", $output, $exec_exit_status );
+	exec( "$bin_dir/phpcs $file --standard=./phpcs-clean.xml.dist -snq", $output, $exec_exit_status );
 	echo implode( "\n", $output );
 	return $exec_exit_status;
 }
@@ -27,10 +27,10 @@ function run_phpcs_changed( $file, $git, $base_branch, $bin_dir ) {
 	exec( "$git diff $base_branch $file > $name.diff" );
 
 	exec( "$git show $base_branch:$file > $name.test.php" );
-	exec( "$bin_dir/phpcs $name.test.php --standard=./phpcs.xml.dist --report=json -snq > $name.orig.phpcs" );
+	exec( "$bin_dir/phpcs $name.test.php --standard=./phpcs-clean.xml.dist --report=json -snq > $name.orig.phpcs" );
 
 	exec( "cat $file > $name.test.php" );
-	exec( "$bin_dir/phpcs $name.test.php --standard=./phpcs.xml.dist --report=json -snq > $name.phpcs" );
+	exec( "$bin_dir/phpcs $name.test.php --standard=./phpcs-clean.xml.dist --report=json -snq > $name.phpcs" );
 
 	$cmd = "$bin_dir/phpcs-changed --diff $name.diff --phpcs-orig $name.orig.phpcs --phpcs-new $name.phpcs";
 	exec( $cmd, $output, $exec_exit_status );

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -5,6 +5,7 @@ on:
     paths:
     - '**.php'
     - phpcs.xml.dist
+    - phpcs-clean.xml.dist
     - composer.json
     - .github/workflows/phpcs.yml
     - .github/bin/phpcs-branch.php

--- a/phpcs-clean.xml.dist
+++ b/phpcs-clean.xml.dist
@@ -1,0 +1,35 @@
+<?xml version="1.0" ?>
+<ruleset name="WordPress.org Coding Standards (Clean)">
+	<description>Full WordPress Coding Standards, applied to changed lines and new files only (via .github/bin/phpcs-branch.php). No sniff exclusions — new code is held to the stock standard.</description>
+
+	<!-- Show sniff codes in all reports -->
+	<arg value="ps" />
+	<arg name="colors" />
+
+	<!-- Exclude 3rd-party files -->
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<exclude-pattern>*/plugins/plugin-directory/libs/*</exclude-pattern>
+	<exclude-pattern>*/plugins/theme-directory/lib/*</exclude-pattern>
+	<exclude-pattern>*/plugins/wpf-stripe/stripe-php/*</exclude-pattern>
+
+	<!-- Exclude generated wp-scripts asset files. -->
+	<exclude-pattern>*/plugins/*/build/index.asset.php</exclude-pattern>
+
+	<!-- Exclude JS/CSS files. -->
+	<exclude-pattern>*.js[x]?</exclude-pattern>
+	<exclude-pattern>*.[s]?css</exclude-pattern>
+
+	<!-- Scan all (php) files in the current folder and subfolders -->
+	<file>.</file>
+	<arg name="extensions" value="php" />
+
+	<!-- WordPress.org runs recent versions of WordPress. -->
+	<config name="minimum_wp_version" value="6.9"/>
+
+	<!-- Check for PHP cross-version compatibility. -->
+	<config name="testVersion" value="8.4-"/>
+	<rule ref="PHPCompatibilityWP"/>
+
+	<rule ref="WordPress"/>
+</ruleset>


### PR DESCRIPTION
Let's use `WordPress` as our coding standard. With AI writing most of our code now, it's trivial to have it conform new and updated code to the full standard, and everyone reading the code get to benefit from it.

## What

Adds `phpcs-clean.xml.dist` — the stock **WordPress** coding standard with **no sniff exclusions** — and points the branch linter (`.github/bin/phpcs-branch.php`) at it. Newly written code is now held to the unmodified standard, while the existing tree is only ever checked on the lines a branch actually touches.

## How it works

The linter already scopes itself to changed lines + new files:

- **Modified files** → `phpcs-changed`, reporting only on lines the branch changed.
- **New files** → full `phpcs` on the whole file.

Both paths now pass `--standard=./phpcs-clean.xml.dist`. Existing code is untouched until someone edits it.

## Scope of each ruleset

| File | Standard | Used by |
|------|----------|---------|
| `phpcs.xml.dist` | WordPress + ~50 exclusions | `composer lint` (whole repo) — **unchanged** |
| `phpcs-clean.xml.dist` | Stock `WordPress`, no exclusions | `phpcs-branch.php` (changed lines + new files) |

`phpcs-clean.xml.dist` keeps only the environment config (`minimum_wp_version`, `testVersion`, `PHPCompatibilityWP`) and the shared file/vendor `exclude-pattern`s.

## Note

The stock `WordPress.WP.Capabilities` sniff is now active on changed code and will flag wporg-specific custom capabilities as unknown. When that happens, the cap gets documented in place rather than silenced:

```xml
<rule ref="WordPress.WP.Capabilities">
    <properties>
        <property name="custom_capabilities" type="array">
            <element value="plugin_admin_edit" />
        </property>
    </properties>
</rule>
```

Because this only fires on changed lines and new files, the list grows only with caps that actually touch new code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0178d9rQN6YbCuz5LetN7Rzi