### PR TITLE
Support HelpHub: Tidy up contributor and codex language link output

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/support-helphub/inc/helphub-codex-languages/class-helphub-codex-languages.php
+++ b/wordpress.org/public_html/wp-content/plugins/support-helphub/inc/helphub-codex-languages/class-helphub-codex-languages.php
@@ -172,7 +172,14 @@ final class HelpHub_Codex_Languages {
 		$i    = 0;
 		foreach ( $args as $key => $value ) {
 			if ( null != $value ) {
-				$str .= sprintf( ' &bull; <a class="external text" href="' . $lang_table[ $i ][3] . '">' . $lang_table[ $i ][1] . '</a>', $value );
+				// Encode the value for the URL path, keeping slashes and colons that Codex titles use.
+				$path = str_replace( array( '%2F', '%3A' ), array( '/', ':' ), rawurlencode( $value ) );
+				$url  = sprintf( $lang_table[ $i ][3], $path );
+				$str .= sprintf(
+					' &bull; <a class="external text" href="%1$s">%2$s</a>',
+					esc_url( $url ),
+					esc_html( $lang_table[ $i ][1] )
+				);
 			}
 			$i++;
 		}

--- a/wordpress.org/public_html/wp-content/plugins/support-helphub/inc/helphub-contributors/admin/class-helphub-contributors-admin.php
+++ b/wordpress.org/public_html/wp-content/plugins/support-helphub/inc/helphub-contributors/admin/class-helphub-contributors-admin.php
@@ -117,7 +117,7 @@ class Helphub_Contributors_Admin {
 	 */
 	public function save_post( $post_id, $post ) {
 		// Verify nonce.
-		if ( ! isset( $_POST['helphub_contributors_nonce'] ) || ! wp_verify_nonce( $_POST['helphub_contributors_nonce'], 'helphub-contributors-save' ) ) {
+		if ( ! isset( $_POST['helphub_contributors_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['helphub_contributors_nonce'] ) ), 'helphub-contributors-save' ) ) {
 			return;
 		}
 
@@ -133,7 +133,21 @@ class Helphub_Contributors_Admin {
 			return;
 		}
 
-		$contributors = $_POST['helphub_contributors'];
+		$contributors = array();
+
+		// Contributors are looked up by user_nicename, so reduce each value to a nicename-safe slug.
+		foreach ( (array) wp_unslash( $_POST['helphub_contributors'] ) as $contributor ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Each value is sanitized with sanitize_title() below; the sniff cannot follow it into the loop.
+			// Guard against nested arrays, which would fatal in sanitize_title().
+			if ( ! is_string( $contributor ) ) {
+				continue;
+			}
+
+			$contributor = sanitize_title( $contributor );
+
+			if ( '' !== $contributor && ! in_array( $contributor, $contributors, true ) ) {
+				$contributors[] = $contributor;
+			}
+		}
 
 		update_post_meta( $post_id, 'helphub_contributors', $contributors );
 	}
@@ -169,15 +183,17 @@ class Helphub_Contributors_Admin {
 
 		if ( is_array( $contributors ) ) :
 			foreach ( $contributors as $contributor ) {
-				$contributor_link = '<a href="https://profiles.wordpress.org/' . esc_html( $contributor ) . '/">@' . esc_html( $contributor ) . '</a>';
+				printf(
+					'<a href="%1$s">@%2$s</a>',
+					esc_url( 'https://profiles.wordpress.org/' . $contributor . '/' ),
+					esc_html( $contributor )
+				);
 
-				if ( end( $contributors ) == $contributor ) {
-					$contributor_link .= esc_html__( '.', 'wporg-forums' );
+				if ( end( $contributors ) === $contributor ) {
+					esc_html_e( '.', 'wporg-forums' );
 				} else {
-					$contributor_link .= esc_html__( ', ', 'wporg-forums' );
+					esc_html_e( ', ', 'wporg-forums' );
 				}
-
-				echo $contributor_link;
 			}
 		endif;
 	}

--- a/wordpress.org/public_html/wp-content/plugins/support-helphub/inc/helphub-contributors/public/class-helphub-contributors-public.php
+++ b/wordpress.org/public_html/wp-content/plugins/support-helphub/inc/helphub-contributors/public/class-helphub-contributors-public.php
@@ -149,7 +149,7 @@ class HelpHub_Contributors_Public {
 
 						// Display message if no user is found with provided username.
 						/* translators: %s: Username, do not translate. */
-						$contributors_items .= '<div class="contributor contributor-not-found"><p>' . sprintf( __( '%s is not a valid username.', 'wporg-forums' ), '<strong>' . $contributor . '</strong>' ) . '</p></div>';
+						$contributors_items .= '<div class="contributor contributor-not-found"><p>' . sprintf( __( '%s is not a valid username.', 'wporg-forums' ), '<strong>' . esc_html( $contributor ) . '</strong>' ) . '</p></div>';
 
 					endif; // is_object( $contributor_object )
 


### PR DESCRIPTION
Minor consistency pass on the Support HelpHub output:

- Escapes contributor names consistently on output in the Contributors list and admin column, and normalizes the profile links through `esc_url()`.
- Normalizes submitted contributor values to nicename-safe slugs on save, collapsing duplicates.
- Runs the `codex_languages` shortcode links through `esc_url()`/`esc_html()`, encoding the attribute value into the URL path while preserving the slashes and colons that Codex titles use.

No behavior change for valid input; verified locally that existing contributor links and all codex language links still render as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UNnLdnE7etihGNvsWY1qGE