### PR TITLE
Plugin Directory: Validate empty search submissions

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/inc/block-config.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/inc/block-config.php
@@ -331,14 +331,16 @@ function set_rating_data( $data, $post_id ) {
 }
 
 /**
- * Filters the search block to remove the required attribute, and add the query fields.
+ * Filters the search block to remove the required attribute on search results, and add the query fields.
  *
  * @param string $block_content
  * @return string
  */
 function filter_search_block( $block_content ) {
-	// Remove the required attribute
-	$block_content = preg_replace( '/(<input[^>]*)\s+required\s*([^>]*)>/', '$1$2>', $block_content );
+	if ( is_search() ) {
+		// Remove the required attribute, so an empty submission can clear the current search.
+		$block_content = preg_replace( '/(<input[^>]*)\s+required\s*([^>]*)>/', '$1$2>', $block_content );
+	}
 
 	/* Temporarily disable this until filters are enabled.
 	// Insert the current query filters into the search form.


### PR DESCRIPTION
Empty search submissions in the Plugin Directory currently reload the page silently, while the Theme Directory shows the browser's native "Please fill out this field" validation message.

The core search block ships with a `required` attribute on its input, which the Theme Directory keeps. The Plugin Directory theme strips it in `filter_search_block()` — deliberately, per r13345, so that submitting an empty form on a search results page can clear the current search.

This PR restores the `required` attribute everywhere except on search result pages (`is_search()`), so:

- Empty submissions from the homepage and archive pages now trigger the native browser validation, matching the Theme Directory.
- Submitting a cleared field on a search results page still resets the search, preserving the behavior r13345 introduced.

Fixes https://meta.trac.wordpress.org/ticket/8339

🤖 Generated with [Claude Code](https://claude.com/claude-code)