### PR TITLE
wporg-login: Ensure registration cookies are treated as strings

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/pending-create.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/pending-create.php
@@ -18,8 +18,8 @@ if ( ! empty( $sso::$matched_route_params['confirm_user'] ) ) {
 	die();
 }
 
-$activation_user = $_COOKIE['wporg_confirm_user'] ?? false;
-$activation_key  = $_COOKIE['wporg_confirm_key']  ?? false;
+$activation_user = is_string( $_COOKIE['wporg_confirm_user'] ?? null ) ? $_COOKIE['wporg_confirm_user'] : '';
+$activation_key  = is_string( $_COOKIE['wporg_confirm_key']  ?? null ) ? $_COOKIE['wporg_confirm_key']  : '';
 
 $pending_user = wporg_get_pending_user( $activation_user );
 if ( ! $pending_user ) {

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/pending-profile.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/pending-profile.php
@@ -18,8 +18,8 @@ if ( ! empty( $sso::$matched_route_params['profile_user'] ) ) {
 	die();
 }
 
-$profile_user = $_COOKIE['wporg_profile_user'] ?? false;
-$profile_key  = $_COOKIE['wporg_profile_key']  ?? false;
+$profile_user = is_string( $_COOKIE['wporg_profile_user'] ?? null ) ? $_COOKIE['wporg_profile_user'] : '';
+$profile_key  = is_string( $_COOKIE['wporg_profile_key']  ?? null ) ? $_COOKIE['wporg_profile_key']  : '';
 
 $pending_user = wporg_get_pending_user( $profile_user );
 


### PR DESCRIPTION
PHP builds an array from `name[key]=…` cookie syntax, so the identity cookies read by the `pending-create` and `pending-profile` templates are not guaranteed to be strings. An array value passed through to `urlencode()` in the link-expired redirect fatals on PHP 8 (`TypeError` → HTTP 500).

This coerces the cookie values to strings, treating a non-string cookie as empty. The empty string is intentionally falsy, matching the previous `false` default downstream: `wporg_get_pending_user( '' )` returns `false` and the request redirects to `/linkexpired` as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)