### PR TITLE
Trac: Fix self-closed script/iframe tags swallowing following markup

### DIFF
--- a/trac.wordpress.org/templates/update-headers.php
+++ b/trac.wordpress.org/templates/update-headers.php
@@ -77,6 +77,13 @@ function save_domdocument( $file, $dom ) {
 
 	$html = $dom->saveXML();
 
+	// saveXML() self-closes empty raw-text/RCDATA tags, which is invalid in text/html and swallows following markup.
+	$html = preg_replace(
+		'#<(script|style|textarea|title|iframe|noscript)\b([^>]*?)\s*/>#i',
+		'<$1$2></$1>',
+		$html
+	);
+
 	// Remove the XML header
 	$html = preg_replace( "#^<\?xml.+>\n?#i",  '', $html );
 

--- a/trac.wordpress.org/templates/wporg-footer.html
+++ b/trac.wordpress.org/templates/wporg-footer.html
@@ -70,13 +70,13 @@
 The WordPress® trademark is the intellectual property of the WordPress Foundation.</footer><script type="speculationrules">
 {"prefetch":[{"source":"document","where":{"and":[{"href_matches":"/*"},{"not":{"href_matches":["/wp-*.php","/wp-admin/*","/files/*","/wp-content/*","/wp-content/plugins/*","/wp-content/themes/wporg-main-2022/*","/wp-content/themes/wporg-parent-2021/*","/*\\?(.+)"]}},{"not":{"selector_matches":"a[rel~=\"nofollow\"]"}},{"not":{"selector_matches":".no-prefetch, .no-prefetch a"}}]},"eagerness":"conservative"}]}
 </script>
-<script fetchpriority="low" id="@wordpress/block-library/navigation/view-js-module" src="https://s.w.org/wp-content/plugins/gutenberg/build/modules/block-library/navigation/view.min.js?ver=243a659f91c3dc9841c7-20240308-094b843005bd3abe0322893e8480b312" type="module"/>
-<script data-wp-strategy="defer" defer="defer" id="wporg-time-view-script-js" src="https://s.w.org/wp-content/mu-plugins/pub-sync/blocks/time/build/view.js?ver=385bfe9134bf98c52dda-eb994f31a57ea2c77ae140364ad431a0"/>
+<script fetchpriority="low" id="@wordpress/block-library/navigation/view-js-module" src="https://s.w.org/wp-content/plugins/gutenberg/build/modules/block-library/navigation/view.min.js?ver=243a659f91c3dc9841c7-20240308-094b843005bd3abe0322893e8480b312" type="module"></script>
+<script data-wp-strategy="defer" defer="defer" id="wporg-time-view-script-js" src="https://s.w.org/wp-content/mu-plugins/pub-sync/blocks/time/build/view.js?ver=385bfe9134bf98c52dda-eb994f31a57ea2c77ae140364ad431a0"></script>
 <script id="wporg-global-header-script-js-extra">//<![CDATA[
 var wporgGlobalHeaderI18n = {"openSearchLabel":"Open Search","closeSearchLabel":"Close Search","overflowMenuLabel":"More menu"};
 //# sourceURL=wporg-global-header-script-js-extra
 //]]></script>
-<script id="wporg-global-header-script-js" src="https://s.w.org/wp-content/mu-plugins/pub-sync/blocks/global-header-footer/js/view.js?ver=1751336038-5fff58281111c981dbcc2f62b7761c8f"/>
+<script id="wporg-global-header-script-js" src="https://s.w.org/wp-content/mu-plugins/pub-sync/blocks/global-header-footer/js/view.js?ver=1751336038-5fff58281111c981dbcc2f62b7761c8f"></script>
 <script id="wp-emoji-settings" type="application/json">
 {"baseUrl":"https://s.w.org/images/core/emoji/17.0.2/72x72/","ext":".png","svgUrl":"https://s.w.org/images/core/emoji/17.0.2/svg/","svgExt":".svg","source":{"concatemoji":"https://s.w.org/wp-includes/js/wp-emoji-release.min.js?ver=7.0-beta3-61853-f0cc9ba5cf46af0cd73d521803e3b07e"}}
 </script>

--- a/trac.wordpress.org/templates/wporg-header.html
+++ b/trac.wordpress.org/templates/wporg-header.html
@@ -1,4 +1,4 @@
-		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P24PF4B" height="0" width="0" style="display:none;visibility:hidden"/></noscript>
+		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P24PF4B" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 	<header class="global-header wp-block-group wp-block-wporg-global-header">
 <figure class="wp-block-image global-header__wporg-logo-mark">
 	<a href="https://wordpress.org/">


### PR DESCRIPTION
## Summary

`update-headers.php` builds the Trac global header/footer templates by fetching the wordpress.org header/footer and serializing them with `DOMDocument::saveXML()`. `saveXML()` self-closes empty elements — so an external `<script src="…"></script>` comes out as `<script src="…"/>`.

In a `text/html` document, `/>` does **not** close raw-text / RCDATA elements (`script`, `style`, `textarea`, `title`, `iframe`, `noscript`). The parser leaves the tag open and treats everything up to the next matching close tag as **text**.

The result in the generated footer: the self-closed `<script id="wporg-global-header-script-js" src="…"/>` absorbed the adjacent `<script id="wp-emoji-settings" type="application/json">…</script>` as its own ignored text. That node never entered the DOM, so core's emoji loader hit:

```
Uncaught TypeError: Cannot read properties of null (reading 'textContent')
    at wp-emoji-loader.min.js
```

Same swallowing also silently dropped the `wporg-time-view` script and a GTM `<iframe/>` in the header.

## Fix

After `saveXML()`, expand self-closed raw-text/RCDATA tags back to explicit closers:

```php
$html = preg_replace(
    '#<(script|style|textarea|title|iframe|noscript)\b([^>]*?)\s*/>#i',
    '<$1$2></$1>',
    $html
);
```

Void elements are intentionally excluded so `<br/>` is never turned into an invalid `<br></br>` (which parses as two line breaks).

The committed `wporg-header.html` / `wporg-footer.html` are updated to match — I applied the identical regex to them, since the generator can't be re-run here (it fetches the live header/footer). `wporg-head.html` had no self-closed raw-text tags.

## Testing

- Diff shows the three footer scripts and the header GTM iframe change from `…/>` to `…></…>`; `#wp-emoji-settings` is now a proper sibling node.
- On a Trac 1.6 page with the corrected templates, `document.getElementById('wp-emoji-settings')` resolves and the emoji-loader TypeError is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U3ALfvPuo3XeQ6hdUwsnBa
