### PR TITLE
Trac Notifications: Restore styling for the components archive table

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/trac-notifications/trac-components.php
+++ b/wordpress.org/public_html/wp-content/plugins/trac-notifications/trac-components.php
@@ -314,8 +314,10 @@ ul.ticket-list .focus { display: inline-block; border-radius: 3px; background: #
 .history.growing:before, .history.shrinking:before { font-family: Dashicons; font-size: 30px; vertical-align: middle; line-height: 15px; }
 .history.growing:before { content: "\f142"; color: red }
 .history.shrinking:before { content: "\f140"; color: green }
-td.right { text-align: right; }
-body.post-type-archive-component table td { vertical-align: middle; }
+td.right, th.right { text-align: right; }
+body.post-type-archive-component table th,
+body.post-type-archive-component table td { vertical-align: middle; padding: 4px 8px; border-bottom: 1px solid #eee; }
+body.post-type-archive-component table tr:last-child td { border-bottom: none; }
 td.maintainers { padding-top: 4px; padding-bottom: 4px; height: 26px; }
 td.maintainers img.avatar { margin-right: 5px; }
 .component-info .create-new-ticket { float: right; margin-top: 25px; }
@@ -709,7 +711,7 @@ jQuery( function( $ ) {
 		static $once = true;
 		if ( $once ) {
 			$once = false;
-			echo '<thead><tr><td>Component</td><td>Tickets</td><td>7 Days</td><td>0&nbsp;Replies</td><td>Maintainers</td></tr></thead>';
+			echo '<thead><tr><th>Component</th><th class="right">Tickets</th><th class="right">7 Days</th><th class="right">0&nbsp;Replies</th><th>Maintainers</th></tr></thead>';
 		}
 
 		$arrow = '';


### PR DESCRIPTION
The components archive table on make.wordpress.org (e.g. [make/meta/components](https://make.wordpress.org/meta/components/), [make/core/components](https://make.wordpress.org/core/components/)) lost all cell padding and row separation, leaving counts, `!!` markers, and maintainer avatars running into each other.

### Cause

The table is rendered by `archive-component.php` as a classless `<table>` directly in `#primary`, outside any `.entry-content` wrapper. Before the 2024 Make redesign, the `wporg-breathe` child theme styled tables globally (`td { padding: 10px; border-bottom: 1px solid #eee; }`, gray `thead` band, outer border), which this table relied on. The redesigned `wporg-breathe-2024` theme scopes all table styling to `.entry-content` and sets `thead { background: unset }`, so the table fell through to the parent theme's zero-padding reset with nothing re-adding padding.

### Fix

- Add cell padding (`4px 8px`) and hairline row separators to the page-specific styles the plugin already outputs for `body.post-type-archive-component`.
- Switch the header row to semantic `<th>` cells and right-align the numeric column headers (Tickets, 7 Days, 0 Replies) over their right-aligned data. The headers were always left-aligned, but that only read as intentional on the gray `thead` band the redesign removed.

Kept deliberately scoped to the components archive rather than restoring global table chrome the redesign opted out of.

Note: the `<thead>` markup is cached in the 5-minute `trac_components_page` transient, so the header change appears shortly after deploy; the CSS is instant.

Fixes https://meta.trac.wordpress.org/ticket/8288.

🤖 Generated with [Claude Code](https://claude.com/claude-code)