### PR TITLE
Trac: Modernize wp-trac.js for jQuery 3 / Trac 1.6 and tidy ticket styling

### DIFF
--- a/wordpress.org/public_html/style/trac/wp-trac.css
+++ b/wordpress.org/public_html/style/trac/wp-trac.css
@@ -398,9 +398,7 @@ table.progress td.closed {
 #ticket {
 	background: #f9f9f9;
 	border: 1px solid #ccc;
-}
-#content.ticket .ticketdraft {
-	border: 1px solid #ccc;
+	padding: 0;
 }
 #ticket > h2 {
 	font-size: 16px;
@@ -763,12 +761,11 @@ fieldset {
 	box-shadow: none;
 }
 div.trac-content {
-	-webkit-border-radius: 3px;
-	border-radius: 3px;
+	border: none;
+	margin: 0;
 }
 .foldable :link, .foldable :visited {
-	-webkit-border-radius: 3px;
-	border-radius: 3px;
+	border: none;
 }
 .foldable a:hover {
 	text-decoration: none; /* for bb's */
@@ -1097,6 +1094,9 @@ body.plugins #main .newticket-not-here .support {
 }
 #propertyform[action*="/newticket"] #properties table.trac-properties > tbody > tr > td#focuses {
 	padding-left: 58px;
+}
+#propertyform[action*="/newticket"] ~ #commits {
+	display: none;
 }
 #propertyform > .buttons {
 	clear: right;

--- a/wordpress.org/public_html/style/trac/wp-trac.js
+++ b/wordpress.org/public_html/style/trac/wp-trac.js
@@ -1547,7 +1547,7 @@ var wpTrac, coreKeywordList, gardenerKeywordList, hideFromNewTickets, reservedTe
 				$.ajax({
 					url: endpoint + '?trac-notifications=' + ticket,
 					xhrFields: { withCredentials: true }
-				}).success( function( data ) {
+				}).done( function( data ) {
 					if ( data.success ) {
 						render( data.data['notifications-box'] );
 						if ( data.data.maintainers ) {
@@ -1683,7 +1683,7 @@ var wpTrac, coreKeywordList, gardenerKeywordList, hideFromNewTickets, reservedTe
 						'trac-ticket-subs' : true,
 						'tickets' : tickets
 					}
-				}).success( function( data ) {
+				}).done( function( data ) {
 					if ( ! data.success ) {
 						return;
 					}
@@ -1790,7 +1790,7 @@ var wpTrac, coreKeywordList, gardenerKeywordList, hideFromNewTickets, reservedTe
 						+ '&ticket=' + ticket
 						+ ( authenticated ? '&authenticated=1' : '' )
 						+ ( ( authenticated && 'URL' in window ) ? '&_lastmod=' + ( new URL( jQuery('a.timeline').last().prop('href') ) ).searchParams.get( 'from' ) : '' )
-				).success( function( data ) {
+				).done( function( data ) {
 					// Update the number
 					container.find( 'h3 .trac-count' ).removeClass( 'hidden' ).find( 'span' ).text( data.length );
 
@@ -1860,7 +1860,7 @@ var wpTrac, coreKeywordList, gardenerKeywordList, hideFromNewTickets, reservedTe
 							+ '?trac=' + trac
 							+ '&author=' + user
 							+ ( authenticated ? '&authenticated=1' : '' )
-					).success( function( ticketList ) {
+					).done( function( ticketList ) {
 						document.location = document.location.toString() +
 							( document.location.search ? '&' : '?' ) +
 							'GITHUBTICKETS=' + ticketList.join(',');
@@ -2165,13 +2165,8 @@ var wpTrac, coreKeywordList, gardenerKeywordList, hideFromNewTickets, reservedTe
 
 		}() ),
 
-		patchTracFor122Changes: function() {
-			// TODO: This needs to be removed, the Trac assets on s.w.org are probably outdated and need updating.
-			console.log( "wp-trac: Applying compat patches for Trac 1.2.2" );
-			// From Trac 1.2.2 threaded_comments.js:
-			window.applyCommentsOrder = window.applyCommentsOrder || function() {}
-
-			// Add Params to s.w.org scripts and stylesheets when loaded dynamically.
+		addDynamicAssetCacheBuster: function() {
+			// Add cache-busting params to s.w.org scripts and stylesheets when loaded dynamically.
 			var cache_buster = jQuery('script[src^="https://s.w.org"][src*="v="]').attr('src');
 			if ( cache_buster ) {
 				cache_buster = cache_buster.match(/v=([0-9]+)$/)[1];
@@ -2190,13 +2185,6 @@ var wpTrac, coreKeywordList, gardenerKeywordList, hideFromNewTickets, reservedTe
 			$.loadStyleSheet = function( href ) {
 				return oldLoadStylesheet( maybe_add_cache_buster( href ) );
 			}
-
-			// From Trac 1.2.2 trac.js:
-			$.loadScript                = $.loadScript                || function() {}
-			$.fn.exclusiveOnClick       = $.fn.exclusiveOnClick       || function() {}
-			$.fn.addSelectAllCheckboxes = $.fn.addSelectAllCheckboxes || function() {}
-			$.fn.disableOnSubmit        = $.fn.disableOnSubmit        || function() {}
-			$.fn.disableSubmit          = $.fn.disableSubmit          || function() {}
 		},
 
 		disableTracAutoFocus: function() {
@@ -2210,7 +2198,7 @@ var wpTrac, coreKeywordList, gardenerKeywordList, hideFromNewTickets, reservedTe
 
 	// Perform this as soon as this file loads.
 	wpTrac.disableTracAutoFocus();
-	wpTrac.patchTracFor122Changes();
+	wpTrac.addDynamicAssetCacheBuster();
 
 })(jQuery);
 


### PR DESCRIPTION
## Summary

Cleanup of the wp-trac assets now that Trac 1.6 — with jQuery 3 and updated core JS — is live.

### wp-trac.js
- **jQuery 3 compatibility:** replace the deprecated `.success()` with `.done()`. `.success()` was removed in jQuery 3 (which Trac 1.6 bundles), so the notification and session auth-check AJAX callbacks were throwing `$.ajax(...).success is not a function`.
- **Remove the dead Trac 1.2.2 compat stubs.** These were added in 2018 (#3526) to shim functions the then-outdated CDN `trac.js` was missing. Trac 1.6 now ships the real `trac.js` / `threaded_comments.js` functions, so the `x = x || function(){}` fallbacks never install. Only the s.w.org dynamic-asset cache-buster is kept, with `patchTracFor122Changes()` renamed to `addDynamicAssetCacheBuster()`.

### wp-trac.css
- Remove leftover border-radii and the redundant `.ticketdraft` / `.trac-content` borders, zero out `#ticket` padding, and hide the commits box on the new-ticket form.

## Testing
- On a Trac 1.6 ticket the `$.ajax(...).success is not a function` errors are gone; the notifications box renders and the 5-minute auth check runs.
- Verified against the updated live Trac assets ("Update trac css/js assets") that the previously-shimmed functions are now defined by Trac core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U3ALfvPuo3XeQ6hdUwsnBa
