### PR TITLE
Also Viewing: Fix PHP warning when listing viewers alongside a moderator

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-directory-compat.php
+++ b/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-directory-compat.php
@@ -1136,19 +1136,22 @@ abstract class Directory_Compat {
 
 		// Plugins
 		if ( 'plugin' == $this->compat() ) {
-			$slugs = $wpdb->get_col( $wpdb->prepare(
-				"SELECT DISTINCT p.post_name
-					FROM %i AS t
-						LEFT JOIN %i AS tt ON tt.term_id = t.term_id
-						LEFT JOIN %i AS tr ON tr.term_taxonomy_id = tt.term_taxonomy_id
-						LEFT JOIN %i AS p ON tr.object_id = p.ID
-					WHERE tt.taxonomy IN( 'plugin_contributors', 'plugin_support_reps', 'plugin_committers' ) AND t.name = %s",
+			$user = get_user_by( 'id', $user_id );
+			if ( $user ) {
+				$slugs = $wpdb->get_col( $wpdb->prepare(
+					"SELECT DISTINCT p.post_name
+						FROM %i AS t
+							LEFT JOIN %i AS tt ON tt.term_id = t.term_id
+							LEFT JOIN %i AS tr ON tr.term_taxonomy_id = tt.term_taxonomy_id
+							LEFT JOIN %i AS p ON tr.object_id = p.ID
+						WHERE tt.taxonomy IN( 'plugin_contributors', 'plugin_support_reps', 'plugin_committers' ) AND t.name = %s",
 					$wpdb->base_prefix . WPORG_PLUGIN_DIRECTORY_BLOGID . '_terms',
 					$wpdb->base_prefix . WPORG_PLUGIN_DIRECTORY_BLOGID . '_term_taxonomy',
 					$wpdb->base_prefix . WPORG_PLUGIN_DIRECTORY_BLOGID . '_term_relationships',
 					$wpdb->base_prefix . WPORG_PLUGIN_DIRECTORY_BLOGID . '_posts',
-					get_user_by( 'id', $user_id )->user_nicename
-			) );
+					$user->user_nicename
+				) );
+			}
 		}
 
 		wp_cache_set( $cache_key, $slugs, $cache_group, HOUR_IN_SECONDS );

--- a/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-directory-compat.php
+++ b/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-directory-compat.php
@@ -1123,7 +1123,7 @@ abstract class Directory_Compat {
 		}
 		$slugs = [];
 
-		// Deleted users have no objects; cache the empty result.
+		// Nonexistent users have no objects; cache the empty result.
 		$user = get_user_by( 'id', $user_id );
 		if ( ! $user ) {
 			wp_cache_set( $cache_key, $slugs, $cache_group, HOUR_IN_SECONDS );

--- a/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-directory-compat.php
+++ b/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-directory-compat.php
@@ -1123,6 +1123,13 @@ abstract class Directory_Compat {
 		}
 		$slugs = [];
 
+		// Deleted users have no objects; cache the empty result.
+		$user = get_user_by( 'id', $user_id );
+		if ( ! $user ) {
+			wp_cache_set( $cache_key, $slugs, $cache_group, HOUR_IN_SECONDS );
+			return $slugs;
+		}
+
 		// Themes.
 		if ( 'theme' == $this->compat() ) {
 			$slugs = $wpdb->get_col( $wpdb->prepare(
@@ -1136,22 +1143,19 @@ abstract class Directory_Compat {
 
 		// Plugins
 		if ( 'plugin' == $this->compat() ) {
-			$user = get_user_by( 'id', $user_id );
-			if ( $user ) {
-				$slugs = $wpdb->get_col( $wpdb->prepare(
-					"SELECT DISTINCT p.post_name
-						FROM %i AS t
-							LEFT JOIN %i AS tt ON tt.term_id = t.term_id
-							LEFT JOIN %i AS tr ON tr.term_taxonomy_id = tt.term_taxonomy_id
-							LEFT JOIN %i AS p ON tr.object_id = p.ID
-						WHERE tt.taxonomy IN( 'plugin_contributors', 'plugin_support_reps', 'plugin_committers' ) AND t.name = %s",
-					$wpdb->base_prefix . WPORG_PLUGIN_DIRECTORY_BLOGID . '_terms',
-					$wpdb->base_prefix . WPORG_PLUGIN_DIRECTORY_BLOGID . '_term_taxonomy',
-					$wpdb->base_prefix . WPORG_PLUGIN_DIRECTORY_BLOGID . '_term_relationships',
-					$wpdb->base_prefix . WPORG_PLUGIN_DIRECTORY_BLOGID . '_posts',
-					$user->user_nicename
-				) );
-			}
+			$slugs = $wpdb->get_col( $wpdb->prepare(
+				"SELECT DISTINCT p.post_name
+					FROM %i AS t
+						LEFT JOIN %i AS tt ON tt.term_id = t.term_id
+						LEFT JOIN %i AS tr ON tr.term_taxonomy_id = tt.term_taxonomy_id
+						LEFT JOIN %i AS p ON tr.object_id = p.ID
+					WHERE tt.taxonomy IN( 'plugin_contributors', 'plugin_support_reps', 'plugin_committers' ) AND t.name = %s",
+				$wpdb->base_prefix . WPORG_PLUGIN_DIRECTORY_BLOGID . '_terms',
+				$wpdb->base_prefix . WPORG_PLUGIN_DIRECTORY_BLOGID . '_term_taxonomy',
+				$wpdb->base_prefix . WPORG_PLUGIN_DIRECTORY_BLOGID . '_term_relationships',
+				$wpdb->base_prefix . WPORG_PLUGIN_DIRECTORY_BLOGID . '_posts',
+				$user->user_nicename
+			) );
 		}
 
 		wp_cache_set( $cache_key, $slugs, $cache_group, HOUR_IN_SECONDS );

--- a/wordpress.org/public_html/wp-content/plugins/wporg-bbp-also-viewing/wporg-bbp-also-viewing.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-bbp-also-viewing/wporg-bbp-also-viewing.php
@@ -44,9 +44,6 @@ function init() {
 	} );
 	add_action( 'also_viewing_cleanup', __NAMESPACE__ . '\cron_cleanup' );
 
-	// Remove a deleted user's records right away.
-	add_action( 'deleted_user', __NAMESPACE__ . '\deleted_user' );
-
 	// If the user can't enable it, we can skip registering the panels and such.
 	if ( ! allowed_for_user() ) {
 		return;
@@ -265,14 +262,8 @@ function get_currently_viewing( $page ) {
 			continue;
 		}
 
-		// Ignore records of deleted users.
-		$user = get_user_by( 'id', $u->user_id );
-		if ( ! $user ) {
-			continue;
-		}
-
 		$return[] = [
-			'who'      => $user->display_name,
+			'who'      => get_user_by( 'id', $u->user_id )->display_name,
 			'isTyping' => (bool) $u->typing,
 			'user_id'  => (int) $u->user_id,
 		];
@@ -435,15 +426,6 @@ function clear_viewing( $page = null, $user_id = false ) {
 	foreach ( $pages as $p ) {
 		wp_cache_delete( $p, CACHE_GROUP );
 	}
-}
-
-/**
- * Remove a deleted user's viewing records right away.
- *
- * @param int $user_id The deleted user's ID.
- */
-function deleted_user( $user_id ) {
-	clear_viewing( null, $user_id );
 }
 
 /**

--- a/wordpress.org/public_html/wp-content/plugins/wporg-bbp-also-viewing/wporg-bbp-also-viewing.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-bbp-also-viewing/wporg-bbp-also-viewing.php
@@ -44,6 +44,9 @@ function init() {
 	} );
 	add_action( 'also_viewing_cleanup', __NAMESPACE__ . '\cron_cleanup' );
 
+	// Remove a deleted user's records right away.
+	add_action( 'deleted_user', __NAMESPACE__ . '\deleted_user' );
+
 	// If the user can't enable it, we can skip registering the panels and such.
 	if ( ! allowed_for_user() ) {
 		return;
@@ -301,25 +304,14 @@ function get_others_currently_viewing( $page ) {
 		return array_values( $users );
 	}
 
-	// Anonymize mods for other users.
-	foreach ( $users as &$u ) {
-		if ( user_can( $u['user_id'], 'moderate' ) ) {
-			$u['who']     = '';
-			$u['user_id'] = 0;
-		}
-	}
-
-	// Anonymize users unless they've got similar caps.
+	// Anonymize mods, and users unless they've got similar caps.
 	// Plugin support reps can see other reps and committers -for their own plugins-.
 	$current_user_objects = get_user_object_slugs( get_current_user_id() );
 	foreach ( $users as &$u ) {
-		// Skip users that have already been anonymized.
-		if ( ! $u['user_id'] ) {
-			continue;
-		}
-
-		$user_objects = get_user_object_slugs( $u['user_id'] );
-		if ( ! array_intersect( $current_user_objects, $user_objects ) ) {
+		if (
+			user_can( $u['user_id'], 'moderate' ) ||
+			! array_intersect( $current_user_objects, get_user_object_slugs( $u['user_id'] ) )
+		) {
 			$u['who']     = '';
 			$u['user_id'] = 0;
 		}
@@ -443,6 +435,15 @@ function clear_viewing( $page = null, $user_id = false ) {
 	foreach ( $pages as $p ) {
 		wp_cache_delete( $p, CACHE_GROUP );
 	}
+}
+
+/**
+ * Remove a deleted user's viewing records right away.
+ *
+ * @param int $user_id The deleted user's ID.
+ */
+function deleted_user( $user_id ) {
+	clear_viewing( null, $user_id );
 }
 
 /**

--- a/wordpress.org/public_html/wp-content/plugins/wporg-bbp-also-viewing/wporg-bbp-also-viewing.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-bbp-also-viewing/wporg-bbp-also-viewing.php
@@ -262,8 +262,14 @@ function get_currently_viewing( $page ) {
 			continue;
 		}
 
+		// Ignore records of deleted users.
+		$user = get_user_by( 'id', $u->user_id );
+		if ( ! $user ) {
+			continue;
+		}
+
 		$return[] = [
-			'who'      => get_user_by( 'id', $u->user_id )->display_name,
+			'who'      => $user->display_name,
 			'isTyping' => (bool) $u->typing,
 			'user_id'  => (int) $u->user_id,
 		];
@@ -307,6 +313,11 @@ function get_others_currently_viewing( $page ) {
 	// Plugin support reps can see other reps and committers -for their own plugins-.
 	$current_user_objects = get_user_object_slugs( get_current_user_id() );
 	foreach ( $users as &$u ) {
+		// Skip users that have already been anonymized.
+		if ( ! $u['user_id'] ) {
+			continue;
+		}
+
 		$user_objects = get_user_object_slugs( $u['user_id'] );
 		if ( ! array_intersect( $current_user_objects, $user_objects ) ) {
 			$u['who']     = '';


### PR DESCRIPTION
## Problem

Production is logging this warning on the Also Viewing REST endpoint:

```
E_WARNING: Attempt to read property "user_nicename" on false
in support-forums/inc/class-directory-compat.php:1150
Source: GET https://wordpress.org/support/wp-json/wporg/v1/currentlyViewing/forum/how-to-and-troubleshooting
```

## Root cause

For requesters without `moderate`/`list_users`, `get_others_currently_viewing()` anonymizes moderators in the viewer list by setting their `user_id` to `0` — and then passes that same array into the object-slug comparison loop. That calls `get_user_object_slugs( 0 )`, which reaches `Directory_Compat::get_user_object_slugs()` where `get_user_by( 'id', 0 )` always returns `false` and was dereferenced without a check.

## Fix

- Merge the two anonymization loops in `get_others_currently_viewing()` into one, so anonymized (`user_id = 0`) entries never reach the object-slug comparison in the first place. Short-circuit evaluation preserves the old behavior of not looking up slugs for moderators.
- Guard the `get_user_by()` call at the top of `Directory_Compat::get_user_object_slugs()` as a backstop for nonexistent IDs. It sits after the cache read, so cache hits pay no extra lookup, and the empty result is cached like any other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYVQtgZbwEGL7mk1NHEZyH