### PR TITLE
Topic Archive: Fix PHP warning when a singular query matches no post

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/wporg-bbp-topic-archive/wporg-bbp-topic-archive.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-bbp-topic-archive/wporg-bbp-topic-archive.php
@@ -34,19 +34,17 @@ class WPORG_bbPress_Topic_Archive {
 	}
 
 	public function maybe_add_robots() {
-		global $post;
-
 		if (
-			is_singular()
+			bbp_is_single_topic()
 		&&
-			bbp_is_topic( $post->ID )
+			bbp_get_topic_id()
 		&&
 			(
 				// Thread last modified is over 3 years old
-				( time() - get_post_time( 'U', true, bbp_get_topic_last_active_id( $post->ID ) ) > 3 * YEAR_IN_SECONDS )
+				( time() - get_post_time( 'U', true, bbp_get_topic_last_active_id() ) > 3 * YEAR_IN_SECONDS )
 			||
 				// Closed thread with no replies
-				( bbp_is_topic_closed( $post->ID ) && ! bbp_get_topic_reply_count( $post->ID, true ) )
+				( bbp_is_topic_closed() && ! bbp_get_topic_reply_count( 0, true ) )
 			)
 		) {
 			echo '<meta name="robots" content="noindex,follow" />' . "\n";


### PR DESCRIPTION
## Problem

Production is logging this warning from `bbp_head`:

```
E_WARNING: Attempt to read property "ID" on null
in wporg-bbp-topic-archive/wporg-bbp-topic-archive.php:42
Source: POST https://test.wordpress.org/support/users/{username}/replies/
```

## Root cause

`maybe_add_robots()` assumed `is_singular()` guarantees a populated `$post` global. That invariant can break: `WP::parse_request()` also reads public query vars from the POST body, so a (scanner) POST containing `topic=...` to a bbPress user page makes the main query singular-shaped while matching no post. bbPress keeps the user page rendering as a 200, so `bbp_head` fires with `is_singular()` true and `$post` null.

## Fix

Resolve the topic via `bbp_get_topic_id()` and gate on `bbp_is_single_topic()`, which work off the queried object instead of dereferencing the `$post` global.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYVQtgZbwEGL7mk1NHEZyH