### PR TITLE
Registration: Simplify the messaging shown for pending registrations

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/functions-restapi.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/functions-restapi.php
@@ -54,11 +54,9 @@ function wporg_login_rest_username_exists( $request ) {
 			'available' => false,
 			'error' => sprintf(
 				__( 'That username is already in use.', 'wporg' ) . '<br>' .
-				/* translators: %s Email address */
-				__( 'Your account is pending approval. You will receive an email at %s to set your password when approved.', 'wporg' ) . 
-				/* translators: %s Email address */
-				'<br>' . __( 'Please contact %s for more details.', 'wporg' ),
-				'<code>' . esc_html( $pending['user_email'] ) . '</code>',
+				__( 'Your account is pending approval. You will receive an email to set your password when approved.', 'wporg' ) . '<br>' .
+				/* translators: %s Support email address */
+				__( 'Please contact %s for more details.', 'wporg' ),
 				'<a href="mailto:' . $sso::SUPPORT_EMAIL . '">' . $sso::SUPPORT_EMAIL . '</a>'
 			),
 			'avatar' => get_avatar( $pending['user_email'], 64 ),
@@ -122,11 +120,9 @@ function wporg_login_rest_email_in_use( $request ) {
 			'available' => false,
 			'error' => sprintf(
 				__( 'That email address already has an account.', 'wporg' ) . '<br>' .
-				/* translators: %s Email address */
-				__( 'Your account is pending approval. You will receive an email at %s to set your password when approved.', 'wporg' ) . 
-				/* translators: %s Email address */
-				'<br>' . __( 'Please contact %s for more details.', 'wporg' ),
-				'<code>' . esc_html( $pending['user_email'] ) . '</code>',
+				__( 'Your account is pending approval. You will receive an email to set your password when approved.', 'wporg' ) . '<br>' .
+				/* translators: %s Support email address */
+				__( 'Please contact %s for more details.', 'wporg' ),
 				'<a href="mailto:' . $sso::SUPPORT_EMAIL . '">' . $sso::SUPPORT_EMAIL . '</a>'
 			),
 			'avatar' => get_avatar( $email, 64 ),


### PR DESCRIPTION
The username and email availability checks both echo the registrant's address back into the message they return:

> Your account is pending approval. You will receive an email at `someone@example.com` to set your password when approved.

The registration form already shows what was entered in the field directly above the message, so repeating it isn't adding much. Dropping it also lets the two near-identical strings collapse into a single shared one, so there's one less thing to keep in sync (and one less to translate).

The `at %s` variant stays as-is on `pending-create.php` and `pending-profile.php`. Those are reached through a keyed link from the confirmation email, and the address is genuinely useful there — particularly on the profile screen, which offers to correct it.

No change to the avatars or to the resend-confirmation flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)