### PR TITLE
Trac: Detect ticket preview via the ticketdraft box

### DIFF
--- a/trac.wordpress.org/templates/site_footer.html
+++ b/trac.wordpress.org/templates/site_footer.html
@@ -3,7 +3,7 @@
   Jinja2 replacement for the tail of the old Genshi site.html <body> match.
   Trac auto-includes this file (see TracInterfaceCustomization).
 #}
-# set scripts_version = '236'
+# set scripts_version = '237'
 # set project_slug = req.environ['HTTP_HOST'].split(':')[0].split('.')[0]
 # set wporg_endpoint = 'https://make.wordpress.org/' + project_slug + '/'
 # set notifications_enabled = project_slug in ['core', 'meta']

--- a/trac.wordpress.org/templates/site_head.html
+++ b/trac.wordpress.org/templates/site_head.html
@@ -4,7 +4,7 @@
   Trac auto-includes this file (see TracInterfaceCustomization). Only additive
   markup belongs here; DOM rewrites now live in wp-trac.js / wp-trac.css.
 #}
-# set scripts_version = '236'
+# set scripts_version = '237'
 # set project_slug = req.environ['HTTP_HOST'].split(':')[0].split('.')[0]
 
 ## WP.org global <head> markup (kept in sync by update-headers.php)

--- a/wordpress.org/public_html/style/trac/wp-trac-jinja-compat.js
+++ b/wordpress.org/public_html/style/trac/wp-trac-jinja-compat.js
@@ -162,7 +162,7 @@ jQuery( function ( $ ) {
 		}
 
 		// A preview page is showing when Trac has rendered the change/preview area.
-		var isPreview = $( '#ticketchange, #changelog, #preview' ).length > 0; // TODO(verify)
+		var isPreview = $( '#ticketbox.ticketdraft' ).length > 0;
 
 		// Force non-gardeners to preview before posting.
 		if ( ! window.wpBugGardener && ! isPreview ) {


### PR DESCRIPTION
### Summary

The preview-detection logic in `wp-trac-jinja-compat.js` relied on a guessed set of selectors (`#ticketchange, #changelog, #preview`) that were flagged with a `// TODO(verify)` comment. When previewing a ticket, Trac renders the draft ticket inside `#ticketbox.ticketdraft`, so this keys preview detection off that element instead.

This affects two behaviors that gate on `isPreview`:
- Forcing non-gardeners to preview before posting.
- Showing the Security-component alert on preview.

### Change

```diff
-var isPreview = $( '#ticketchange, #changelog, #preview' ).length > 0; // TODO(verify)
+var isPreview = $( '#ticketbox.ticketdraft' ).length > 0;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)