### PR TITLE
Theme Directory: Indicate upload progress on the theme upload form

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/upload.php
@@ -125,6 +125,21 @@ function wporg_themes_render_upload_shortcode() {
 		} )();
 JS;
 
+	$upload_style = <<<'CSS'
+		#upload_button:disabled {
+			opacity: 0.6;
+			cursor: not-allowed;
+		}
+CSS;
+
+	wp_register_script( 'wporg-themes-upload', false, array(), false, true );
+	wp_enqueue_script( 'wporg-themes-upload' );
+	wp_add_inline_script( 'wporg-themes-upload', $upload_script );
+
+	wp_register_style( 'wporg-themes-upload', false );
+	wp_enqueue_style( 'wporg-themes-upload' );
+	wp_add_inline_style( 'wporg-themes-upload', $upload_style );
+
 	return $notice . '<h2>' . __( 'Select your zipped theme file', 'wporg-themes' ) . '</h2>
 		<form
 			enctype="multipart/form-data"
@@ -149,14 +164,7 @@ JS;
 			</p>
 
 			<button id="upload_button" class="button" type="submit" value="' . esc_attr__( 'Upload', 'wporg-themes' ) . '" data-uploading-label="' . esc_attr__( 'Uploading&hellip;', 'wporg-themes' ) . '">' . esc_html__( 'Upload', 'wporg-themes' ) . '</button>
-		</form>
-		<style>
-			#upload_button:disabled {
-				opacity: 0.6;
-				cursor: not-allowed;
-			}
-		</style>
-		<script>' . $upload_script . '</script>';
+		</form>';
 }
 
 /**

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/upload.php
@@ -132,11 +132,11 @@ JS;
 		}
 CSS;
 
-	wp_register_script( 'wporg-themes-upload', false, array(), false, true );
+	wp_register_script( 'wporg-themes-upload', false, array(), '1.0', true );
 	wp_enqueue_script( 'wporg-themes-upload' );
 	wp_add_inline_script( 'wporg-themes-upload', $upload_script );
 
-	wp_register_style( 'wporg-themes-upload', false );
+	wp_register_style( 'wporg-themes-upload', false, array(), '1.0' );
 	wp_enqueue_style( 'wporg-themes-upload' );
 	wp_add_inline_style( 'wporg-themes-upload', $upload_style );
 

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/upload.php
@@ -104,13 +104,33 @@ function wporg_themes_render_upload_shortcode() {
 		}
 	}
 
+	$upload_script = <<<'JS'
+		( function() {
+			document.getElementById( 'upload_form' ).addEventListener( 'submit', function( event ) {
+				/*
+				 * Defer, to see whether another submit handler (such as the
+				 * 2FA revalidation modal) cancels the submission.
+				 */
+				setTimeout( function() {
+					if ( event.defaultPrevented ) {
+						return;
+					}
+
+					var button = document.getElementById( 'upload_button' );
+
+					button.disabled    = true;
+					button.textContent = button.dataset.uploadingLabel;
+				} );
+			} );
+		} )();
+JS;
+
 	return $notice . '<h2>' . __( 'Select your zipped theme file', 'wporg-themes' ) . '</h2>
 		<form
 			enctype="multipart/form-data"
 			id="upload_form"
 			method="POST"
 			action=""
-			onsubmit="document.getElementById(\'upload_button\').disabled = true"
 			data-2fa-required
 		>
 			' . wp_nonce_field( 'wporg-themes-upload', '_wpnonce', true, false ) . '
@@ -128,8 +148,15 @@ function wporg_themes_render_upload_shortcode() {
 				<label><input type="checkbox" required="required" name="required_terms[gpl]"><span>' . sprintf( __( 'The theme, and all included assets, <a href="%s">are licenced as GPL or are under a GPL compatible license</a>.', 'wporg-themes' ), 'https://make.wordpress.org/themes/handbook/review/required/#1-licensing-copyright' ) . '</span></label>
 			</p>
 
-			<button id="upload_button" class="button" type="submit" value="' . esc_attr__( 'Upload', 'wporg-themes' ) . '">' . esc_html__( 'Upload', 'wporg-themes' ) . '</button>
-		</form>';
+			<button id="upload_button" class="button" type="submit" value="' . esc_attr__( 'Upload', 'wporg-themes' ) . '" data-uploading-label="' . esc_attr__( 'Uploading&hellip;', 'wporg-themes' ) . '">' . esc_html__( 'Upload', 'wporg-themes' ) . '</button>
+		</form>
+		<style>
+			#upload_button:disabled {
+				opacity: 0.6;
+				cursor: not-allowed;
+			}
+		</style>
+		<script>' . $upload_script . '</script>';
 }
 
 /**


### PR DESCRIPTION
Fixes #7852

As noted in #438, the Theme Directory upload page has no visible "upload in progress" state on its submit button in the new (2024) theme — the old theme relied on `button[disabled]` styles that no longer exist.

This change makes the upload state explicit, following the pattern already used by the Plugin Directory upload form (`data-uploading-label`):

- When the form submission proceeds, the submit button is disabled and its label changes from **Upload** to **Uploading…**.
- A `#upload_button:disabled` style greys the button out (`opacity: 0.6`, `cursor: not-allowed`), matching the disabled-button treatment in `wporg-plugins-2024`. Since neither `wporg-parent-2021` nor `wporg-mu-plugins` ship `:disabled` button styles, the style is attached to an inline-only `wporg-themes-upload` handle via `wp_add_inline_style()` so it works in both the old and new theme; the submit handler is attached the same way via `wp_add_inline_script()` (footer, after the form markup).
- The previous inline `onsubmit` handler disabled the button unconditionally — including when the 2FA revalidation script cancels the submission to show its modal, which left the button stuck disabled if the modal was dismissed. The new handler defers until after all submit handlers have run and checks `event.defaultPrevented`, so the button state only changes when the upload is actually underway. Once revalidation completes and the form is re-submitted via `requestSubmit()`, the state is applied as usual.

The button markup keeps the `id="upload_button" class="button"` prefix so the `theme-upload-form` block in `wporg-themes-2024` continues to rewrite it into a `wp-block-button__link`; the new `data-uploading-label` attribute is carried through that rewrite (verified against the block's `preg_replace`).

Verified in the local theme-directory wp-env environment (Chromium): the plain submit path flips the button to disabled + "Uploading…", and — with the production `wporg-two-factor` revalidation script injected (the local env stubs it out) — the button stays "Upload" while the revalidation modal is open, remains usable if the modal is dismissed, and flips to "Uploading…" once revalidation completes and the form re-submits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
