### PR TITLE
o2 Posting Access: Apply the pending review status on all post creation paths

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -84,6 +84,11 @@ jobs:
             wp-env-args: "--config theme-directory/.wp-env.test.json"
             container: tests-cli
             plugin-name: theme-directory
+          - name: Make - o2 Posting Access
+            working-directory: environments
+            wp-env-args: "--config make/.wp-env.test.json"
+            container: tests-cli
+            plugin-name: wporg-o2-posting-access
     steps:
       - uses: actions/checkout@v4
 

--- a/environments/make/.wp-env.test.json
+++ b/environments/make/.wp-env.test.json
@@ -1,0 +1,14 @@
+{
+	"core": "WordPress/WordPress#master",
+	"phpVersion": "8.4",
+	"plugins": [
+		"../wordpress.org/public_html/wp-content/plugins/wporg-o2-posting-access",
+		"../wordpress.org/public_html/wp-content/plugins/o2-private-posts",
+		"../wordpress.org/public_html/wp-content/plugins/wporg-make-sites-cpt",
+		"../wordpress.org/public_html/wp-content/plugins/wporg-meeting-posttype",
+		"../wordpress.org/public_html/wp-content/plugins/trac-notifications"
+	],
+	"lifecycleScripts": {
+		"afterStart": "bash make/bin/after-start-test.sh"
+	}
+}

--- a/environments/make/bin/after-start-test.sh
+++ b/environments/make/bin/after-start-test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Runs after wp-env start for the test environment.
+# Installs PHPUnit 11 and Yoast polyfills in the test container.
+#
+
+CONFIG="--config make/.wp-env.test.json"
+RUN="npx wp-env $CONFIG run tests-cli"
+
+echo "Installing PHPUnit 11 and polyfills..."
+$RUN composer global require -W phpunit/phpunit:^11.0 2>&1
+$RUN composer require --dev yoast/phpunit-polyfills:^4.0 --working-dir=/wordpress-phpunit 2>&1

--- a/environments/package.json
+++ b/environments/package.json
@@ -18,6 +18,8 @@
 		"themes:test": "npm run themes:test:env -- start && npm run themes:test:env -- run tests-cli --env-cwd=wp-content/plugins/theme-directory phpunit",
 		"handbook:test:env": "wp-env --config handbook/.wp-env.test.json",
 		"handbook:test": "npm run handbook:test:env -- start && npm run handbook:test:env -- run tests-cli --env-cwd=wp-content/plugins/handbook phpunit",
+		"make:test:env": "wp-env --config make/.wp-env.test.json",
+		"make:test": "npm run make:test:env -- start && npm run make:test:env -- run tests-cli --env-cwd=wp-content/plugins/wporg-o2-posting-access phpunit",
 		"jobs:env": "wp-env --config jobs/.wp-env.json",
 		"browsehappy:env": "wp-env --config browsehappy/.wp-env.json",
 		"translate:env": "wp-env --config translate/.wp-env.json",

--- a/wordpress.org/public_html/wp-content/plugins/wporg-o2-posting-access/phpunit.xml.dist
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-o2-posting-access/phpunit.xml.dist
@@ -1,0 +1,11 @@
+<phpunit
+	bootstrap="phpunit/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	>
+	<testsuites>
+		<testsuite name="wporg-o2-posting-access">
+			<directory suffix=".php">./phpunit/tests/</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/wordpress.org/public_html/wp-content/plugins/wporg-o2-posting-access/phpunit/bootstrap.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-o2-posting-access/phpunit/bootstrap.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * PHPUnit bootstrap file.
+ *
+ * @package wporg-o2-posting-access
+ */
+
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
+
+if ( ! $_tests_dir && file_exists( '/wordpress-phpunit/includes/functions.php' ) ) {
+	// wp-env mounts the WordPress test suite here.
+	$_tests_dir = '/wordpress-phpunit/';
+} elseif ( ! $_tests_dir ) {
+	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib/tests/phpunit/';
+}
+
+if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
+	echo 'Could not find the WordPress test suite. Set WP_TESTS_DIR to its path.' . PHP_EOL;
+	exit( 1 );
+}
+
+// Set polyfills path if available (required by WP test suite).
+if ( ! defined( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' ) && file_exists( $_tests_dir . '/vendor/yoast/phpunit-polyfills' ) ) {
+	define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', $_tests_dir . '/vendor/yoast/phpunit-polyfills' );
+}
+
+/*
+ * This suite only has meaning on multisite. is_user_member_of_blog() returns
+ * true unconditionally when ! is_multisite(), which makes both the capability
+ * grant and user_can_publish() no-ops, so every assertion here would pass
+ * without exercising a single line of the plugin.
+ */
+define( 'WP_TESTS_MULTISITE', true );
+
+/*
+ * The plugin's init() bails without this. Nothing it does calls into o2, so the
+ * constant is all that is needed to exercise the hooks under test.
+ */
+define( 'O2__PLUGIN_LOADED', true );
+
+// Give access to tests_add_filter() function.
+require_once $_tests_dir . '/includes/functions.php';
+
+/**
+ * Manually loads the plugin being tested.
+ */
+function wporg_o2_posting_access_manually_load_plugin() {
+	require_once dirname( __DIR__ ) . '/wporg-o2-posting-access.php';
+}
+tests_add_filter( 'muplugins_loaded', 'wporg_o2_posting_access_manually_load_plugin' );
+
+// Start up the WP testing environment.
+require $_tests_dir . '/includes/bootstrap.php';
+
+// Include the base test case.
+require __DIR__ . '/includes/testcase.php';

--- a/wordpress.org/public_html/wp-content/plugins/wporg-o2-posting-access/phpunit/includes/testcase.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-o2-posting-access/phpunit/includes/testcase.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * Base test case for the o2 Posting Access plugin.
+ *
+ * WordPress ships `WP_UnitTestCase`, but its `set_up()` calls
+ * `PHPUnit\Util\Test::parseTestMethodAnnotations()`, which PHPUnit 10 removed.
+ * WordPress has no PHPUnit 10+ compatible release, so extending it fails every
+ * test before a single assertion runs. This mirrors the approach the handbook
+ * plugin's suite takes.
+ *
+ * @package wporg-o2-posting-access
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Provides WordPress fixtures and multisite membership helpers.
+ */
+abstract class WPorg_O2_Posting_Access_TestCase extends TestCase {
+
+	/**
+	 * Shared fixture factory.
+	 *
+	 * @var WP_UnitTest_Factory|null
+	 */
+	protected static $factory_instance = null;
+
+	/**
+	 * Hook globals captured before the first test, restored after each test.
+	 *
+	 * @var array
+	 */
+	protected static $hooks_saved = array();
+
+	/**
+	 * Fixture factory.
+	 *
+	 * @var WP_UnitTest_Factory
+	 */
+	protected $factory;
+
+	/**
+	 * Returns the fixture factory, creating it on first use.
+	 *
+	 * @return WP_UnitTest_Factory
+	 */
+	protected static function factory() {
+		if ( ! self::$factory_instance ) {
+			self::$factory_instance = new WP_UnitTest_Factory();
+		}
+
+		return self::$factory_instance;
+	}
+
+	/**
+	 * Prepares a clean WordPress state before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->factory = static::factory();
+
+		if ( ! self::$hooks_saved ) {
+			$this->backup_hooks();
+		}
+
+		wp_cache_flush();
+
+		$this->start_transaction();
+	}
+
+	/**
+	 * Rolls back database and global state after each test.
+	 */
+	public function tearDown(): void {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Transaction control has no caching or API equivalent.
+		$wpdb->query( 'ROLLBACK' );
+
+		remove_filter( 'query', array( $this, 'create_temporary_tables' ) );
+		remove_filter( 'query', array( $this, 'drop_temporary_tables' ) );
+
+		$this->restore_hooks();
+
+		wp_set_current_user( 0 );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Wraps the test in a transaction so database writes never persist.
+	 */
+	protected function start_transaction() {
+		global $wpdb;
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Transaction control has no caching or API equivalent.
+		$wpdb->query( 'SET autocommit = 0;' );
+		$wpdb->query( 'START TRANSACTION;' );
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		add_filter( 'query', array( $this, 'create_temporary_tables' ) );
+		add_filter( 'query', array( $this, 'drop_temporary_tables' ) );
+	}
+
+	/**
+	 * Rewrites CREATE TABLE statements to create temporary tables.
+	 *
+	 * @param string $query The query to filter.
+	 * @return string
+	 */
+	public function create_temporary_tables( $query ) {
+		if ( str_starts_with( trim( $query ), 'CREATE TABLE' ) ) {
+			return substr_replace( trim( $query ), 'CREATE TEMPORARY TABLE', 0, 12 );
+		}
+
+		return $query;
+	}
+
+	/**
+	 * Rewrites DROP TABLE statements to drop temporary tables.
+	 *
+	 * @param string $query The query to filter.
+	 * @return string
+	 */
+	public function drop_temporary_tables( $query ) {
+		if ( str_starts_with( trim( $query ), 'DROP TABLE' ) ) {
+			return substr_replace( trim( $query ), 'DROP TEMPORARY TABLE', 0, 10 );
+		}
+
+		return $query;
+	}
+
+	/**
+	 * Snapshots the hook globals.
+	 */
+	protected function backup_hooks() {
+		self::$hooks_saved['wp_filter'] = array();
+
+		foreach ( $GLOBALS['wp_filter'] as $hook_name => $hook_object ) {
+			self::$hooks_saved['wp_filter'][ $hook_name ] = clone $hook_object;
+		}
+
+		foreach ( array( 'wp_actions', 'wp_filters', 'wp_current_filter' ) as $key ) {
+			self::$hooks_saved[ $key ] = $GLOBALS[ $key ] ?? array();
+		}
+	}
+
+	/**
+	 * Restores the hook globals from the snapshot.
+	 */
+	protected function restore_hooks() {
+		if ( ! isset( self::$hooks_saved['wp_filter'] ) ) {
+			return;
+		}
+
+		$GLOBALS['wp_filter'] = array();
+
+		foreach ( self::$hooks_saved['wp_filter'] as $hook_name => $hook_object ) {
+			$GLOBALS['wp_filter'][ $hook_name ] = clone $hook_object;
+		}
+
+		foreach ( array( 'wp_actions', 'wp_filters', 'wp_current_filter' ) as $key ) {
+			if ( isset( self::$hooks_saved[ $key ] ) ) {
+				$GLOBALS[ $key ] = self::$hooks_saved[ $key ];
+			}
+		}
+	}
+
+	/**
+	 * Creates a user who is not a member of the current blog.
+	 *
+	 * The is_user_member_of_blog() check tests for the *presence* of the blog's
+	 * capabilities user meta key, so clearing the role is not enough -- the key
+	 * has to be deleted outright, which is what remove_user_from_blog() does.
+	 *
+	 * @param array $args Optional. Arguments to pass to the user factory.
+	 * @return int The new user's ID.
+	 */
+	protected function create_non_member( $args = array() ) {
+		$user_id = $this->factory()->user->create( array_merge( array( 'role' => 'author' ), $args ) );
+
+		remove_user_from_blog( $user_id, get_current_blog_id() );
+
+		wp_cache_delete( $user_id, 'user_meta' );
+
+		/*
+		 * Guard against the fixture silently becoming a member, which would
+		 * make every assertion built on it pass for the wrong reason.
+		 */
+		if ( is_user_member_of_blog( $user_id, get_current_blog_id() ) ) {
+			$this->fail( 'Fixture user is still a member of the blog; the non-member tests would be vacuous.' );
+		}
+
+		return $user_id;
+	}
+}

--- a/wordpress.org/public_html/wp-content/plugins/wporg-o2-posting-access/phpunit/tests/WPorg_O2_Posting_Access_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-o2-posting-access/phpunit/tests/WPorg_O2_Posting_Access_Test.php
@@ -1,0 +1,558 @@
+<?php // phpcs:disable WordPress.Files.FileName.NotHyphenatedLowercase -- PHPUnit only finds a test class in a file named after it.
+/**
+ * Tests for the o2 Posting Access plugin.
+ *
+ * @package wporg-o2-posting-access
+ */
+
+defined( 'ABSPATH' ) || die();
+
+use WordPressdotorg\o2\Posting_Access\Plugin;
+
+/**
+ * Covers who may post on an o2 site, and what happens to what they post.
+ */
+class WPorg_O2_Posting_Access_Test extends WPorg_O2_Posting_Access_TestCase {
+
+	/**
+	 * A user who is not a member of the blog and has never published.
+	 *
+	 * @var int
+	 */
+	protected $non_member;
+
+	/**
+	 * The plugin instance under test.
+	 *
+	 * @var Plugin
+	 */
+	protected $plugin;
+
+	/**
+	 * Sets up a non-member acting as the current user.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->plugin     = new Plugin();
+		$this->non_member = $this->create_non_member();
+
+		wp_set_current_user( $this->non_member );
+	}
+
+	/*
+	 * Capabilities: the grant that makes the o2 front end usable at all.
+	 */
+
+	/**
+	 * Non-members get posting capabilities so the o2 editor renders for them.
+	 * o2 gates both its post form and its create endpoint on 'publish_posts'.
+	 */
+	public function test_non_member_receives_posting_capabilities() {
+		$this->assertTrue( user_can( $this->non_member, 'edit_posts' ) );
+		$this->assertTrue( user_can( $this->non_member, 'publish_posts' ) );
+		$this->assertTrue( user_can( $this->non_member, 'edit_published_posts' ) );
+	}
+
+	/**
+	 * The grant must not extend to capabilities the plugin never intended.
+	 */
+	public function test_non_member_receives_no_other_capabilities() {
+		$this->assertFalse( user_can( $this->non_member, 'edit_others_posts' ) );
+		$this->assertFalse( user_can( $this->non_member, 'delete_posts' ) );
+		$this->assertFalse( user_can( $this->non_member, 'unfiltered_html' ) );
+		$this->assertFalse( user_can( $this->non_member, 'manage_options' ) );
+	}
+
+	/**
+	 * Logged out visitors must never be granted anything.
+	 */
+	public function test_logged_out_user_receives_no_capabilities() {
+		wp_set_current_user( 0 );
+
+		$this->assertFalse( current_user_can( 'edit_posts' ) );
+		$this->assertFalse( current_user_can( 'publish_posts' ) );
+	}
+
+	/**
+	 * The guard reads the filter's $user argument rather than the current user,
+	 * so a capability check made *about* another user while someone is logged
+	 * in must not grant that user anything.
+	 */
+	public function test_grant_does_not_leak_to_other_users() {
+		$this->assertFalse( user_can( 0, 'publish_posts' ) );
+	}
+
+	/*
+	 * Publishing policy: user_can_publish() decides who skips review.
+	 */
+
+	/**
+	 * A non-member with no published post has not earned publishing rights.
+	 */
+	public function test_user_can_publish_is_false_for_fresh_non_member() {
+		$this->assertFalse( $this->plugin->user_can_publish( $this->non_member ) );
+	}
+
+	/**
+	 * Blog members always publish directly.
+	 */
+	public function test_user_can_publish_is_true_for_member() {
+		$member = $this->factory()->user->create( array( 'role' => 'contributor' ) );
+
+		$this->assertTrue( $this->plugin->user_can_publish( $member ) );
+	}
+
+	/**
+	 * A user who does not exist can never publish.
+	 */
+	public function test_user_can_publish_is_false_for_unknown_user() {
+		$this->assertFalse( $this->plugin->user_can_publish( PHP_INT_MAX ) );
+	}
+
+	/**
+	 * The 'moderation_keys' option blocks a user whose email address matches,
+	 * and it is checked before the published-post allowance.
+	 */
+	public function test_user_can_publish_respects_moderation_keys() {
+		$spammer = $this->create_non_member( array( 'user_email' => 'nuisance@blocked.example' ) );
+
+		wp_set_current_user( 0 );
+		$this->factory()->post->create(
+			array(
+				'post_author' => $spammer,
+				'post_status' => 'publish',
+			)
+		);
+
+		update_option( 'moderation_keys', "blocked.example\nsomething-else" );
+
+		$this->assertFalse( $this->plugin->user_can_publish( $spammer ) );
+	}
+
+	/**
+	 * The 'wporg_o2_user_can_publish' filter has the final say.
+	 */
+	public function test_user_can_publish_is_filterable() {
+		wp_set_current_user( 0 );
+		$this->factory()->post->create(
+			array(
+				'post_author' => $this->non_member,
+				'post_status' => 'publish',
+			)
+		);
+
+		$deny = '__return_false';
+		add_filter( 'wporg_o2_user_can_publish', $deny );
+		$result = $this->plugin->user_can_publish( $this->non_member );
+		remove_filter( 'wporg_o2_user_can_publish', $deny );
+
+		$this->assertFalse( $result );
+	}
+
+	/*
+	 * Submissions are held for review, whichever write path they arrive on.
+	 */
+
+	/**
+	 * The REST controller does not pass 'post_author'; wp_insert_post() resolves
+	 * it from the current user into $data. Reading the author from $postarr
+	 * instead of $data would miss this case entirely, so it is pinned explicitly.
+	 */
+	public function test_publish_without_explicit_author_is_downgraded() {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => 'No explicit author',
+				'post_content' => 'Body.',
+				'post_status'  => 'publish',
+			)
+		);
+
+		$this->assertNotInstanceOf( WP_Error::class, $post_id );
+		$this->assertSame( 'pending', get_post_status( $post_id ) );
+	}
+
+	/**
+	 * The straightforward case: an explicit self-authored publish.
+	 */
+	public function test_publish_with_explicit_author_is_downgraded() {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => 'Explicit author',
+				'post_content' => 'Body.',
+				'post_status'  => 'publish',
+				'post_author'  => $this->non_member,
+			)
+		);
+
+		$this->assertSame( 'pending', get_post_status( $post_id ) );
+	}
+
+	/**
+	 * The REST controller is one of the paths that does not run o2's own filter.
+	 */
+	public function test_rest_create_is_downgraded() {
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
+		$request->set_body_params(
+			array(
+				'title'   => 'Created over REST',
+				'content' => 'Body.',
+				'status'  => 'publish',
+			)
+		);
+
+		$response = rest_do_request( $request );
+		$data     = $response->get_data();
+
+		$this->assertLessThan( 400, $response->get_status(), 'Creation itself should still be permitted.' );
+		$this->assertSame( 'pending', $data['status'] );
+		$this->assertSame( 'pending', get_post_status( $data['id'] ) );
+	}
+
+	/**
+	 * Scheduling is publishing with a delay, so 'future' has to be caught too.
+	 */
+	public function test_future_status_is_downgraded() {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Scheduled',
+				'post_status' => 'future',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', time() + DAY_IN_SECONDS ),
+				'post_author' => $this->non_member,
+			)
+		);
+
+		$this->assertSame( 'pending', get_post_status( $post_id ) );
+	}
+
+	/**
+	 * 'private' bypasses review just as 'publish' does.
+	 */
+	public function test_private_status_is_downgraded() {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Private',
+				'post_status' => 'private',
+				'post_author' => $this->non_member,
+			)
+		);
+
+		$this->assertSame( 'pending', get_post_status( $post_id ) );
+	}
+
+	/**
+	 * Publishing must not be reachable by updating an existing pending post.
+	 */
+	public function test_updating_own_pending_post_to_publish_is_downgraded() {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Two step',
+				'post_status' => 'pending',
+				'post_author' => $this->non_member,
+			)
+		);
+
+		wp_update_post(
+			array(
+				'ID'          => $post_id,
+				'post_status' => 'publish',
+			)
+		);
+
+		$this->assertSame( 'pending', get_post_status( $post_id ) );
+	}
+
+	/**
+	 * The capabilities granted are the defaults for every post type registered
+	 * with capability_type 'post', so the downgrade has to cover those too.
+	 */
+	public function test_custom_post_type_publish_is_downgraded() {
+		register_post_type(
+			'wporg_test_cpt',
+			array(
+				'public'          => true,
+				'capability_type' => 'post',
+			)
+		);
+
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'CPT publish',
+				'post_type'   => 'wporg_test_cpt',
+				'post_status' => 'publish',
+				'post_author' => $this->non_member,
+			)
+		);
+
+		unregister_post_type( 'wporg_test_cpt' );
+
+		$this->assertSame( 'pending', get_post_status( $post_id ) );
+	}
+
+	/**
+	 * The o2 front end path downgrades through the 'o2_create_post' filter,
+	 * before the post ever reaches wp_insert_post().
+	 */
+	public function test_o2_create_post_is_downgraded() {
+		$post              = new stdClass();
+		$post->post_author = $this->non_member;
+		$post->post_status = 'publish';
+
+		$filtered = $this->plugin->save_new_post_as_pending( $post );
+
+		$this->assertSame( 'pending', $filtered->post_status );
+	}
+
+	/**
+	 * The same filter leaves a member's post alone.
+	 */
+	public function test_o2_create_post_is_not_downgraded_for_member() {
+		$member = $this->factory()->user->create( array( 'role' => 'author' ) );
+
+		$post              = new stdClass();
+		$post->post_author = $member;
+		$post->post_status = 'publish';
+
+		$filtered = $this->plugin->save_new_post_as_pending( $post );
+
+		$this->assertSame( 'publish', $filtered->post_status );
+	}
+
+	/*
+	 * The downgrade runs on every insert site-wide, so it must be narrow.
+	 */
+
+	/**
+	 * A blog member publishing normally must be untouched.
+	 */
+	public function test_member_publish_is_not_downgraded() {
+		$member = $this->factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $member );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Member post',
+				'post_status' => 'publish',
+				'post_author' => $member,
+			)
+		);
+
+		$this->assertSame( 'publish', get_post_status( $post_id ) );
+	}
+
+	/**
+	 * Programmatic inserts -- cron, WP-CLI, importers -- run with no current
+	 * user. Downgrading those would silently unpublish content site-wide.
+	 */
+	public function test_insert_with_no_current_user_is_not_downgraded() {
+		wp_set_current_user( 0 );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Cron post',
+				'post_status' => 'publish',
+				'post_author' => $this->non_member,
+			)
+		);
+
+		$this->assertSame( 'publish', get_post_status( $post_id ) );
+	}
+
+	/**
+	 * An editor publishing on behalf of a non-member is a deliberate editorial
+	 * act and must not be downgraded.
+	 */
+	public function test_editorial_publish_on_behalf_of_non_member_is_not_downgraded() {
+		$editor = $this->factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Published for someone else',
+				'post_status' => 'publish',
+				'post_author' => $this->non_member,
+			)
+		);
+
+		$this->assertSame( 'publish', get_post_status( $post_id ) );
+	}
+
+	/**
+	 * The o2 create path calls get_default_post_to_edit( 'post', true ), which
+	 * inserts an auto-draft before the real save. Clamping that would break the
+	 * front end editor for everyone.
+	 */
+	public function test_auto_draft_is_not_downgraded() {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Auto draft',
+				'post_status' => 'auto-draft',
+				'post_author' => $this->non_member,
+			)
+		);
+
+		$this->assertSame( 'auto-draft', get_post_status( $post_id ) );
+	}
+
+	/**
+	 * Drafts are already unpublished and must be left alone.
+	 */
+	public function test_draft_is_not_downgraded() {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Draft',
+				'post_status' => 'draft',
+				'post_author' => $this->non_member,
+			)
+		);
+
+		$this->assertSame( 'draft', get_post_status( $post_id ) );
+	}
+
+	/**
+	 * Once a non-member has a published post they are trusted to publish
+	 * directly -- the plugin's trust-on-first-approval design.
+	 */
+	public function test_non_member_with_published_post_may_publish() {
+		/*
+		 * Seeded with no current user, because creating it as the non-member
+		 * would send the fixture itself to 'pending' -- which is exactly what
+		 * the rest of this suite asserts.
+		 */
+		wp_set_current_user( 0 );
+		$this->factory()->post->create(
+			array(
+				'post_author' => $this->non_member,
+				'post_status' => 'publish',
+			)
+		);
+		wp_set_current_user( $this->non_member );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Second post',
+				'post_status' => 'publish',
+				'post_author' => $this->non_member,
+			)
+		);
+
+		$this->assertSame( 'publish', get_post_status( $post_id ) );
+	}
+
+	/**
+	 * The moderation workflow the downgrade exists to feed: a moderator
+	 * approving a non-member's pending post must actually publish it.
+	 */
+	public function test_moderator_can_approve_a_pending_post() {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Awaiting review',
+				'post_status' => 'publish',
+				'post_author' => $this->non_member,
+			)
+		);
+
+		$this->assertSame( 'pending', get_post_status( $post_id ), 'Precondition: the post starts out pending.' );
+
+		$editor = $this->factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor );
+
+		wp_update_post(
+			array(
+				'ID'          => $post_id,
+				'post_status' => 'publish',
+			)
+		);
+
+		$this->assertSame( 'publish', get_post_status( $post_id ) );
+	}
+
+	/*
+	 * How a post awaiting review is presented.
+	 */
+
+	/**
+	 * Pending posts are labelled so nobody mistakes one for published content.
+	 */
+	public function test_pending_post_title_is_prefixed() {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Awaiting review',
+				'post_status' => 'pending',
+				'post_author' => $this->non_member,
+			)
+		);
+
+		$this->assertSame( 'Pending Review: Awaiting review', $this->plugin->prepend_pending_notice( 'Awaiting review', $post_id ) );
+	}
+
+	/**
+	 * Published posts keep their title untouched.
+	 */
+	public function test_published_post_title_is_not_prefixed() {
+		wp_set_current_user( 0 );
+		$post_id = $this->factory()->post->create(
+			array(
+				'post_title'  => 'Live post',
+				'post_status' => 'publish',
+			)
+		);
+
+		$this->assertSame( 'Live post', $this->plugin->prepend_pending_notice( 'Live post', $post_id ) );
+	}
+
+	/**
+	 * Comments stay shut on a post that is not publicly visible yet.
+	 */
+	public function test_comments_are_closed_for_pending_posts() {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Awaiting review',
+				'post_status' => 'pending',
+				'post_author' => $this->non_member,
+			)
+		);
+
+		$this->assertFalse( $this->plugin->close_comments_for_pending_posts( true, $post_id ) );
+	}
+
+	/**
+	 * Published posts keep whatever comment status they already had.
+	 */
+	public function test_comments_are_left_open_for_published_posts() {
+		wp_set_current_user( 0 );
+		$post_id = $this->factory()->post->create(
+			array(
+				'post_title'  => 'Live post',
+				'post_status' => 'publish',
+			)
+		);
+
+		$this->assertTrue( $this->plugin->close_comments_for_pending_posts( true, $post_id ) );
+	}
+
+	/**
+	 * The submit button tells the user their post will be reviewed.
+	 */
+	public function test_post_button_is_relabelled_for_non_members() {
+		$this->assertSame( 'Submit for review', $this->plugin->replace_post_button_label( 'Post', 'Post', 'Verb, to post', 'o2' ) );
+	}
+
+	/**
+	 * Members keep the plain "Post" button.
+	 */
+	public function test_post_button_is_not_relabelled_for_members() {
+		$member = $this->factory()->user->create( array( 'role' => 'author' ) );
+		wp_set_current_user( $member );
+
+		$this->assertSame( 'Post', $this->plugin->replace_post_button_label( 'Post', 'Post', 'Verb, to post', 'o2' ) );
+	}
+
+	/**
+	 * Unrelated strings pass through untouched.
+	 */
+	public function test_unrelated_translations_are_untouched() {
+		$this->assertSame( 'Post', $this->plugin->replace_post_button_label( 'Post', 'Post', 'Noun, a post', 'o2' ) );
+		$this->assertSame( 'Post', $this->plugin->replace_post_button_label( 'Post', 'Post', 'Verb, to post', 'default' ) );
+	}
+}

--- a/wordpress.org/public_html/wp-content/plugins/wporg-o2-posting-access/wporg-o2-posting-access.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-o2-posting-access/wporg-o2-posting-access.php
@@ -32,6 +32,7 @@ class Plugin {
 
 			add_filter( 'gettext_with_context', [ $this, 'replace_post_button_label' ], 10, 4 );
 			add_filter( 'o2_create_post', [ $this, 'save_new_post_as_pending' ] );
+			add_filter( 'wp_insert_post_data', array( $this, 'enforce_pending_status' ) );
 			add_filter( 'the_title', [ $this, 'prepend_pending_notice' ], 10, 2 );
 			add_filter( 'comments_open', [ $this, 'close_comments_for_pending_posts' ], 10, 2 );
 		}
@@ -157,6 +158,39 @@ class Plugin {
 	}
 
 	/**
+	 * Applies the 'pending' status to submissions from users who can't publish.
+	 *
+	 * The capabilities granted in add_post_capabilities() are primitive capabilities
+	 * that every write path honors, so the review step can't live on o2's front end
+	 * 'o2_create_post' filter alone -- it has to apply wherever a post is created.
+	 * Only posts a logged-in user is authoring for themselves are affected, so
+	 * editorial and programmatic inserts are left alone.
+	 *
+	 * @param array $data An array of slashed, sanitized, and processed post data.
+	 * @return array Filtered post data.
+	 */
+	public function enforce_pending_status( $data ) {
+		$author = (int) ( $data['post_author'] ?? 0 );
+
+		if ( ! $author || get_current_user_id() !== $author ) {
+			return $data;
+		}
+
+		$exempt_statuses = array( 'draft', 'pending', 'auto-draft', 'trash', 'inherit' );
+		if ( in_array( $data['post_status'], $exempt_statuses, true ) ) {
+			return $data;
+		}
+
+		if ( $this->user_can_publish( $author ) ) {
+			return $data;
+		}
+
+		$data['post_status'] = 'pending';
+
+		return $data;
+	}
+
+	/**
 	 * Replaces the button label "Post" with "Submit for review" if current user
 	 * can't publish a post with post status 'publish'.
 	 *
@@ -239,7 +273,7 @@ class Plugin {
 	 * @return array Array of all the user's capabilities.
 	 */
 	public function add_post_capabilities( $allcaps, $caps, $args, $user ) {
-		if ( ! is_user_logged_in() || in_array( 'publish_posts', $allcaps, true ) || is_user_member_of_blog( $user->ID ) ) {
+		if ( empty( $user->ID ) || ! empty( $allcaps['publish_posts'] ) || is_user_member_of_blog( $user->ID ) ) {
 			return $allcaps;
 		}
 


### PR DESCRIPTION
The plugin grants non-members `publish_posts`, `edit_posts` and `edit_published_posts` so o2's front end renders its post form for them, and then holds their submissions for review. That second step is attached only to o2's own `o2_create_post` filter, so it applies to the front end editor but not to the other ways a post can be created.

### Changes

- Move the status handling to `wp_insert_post_data`, which every creation path runs through. The filter only touches posts a logged-in user is authoring for themselves, so editorial, cron and WP-CLI inserts are left alone, and it exempts statuses that are not publicly visible so o2's auto-draft step is unaffected.
- Correct two checks in `add_post_capabilities()`. The `in_array()` short-circuit searched the values of a `cap => bool` map rather than its keys, so it never matched; and the guard consulted the current user rather than the user the filter was called for.

### Tests

Adds a PHPUnit suite covering the plugin's posting access behaviour: the capability grant, `user_can_publish()` (including the `moderation_keys` and filter branches), the review status across creation paths, and how a post awaiting review is presented.

The suite runs as multisite. `is_user_member_of_blog()` returns true unconditionally when `! is_multisite()`, which makes both the capability grant and `user_can_publish()` no-ops, so on single site the assertions would pass without exercising any of this code. `WP_TESTS_MULTISITE` is defined in the plugin's bootstrap rather than via wp-env's `multisite` option, which conflicts with the test suite's own network install.

Also adds a `make` wp-env environment for the make.wordpress.org plugins to run it in, and a matching CI job.

```
OK (32 tests, 43 assertions)
```