### PR TITLE
Plugin Sumission: Provide a button to let the user plugin check before submitting

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-upload.php
@@ -618,6 +618,19 @@ class Upload {
 					</small>
 				</div>
 
+				<div id="plugin-check-preview" class="plugin-check-preview" hidden>
+					<p>
+						<button type="button" id="plugin-check-preview-button" class="wp-block-button__link">
+							<?php esc_html_e( 'Test with Plugin Check in Playground', 'wporg-plugins' ); ?>
+						</button>
+						<br>
+						<small>
+							<?php esc_html_e( 'Runs the selected zip through the Plugin Check plugin, inside a WordPress Playground running in your browser. Your zip is not uploaded to WordPress.org for this.', 'wporg-plugins' ); ?>
+						</small>
+					</p>
+					<div class="plugin-check-preview-frame" hidden></div>
+				</div>
+
 				<p>
 					<label>
 						<?php _e( 'Additional Information', 'wporg-plugins' ); ?><br>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/js/upload.js
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/js/upload.js
@@ -157,7 +157,7 @@
 					// Preselection is best-effort; the dropdown still lets the user pick manually.
 				}
 
-				$previewButton.text( buttonText );
+				$previewButton.prop( 'disabled', false ).text( buttonText );
 			} catch ( error ) {
 				$frameContainer.prop( 'hidden', true ).empty();
 				$previewButton.prop( 'disabled', false ).text( buttonText );

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/js/upload.js
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/js/upload.js
@@ -49,4 +49,120 @@
 		$(this).hide().parents('ul').find('.plugin-upload-form.hidden').removeClass( 'hidden' );
 	} );
 
+	// Pre-submission Plugin Check, in an embedded WordPress Playground.
+	var $uploadForm     = $( '#upload_form' ),
+		$fileInput      = $uploadForm.find( 'input.plugin-file' ),
+		$preview        = $( '#plugin-check-preview' ),
+		$previewButton  = $( '#plugin-check-preview-button' ),
+		$frameContainer = $preview.find( '.plugin-check-preview-frame' );
+
+	// Runs in Playground after boot: return the basename (e.g. "my-plugin/my-plugin.php")
+	// of the just-installed plugin, so we can preselect it in the Plugin Check dropdown.
+	// Plugin Check matches ?plugin= against the full basename, not just the folder name.
+	var detectPluginBasename = [
+		'<?php',
+		'require "/wordpress/wp-load.php";',
+		'require_once ABSPATH . "wp-admin/includes/plugin.php";',
+		'$exclude = array( "akismet/akismet.php", "hello.php" );',
+		'$targets = array();',
+		'foreach ( array_keys( get_plugins() ) as $basename ) {',
+		'	if ( in_array( $basename, $exclude, true ) || false !== strpos( $basename, "plugin-check" ) ) {',
+		'		continue;',
+		'	}',
+		'	$targets[] = $basename;',
+		'}',
+		'echo 1 === count( $targets ) ? $targets[0] : "";'
+	].join( '\n' );
+
+	if ( $uploadForm.length && $preview.length ) {
+		$fileInput.on( 'change', function() {
+			// Reveal the button once a zip is selected; reset any earlier Playground run.
+			$preview.prop( 'hidden', ! this.files.length );
+			$frameContainer.prop( 'hidden', true ).empty();
+			$previewButton.prop( 'disabled', false );
+		} );
+
+		$previewButton.on( 'click', async function() {
+			var file = $fileInput[0].files[0],
+				buttonText = $previewButton.text();
+
+			if ( ! file ) {
+				return;
+			}
+
+			$previewButton.prop( 'disabled', true ).text( wp.i18n ? wp.i18n.__( 'Loading Playground…', 'wporg-plugins' ) : 'Loading Playground…' );
+
+			try {
+				var playgroundApi = await import( /* webpackIgnore: true */ 'https://playground.wordpress.net/client/index.js' ),
+					zipBytes      = new Uint8Array( await file.arrayBuffer() ),
+					iframe        = document.createElement( 'iframe' );
+
+				iframe.className = 'plugin-check-preview-iframe';
+				iframe.style.cssText = 'width: 100%; height: 80vh; border: 1px solid #c3c4c7; border-radius: 2px;';
+
+				$frameContainer.prop( 'hidden', false ).empty().append( iframe );
+				iframe.scrollIntoView( { behavior: 'smooth', block: 'nearest' } );
+
+				var client = await playgroundApi.startPlaygroundWeb( {
+					iframe: iframe,
+					remoteUrl: 'https://playground.wordpress.net/remote.html',
+					blueprint: {
+						landingPage: '/wp-admin/admin.php?page=plugin-check',
+						preferredVersions: {
+							php: '7.4', // Minimum recommended PHP, as with the server-generated blueprints.
+							wp: 'latest'
+						},
+						features: {
+							networking: true
+						},
+						steps: [
+							{
+								step: 'login',
+								username: 'admin',
+								password: 'password'
+							},
+							{
+								step: 'installPlugin',
+								pluginData: {
+									resource: 'wordpress.org/plugins',
+									slug: 'plugin-check'
+								}
+							},
+							{
+								step: 'installPlugin',
+								pluginData: {
+									resource: 'literal',
+									name: file.name,
+									contents: zipBytes
+								},
+								options: {
+									activate: false
+								}
+							}
+						]
+					}
+				} );
+
+				// Preselect the uploaded plugin in the Plugin Check dropdown by its basename.
+				// The user still clicks "Check it!" themselves.
+				try {
+					var result   = await client.run( { code: detectPluginBasename } ),
+						basename = ( result.text || '' ).trim();
+
+					if ( basename ) {
+						await client.goTo( '/wp-admin/admin.php?page=plugin-check&plugin=' + encodeURIComponent( basename ) );
+					}
+				} catch ( selectError ) {
+					// Preselection is best-effort; the dropdown still lets the user pick manually.
+				}
+
+				$previewButton.text( buttonText );
+			} catch ( error ) {
+				$frameContainer.prop( 'hidden', true ).empty();
+				$previewButton.prop( 'disabled', false ).text( buttonText );
+				window.alert( 'WordPress Playground could not be loaded: ' + ( error.message || error ) );
+			}
+		} );
+	}
+
 })( jQuery );

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/js/upload.js
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/js/upload.js
@@ -98,7 +98,8 @@
 					iframe        = document.createElement( 'iframe' );
 
 				iframe.className = 'plugin-check-preview-iframe';
-				iframe.style.cssText = 'width: 100%; height: 80vh; border: 1px solid #c3c4c7; border-radius: 2px;';
+				iframe.title = wp.i18n ? wp.i18n.__( 'Plugin Check preview (WordPress Playground)', 'wporg-plugins' ) : 'Plugin Check preview (WordPress Playground)';
+				iframe.style.cssText = 'width: 100%; height: 80vh; border: 1px solid #c3c4c7; border-radius: 2px';
 
 				$frameContainer.prop( 'hidden', false ).empty().append( iframe );
 				iframe.scrollIntoView( { behavior: 'smooth', block: 'nearest' } );


### PR DESCRIPTION
### Summary
Adds a button **Test with Plugin Check in Playground** step to the plugin upload form to make it easier for plugin developers to confirm their plugin passes [Plugin Check](https://wordpress.org/plugins/plugin-check/) **before** submitting.

I believe Plugin Check is available after submission already, a reason for this implementation might have been so that the plugin file is available as a hosted ZIP somewhere. This avoids this by using the [Playground API Client](https://developer.wordpress.org/playground/developers/apis/javascript-api/playground-api-client/).

https://github.com/user-attachments/assets/070857da-004b-460c-9283-ed8131b6b036

### What this adds
- A Plugin Check button that appears once a zip is selected.
- Clicking it boots WordPress Playground in an inline iframe (via `@wp-playground/client`), installs `plugin-check` from wordpress.org, and installs the selected local zip as literal bytes without uploading anything yet.
- Playground lands on the Plugin Check admin screen with the uploaded preselected; the developer clicks "Check it!" to run the checks.

### How it works
- The zip is read client-side (`File.arrayBuffer()`) and passed to the blueprint as a `literal` resource, so the file doesn'd need to be uploaded.
- After Playground has booted, we use `run` to execute PHP code in Playground to determine the plugin basename.
- Then we navigate to the Plugin Check Admin page and pre-select the plugin.

### Files changed
- `plugin-directory/shortcodes/class-upload.php` — preview UI in the upload form.
- `wporg-plugins-2024/js/upload.js` — Playground handling

### Notes / follow-ups
- In this state it is purely advisory and client-side; it complements, not replaces, server-side checks. The existing post-submission flow is unchanged.
- Plugin Check's static checks are the reliable subset under WASM PHP; runtime checks would need further validation.
- Possible follow-up: wire the completed run to the "tested with Plugin Check" confirmation checkbox.


