### PR TITLE
Trac: Escape check run provider names and statuses in the PR status output.

### DIFF
--- a/wordpress.org/public_html/style/trac/wp-trac.js
+++ b/wordpress.org/public_html/style/trac/wp-trac.js
@@ -1866,7 +1866,8 @@ var wpTrac, coreKeywordList, gardenerKeywordList, hideFromNewTickets, reservedTe
 			// Logic to determine what the PRs status is
 			function prStatus( data ) {
 				var stack = [],
-					emojiState = '';
+					emojiState = '',
+					providerText, checkStatus;
 
 				// Closed? Skip everything else.
 				if ( data.closed_at ) {
@@ -1912,18 +1913,21 @@ var wpTrac, coreKeywordList, gardenerKeywordList, hideFromNewTickets, reservedTe
 				// Unit Tests?
 				if ( data.check_runs ) {
 					for ( var provider in data.check_runs ) {
+						providerText = $( '<span>' ).text( provider ).html();
+						checkStatus  = $( '<span>' ).text( data.check_runs[ provider ] ).html();
+
 						switch ( data.check_runs[ provider ] ) {
 							case 'in_progress':
-								stack.push( provider + ' running' );
+								stack.push( providerText + ' running' );
 								break;
 							case 'failed':
 								emojiState = '❌';
-								stack.push( provider );
+								stack.push( providerText );
 								break;
 							case 'success':
 								continue;
 							default:
-								stack.push( provider + ' ' + data.check_runs[ provider ] );
+								stack.push( providerText + ' ' + checkStatus );
 								break;
 						}
 					}


### PR DESCRIPTION
In the githubPRs module, `prStatus()` pushed the `check_runs` provider key (a GitHub App name) and its free-text status value into the returned string unescaped. `renderPR()` concatenates that string into the HTML passed to `container.append()`, so both rendered as markup instead of text.

This escapes both values with the same jQuery `$( '<span>' ).text( value ).html()` idiom already used for the review states below. The `switch` still matches on the raw value, so the `in_progress`/`failed`/`success` behavior is unchanged — only what gets rendered differs.

Note: PR #734 rewrites this file wholesale; its branch already carries the equivalent fix in the modernized style (obenland/wordpress.org@7b64e37f4), so whichever lands second resolves the overlap by keeping its own version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)