### PR TITLE
Plugin Directory: Block a release when a security scan reports a high risk score

### DIFF
--- a/environments/plugin-directory/.wp-env.test.json
+++ b/environments/plugin-directory/.wp-env.test.json
@@ -4,7 +4,13 @@
 	"plugins": [
 		"../wordpress.org/public_html/wp-content/plugins/plugin-directory"
 	],
+	"mappings": {
+		"wp-content/env-bin": "./plugin-directory/bin"
+	},
 	"lifecycleScripts": {
 		"afterStart": "bash plugin-directory/bin/after-start-test.sh"
+	},
+	"config": {
+		"PLUGINS_TABLE_PREFIX": "wp_"
 	}
 }

--- a/environments/plugin-directory/bin/after-start-test.sh
+++ b/environments/plugin-directory/bin/after-start-test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Runs after wp-env start for the test environment.
-# Installs PHPUnit 11 and Yoast polyfills in the test container.
+# Installs PHPUnit 11 and Yoast polyfills, and creates the stub tables tests read.
 #
 
 CONFIG="--config plugin-directory/.wp-env.test.json"
@@ -10,3 +10,7 @@ RUN="npx wp-env $CONFIG run tests-cli"
 echo "Installing PHPUnit 11 and polyfills..."
 $RUN composer global require -W phpunit/phpunit:^11.0 2>&1
 $RUN composer require --dev yoast/phpunit-polyfills:^4.0 --working-dir=/wordpress-phpunit 2>&1
+
+# Create stub database tables that exist outside WordPress on production.
+echo "Creating stub database tables..."
+$RUN -- wp db import wp-content/env-bin/database-tables.sql

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -145,6 +145,8 @@
 		<properties>
 			<property name="custom_test_classes" type="array">
 				<element value="Release_Block_Test_Case"/>
+				<element value="Gandalf_Scan_Test_Case"/>
+				<element value="Gandalf_Callback_Test_Case"/>
 			</property>
 		</properties>
 	</rule>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -138,4 +138,14 @@
 		<exclude name="WordPress.Security.NonceVerification.Missing" />
 		<exclude name="WordPress.Security.NonceVerification.Recommended" />
 	</rule>
+
+	<!-- Recognise project test-case bases so the FileName sniff exempts their subclasses (whose
+	     names must match their class, not be hyphenated, so PHPUnit can discover them). -->
+	<rule ref="WordPress.Files.FileName">
+		<properties>
+			<property name="custom_test_classes" type="array">
+				<element value="Release_Block_Test_Case"/>
+			</property>
+		</properties>
+	</rule>
 </ruleset>

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/metabox/class-controls.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/metabox/class-controls.php
@@ -81,11 +81,21 @@ class Controls {
 			<p>
 			<?php
 			if ( $blocked ) {
-				printf(
-					/* translators: %s: version */
-					esc_html__( 'Version %s is blocked and is being held from sites. Force-releasing overrides the block.', 'wporg-plugins' ),
-					esc_html( $version )
-				);
+				$block = $release['release_block'];
+				if ( isset( $block['risk_score'] ) ) {
+					printf(
+						/* translators: 1: version, 2: security scan risk score */
+						esc_html__( 'Version %1$s is blocked by a security scan (risk score %2$s) and is being held from sites. Force-releasing overrides the block.', 'wporg-plugins' ),
+						esc_html( $version ),
+						esc_html( $block['risk_score'] )
+					);
+				} else {
+					printf(
+						/* translators: %s: version */
+						esc_html__( 'Version %s is blocked and is being held from sites. Force-releasing overrides the block.', 'wporg-plugins' ),
+						esc_html( $version )
+					);
+				}
 			} else {
 				printf(
 					/* translators: 1: version, 2: relative time until cooldown expires, 3: absolute UTC timestamp */

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/metabox/class-controls.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/metabox/class-controls.php
@@ -46,11 +46,12 @@ class Controls {
 	}
 
 	/**
-	 * Display the release cooldown status and (for reviewers) a force-release control.
+	 * Display the release hold status and (for reviewers) force-release and block controls.
 	 *
-	 * Bails when there's no current release to gate, when the release has no cooldown
-	 * delay (feature off at release-creation, or already force-released), or when the
-	 * cooldown window has elapsed.
+	 * Shows one of two messages: a countdown while a release is cooling down, or a block
+	 * notice when the release is being held (which outlasts the cooldown window). Reviewers
+	 * can force-release either way, and can block a version that's still cooling down. Bails
+	 * when there's no current release, or when it's neither held nor still cooling down.
 	 */
 	protected static function display_release_cooldown() {
 		$post = get_post();
@@ -65,13 +66,13 @@ class Controls {
 			return;
 		}
 
-		$release_delay = (int) ( $release['release_delay'] ?? 0 );
-		if ( ! $release_delay ) {
-			return;
-		}
-
+		$blocked        = API_Update_Updater::is_release_blocked( $release );
+		$release_delay  = (int) ( $release['release_delay'] ?? 0 );
 		$cooldown_until = API_Update_Updater::compute_release_time( $post, $release ) + $release_delay;
-		if ( $cooldown_until <= time() ) {
+		$in_cooldown    = $release_delay && $cooldown_until > time();
+
+		// Nothing to surface unless the release is held or still cooling down.
+		if ( ! $blocked && ! $in_cooldown ) {
 			return;
 		}
 
@@ -79,21 +80,29 @@ class Controls {
 		<div class="misc-pub-section misc-pub-release-cooldown">
 			<p>
 			<?php
-			printf(
-				/* translators: 1: version, 2: relative time until cooldown expires, 3: absolute UTC timestamp */
-				esc_html__( 'Version %1$s is in the release cooldown — it will be served to sites in %2$s (at %3$s UTC).', 'wporg-plugins' ),
-				esc_html( $version ),
-				esc_html( human_time_diff( time(), $cooldown_until ) ),
-				esc_html( gmdate( 'Y-m-d H:i', $cooldown_until ) )
-			);
+			if ( $blocked ) {
+				printf(
+					/* translators: %s: version */
+					esc_html__( 'Version %s is blocked and is being held from sites. Force-releasing overrides the block.', 'wporg-plugins' ),
+					esc_html( $version )
+				);
+			} else {
+				printf(
+					/* translators: 1: version, 2: relative time until cooldown expires, 3: absolute UTC timestamp */
+					esc_html__( 'Version %1$s is in the release cooldown — it will be served to sites in %2$s (at %3$s UTC).', 'wporg-plugins' ),
+					esc_html( $version ),
+					esc_html( human_time_diff( time(), $cooldown_until ) ),
+					esc_html( gmdate( 'Y-m-d H:i', $cooldown_until ) )
+				);
+			}
 			?>
 			</p>
 			<?php if ( current_user_can( 'plugin_review', $post ) ) : ?>
 				<p>
-					<label for="force_release_reason"><?php esc_html_e( 'Force-release reason (required):', 'wporg-plugins' ); ?></label>
+					<label for="release_action_reason"><?php esc_html_e( 'Reason (required):', 'wporg-plugins' ); ?></label>
 					<textarea
-						id="force_release_reason"
-						name="force_release_reason"
+						id="release_action_reason"
+						name="release_action_reason"
 						rows="2"
 						style="width: 100%;"
 						placeholder="<?php esc_attr_e( 'e.g. urgent security fix for CVE-…', 'wporg-plugins' ); ?>"
@@ -109,6 +118,17 @@ class Controls {
 						);
 						?>
 					</button>
+					<?php if ( $in_cooldown && ! $blocked ) : ?>
+						<button type="submit" name="block_release_version" value="<?php echo esc_attr( $version ); ?>" class="button">
+							<?php
+							printf(
+								/* translators: %s: version */
+								esc_html__( 'Block %s from sites', 'wporg-plugins' ),
+								esc_html( $version )
+							);
+							?>
+						</button>
+					<?php endif; ?>
 				</p>
 			<?php endif; ?>
 		</div>
@@ -116,12 +136,14 @@ class Controls {
 	}
 
 	/**
-	 * Save handler for reviewer force-release submissions from the Controls metabox.
+	 * Save handler for reviewer force-release and block submissions from the Controls metabox.
 	 *
 	 * @param int $post_id The post being saved.
 	 */
 	public static function save_post( $post_id ) {
-		if ( empty( $_POST['force_release_version'] ) ) {
+		$is_force_release = ! empty( $_POST['force_release_version'] );
+		$is_block         = ! empty( $_POST['block_release_version'] );
+		if ( ! $is_force_release && ! $is_block ) {
 			return;
 		}
 
@@ -139,20 +161,30 @@ class Controls {
 		check_admin_referer( 'update-post_' . $post_id );
 
 		$version           = get_post_meta( $post->ID, 'version', true );
-		$submitted_version = sanitize_text_field( wp_unslash( $_POST['force_release_version'] ) );
+		$submitted_version = sanitize_text_field( wp_unslash( $is_force_release ? $_POST['force_release_version'] : $_POST['block_release_version'] ) );
 		if ( $submitted_version !== $version ) {
 			// Submitted version doesn't match current — a newer commit landed since the form was rendered.
 			return;
 		}
 
-		$reason = isset( $_POST['force_release_reason'] )
-			? trim( sanitize_textarea_field( wp_unslash( $_POST['force_release_reason'] ) ) )
+		$reason = isset( $_POST['release_action_reason'] )
+			? trim( sanitize_textarea_field( wp_unslash( $_POST['release_action_reason'] ) ) )
 			: '';
 		if ( ! $reason ) {
 			return;
 		}
 
-		API_Update_Updater::force_release( $post->post_name, $reason );
+		if ( $is_force_release ) {
+			API_Update_Updater::force_release( $post->post_name, $reason );
+		} else {
+			API_Update_Updater::block_release(
+				$post->post_name,
+				array(
+					'reason'     => $reason,
+					'blocked_by' => wp_get_current_user()->user_login,
+				)
+			);
+		}
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-plugin-directory.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-plugin-directory.php
@@ -1754,6 +1754,15 @@ class Plugin_Directory {
 			unset( $release['discarded'] );
 		}
 
+		/*
+		 * Clear a release block so the release can be served.
+		 * See Jobs\API_Update_Updater::force_release().
+		 */
+		if ( ! empty( $data['unblock'] ) ) {
+			unset( $release['release_block'] );
+		}
+		unset( $release['unblock'] );
+
 		$releases = self::get_releases( $plugin );
 
 		// Find any other releases using this slug (as in the case of updates) and remove it.

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-api-update-updater.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-api-update-updater.php
@@ -299,7 +299,7 @@ class API_Update_Updater {
 	/**
 	 * Whether a release is being held out of `update_source` by a block.
 	 *
-	 * A block is set by a reviewer, and cleared by a force-release.
+	 * A block is set either by a high-risk security scan or by a reviewer.
 	 *
 	 * @param array|bool $release The release row from Plugin_Directory::get_release(), or false.
 	 * @return bool True when the release is being held out of `update_source`.
@@ -385,14 +385,22 @@ class API_Update_Updater {
 
 		// A force-release also overrides a block; note that in the audit trail.
 		if ( self::is_release_blocked( $release ) ) {
-			Tools::audit_log(
-				sprintf(
+			$block = $release['release_block'];
+			if ( isset( $block['risk_score'] ) ) {
+				$message = sprintf(
+					'Force-released version %1$s, overriding the security-scan block (risk score %2$s). Reason: %3$s',
+					$version,
+					$block['risk_score'],
+					$reason
+				);
+			} else {
+				$message = sprintf(
 					'Force-released version %1$s, overriding the release block. Reason: %2$s',
 					$version,
 					$reason
-				),
-				$post
-			);
+				);
+			}
+			Tools::audit_log( $message, $post );
 		} else {
 			Tools::audit_log(
 				sprintf(
@@ -421,13 +429,15 @@ class API_Update_Updater {
 	/**
 	 * Hold a plugin's current version out of `update_source` until it's force-released.
 	 *
-	 * The counterpart to force_release(). Callers apply their own preconditions first; this
-	 * only refuses when there's nothing left to hold.
+	 * The counterpart to force_release(), shared by the reviewer control and the security
+	 * scan. Callers apply their own preconditions first; this only refuses when there's
+	 * nothing left to hold.
 	 *
 	 * Capability checks must be performed by the caller.
 	 *
 	 * @param string $plugin_slug The plugin slug.
-	 * @param array  $block       The block to record: 'reason' and 'blocked_by'.
+	 * @param array  $block       The block to record: 'reason' and 'blocked_by' for a reviewer
+	 *                            block, or 'scan_id' and 'risk_score' for a security scan.
 	 * @return bool True when the version was held, false when there was nothing to hold.
 	 */
 	public static function block_release( $plugin_slug, $block ) {
@@ -458,14 +468,21 @@ class API_Update_Updater {
 			)
 		);
 
-		Tools::audit_log(
-			sprintf(
+		if ( isset( $block['risk_score'] ) ) {
+			$message = sprintf(
+				'A security scan blocked version %1$s from being served (risk score %2$s).',
+				$version,
+				$block['risk_score']
+			);
+		} else {
+			$message = sprintf(
 				'Blocked version %1$s from being served to sites. Reason: %2$s',
 				$version,
 				$block['reason']
-			),
-			$post
-		);
+			);
+		}
+
+		Tools::audit_log( $message, $post );
 
 		// Re-run so a version scheduled to serve at cooldown-end is held now instead.
 		self::update_single_plugin( $plugin_slug );

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-api-update-updater.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-api-update-updater.php
@@ -86,14 +86,16 @@ class API_Update_Updater {
 		$requires_plugins = get_post_meta( $post->ID, 'requires_plugins', true );
 		$release          = Plugin_Directory::get_release( $post, $version );
 		$release_time     = self::compute_release_time( $post, $release );
-		$existing_version = (string) $wpdb->get_var(
-			$wpdb->prepare(
-				"SELECT version FROM {$wpdb->prefix}update_source WHERE plugin_slug = %s",
-				$post->post_name
-			)
-		);
+		$existing_version = self::get_served_version( $post->post_name );
 
 		$release_delay = (int) ( $release['release_delay'] ?? 0 );
+
+		if ( self::is_release_blocked( $release ) && $existing_version !== (string) $version ) {
+			wp_clear_scheduled_hook( "release_to_update_api:{$post->post_name}" );
+			self::sync_availability( $post );
+
+			return true;
+		}
 
 		/*
 		 * Defer the write for new versions still inside the cooldown window. While
@@ -109,6 +111,8 @@ class API_Update_Updater {
 			$cooldown_until = $release_time + $release_delay;
 			if ( $cooldown_until > time() ) {
 				self::queue_release_to_update_api( $post->post_name, $cooldown_until );
+				self::sync_availability( $post );
+
 				return true;
 			}
 		}
@@ -127,16 +131,7 @@ class API_Update_Updater {
 			'last_stable_tag' => $post->last_stable_tag ?? '',
 		);
 
-		if ( in_array( $post->post_status, array( 'disabled', 'closed' ) ) ) {
-			$closed_data = Template::get_close_data( $post );
-			if ( $closed_data ) {
-				// Close date is sometimes unknown, only include the Day of closure.
-				$meta['closed_at'] = $closed_data['date'] ? gmdate( 'Y-m-d', strtotime( $closed_data['date'] ) ) : false;
-				if ( $closed_data['public'] ) {
-					$meta['closed_reason'] = $closed_data['reason'] ?: 'unknown';
-				}
-			}
-		}
+		$meta = array_merge( $meta, self::get_closed_meta( $post ) );
 
 		// Add phased rollout strategy data if needed.
 		if ( $release && ! empty( $release['rollout_strategy'] ) ) {
@@ -198,7 +193,7 @@ class API_Update_Updater {
 		// Sync the latest version to Stats.
 		if ( function_exists( '\WordPressdotorg\Stats\sync_latest_version' ) ) {
 			\WordPressdotorg\Stats\sync_latest_version(
-				'plugin', 
+				'plugin',
 				array(
 					$plugin_slug => $version
 				)
@@ -206,6 +201,111 @@ class API_Update_Updater {
 		}
 
 		return true;
+	}
+
+	/**
+	 * The closure fields recorded in `update_source`'s `meta` column.
+	 *
+	 * @param \WP_Post $post The plugin post.
+	 * @return array Empty for a plugin that is neither closed nor disabled.
+	 */
+	protected static function get_closed_meta( $post ) {
+		if ( ! in_array( $post->post_status, array( 'disabled', 'closed' ) ) ) {
+			return array();
+		}
+
+		$closed_data = Template::get_close_data( $post );
+		if ( ! $closed_data ) {
+			return array();
+		}
+
+		// Close date is sometimes unknown, only include the Day of closure.
+		$meta = array(
+			'closed_at' => $closed_data['date'] ? gmdate( 'Y-m-d', strtotime( $closed_data['date'] ) ) : false,
+		);
+
+		if ( $closed_data['public'] ) {
+			$meta['closed_reason'] = $closed_data['reason'] ?: 'unknown';
+		}
+
+		return $meta;
+	}
+
+	/**
+	 * Apply the plugin's availability and closure state to the `update_source` row without
+	 * disturbing the version it serves.
+	 *
+	 * Whenever a new version is held back — by the release cooldown or by a block —
+	 * update_single_plugin() returns early, because the row has to keep serving the previous
+	 * version and the version-specific columns are all derived from post meta describing the
+	 * held one. A status change still has to reach sites immediately though: closing a plugin
+	 * whose next version is on hold must stop the current version being offered. So the
+	 * availability and closure fields are written on their own, and the rest of the row is
+	 * left as it is.
+	 *
+	 * @param \WP_Post $post The plugin post.
+	 */
+	protected static function sync_availability( $post ) {
+		global $wpdb;
+
+		// Fetched as a row, not a single value: `meta` is nullable, so a null there would be
+		// indistinguishable from the plugin having no row at all.
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT `meta` FROM `{$wpdb->prefix}update_source` WHERE `plugin_slug` = %s",
+				$post->post_name
+			),
+			ARRAY_A
+		);
+
+		// Nothing is being served, so there's no availability to correct.
+		if ( ! $row ) {
+			return;
+		}
+
+		$meta = $row['meta'] ? (array) maybe_unserialize( $row['meta'] ) : array();
+
+		// Rebuild rather than merge, so re-opening a plugin drops the closure fields again.
+		unset( $meta['closed_at'], $meta['closed_reason'] );
+		$meta = array_merge( $meta, self::get_closed_meta( $post ) );
+
+		$wpdb->update(
+			$wpdb->prefix . 'update_source',
+			array(
+				'available' => (int) in_array( $post->post_status, array( 'publish', 'disabled' ) ),
+				'meta'      => $meta ? serialize( $meta ) : '',
+			),
+			array( 'plugin_slug' => $post->post_name )
+		);
+	}
+
+	/**
+	 * The version currently served from `update_source`.
+	 *
+	 * @param string $plugin_slug The plugin slug.
+	 * @return string The served version, or '' when the plugin isn't in `update_source`.
+	 */
+	public static function get_served_version( $plugin_slug ) {
+		global $wpdb;
+
+		return (string) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT version FROM {$wpdb->prefix}update_source WHERE plugin_slug = %s",
+				$plugin_slug
+			)
+		);
+	}
+
+	/**
+	 * Whether a release is being held out of `update_source` by a block.
+	 *
+	 * A block is set by a reviewer, and cleared by a force-release.
+	 *
+	 * @param array|bool $release The release row from Plugin_Directory::get_release(), or false.
+	 * @return bool True when the release is being held out of `update_source`.
+	 */
+	public static function is_release_blocked( $release ) {
+		return is_array( $release ) && ! empty( $release['release_block'] );
 	}
 
 	/**
@@ -283,25 +383,94 @@ class API_Update_Updater {
 			return false;
 		}
 
-		Tools::audit_log(
-			sprintf(
-				'Force-released version %s, bypassing the %d-hour release cooldown. Reason: %s',
-				$version,
-				(int) ( $release['release_delay'] ?? 0 ) / HOUR_IN_SECONDS,
-				$reason
-			),
-			$post
-		);
+		// A force-release also overrides a block; note that in the audit trail.
+		if ( self::is_release_blocked( $release ) ) {
+			Tools::audit_log(
+				sprintf(
+					'Force-released version %1$s, overriding the release block. Reason: %2$s',
+					$version,
+					$reason
+				),
+				$post
+			);
+		} else {
+			Tools::audit_log(
+				sprintf(
+					'Force-released version %s, bypassing the %d-hour release cooldown. Reason: %s',
+					$version,
+					(int) ( $release['release_delay'] ?? 0 ) / HOUR_IN_SECONDS,
+					$reason
+				),
+				$post
+			);
+		}
 
 		Plugin_Directory::add_release(
 			$post,
 			array(
 				'tag'           => $release['tag'],
 				'release_delay' => 0,
+				// Clear any release block so update_single_plugin() serves the version.
+				'unblock'       => true,
 			)
 		);
 
 		return self::update_single_plugin( $plugin_slug );
+	}
+
+	/**
+	 * Hold a plugin's current version out of `update_source` until it's force-released.
+	 *
+	 * The counterpart to force_release(). Callers apply their own preconditions first; this
+	 * only refuses when there's nothing left to hold.
+	 *
+	 * Capability checks must be performed by the caller.
+	 *
+	 * @param string $plugin_slug The plugin slug.
+	 * @param array  $block       The block to record: 'reason' and 'blocked_by'.
+	 * @return bool True when the version was held, false when there was nothing to hold.
+	 */
+	public static function block_release( $plugin_slug, $block ) {
+		$post = Plugin_Directory::get_plugin_post( $plugin_slug );
+		if ( ! $post ) {
+			return false;
+		}
+
+		$version = get_post_meta( $post->ID, 'version', true );
+		$release = Plugin_Directory::get_release( $post, $version );
+
+		if ( ! $release ) {
+			return false;
+		}
+
+		// Already live: the version is being served, so there's nothing left to hold back.
+		if ( self::get_served_version( $plugin_slug ) === (string) $version ) {
+			return false;
+		}
+
+		$block['blocked_at'] = time();
+
+		Plugin_Directory::add_release(
+			$post,
+			array(
+				'tag'           => $release['tag'],
+				'release_block' => $block,
+			)
+		);
+
+		Tools::audit_log(
+			sprintf(
+				'Blocked version %1$s from being served to sites. Reason: %2$s',
+				$version,
+				$block['reason']
+			),
+			$post
+		);
+
+		// Re-run so a version scheduled to serve at cooldown-end is held now instead.
+		self::update_single_plugin( $plugin_slug );
+
+		return true;
 	}
 
 	static function get_plugin_assets( $post ) {

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan-gandalf.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan-gandalf.php
@@ -7,6 +7,7 @@
 
 namespace WordPressdotorg\Plugin_Directory\Jobs;
 
+use WordPressdotorg\Plugin_Directory\Plugin_Directory;
 use WordPressdotorg\Plugin_Directory\Template;
 use WP_Error;
 use WP_Http;
@@ -29,6 +30,9 @@ class Plugin_Scan_Gandalf {
 
 	/** Gandalf scan endpoint. */
 	const ENDPOINT = 'https://gandalf.wordpress.org/scan';
+
+	/** Risk score at or above which a completed scan blocks the release from being served. */
+	const RISK_SCORE_BLOCK_THRESHOLD = 8;
 
 	/**
 	 * Dispatch a Gandalf scan from the importer context carried through cron.
@@ -178,8 +182,33 @@ class Plugin_Scan_Gandalf {
 		}
 
 		if ( 'completed' === $data['status'] ) {
-			if ( $data['findings_count'] > 0 ) {
-				self::notify_slack(
+			/*
+			 * Precedence: a high enough risk score blocks the release outright; otherwise findings
+			 * raise the usual advisory alert. `risk_score` is read defensively because the callback
+			 * route doesn't validate it, and because Gandalf doesn't send it yet.
+			 */
+			$risk_score = ( isset( $data['risk_score'] ) && is_numeric( $data['risk_score'] ) ) ? (float) $data['risk_score'] : null;
+
+			if ( null !== $risk_score && $risk_score >= self::RISK_SCORE_BLOCK_THRESHOLD ) {
+				/*
+				 * Auto-blocking is disabled. Enable by restoring:
+				 *
+				 * $held = self::block_release( $plugin, $pending_record, $scan_id, $risk_score );
+				 */
+				$held = false;
+
+				self::notify_slack_blocked(
+					$plugin,
+					[
+						'version'     => $pending_record['version'],
+						'release_ref' => $pending_record['release_ref'],
+						'risk_score'  => $risk_score,
+						'held'        => $held,
+						'report_url'  => $data['report_url'] ?? '',
+					]
+				);
+			} elseif ( $data['findings_count'] > 0 ) {
+				self::notify_slack_findings(
 					$plugin,
 					[
 						'version'         => $pending_record['version'],
@@ -199,6 +228,42 @@ class Plugin_Scan_Gandalf {
 		update_post_meta( $plugin->ID, self::PENDING_META_KEY, $pending );
 
 		return true;
+	}
+
+	/**
+	 * Hold the scanned release, once the verdict is known to still apply to it.
+	 *
+	 * @param \WP_Post $plugin         The plugin post.
+	 * @param array    $pending_record The pending scan record (version, release_ref).
+	 * @param string   $scan_id        The Gandalf scan ID.
+	 * @param float    $risk_score     The reported risk score.
+	 * @return bool True when the release was held, false when there was nothing to hold.
+	 */
+	protected static function block_release( $plugin, $pending_record, $scan_id, $risk_score ) {
+		$version = (string) $pending_record['version'];
+
+		// A newer release landed since this scan was dispatched; the scanned version is moot.
+		if ( (string) get_post_meta( $plugin->ID, 'version', true ) !== $version ) {
+			return false;
+		}
+
+		$release = Plugin_Directory::get_release( $plugin, $version );
+		if ( ! $release ) {
+			return false;
+		}
+
+		// No cooldown was captured at release creation, so the version was served at import.
+		if ( empty( $release['release_delay'] ) ) {
+			return false;
+		}
+
+		return API_Update_Updater::block_release(
+			$plugin->post_name,
+			[
+				'scan_id'    => $scan_id,
+				'risk_score' => $risk_score,
+			]
+		);
 	}
 
 	/**
@@ -236,12 +301,16 @@ class Plugin_Scan_Gandalf {
 	}
 
 	/**
-	 * Notify Slack about a Gandalf scan with findings.
+	 * Alert Slack about a scan that reported findings.
+	 *
+	 * Dedupes on the verdict hash so an unchanged result isn't reported twice, and is skipped
+	 * when no hash is present, since there's nothing to dedupe on.
 	 *
 	 * @param \WP_Post $plugin The plugin post.
-	 * @param array    $record The completed scan summary.
+	 * @param array    $record 'version', 'release_ref', 'findings_count', 'severity_counts',
+	 *                         'verdict_hash', 'report_url'.
 	 */
-	protected static function notify_slack( $plugin, $record ) {
+	protected static function notify_slack_findings( $plugin, $record ) {
 		if ( empty( $record['verdict_hash'] ) ) {
 			return;
 		}
@@ -261,14 +330,71 @@ class Plugin_Scan_Gandalf {
 		$already_notified[ $record['verdict_hash'] ] = time();
 		update_post_meta( $plugin->ID, self::NOTIFIED_META_KEY, $already_notified );
 
-		if ( ! defined( 'PLUGIN_REVIEW_ALERT_SLACK_CHANNEL' ) || ! function_exists( 'slack_dm' ) ) {
-			return;
+		$detail = [ sprintf( 'Findings: %d', $record['findings_count'] ) ];
+
+		$severity_summary = [];
+		foreach ( (array) ( $record['severity_counts'] ?? [] ) as $severity => $count ) {
+			if ( $count > 0 ) {
+				$severity_summary[] = "{$severity}: {$count}";
+			}
+		}
+		if ( $severity_summary ) {
+			$detail[] = 'Severity: ' . implode( ', ', $severity_summary );
 		}
 
-		$active_installs = (int) get_post_meta( $plugin->ID, 'active_installs', true );
-		$install_line    = sprintf( '%s+ active installs', number_format_i18n( $active_installs ) );
-		if ( $active_installs >= 10000 ) {
-			$install_line = ":bangbang::bangbang::bangbang: {$install_line} :bangbang::bangbang::bangbang:";
+		self::send_slack_alert(
+			$plugin,
+			'A security scan detected findings in *%s*',
+			$record['version'],
+			$record['release_ref'],
+			$detail,
+			$record['report_url']
+		);
+	}
+
+	/**
+	 * Alert Slack about a high-risk verdict. Always sends: a high score needs a human either way.
+	 *
+	 * @param \WP_Post $plugin The plugin post.
+	 * @param array    $record 'version', 'release_ref', 'risk_score', 'report_url', and 'held'
+	 *                         (whether the release was held).
+	 */
+	protected static function notify_slack_blocked( $plugin, $record ) {
+		if ( ! empty( $record['held'] ) ) {
+			$headline = 'A security scan *blocked* a release of *%s*';
+			$status   = 'Held out of the update API until a reviewer force-releases it.';
+		} else {
+			$headline = 'A security scan flagged a release of *%s*';
+			$status   = 'Not held automatically. Review the version and block it from the plugin page if warranted.';
+		}
+
+		self::send_slack_alert(
+			$plugin,
+			$headline,
+			$record['version'],
+			$record['release_ref'],
+			[
+				sprintf( 'Risk score: %s (flags at %s)', $record['risk_score'], self::RISK_SCORE_BLOCK_THRESHOLD ),
+				$status,
+			],
+			$record['report_url']
+		);
+	}
+
+	/**
+	 * Send a plugin-review Slack alert: the shared envelope for the scan notifications — the
+	 * plugin title, active-install count, version line, and links.
+	 *
+	 * @param \WP_Post $plugin      The plugin post.
+	 * @param string   $headline    A sprintf format with a single %s for the plugin title.
+	 * @param string   $version     The scanned version.
+	 * @param string   $release_ref The scanned release ref.
+	 * @param string[] $detail      Lines describing the result, placed after the version line.
+	 * @param string   $report_url  Link to the scan report, or '' when there isn't one.
+	 */
+	private static function send_slack_alert( $plugin, $headline, $version, $release_ref, $detail, $report_url ) {
+		if ( ! defined( 'PLUGIN_REVIEW_ALERT_SLACK_CHANNEL' ) || ! function_exists( 'slack_dm' ) ) {
+			return;
 		}
 
 		$title = $plugin->post_title;
@@ -276,31 +402,21 @@ class Plugin_Scan_Gandalf {
 			$title .= ' (closed)';
 		}
 
-		$body = sprintf(
-			"Gandalf scan detected findings in *%s*\n%s\nVersion: %s (%s)\nFindings: %d\n",
-			$title,
-			$install_line,
-			$record['version'],
-			$record['release_ref'],
-			$record['findings_count']
-		);
-
-		if ( ! empty( $record['severity_counts'] ) ) {
-			$severity_summary = [];
-			foreach ( $record['severity_counts'] as $severity => $count ) {
-				if ( $count > 0 ) {
-					$severity_summary[] = "{$severity}: {$count}";
-				}
-			}
-
-			if ( $severity_summary ) {
-				$body .= 'Severity: ' . implode( ', ', $severity_summary ) . "\n";
-			}
+		$active_installs = (int) get_post_meta( $plugin->ID, 'active_installs', true );
+		$install_line    = sprintf( '%s+ active installs', number_format_i18n( $active_installs ) );
+		if ( $active_installs >= 10000 ) {
+			$install_line = ":warning: {$install_line}";
 		}
 
+		$body  = sprintf( $headline, $title ) . "\n";
+		$body .= $install_line . "\n";
+		$body .= sprintf( "Version: %s (%s)\n", $version, $release_ref );
+		$body .= implode( "\n", $detail ) . "\n";
 		$body .= sprintf( "Details: https://wordpress.org/plugins/wp-admin/post.php?post=%s&action=edit\n", $plugin->ID );
 		$body .= sprintf( "Plugin: https://wordpress.org/plugins/%s/\n", $plugin->post_name );
-		$body .= sprintf( "Report: %s\n", $record['report_url'] );
+		if ( ! empty( $report_url ) ) {
+			$body .= sprintf( "Report: %s\n", $report_url );
+		}
 
 		slack_dm( $body, PLUGIN_REVIEW_ALERT_SLACK_CHANNEL, true );
 	}

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/phpunit.xml
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/phpunit.xml
@@ -7,6 +7,7 @@
 		<testsuite name="plugin-directory">
 			<directory suffix=".php">tests/</directory>
 			<exclude>tests/bootstrap.php</exclude>
+			<exclude>tests/Release_Block_Test_Case.php</exclude>
 			<exclude>tests/wporg-url-schemes.php</exclude>
 			<exclude>tests/wporg-plugin-api.php</exclude>
 			<exclude>tests/wporg-plugin-api-performance.php</exclude>

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/phpunit.xml
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/phpunit.xml
@@ -8,6 +8,8 @@
 			<directory suffix=".php">tests/</directory>
 			<exclude>tests/bootstrap.php</exclude>
 			<exclude>tests/Release_Block_Test_Case.php</exclude>
+			<exclude>tests/Gandalf_Scan_Test_Case.php</exclude>
+			<exclude>tests/Gandalf_Callback_Test_Case.php</exclude>
 			<exclude>tests/wporg-url-schemes.php</exclude>
 			<exclude>tests/wporg-plugin-api.php</exclude>
 			<exclude>tests/wporg-plugin-api-performance.php</exclude>

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Gandalf_Callback_Test_Case.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Gandalf_Callback_Test_Case.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Shared harness for full-chain tests of the Gandalf scan callback route,
+ * `plugins/v1/plugin/{slug}/gandalf-scan`.
+ *
+ * Takes the scan fixture and drives callbacks through the REST route the way Gandalf does —
+ * authentication, routing, and the write to `update_source`. Subclasses assert what a
+ * particular verdict does; the route-level authentication is covered here, once.
+ *
+ * Contains no tests of its own beyond that, so it's excluded from the suite in phpunit.xml
+ * and loaded on demand by the test bootstrap's autoloader when a subclass extends it.
+ *
+ * @package WordPressdotorg\Plugin_Directory\Tests
+ */
+
+/**
+ * @group jobs
+ */
+abstract class Gandalf_Callback_Test_Case extends Gandalf_Scan_Test_Case {
+
+	/**
+	 * The shared secret to define, when nothing else has.
+	 */
+	const SECRET = 'gandalf-callback-testcase-secret';
+
+	/**
+	 * The plugin slug under test.
+	 */
+	const SLUG = 'gandalf-callback-testcase';
+
+	/**
+	 * Both directions of the integration gate on the shared secret, so without it the
+	 * route only ever answers 401.
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
+		if ( ! defined( 'WP_GANDALF_SCAN_SHARED_SECRET' ) ) {
+			define( 'WP_GANDALF_SCAN_SHARED_SECRET', static::SECRET );
+		}
+	}
+
+	/**
+	 * The secret the route will actually accept.
+	 *
+	 * Read back rather than assumed to be static::SECRET: it's a constant, so anything that
+	 * defined one first — a sandbox mu-plugin, another suite — wins, and the tests would then
+	 * authenticate with a secret the route rejects and fail as a wall of 401s.
+	 *
+	 * @return string
+	 */
+	protected static function secret() {
+		return defined( 'WP_GANDALF_SCAN_SHARED_SECRET' ) ? WP_GANDALF_SCAN_SHARED_SECRET : static::SECRET;
+	}
+
+	/**
+	 * POST a callback to the route, as Gandalf would.
+	 *
+	 * @param array            $body   The callback body.
+	 * @param string|null|bool $secret The bearer secret, null for the correct one, or false to
+	 *                                 send no Authorization header at all.
+	 * @return \WP_REST_Response
+	 */
+	protected function post_callback( $body, $secret = null ) {
+		if ( null === $secret ) {
+			$secret = static::secret();
+		}
+
+		$request = new WP_REST_Request( 'POST', '/plugins/v1/plugin/' . static::SLUG . '/gandalf-scan' );
+
+		if ( false !== $secret ) {
+			$request->set_header( 'authorization', 'Bearer ' . $secret );
+		}
+
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( wp_json_encode( $body ) );
+
+		return rest_do_request( $request );
+	}
+
+	/**
+	 * A callback that authenticated and matched its pending scan is processed and no longer in flight.
+	 */
+	public function test_a_processed_callback_clears_the_pending_scan() {
+		$response = $this->post_callback( $this->callback_data() );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( array(), $this->get_pending_scans() );
+	}
+
+	/**
+	 * The route is authenticated: a callback without the shared secret changes nothing.
+	 */
+	public function test_a_callback_without_the_shared_secret_is_rejected() {
+		$response = $this->post_callback( $this->callback_data(), false );
+
+		$this->assertSame( 401, $response->get_status() );
+		$this->assertSame( static::SERVED_VERSION, $this->get_served_version() );
+	}
+
+	/**
+	 * The secret is compared, not merely required.
+	 */
+	public function test_a_callback_with_the_wrong_shared_secret_is_rejected() {
+		$response = $this->post_callback( $this->callback_data(), 'not-the-secret' );
+
+		$this->assertSame( 401, $response->get_status() );
+		$this->assertSame( static::SERVED_VERSION, $this->get_served_version() );
+	}
+}

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Gandalf_Risk_Score_Block_Callback_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Gandalf_Risk_Score_Block_Callback_Test.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Full-chain tests for the risk-score block: a scan callback arrives over the REST route,
+ * `plugins/v1/plugin/{slug}/gandalf-scan`, and the release is held from sites or not.
+ *
+ * The route harness (fixture, POST helper, and the route-level authentication tests) lives in
+ * Gandalf_Callback_Test_Case; this covers what a risk-score verdict does end to end. The
+ * handler's finer branches are covered directly in Gandalf_Risk_Score_Block_Test.
+ *
+ * @package WordPressdotorg\Plugin_Directory\Tests
+ */
+
+use WordPressdotorg\Plugin_Directory\Jobs\API_Update_Updater;
+use WordPressdotorg\Plugin_Directory\Jobs\Plugin_Scan_Gandalf;
+
+/**
+ * Covers what a risk-score verdict, delivered over the API, does to a release waiting out its delay.
+ *
+ * @group jobs
+ */
+class Gandalf_Risk_Score_Block_Callback_Test extends Gandalf_Callback_Test_Case {
+
+	/**
+	 * The headline behaviour: Gandalf reports a blocking risk score over the API, and the
+	 * version it scanned is held back — the previous one keeps being served — and recorded.
+	 */
+	public function test_a_blocking_score_over_the_api_holds_the_version() {
+		$this->markTestSkipped( 'Auto-blocking on a risk score is disabled; see Plugin_Scan_Gandalf::handle_callback().' );
+
+		$response = $this->post_callback( $this->callback_data( array( 'risk_score' => Plugin_Scan_Gandalf::RISK_SCORE_BLOCK_THRESHOLD ) ) );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( static::SERVED_VERSION, $this->get_served_version() );
+		$this->assertSame( (float) Plugin_Scan_Gandalf::RISK_SCORE_BLOCK_THRESHOLD, $this->get_release_block()['risk_score'] );
+		$this->assertSame( static::SCAN_ID, $this->get_release_block()['scan_id'] );
+	}
+
+	/**
+	 * The block outlasts the cooldown: once the delay elapses, the reconciliation run that
+	 * would normally serve the new version still leaves the old one in place.
+	 */
+	public function test_a_held_version_is_not_served_when_its_delay_later_elapses() {
+		$this->markTestSkipped( 'Auto-blocking on a risk score is disabled; see Plugin_Scan_Gandalf::handle_callback().' );
+
+		$this->post_callback( $this->callback_data( array( 'risk_score' => 9 ) ) );
+
+		// Age the commit past the delay; without the block this run would serve NEW_VERSION.
+		$this->elapse_cooldown();
+		API_Update_Updater::update_single_plugin( static::SLUG );
+
+		$this->assertSame( static::SERVED_VERSION, $this->get_served_version() );
+	}
+
+
+	/**
+	 * A score below the threshold is not a block; the release is left to its normal delay.
+	 */
+	public function test_a_score_below_the_threshold_over_the_api_does_not_block() {
+		$response = $this->post_callback( $this->callback_data( array( 'risk_score' => Plugin_Scan_Gandalf::RISK_SCORE_BLOCK_THRESHOLD - 1 ) ) );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertNull( $this->get_release_block() );
+	}
+
+	/**
+	 * An absent risk_score — every scan until Gandalf sends one — never blocks.
+	 */
+	public function test_an_absent_risk_score_over_the_api_does_not_block() {
+		$response = $this->post_callback( $this->callback_data() );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertNull( $this->get_release_block() );
+	}
+
+	/**
+	 * A blocking score for a version that is already live can't un-ship it: `update_source`
+	 * is left untouched and nothing is held.
+	 */
+	public function test_a_blocking_score_for_an_already_served_version_is_left_untouched() {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery -- `update_source` lives outside WordPress; there is no API for it.
+		$wpdb->update(
+			$wpdb->prefix . 'update_source',
+			array( 'version' => static::NEW_VERSION ),
+			array( 'plugin_slug' => static::SLUG )
+		);
+
+		$response = $this->post_callback( $this->callback_data( array( 'risk_score' => 9 ) ) );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( static::NEW_VERSION, $this->get_served_version() );
+		$this->assertNull( $this->get_release_block() );
+	}
+
+	/**
+	 * A reviewer force-release closes the loop: a version blocked over the API is served, and
+	 * the block cleared.
+	 */
+	public function test_force_release_after_an_api_block_serves_the_version() {
+		$this->markTestSkipped( 'Auto-blocking on a risk score is disabled; see Plugin_Scan_Gandalf::handle_callback().' );
+
+		$this->post_callback( $this->callback_data( array( 'risk_score' => 9 ) ) );
+
+		$result = API_Update_Updater::force_release( static::SLUG, 'Reviewed the scan; false positive.' );
+
+		$this->assertTrue( $result );
+		$this->assertNull( $this->get_release_block() );
+		$this->assertSame( static::NEW_VERSION, $this->get_served_version() );
+	}
+}

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Gandalf_Risk_Score_Block_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Gandalf_Risk_Score_Block_Test.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * Tests for the Gandalf risk-score block: holding a high-risk version out of `update_source`
+ * until a reviewer force-releases it, and the cases where there's nothing to hold.
+ *
+ * @package WordPressdotorg\Plugin_Directory\Tests
+ */
+
+use WordPressdotorg\Plugin_Directory\Jobs\API_Update_Updater;
+use WordPressdotorg\Plugin_Directory\Jobs\Plugin_Scan_Gandalf;
+
+/**
+ * Covers Plugin_Scan_Gandalf::handle_callback()'s blocking path and its interaction with the
+ * release delay and the reviewer force-release.
+ *
+ * @group jobs
+ */
+class Gandalf_Risk_Score_Block_Test extends Gandalf_Scan_Test_Case {
+
+	/**
+	 * The plugin slug under test.
+	 */
+	const SLUG = 'gandalf-block-test';
+
+	/**
+	 * A score at the threshold holds the version: the previous one keeps being served,
+	 * the block is recorded, and any deferred serve is cancelled.
+	 */
+	public function test_a_blocking_score_holds_the_version() {
+		$this->markTestSkipped( 'Auto-blocking on a risk score is disabled; see Plugin_Scan_Gandalf::handle_callback().' );
+
+		Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->callback_data( array( 'risk_score' => 8 ) ) );
+
+		$this->assertSame( self::SERVED_VERSION, $this->get_served_version() );
+		$this->assertSame( 8.0, $this->get_release_block()['risk_score'] );
+		$this->assertSame( self::SCAN_ID, $this->get_release_block()['scan_id'] );
+		$this->assertFalse( wp_next_scheduled( 'release_to_update_api:' . self::SLUG ) );
+	}
+
+	/**
+	 * A score above the threshold blocks just the same.
+	 */
+	public function test_a_score_above_the_threshold_holds_the_version() {
+		$this->markTestSkipped( 'Auto-blocking on a risk score is disabled; see Plugin_Scan_Gandalf::handle_callback().' );
+
+		Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->callback_data( array( 'risk_score' => 9.5 ) ) );
+
+		$this->assertSame( self::SERVED_VERSION, $this->get_served_version() );
+		$this->assertNotNull( $this->get_release_block() );
+	}
+
+
+	/**
+	 * A score below the threshold is not a block; the release follows its normal delay.
+	 */
+	public function test_a_score_below_the_threshold_does_not_block() {
+		Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->callback_data( array( 'risk_score' => 7.9 ) ) );
+
+		$this->assertNull( $this->get_release_block() );
+	}
+
+	/**
+	 * An absent risk_score — every scan until Gandalf sends one — never blocks.
+	 */
+	public function test_an_absent_risk_score_does_not_block() {
+		Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->callback_data() );
+
+		$this->assertNull( $this->get_release_block() );
+	}
+
+	/**
+	 * A non-numeric risk_score is ignored rather than read as a block.
+	 */
+	public function test_a_non_numeric_risk_score_does_not_block() {
+		Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->callback_data( array( 'risk_score' => 'high' ) ) );
+
+		$this->assertNull( $this->get_release_block() );
+	}
+
+	/**
+	 * A reviewer force-release overrides the block: the held version is served and the block cleared.
+	 */
+	public function test_force_release_clears_the_block_and_serves() {
+		$this->markTestSkipped( 'Auto-blocking on a risk score is disabled; see Plugin_Scan_Gandalf::handle_callback().' );
+
+		Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->callback_data( array( 'risk_score' => 8 ) ) );
+
+		$result = API_Update_Updater::force_release( self::SLUG, 'Reviewed the scan; false positive.' );
+
+		$this->assertTrue( $result );
+		$this->assertNull( $this->get_release_block() );
+		$this->assertSame( self::NEW_VERSION, $this->get_served_version() );
+	}
+
+	/**
+	 * The override is recorded, naming the block it bypassed.
+	 */
+	public function test_force_release_records_the_override_in_the_audit_log() {
+		$this->markTestSkipped( 'Auto-blocking on a risk score is disabled; see Plugin_Scan_Gandalf::handle_callback().' );
+
+		Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->callback_data( array( 'risk_score' => 8 ) ) );
+
+		API_Update_Updater::force_release( self::SLUG, 'Reviewed the scan; false positive.' );
+
+		$notes = get_comments(
+			array(
+				'post_id' => $this->plugin->ID,
+				'type'    => 'internal-note',
+			)
+		);
+
+		$override = array_filter(
+			$notes,
+			function ( $note ) {
+				return false !== strpos( $note->comment_content, 'overriding the security-scan block' );
+			}
+		);
+
+		$this->assertCount( 1, $override );
+	}
+
+	/**
+	 * When the version is already live — the delay elapsed before the verdict arrived — a
+	 * blocking score can't un-ship it: `update_source` is left untouched and nothing is held.
+	 */
+	public function test_a_blocking_score_leaves_an_already_served_version_untouched() {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery -- `update_source` lives outside WordPress; there is no API for it.
+		$wpdb->update(
+			$wpdb->prefix . 'update_source',
+			array( 'version' => self::NEW_VERSION ),
+			array( 'plugin_slug' => self::SLUG )
+		);
+
+		Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->callback_data( array( 'risk_score' => 8 ) ) );
+
+		$this->assertSame( self::NEW_VERSION, $this->get_served_version() );
+		$this->assertNull( $this->get_release_block() );
+	}
+
+	/**
+	 * A verdict on a version that a newer commit has already superseded does not hold anything.
+	 */
+	public function test_a_blocking_score_for_a_superseded_version_does_not_block() {
+		update_post_meta( $this->plugin->ID, 'version', '3.0' );
+
+		Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->callback_data( array( 'risk_score' => 8 ) ) );
+
+		$this->assertNull( $this->get_release_block() );
+		$this->assertSame( self::SERVED_VERSION, $this->get_served_version() );
+	}
+
+	/**
+	 * With no delay captured at release creation, the version was served at import, so there's
+	 * nothing left to hold.
+	 */
+	public function test_a_blocking_score_does_not_block_a_release_that_had_no_delay() {
+		$this->set_releases( array( $this->release( array( 'release_delay' => 0 ) ) ) );
+
+		Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->callback_data( array( 'risk_score' => 8 ) ) );
+
+		$this->assertNull( $this->get_release_block() );
+	}
+
+	/**
+	 * A held version stays held across the reconciliation cron that would otherwise serve it.
+	 */
+	public function test_a_held_version_is_not_served_by_a_later_update_run() {
+		$this->markTestSkipped( 'Auto-blocking on a risk score is disabled; see Plugin_Scan_Gandalf::handle_callback().' );
+
+		Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->callback_data( array( 'risk_score' => 8 ) ) );
+
+		// The delay has since elapsed; without the block this would serve 2.0.
+		$this->elapse_cooldown();
+
+		API_Update_Updater::update_single_plugin( self::SLUG );
+
+		$this->assertSame( self::SERVED_VERSION, $this->get_served_version() );
+	}
+}

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Gandalf_Scan_Test_Case.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Gandalf_Scan_Test_Case.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Shared fixture for tests about what a Gandalf scan verdict does to a release.
+ *
+ * Adds an in-flight scan of NEW_VERSION to the release fixture, a builder for the callback
+ * payload Gandalf sends.
+ *
+ * Contains no tests of its own, so it's excluded from the suite in phpunit.xml and loaded on
+ * demand by the test bootstrap's autoloader when a subclass extends it.
+ *
+ * @package WordPressdotorg\Plugin_Directory\Tests
+ */
+
+use WordPressdotorg\Plugin_Directory\Jobs\Plugin_Scan_Gandalf;
+
+/**
+ * @group jobs
+ */
+abstract class Gandalf_Scan_Test_Case extends Release_Block_Test_Case {
+
+	/**
+	 * The scan the callbacks under test report on.
+	 */
+	const SCAN_ID = '9a7b6c5d-0000-4000-8000-0123456789ab';
+
+	/**
+	 * The release fixture, plus a scan of NEW_VERSION awaiting its verdict.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->set_pending_scan( static::NEW_VERSION );
+	}
+
+	/**
+	 * Record an in-flight scan so handle_callback() recognizes the callback.
+	 *
+	 * @param string $version The version being scanned.
+	 */
+	protected function set_pending_scan( $version ) {
+		update_post_meta(
+			$this->plugin->ID,
+			Plugin_Scan_Gandalf::PENDING_META_KEY,
+			array(
+				static::SCAN_ID => array(
+					'version'      => $version,
+					'release_ref'  => $version,
+					'requested_at' => time(),
+				),
+			)
+		);
+	}
+
+	/**
+	 * The pending scans still awaiting a callback.
+	 *
+	 * @return array
+	 */
+	protected function get_pending_scans() {
+		$pending = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::PENDING_META_KEY, true );
+
+		return $pending ? $pending : array();
+	}
+
+	/**
+	 * A well-formed completed-scan payload, as Gandalf would send it. The scanned version has
+	 * no findings; a verdict field like risk_score is added per-test via $overrides.
+	 *
+	 * @param array $overrides Values to override on the default payload.
+	 * @return array
+	 */
+	protected function callback_data( $overrides = array() ) {
+		return array_merge(
+			array(
+				'scan_id'         => static::SCAN_ID,
+				'status'          => 'completed',
+				'version'         => static::NEW_VERSION,
+				'release_ref'     => static::NEW_VERSION,
+				'findings_count'  => 0,
+				'severity_counts' => array(),
+				'verdict_hash'    => 'abc123',
+				'report_url'      => 'https://gandalf.wordpress.org/report/abc123',
+			),
+			$overrides
+		);
+	}
+}

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Release_Block_Test_Case.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Release_Block_Test_Case.php
@@ -1,0 +1,224 @@
+<?php
+/**
+ * Shared fixture for tests about holding a release out of `update_source`.
+ *
+ * Seeds a published plugin serving SERVED_VERSION with NEW_VERSION committed just now and
+ * waiting out a 24-hour release delay — the state every block, force-release, and cooldown
+ * test starts from — and provides the helpers for reading and writing what's actually served.
+ *
+ * Contains no tests of its own, so it's excluded from the suite in phpunit.xml and loaded on
+ * demand by the test bootstrap's autoloader when a subclass extends it.
+ *
+ * @package WordPressdotorg\Plugin_Directory\Tests
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group jobs
+ */
+abstract class Release_Block_Test_Case extends TestCase {
+
+	/**
+	 * The delay captured on the release under test.
+	 */
+	const DELAY = DAY_IN_SECONDS;
+
+	/**
+	 * The plugin slug under test. Subclasses override this so their fixtures can't collide.
+	 */
+	const SLUG = 'release-block-test';
+
+	/**
+	 * The version already being served when a test starts.
+	 */
+	const SERVED_VERSION = '1.0';
+
+	/**
+	 * The new version waiting out its delay, and the one tests hold back.
+	 */
+	const NEW_VERSION = '2.0';
+
+	/**
+	 * The plugin post under test.
+	 *
+	 * @var \WP_Post
+	 */
+	protected $plugin;
+
+	/**
+	 * A plugin serving SERVED_VERSION, with NEW_VERSION committed just now inside its delay.
+	 */
+	protected function setUp(): void {
+		global $wpdb;
+
+		parent::setUp();
+
+		// Tools::audit_log() reads this unconditionally; CLI has no remote address.
+		$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+
+		// post_modified is required: Plugin_Directory::filter_wp_insert_post_data() copies it
+		// from $postarr, and wp_insert_post() doesn't default it, so the insert fails without.
+		$plugin_id = wp_insert_post(
+			array(
+				'post_type'         => 'plugin',
+				'post_name'         => static::SLUG,
+				'post_title'        => static::SLUG,
+				'post_status'       => 'publish',
+				'post_modified'     => current_time( 'mysql' ),
+				'post_modified_gmt' => current_time( 'mysql', 1 ),
+			),
+			true
+		);
+
+		$this->assertNotInstanceOf( WP_Error::class, $plugin_id );
+
+		$this->plugin = get_post( $plugin_id );
+
+		update_post_meta( $plugin_id, 'version', static::NEW_VERSION );
+		update_post_meta( $plugin_id, 'stable_tag', static::NEW_VERSION );
+		update_post_meta( $plugin_id, 'header_name', static::SLUG );
+		update_post_meta( $plugin_id, 'header_author', 'WordPress' );
+		update_post_meta( $plugin_id, 'version_date', gmdate( 'Y-m-d H:i:s', time() ) );
+
+		$this->set_releases( array( $this->release() ) );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery -- `update_source` lives outside WordPress; there is no API for it.
+		$wpdb->query( "TRUNCATE TABLE `{$wpdb->prefix}update_source`" );
+		$this->serve( static::SERVED_VERSION );
+	}
+
+	/**
+	 * Remove the plugin, its meta, any audit-log notes, and any deferred cron event. There's
+	 * no transaction to roll back without WP_UnitTestCase, so state would otherwise leak.
+	 */
+	protected function tearDown(): void {
+		wp_clear_scheduled_hook( 'release_to_update_api:' . static::SLUG );
+
+		foreach ( get_comments( array( 'post_id' => $this->plugin->ID ) ) as $note ) {
+			wp_delete_comment( $note->comment_ID, true );
+		}
+
+		wp_delete_post( $this->plugin->ID, true );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * A complete release row for NEW_VERSION: confirmed, built, inside its delay.
+	 * get_releases() reads keys beyond the ones under test.
+	 *
+	 * @param array $overrides Values to override on the default release.
+	 * @return array
+	 */
+	protected function release( $overrides = array() ) {
+		return array_merge(
+			array(
+				'date'                   => time(),
+				'tag'                    => static::NEW_VERSION,
+				'version'                => static::NEW_VERSION,
+				'zips_built'             => true,
+				'confirmations'          => array(),
+				'confirmed'              => true,
+				'confirmations_required' => 0,
+				'committer'              => array(),
+				'revision'               => array(),
+				'release_delay'          => static::DELAY,
+			),
+			$overrides
+		);
+	}
+
+	/**
+	 * Seed the releases meta directly: get_releases() otherwise falls back to
+	 * prefill_releases_meta(), which reaches out to SVN.
+	 *
+	 * @param array $releases The releases to store.
+	 */
+	protected function set_releases( $releases ) {
+		update_post_meta( $this->plugin->ID, 'releases', $releases );
+	}
+
+	/**
+	 * Put a version into `update_source`, standing in for the currently-served release.
+	 *
+	 * @param string $version The version to serve.
+	 */
+	protected function serve( $version ) {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery -- `update_source` lives outside WordPress; there is no API for it.
+		$wpdb->insert(
+			$wpdb->prefix . 'update_source',
+			array(
+				'plugin_id'    => $this->plugin->ID,
+				'plugin_slug'  => static::SLUG,
+				'available'    => 1,
+				'version'      => $version,
+				'last_updated' => current_time( 'mysql' ),
+			)
+		);
+	}
+
+	/**
+	 * The version currently served from `update_source`.
+	 *
+	 * @return string|null
+	 */
+	protected function get_served_version() {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery -- `update_source` lives outside WordPress, and a cached read would defeat the assertion.
+		return $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT `version` FROM `{$wpdb->prefix}update_source` WHERE `plugin_slug` = %s",
+				static::SLUG
+			)
+		);
+	}
+
+	/**
+	 * The whole `update_source` row, for assertions about availability rather than version.
+	 *
+	 * @return array|null
+	 */
+	protected function get_served_row() {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery -- `update_source` lives outside WordPress, and a cached read would defeat the assertion.
+		return $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT * FROM `{$wpdb->prefix}update_source` WHERE `plugin_slug` = %s",
+				static::SLUG
+			),
+			ARRAY_A
+		);
+	}
+
+	/**
+	 * Move the committed version outside its delay, so the next update run would serve it.
+	 */
+	protected function elapse_cooldown() {
+		update_post_meta( $this->plugin->ID, 'version_date', gmdate( 'Y-m-d H:i:s', time() - ( static::DELAY * 2 ) ) );
+	}
+
+	/**
+	 * The block recorded against a release, if any.
+	 *
+	 * @param string|null $tag The release tag. Defaults to NEW_VERSION.
+	 * @return array|null The `release_block` value, or null when the release isn't held.
+	 */
+	protected function get_release_block( $tag = null ) {
+		if ( null === $tag ) {
+			$tag = static::NEW_VERSION;
+		}
+
+		foreach ( (array) get_post_meta( $this->plugin->ID, 'releases', true ) as $release ) {
+			if ( $tag === $release['tag'] ) {
+				return $release['release_block'] ?? null;
+			}
+		}
+
+		return null;
+	}
+}

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Reviewer_Release_Block_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Reviewer_Release_Block_Test.php
@@ -1,0 +1,362 @@
+<?php
+/**
+ * Tests for the reviewer release block: a reviewer holding a version out of `update_source`
+ * from the Controls metabox, and force-releasing it again.
+ *
+ * Covers both the API — API_Update_Updater::block_release() — and the metabox save handler
+ * that reviewers actually reach it through, including its refusals.
+ *
+ * @package WordPressdotorg\Plugin_Directory\Tests
+ */
+
+use WordPressdotorg\Plugin_Directory\Admin\Metabox\Controls;
+use WordPressdotorg\Plugin_Directory\Jobs\API_Update_Updater;
+
+/**
+ * Covers API_Update_Updater::block_release() and its interaction with the release delay,
+ * the plugin's status, and the reviewer force-release.
+ *
+ * @group jobs
+ */
+class Reviewer_Release_Block_Test extends Release_Block_Test_Case {
+
+	/**
+	 * The plugin slug under test.
+	 */
+	const SLUG = 'reviewer-block-test';
+
+	/**
+	 * The reviewer performing the block.
+	 *
+	 * @var \WP_User
+	 */
+	protected $reviewer;
+
+	/**
+	 * The release fixture, plus a reviewer who can act on it.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$reviewer_id = wp_insert_user(
+			array(
+				'user_login' => 'reviewer-block-user',
+				'user_pass'  => 'password',
+				'user_email' => 'reviewer-block-user@example.org',
+			)
+		);
+		$this->assertNotInstanceOf( WP_Error::class, $reviewer_id );
+
+		$this->reviewer = get_user_by( 'id', $reviewer_id );
+		$this->reviewer->add_cap( 'plugin_review' );
+	}
+
+	/**
+	 * Remove the reviewer, and the request state the metabox tests leave behind.
+	 */
+	protected function tearDown(): void {
+		unset(
+			$_POST['force_release_version'],
+			$_POST['block_release_version'],
+			$_POST['release_action_reason'],
+			$_REQUEST['_wpnonce']
+		);
+
+		wp_set_current_user( 0 );
+		wp_delete_user( $this->reviewer->ID );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * The block payload the Controls metabox sends for a reviewer block.
+	 *
+	 * @return array
+	 */
+	protected function reviewer_block() {
+		return array(
+			'reason'     => 'Suspicious obfuscated code.',
+			'blocked_by' => $this->reviewer->user_login,
+		);
+	}
+
+	/**
+	 * Submit the Controls metabox as the reviewer would, with a valid nonce.
+	 *
+	 * @param array $fields The release-action fields to post.
+	 */
+	protected function submit_controls( $fields ) {
+		wp_set_current_user( $this->reviewer->ID );
+
+		foreach ( $fields as $name => $value ) {
+			$_POST[ $name ] = $value;
+		}
+
+		$_REQUEST['_wpnonce'] = wp_create_nonce( 'update-post_' . $this->plugin->ID );
+
+		Controls::save_post( $this->plugin->ID );
+	}
+
+	/**
+	 * A reviewer block holds the in-cooldown version: the previous one keeps being served, the
+	 * block is recorded with the reason and reviewer, and any deferred serve is cancelled.
+	 */
+	public function test_a_block_holds_the_in_cooldown_version() {
+		$result = API_Update_Updater::block_release( self::SLUG, $this->reviewer_block() );
+
+		$this->assertTrue( $result );
+		$this->assertSame( self::SERVED_VERSION, $this->get_served_version() );
+		$this->assertSame( 'Suspicious obfuscated code.', $this->get_release_block()['reason'] );
+		$this->assertSame( $this->reviewer->user_login, $this->get_release_block()['blocked_by'] );
+		$this->assertFalse( wp_next_scheduled( 'release_to_update_api:' . self::SLUG ) );
+	}
+
+	/**
+	 * The block is recorded in the audit log with the supplied reason.
+	 */
+	public function test_a_block_records_an_audit_note() {
+		API_Update_Updater::block_release( self::SLUG, $this->reviewer_block() );
+
+		$notes = get_comments(
+			array(
+				'post_id' => $this->plugin->ID,
+				'type'    => 'internal-note',
+			)
+		);
+
+		$block_notes = array_filter(
+			$notes,
+			function ( $note ) {
+				return false !== strpos( $note->comment_content, 'Blocked version 2.0 from being served' );
+			}
+		);
+
+		$this->assertCount( 1, $block_notes );
+	}
+
+	/**
+	 * A force-release lifts a reviewer block: the held version is served and the block cleared.
+	 */
+	public function test_force_release_clears_a_reviewer_block_and_serves() {
+		API_Update_Updater::block_release( self::SLUG, $this->reviewer_block() );
+
+		$result = API_Update_Updater::force_release( self::SLUG, 'Reviewed with the author; resolved.' );
+
+		$this->assertTrue( $result );
+		$this->assertNull( $this->get_release_block() );
+		$this->assertSame( self::NEW_VERSION, $this->get_served_version() );
+	}
+
+	/**
+	 * The force-release over a reviewer block is recorded, without a risk score to name.
+	 */
+	public function test_force_release_over_a_reviewer_block_records_the_override() {
+		API_Update_Updater::block_release( self::SLUG, $this->reviewer_block() );
+
+		API_Update_Updater::force_release( self::SLUG, 'Reviewed with the author; resolved.' );
+
+		$notes = get_comments(
+			array(
+				'post_id' => $this->plugin->ID,
+				'type'    => 'internal-note',
+			)
+		);
+
+		$override = array_filter(
+			$notes,
+			function ( $note ) {
+				return false !== strpos( $note->comment_content, 'overriding the release block' );
+			}
+		);
+
+		$this->assertCount( 1, $override );
+	}
+
+	/**
+	 * A version that's already live can't be un-shipped by a block; `update_source` is left alone.
+	 */
+	public function test_a_block_leaves_an_already_served_version_untouched() {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery -- `update_source` lives outside WordPress; there is no API for it.
+		$wpdb->update(
+			$wpdb->prefix . 'update_source',
+			array( 'version' => self::NEW_VERSION ),
+			array( 'plugin_slug' => self::SLUG )
+		);
+
+		$result = API_Update_Updater::block_release( self::SLUG, $this->reviewer_block() );
+
+		$this->assertFalse( $result );
+		$this->assertNull( $this->get_release_block() );
+		$this->assertSame( self::NEW_VERSION, $this->get_served_version() );
+	}
+
+	/**
+	 * With no release row for the current version there's nothing to hold, so the block is a no-op.
+	 */
+	public function test_a_block_without_a_release_does_nothing() {
+		update_post_meta( $this->plugin->ID, 'version', '3.0' );
+
+		$result = API_Update_Updater::block_release( self::SLUG, $this->reviewer_block() );
+
+		$this->assertFalse( $result );
+		$this->assertSame( self::SERVED_VERSION, $this->get_served_version() );
+	}
+
+	/**
+	 * Closing a plugin has to reach sites even while a version is held: the held version stays
+	 * held, but the one still being served stops being offered for update.
+	 */
+	public function test_closing_a_plugin_stops_serving_it_while_a_version_is_held() {
+		API_Update_Updater::block_release( self::SLUG, $this->reviewer_block() );
+
+		wp_update_post(
+			array(
+				'ID'          => $this->plugin->ID,
+				'post_status' => 'closed',
+			)
+		);
+		clean_post_cache( $this->plugin->ID );
+
+		API_Update_Updater::update_single_plugin( self::SLUG );
+
+		$row = $this->get_served_row();
+
+		$this->assertEquals( 0, $row['available'] );
+		$this->assertSame( self::SERVED_VERSION, $row['version'] );
+	}
+
+	/**
+	 * The same holds for a version still inside its cooldown: a close isn't deferred with it.
+	 */
+	public function test_closing_a_plugin_stops_serving_it_during_the_cooldown() {
+		wp_update_post(
+			array(
+				'ID'          => $this->plugin->ID,
+				'post_status' => 'closed',
+			)
+		);
+		clean_post_cache( $this->plugin->ID );
+
+		API_Update_Updater::update_single_plugin( self::SLUG );
+
+		$row = $this->get_served_row();
+
+		$this->assertEquals( 0, $row['available'] );
+		$this->assertSame( self::SERVED_VERSION, $row['version'] );
+	}
+
+	/**
+	 * And re-opening it puts the served version back on offer, still without shipping the
+	 * held one.
+	 */
+	public function test_reopening_a_plugin_serves_the_previous_version_again() {
+		API_Update_Updater::block_release( self::SLUG, $this->reviewer_block() );
+
+		foreach ( array( 'closed', 'publish' ) as $status ) {
+			wp_update_post(
+				array(
+					'ID'          => $this->plugin->ID,
+					'post_status' => $status,
+				)
+			);
+			clean_post_cache( $this->plugin->ID );
+
+			API_Update_Updater::update_single_plugin( self::SLUG );
+		}
+
+		$row = $this->get_served_row();
+
+		$this->assertEquals( 1, $row['available'] );
+		$this->assertSame( self::SERVED_VERSION, $row['version'] );
+	}
+
+	/**
+	 * The metabox path end to end: a reviewer submits the Block button and the version is held.
+	 */
+	public function test_the_metabox_blocks_the_version() {
+		$this->submit_controls(
+			array(
+				'block_release_version' => self::NEW_VERSION,
+				'release_action_reason' => 'Suspicious obfuscated code.',
+			)
+		);
+
+		$this->assertSame( 'Suspicious obfuscated code.', $this->get_release_block()['reason'] );
+		$this->assertSame( $this->reviewer->user_login, $this->get_release_block()['blocked_by'] );
+		$this->assertSame( self::SERVED_VERSION, $this->get_served_version() );
+	}
+
+	/**
+	 * A submission from a user without the reviewer capability does nothing.
+	 */
+	public function test_the_metabox_ignores_a_user_without_the_review_capability() {
+		$this->reviewer->remove_cap( 'plugin_review' );
+
+		$this->submit_controls(
+			array(
+				'block_release_version' => self::NEW_VERSION,
+				'release_action_reason' => 'Suspicious obfuscated code.',
+			)
+		);
+
+		$this->assertNull( $this->get_release_block() );
+	}
+
+	/**
+	 * A save that isn't a release action at all is left alone.
+	 */
+	public function test_the_metabox_ignores_an_unrelated_save() {
+		$this->submit_controls( array( 'release_action_reason' => 'Suspicious obfuscated code.' ) );
+
+		$this->assertNull( $this->get_release_block() );
+	}
+
+	/**
+	 * A reason is required.
+	 */
+	public function test_the_metabox_refuses_a_block_without_a_reason() {
+		$this->submit_controls(
+			array(
+				'block_release_version' => self::NEW_VERSION,
+				'release_action_reason' => '   ',
+			)
+		);
+
+		$this->assertNull( $this->get_release_block() );
+	}
+
+	/**
+	 * A form rendered before a newer commit landed doesn't block the wrong version.
+	 */
+	public function test_the_metabox_refuses_a_stale_version() {
+		update_post_meta( $this->plugin->ID, 'version', '3.0' );
+
+		$this->submit_controls(
+			array(
+				'block_release_version' => self::NEW_VERSION,
+				'release_action_reason' => 'Suspicious obfuscated code.',
+			)
+		);
+
+		$this->assertNull( $this->get_release_block() );
+	}
+
+	/**
+	 * The force-release button ships the held version.
+	 */
+	public function test_the_metabox_force_releases() {
+		API_Update_Updater::block_release( self::SLUG, $this->reviewer_block() );
+
+		$this->submit_controls(
+			array(
+				'force_release_version' => self::NEW_VERSION,
+				'release_action_reason' => 'Reviewed with the author; resolved.',
+			)
+		);
+
+		$this->assertNull( $this->get_release_block() );
+		$this->assertSame( self::NEW_VERSION, $this->get_served_version() );
+	}
+}

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/bootstrap.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/bootstrap.php
@@ -52,3 +52,20 @@ tests_add_filter( 'muplugins_loaded', __NAMESPACE__ . '\manually_load_plugin' );
 
 // Start up the WP testing environment.
 require $_tests_dir . '/includes/bootstrap.php';
+
+/*
+ * Resolve test classes from this directory by name, so the shared `*_Test_Case` bases load
+ * on demand rather than needing to be required in dependency order. PHPUnit loads the test
+ * files themselves; this only ever fires for a base a test file extends.
+ *
+ * Registered last, so it's consulted only for classes nothing else resolved.
+ */
+spl_autoload_register(
+	function ( $class ) {
+		$file = __DIR__ . '/' . $class . '.php';
+
+		if ( file_exists( $file ) ) {
+			require_once $file;
+		}
+	}
+);


### PR DESCRIPTION
## Summary

Adds the scan-driven half of the release block: when a Gandalf scan reports a high `risk_score`
for a plugin version still inside its release cooldown, that version is held out of the update
API indefinitely — the previously served version keeps being served — until a reviewer
force-releases it.

This is the second half of #720, which is now split in two. It builds on #728, which adds the
blocking mechanism itself and the reviewer control.

> [!IMPORTANT]
> **Stacked on #728.** GitHub can't base a fork PR on another fork branch, so this PR's diff
> includes #728's commits. **Review only the last commit** — `Block a release when a security
> scan reports a high risk score`. This should merge after #728.

## How it works

- **Threshold** — `Plugin_Scan_Gandalf::RISK_SCORE_BLOCK_THRESHOLD` (default `8`). A completed
  scan at or above it blocks; below, or absent, it does not.
- **Precedence** — block (risk ≥ threshold) → findings alert (existing) → clean.
- **Only within cooldown** — a verdict for a version that is already live, was superseded by a
  newer commit mid-scan, or had no delay can't un-ship anything; it's escalated to Slack for
  manual action instead of held.
- **Attribution** — `force_release()` and the Controls metabox name the risk score when a scan
  set the block, rather than describing it as a reviewer's.
- **Notifications** — the findings and block Slack alerts now share one sender, and their
  user-facing wording says "security scan" rather than naming the scanner.

## What ships inert

**Auto-blocking on a risk score is disabled.** A high score alerts Slack; a human decides. The
call is one commented-out line in `handle_callback()` to restore.

Gandalf doesn't send `risk_score` yet either, so the field is read defensively and the path stays
inert until both change.

## Tests

- `Gandalf_Risk_Score_Block_Test` drives `handle_callback()` directly for the handler's branches.
- `Gandalf_Risk_Score_Block_Callback_Test` covers the full chain over the REST route — auth,
  routing, the write to `update_source`, force-release closing the loop, the block outlasting
  the cooldown.
- Fixtures build on #728's `Release_Block_Test_Case` via `Gandalf_Scan_Test_Case` →
  `Gandalf_Callback_Test_Case`.

190 tests pass locally, **8 skipped**.

> [!NOTE]
> Because auto-blocking is off, the 8 tests that assert a hold are skipped, and several of the
> remaining `..._does_not_block` tests pass vacuously — nothing blocks, so "it didn't block"
> is not evidence the threshold logic works. Real coverage of this path only exists once the
> commented-out call is restored. Flagging it so the green checkmark isn't read as more than
> it is.

## Notes for reviewers

- **Draft pending SecOps.** Like #717, the policy question is upstream of the code.
- When #717's callback args-schema lands, `risk_score` should join it as an optional
  `{ "type": "number", "minimum": 0 }`. It's read defensively here because trunk's route
  validates none of the callback body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
