### PR TITLE
Theme Directory: Don't auto-approve when Trac ticket creation failed

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
@@ -794,7 +794,7 @@ class WPORG_Themes_Upload {
 					'failed_trac_ticket_creation',
 					sprintf(
 						/* translators: %s: mailto link */
-						__( 'There was an error creating a Trac ticket for your theme, please report this error to %s', 'wporg-themes' ),
+						__( 'There was an error creating a Trac ticket for your theme. This is usually temporary, so please wait a moment and try uploading again. If the error persists, report it to %s.', 'wporg-themes' ),
 						'<a href="mailto:themes@wordpress.org">themes@wordpress.org</a>'
 					)
 				);

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
@@ -1350,9 +1350,13 @@ TICKET;
 				'owner'     => '',
 			) );
 
-			// Themes team auto-approves theme-updates. Note that this only applies to new
-			// ticket creation, so it won't happen on themes with existing outstanding tickets.
-			if ( $this->trac_ticket->priority == 'theme update' ) {
+			/*
+			 * Themes team auto-approves theme-updates. Note that this only applies to new
+			 * ticket creation, so it won't happen on themes with existing outstanding tickets.
+			 *
+			 * Skipped when ticket creation failed, as there's no ticket to act upon.
+			 */
+			if ( $ticket_id && 'theme update' === $this->trac_ticket->priority ) {
 				$release_delay = wporg_themes_get_release_cooldown_delay( $this->theme_slug );
 				if ( $release_delay ) {
 					// Land the update in the `approved` status; the release-to-live cron

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
@@ -794,7 +794,7 @@ class WPORG_Themes_Upload {
 					'failed_trac_ticket_creation',
 					sprintf(
 						/* translators: %s: mailto link */
-						__( 'There was an error creating a Trac ticket for your theme. This is usually temporary, so please wait a moment and try uploading again. If the error persists, report it to %s.', 'wporg-themes' ),
+						__( 'There was an error creating a Trac ticket for your theme. This is usually temporary, so please wait a few minutes and try uploading again. If the error persists, report it to %s.', 'wporg-themes' ),
 						'<a href="mailto:themes@wordpress.org">themes@wordpress.org</a>'
 					)
 				);

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Trac_Ticket_Creation_Failure_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Trac_Ticket_Creation_Failure_Test.php
@@ -12,72 +12,8 @@
 use PHPUnit\Framework\TestCase;
 
 /**
- * A stand-in for `Trac` that records calls instead of talking to Trac.
- */
-class Trac_Test_Double {
-
-	/**
-	 * The value `ticket_create()` returns.
-	 *
-	 * @var bool|int
-	 */
-	public $create_response;
-
-	/**
-	 * The `$id` argument of every `ticket_update()` call.
-	 *
-	 * @var array
-	 */
-	public $updated_ids = array();
-
-	/**
-	 * Constructor.
-	 *
-	 * @param bool|int $create_response The value `ticket_create()` should return.
-	 */
-	public function __construct( $create_response ) {
-		$this->create_response = $create_response;
-	}
-
-	/**
-	 * Records nothing; the tests never reach an existing ticket.
-	 *
-	 * @param int $id Trac ticket id.
-	 * @return bool
-	 */
-	public function ticket_get( $id ) {
-		return false;
-	}
-
-	/**
-	 * Returns the canned response.
-	 *
-	 * @param string $subj Ticket subject line.
-	 * @param string $desc Ticket description.
-	 * @param array  $attr Ticket attributes.
-	 * @return bool|int
-	 */
-	public function ticket_create( $subj, $desc, $attr = array() ) {
-		return $this->create_response;
-	}
-
-	/**
-	 * Records the ticket id it was called with.
-	 *
-	 * @param int    $id      Ticket number.
-	 * @param string $comment Comment.
-	 * @param array  $attr    Ticket attributes.
-	 * @param bool   $notify  Whether to notify.
-	 * @return bool
-	 */
-	public function ticket_update( $id, $comment, $attr = array(), $notify = false ) {
-		$this->updated_ids[] = $id;
-
-		return true;
-	}
-}
-
-/**
+ * Tests that a failed ticket creation is not followed by an auto-approval.
+ *
  * @group upload
  */
 class Trac_Ticket_Creation_Failure_Test extends TestCase {
@@ -130,22 +66,97 @@ class Trac_Ticket_Creation_Failure_Test extends TestCase {
 	}
 
 	/**
+	 * Builds a stand-in for `Trac` that records calls instead of making them.
+	 *
+	 * @param bool|int $create_response The value `ticket_create()` should return.
+	 * @return object
+	 */
+	protected function create_trac_double( $create_response ) {
+		// phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter -- The double mirrors Trac's signatures.
+		return new class( $create_response ) {
+
+			/**
+			 * The value `ticket_create()` returns.
+			 *
+			 * @var bool|int
+			 */
+			public $create_response;
+
+			/**
+			 * The `$id` argument of every `ticket_update()` call.
+			 *
+			 * @var array
+			 */
+			public $updated_ids = array();
+
+			/**
+			 * Constructor.
+			 *
+			 * @param bool|int $create_response The value `ticket_create()` should return.
+			 */
+			public function __construct( $create_response ) {
+				$this->create_response = $create_response;
+			}
+
+			/**
+			 * Stands in for an unknown ticket; the tests never reach an existing one.
+			 *
+			 * @param int $id Trac ticket id.
+			 * @return bool
+			 */
+			public function ticket_get( $id ) {
+				return false;
+			}
+
+			/**
+			 * Returns the canned response.
+			 *
+			 * @param string $subj Ticket subject line.
+			 * @param string $desc Ticket description.
+			 * @param array  $attr Ticket attributes.
+			 * @return bool|int
+			 */
+			public function ticket_create( $subj, $desc, $attr = array() ) {
+				return $this->create_response;
+			}
+
+			/**
+			 * Records the ticket id it was called with.
+			 *
+			 * @param int    $id      Ticket number.
+			 * @param string $comment Comment.
+			 * @param array  $attr    Ticket attributes.
+			 * @param bool   $notify  Whether to notify.
+			 * @return bool
+			 */
+			public function ticket_update( $id, $comment, $attr = array(), $notify = false ) {
+				$this->updated_ids[] = $id;
+
+				return true;
+			}
+		};
+		// phpcs:enable Generic.CodeAnalysis.UnusedFunctionParameter
+	}
+
+	/**
 	 * Builds an upload primed to create a new ticket for a theme update.
 	 *
 	 * The theme post carries no `_status` meta, so there is no open ticket to
 	 * update and a new one gets created.
 	 *
-	 * @param Trac_Test_Double $trac The Trac double to use.
+	 * @param object $trac The Trac double to use.
 	 * @return WPORG_Themes_Upload
 	 */
 	protected function create_upload( $trac ) {
-		$post_id = wp_insert_post( array(
-			'post_type'   => 'repopackage',
-			'post_status' => 'publish',
-			'post_title'  => 'Test Theme',
-			'post_name'   => 'test-theme',
-			'post_author' => 1,
-		) );
+		$post_id = wp_insert_post(
+			array(
+				'post_type'   => 'repopackage',
+				'post_status' => 'publish',
+				'post_title'  => 'Test Theme',
+				'post_name'   => 'test-theme',
+				'post_author' => 1,
+			)
+		);
 
 		$this->post_ids[] = $post_id;
 
@@ -170,7 +181,7 @@ class Trac_Ticket_Creation_Failure_Test extends TestCase {
 	 * update, as there is no ticket to update.
 	 */
 	public function test_failed_ticket_create_skips_auto_approval() {
-		$trac   = new Trac_Test_Double( false );
+		$trac   = $this->create_trac_double( false );
 		$upload = $this->create_upload( $trac );
 
 		$ticket_id = $upload->create_or_update_trac_ticket();
@@ -184,7 +195,7 @@ class Trac_Ticket_Creation_Failure_Test extends TestCase {
 	 * ticket id passed along to the update.
 	 */
 	public function test_successful_ticket_create_is_auto_approved() {
-		$trac   = new Trac_Test_Double( 12345 );
+		$trac   = $this->create_trac_double( 12345 );
 		$upload = $this->create_upload( $trac );
 
 		$ticket_id = $upload->create_or_update_trac_ticket();

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Trac_Ticket_Creation_Failure_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Trac_Ticket_Creation_Failure_Test.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * Tests for handling a failed Trac ticket creation during upload.
+ *
+ * `Trac::ticket_create()` returns false when the RPC call fails. The
+ * auto-approval that follows it used to run regardless, passing that false
+ * along to `Trac::ticket_update()`, which asked Trac for ticket `False`.
+ *
+ * @package theme-directory
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A stand-in for `Trac` that records calls instead of talking to Trac.
+ */
+class Trac_Test_Double {
+
+	/**
+	 * The value `ticket_create()` returns.
+	 *
+	 * @var bool|int
+	 */
+	public $create_response;
+
+	/**
+	 * The `$id` argument of every `ticket_update()` call.
+	 *
+	 * @var array
+	 */
+	public $updated_ids = array();
+
+	/**
+	 * Constructor.
+	 *
+	 * @param bool|int $create_response The value `ticket_create()` should return.
+	 */
+	public function __construct( $create_response ) {
+		$this->create_response = $create_response;
+	}
+
+	/**
+	 * Records nothing; the tests never reach an existing ticket.
+	 *
+	 * @param int $id Trac ticket id.
+	 * @return bool
+	 */
+	public function ticket_get( $id ) {
+		return false;
+	}
+
+	/**
+	 * Returns the canned response.
+	 *
+	 * @param string $subj Ticket subject line.
+	 * @param string $desc Ticket description.
+	 * @param array  $attr Ticket attributes.
+	 * @return bool|int
+	 */
+	public function ticket_create( $subj, $desc, $attr = array() ) {
+		return $this->create_response;
+	}
+
+	/**
+	 * Records the ticket id it was called with.
+	 *
+	 * @param int    $id      Ticket number.
+	 * @param string $comment Comment.
+	 * @param array  $attr    Ticket attributes.
+	 * @param bool   $notify  Whether to notify.
+	 * @return bool
+	 */
+	public function ticket_update( $id, $comment, $attr = array(), $notify = false ) {
+		$this->updated_ids[] = $id;
+
+		return true;
+	}
+}
+
+/**
+ * @group upload
+ */
+class Trac_Ticket_Creation_Failure_Test extends TestCase {
+
+	/**
+	 * IDs of posts created during a test, deleted again on teardown.
+	 *
+	 * @var array
+	 */
+	protected $post_ids = array();
+
+	/**
+	 * The cooldown filter callback, so it can be removed again.
+	 *
+	 * @var callable
+	 */
+	protected $cooldown_callback;
+
+	/**
+	 * Pins the release cooldown, which decides which auto-approval branch runs.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->cooldown_callback = function () {
+			return 12 * HOUR_IN_SECONDS;
+		};
+		add_filter( 'wporg_themes_release_cooldown_delay', $this->cooldown_callback );
+	}
+
+	/**
+	 * Removes the cooldown filter and the posts created during the test.
+	 */
+	protected function tearDown(): void {
+		remove_filter( 'wporg_themes_release_cooldown_delay', $this->cooldown_callback );
+
+		/*
+		 * The plugin prevents repopackages from being deleted; detach that
+		 * specific guard while cleaning up the fixture posts.
+		 */
+		remove_filter( 'before_delete_post', 'wporg_theme_no_delete_repopackage' );
+		foreach ( $this->post_ids as $post_id ) {
+			wp_delete_post( $post_id, true );
+		}
+		add_filter( 'before_delete_post', 'wporg_theme_no_delete_repopackage' );
+
+		$this->post_ids = array();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Builds an upload primed to create a new ticket for a theme update.
+	 *
+	 * The theme post carries no `_status` meta, so there is no open ticket to
+	 * update and a new one gets created.
+	 *
+	 * @param Trac_Test_Double $trac The Trac double to use.
+	 * @return WPORG_Themes_Upload
+	 */
+	protected function create_upload( $trac ) {
+		$post_id = wp_insert_post( array(
+			'post_type'   => 'repopackage',
+			'post_status' => 'publish',
+			'post_title'  => 'Test Theme',
+			'post_name'   => 'test-theme',
+			'post_author' => 1,
+		) );
+
+		$this->post_ids[] = $post_id;
+
+		$upload              = new WPORG_Themes_Upload();
+		$upload->trac        = $trac;
+		$upload->theme_slug  = 'test-theme';
+		$upload->theme_post  = get_post( $post_id );
+		$upload->author      = get_user_by( 'id', 1 );
+		$upload->trac_ticket = (object) array(
+			'summary'     => 'THEME: Test Theme – 1.0',
+			'description' => 'Test description.',
+			'keywords'    => array( 'theme-test-theme' ),
+			'priority'    => 'theme update',
+			'resolution'  => '',
+		);
+
+		return $upload;
+	}
+
+	/**
+	 * A failed ticket creation should not be followed by an auto-approval
+	 * update, as there is no ticket to update.
+	 */
+	public function test_failed_ticket_create_skips_auto_approval() {
+		$trac   = new Trac_Test_Double( false );
+		$upload = $this->create_upload( $trac );
+
+		$ticket_id = $upload->create_or_update_trac_ticket();
+
+		$this->assertFalse( $ticket_id );
+		$this->assertSame( array(), $trac->updated_ids );
+	}
+
+	/**
+	 * A successful ticket creation should still be auto-approved, with the new
+	 * ticket id passed along to the update.
+	 */
+	public function test_successful_ticket_create_is_auto_approved() {
+		$trac   = new Trac_Test_Double( 12345 );
+		$upload = $this->create_upload( $trac );
+
+		$ticket_id = $upload->create_or_update_trac_ticket();
+
+		$this->assertSame( 12345, $ticket_id );
+		$this->assertSame( array( 12345 ), $trac->updated_ids );
+	}
+}


### PR DESCRIPTION
## Problem

Theme uploads are producing a pair of warnings from `theme-directory/lib/class-trac.php`:

```
Trac: ticket.create: transport error - HTTP status code was not 200 (429)   12:22:35  (line 80)
Trac: ticket.update: Couldn't get: Ticket False does not exist              12:22:46  (line 103)
```

They're the same request, 11 seconds apart. `Ticket False` is Python's `repr(False)` — the giveaway that the ticket id was never an integer.

## Root cause

In `WPORG_Themes_Upload::create_or_update_trac_ticket()`:

1. `ticket_create()` fails (here: HTTP 429 from themes.trac) and returns `false`.
2. The auto-approval for `theme update` priority runs **unconditionally**, calling `ticket_update( false, ... )`.
3. `ticket_update()` has no `_ts` in `$attr`, so it calls `ticket_get( false )` — which sends boolean `false` over XML-RPC, and Trac answers `Ticket False does not exist`.

The reported warning is a downstream symptom; the real failure is the `ticket.create` one step earlier.

The unguarded `$ticket_id` dates to 268e1afeb / 4f3f470 (2021); 1200c6f3f reshaped the block for the release cooldown but inherited the gap. The sibling branch above it already gets this right — it checks `$ticket` before updating and sets `$ticket_id = $result ? $ticket_id : false`.

### The 429 makes it worse than noise

`ticket_get()` goes through `rpc_query_retry( 5, ... )`, whose backoff sleeps total 1+2+3+4 = 10 seconds — exactly the observed gap between the two reports. So a creation rejected with **429** sends **five more requests** to a Trac that just asked us to back off, and stalls the user's upload for ten seconds before failing anyway.

## Changes

**1. Guard the auto-approval on a valid ticket id.**

This does not change the upload's outcome: `import()` already handles `! $ticket_id` by rolling back SVN, deleting a new theme post, and returning a `failed_trac_ticket_creation` `WP_Error`. The upload failed before this patch and still fails after it. What the guard removes is the misleading warning and the retry storm against a rate-limited host.

**2. Tell authors to retry instead of emailing the themes team.**

The author saw a red notice reading *"There was an error creating a Trac ticket for your theme, please report this error to themes@wordpress.org"*. For a transient 429 that's the wrong advice — it routes someone to a human for something a retry fixes. Now:

> There was an error creating a Trac ticket for your theme. This is usually temporary, so please wait a few minutes and try uploading again. If the error persists, report it to themes@wordpress.org.

This mirrors what the neighbouring `failed_svn_commit` message already advises.

## Notes for reviewers

- **I deliberately did not add a retry to `ticket_create()`.** It's the one Trac call without one, which is tempting — but unlike `ticket_get()`/`ticket_query()` it's a non-idempotent **write** over a 90s-timeout HTTP call. A create that Trac commits but whose response is lost would return `false`, and a retry would file a duplicate theme ticket. Retrying into a 429 is also precisely the wrong response.
- **The 429 itself is not addressed here** and is worth a separate look: something is rate-limiting `themetracbot` on themes.trac during uploads. This PR stops us from amplifying it, but doesn't explain it.
- **Possibly related, not fixed here:** rollback is asymmetric. Line 789 only deletes the theme post `if ( $is_new_upload && ... )`, but `create_or_update_theme_post()` runs *before* Trac is contacted and the `_ticket_id` write is skipped by the early return. So a failed *update* can leave a repopackage post carrying the new version with no ticket id. SVN is rolled back, so it isn't catastrophic. Flagging rather than asserting — I haven't traced the consequences.
- The `==` → `===` on the guard line is only because the pre-existing loose comparison sits on a line I touched.

## Testing

New `tests/Trac_Ticket_Creation_Failure_Test.php` injects a `Trac` double via the existing `$upload->trac` seam. Verified it fails without the fix, with the production symptom exactly:

```
-Array &0 []
+Array &0 [
+    0 => false,
+]
```

Full theme-directory suite passes (11 tests). The one risky notice in `Search_Published_Filter_Test` is pre-existing.

New code is clean under the upstream `WordPress` standard (`phpcs --standard=WordPress`), not just the repository's customized ruleset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dj5syrJCqZg97fUqaq7nFJ
