### PR TITLE
Theme Directory: Searching within the Commercial/Community views returns no results

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/query-modifications.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/query-modifications.php
@@ -248,6 +248,34 @@ function wporg_themes_search_default_language_fields( $languages ) {
 add_filter( 'jetpack_search_query_languages', 'wporg_themes_search_default_language_fields' );
 
 /**
+ * Keeps Jetpack Search from handling searches within the Commercial/Community views.
+ *
+ * The `theme_business_model` taxonomy is not part of the site's Elasticsearch
+ * index, so the term filter Jetpack builds from the tax query excludes every
+ * document and these searches return no results. Letting them fall back to the
+ * SQL search path, which handles the tax query correctly, works around that
+ * until the taxonomy is indexed.
+ *
+ * @param bool     $should_handle Whether Jetpack Search should handle the query.
+ * @param WP_Query $query         The WP_Query object.
+ * @return bool
+ */
+function wporg_themes_search_skip_business_model_queries( $should_handle, $query ) {
+	if ( ! $should_handle || ! $query->is_search() ) {
+		return $should_handle;
+	}
+
+	foreach ( (array) $query->get( 'tax_query' ) as $tax_query ) {
+		if ( isset( $tax_query['taxonomy'] ) && 'theme_business_model' === $tax_query['taxonomy'] ) {
+			return false;
+		}
+	}
+
+	return $should_handle;
+}
+add_filter( 'jetpack_search_should_handle_query', 'wporg_themes_search_skip_business_model_queries', 10, 2 );
+
+/**
  * Filters SQL clauses, to prioritize translated themes.
  *
  * @param array $clauses


### PR DESCRIPTION
See #8376.

## Problem

`https://wordpress.org/themes/browse/commercial/?s=shop` returns zero results, while `browse/commercial/` alone works fine (same for `browse/community/`). The `theme_business_model` taxonomy is absent from the site's Elasticsearch index — no documents carry `taxonomy.theme_business_model.slug` — so the term filter Jetpack Search builds from the tax query excludes every document.

The taxonomy is missing because WP.com's indexing pipeline strips any taxonomy not in the `Jetpack_Sync_Module_Search::taxonomies` allowlist at document build time. The `plugin_*` taxonomies are in that list (which is how Plugin Directory search works); `theme_business_model` is not.

## Temporary fix

Filter `jetpack_search_should_handle_query` to return `false` for searches carrying a `theme_business_model` tax query, so they fall back to the SQL search path, which already applies the tax filter correctly. The Photo Directory uses the same filter to opt out of Jetpack Search.

This is a workaround: the proper fix is adding `theme_business_model` to the WP.com-side taxonomy allowlist and bulk-reindexing the themes site, after which this filter should be reverted so these searches get ES relevance again.

## Verification

After sandboxing/deploy:
- `browse/commercial/?s=shop` and `browse/community/?s=news` return results.
- A plain `/themes/search/shop/` still uses Jetpack Search (unchanged counts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pfhLmrkpmrMsMMwrZEKJV