### PR TITLE
Trac Watcher: Escape admin output, tighten the props capability, and add tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -89,6 +89,11 @@ jobs:
             wp-env-args: "--config make/.wp-env.test.json"
             container: tests-cli
             plugin-name: wporg-o2-posting-access
+          - name: Make - Trac Watcher
+            working-directory: environments
+            wp-env-args: "--config make/.wp-env.test.json"
+            container: tests-cli
+            plugin-name: wporg-trac-watcher
     steps:
       - uses: actions/checkout@v4
 

--- a/environments/make/.wp-env.test.json
+++ b/environments/make/.wp-env.test.json
@@ -6,9 +6,13 @@
 		"../wordpress.org/public_html/wp-content/plugins/o2-private-posts",
 		"../wordpress.org/public_html/wp-content/plugins/wporg-make-sites-cpt",
 		"../wordpress.org/public_html/wp-content/plugins/wporg-meeting-posttype",
-		"../wordpress.org/public_html/wp-content/plugins/trac-notifications"
+		"../wordpress.org/public_html/wp-content/plugins/trac-notifications",
+		"../wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher"
 	],
 	"lifecycleScripts": {
 		"afterStart": "bash make/bin/after-start-test.sh"
+	},
+	"config": {
+		"WP_CORE_LATEST_RELEASE": "7.0"
 	}
 }

--- a/environments/make/.wp-env.test.json
+++ b/environments/make/.wp-env.test.json
@@ -9,6 +9,9 @@
 		"../wordpress.org/public_html/wp-content/plugins/trac-notifications",
 		"../wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher"
 	],
+	"mappings": {
+		"wp-content/env-bin": "./make/bin"
+	},
 	"lifecycleScripts": {
 		"afterStart": "bash make/bin/after-start-test.sh"
 	},

--- a/environments/make/bin/after-start-test.sh
+++ b/environments/make/bin/after-start-test.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 #
 # Runs after wp-env start for the test environment.
-# Installs PHPUnit 11 and Yoast polyfills in the test container.
+# Installs PHPUnit 11 and Yoast polyfills in the test container, and creates the
+# stub tables that live outside WordPress on production.
 #
 
 CONFIG="--config make/.wp-env.test.json"
@@ -10,3 +11,10 @@ RUN="npx wp-env $CONFIG run tests-cli"
 echo "Installing PHPUnit 11 and polyfills..."
 $RUN composer global require -W phpunit/phpunit:^11.0 2>&1
 $RUN composer require --dev yoast/phpunit-polyfills:^4.0 --working-dir=/wordpress-phpunit 2>&1
+
+# Both databases need these: the development site for browsing, the test site
+# for the suites. The file only uses CREATE TABLE IF NOT EXISTS, so re-importing
+# it on every start is safe.
+echo "Creating stub database tables..."
+npx wp-env $CONFIG run cli -- wp db import wp-content/env-bin/database-tables.sql 2>&1
+$RUN -- wp db import wp-content/env-bin/database-tables.sql 2>&1

--- a/environments/make/bin/database-tables.sql
+++ b/environments/make/bin/database-tables.sql
@@ -1,0 +1,12 @@
+-- Stub tables for local development.
+-- These tables exist outside WordPress on production but are needed locally.
+
+-- Trac Watcher resolves a prop to an account by GitHub username as a last
+-- resort. The table belongs to another part of dotorg, so nothing creates it
+-- here, and every unresolved prop lookup errors without it.
+CREATE TABLE IF NOT EXISTS `wporg_github_users` (
+  `user_id` bigint(20) NOT NULL,
+  `github_user` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`user_id`),
+  KEY `github_user` (`github_user`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/admin/list-table.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/admin/list-table.php
@@ -296,20 +296,29 @@ class Commits_List_Table extends WP_List_Table {
 					}
 				}
 
+				// A committer who has no wp.org account is shown by their SVN username alone.
 				$user = get_user_by( 'login', $item->author );
-				$output .= sprintf(
-					'<br><a href="%1$s">%2$s %3$s<br>%4$s</a>',
-					esc_url( 'https://profiles.wordpress.org/' . $user->user_nicename . '/' ),
-					get_avatar( $user, 32 ),
-					esc_html( $user->display_name ),
-					esc_html( $user->user_login )
-				);
+				if ( $user ) {
+					$output .= sprintf(
+						'<br><a href="%1$s">%2$s %3$s<br>%4$s</a>',
+						esc_url( 'https://profiles.wordpress.org/' . $user->user_nicename . '/' ),
+						get_avatar( $user, 32 ),
+						esc_html( $user->display_name ),
+						esc_html( $user->user_login )
+					);
+				} else {
+					$output .= sprintf( '<br>%s', esc_html( $item->author ) );
+				}
 
 
 				return $output;
 
 			case 'author':
 				$user = get_user_by( 'login', $item->author );
+				if ( ! $user ) {
+					return esc_html( $item->author );
+				}
+
 				return sprintf(
 					'<a href="%1$s">%2$s %3$s</a>',
 					esc_url( 'https://profiles.wordpress.org/' . $user->user_nicename . '/' ),

--- a/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/admin/list-table.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/admin/list-table.php
@@ -298,8 +298,8 @@ class Commits_List_Table extends WP_List_Table {
 
 				$user = get_user_by( 'login', $item->author );
 				$output .= sprintf(
-					'<br><a href="https://profiles.wordpress.org/%s/">%s %s<br>%s</a>',
-					$user->user_nicename,
+					'<br><a href="%1$s">%2$s %3$s<br>%4$s</a>',
+					esc_url( 'https://profiles.wordpress.org/' . $user->user_nicename . '/' ),
 					get_avatar( $user, 32 ),
 					esc_html( $user->display_name ),
 					esc_html( $user->user_login )
@@ -311,10 +311,10 @@ class Commits_List_Table extends WP_List_Table {
 			case 'author':
 				$user = get_user_by( 'login', $item->author );
 				return sprintf(
-					'<a href="https://profiles.wordpress.org/%s">%s %s</a>',
-					$user->user_nicename,
+					'<a href="%1$s">%2$s %3$s</a>',
+					esc_url( 'https://profiles.wordpress.org/' . $user->user_nicename . '/' ),
 					get_avatar( $user, 32 ),
-					$user->display_name
+					esc_html( $user->display_name )
 				);
 
 			case 'message':
@@ -324,17 +324,24 @@ class Commits_List_Table extends WP_List_Table {
 				foreach ( $item->props as $prop => $user_id ) {
 					$user = $user_id ? get_user_by( 'ID', $user_id ) : false;
 
-					if ( false === stripos( $message, $prop ) ) {
-						$message .= "<em>Missed Prop: $prop</em> ";
+					/*
+					 * The message has already been passed through esc_html() by format_for_trac(), so the
+					 * prop has to be escaped before it's matched against it, and before it's inserted.
+					 */
+					$prop_html = esc_html( $prop );
+
+					if ( false === stripos( $message, $prop_html ) ) {
+						$message .= "<em>Missed Prop: {$prop_html}</em> ";
 					}
 
 					if ( $user && strtolower( $prop ) != strtolower( $user->user_login ) && strtolower( $prop ) != strtolower( $user->user_nicename ) ) {
 						// User is a typo or mis-prop.
-						$message = str_ireplace( $prop, "<del class='replace'>{$prop}</del><ins>{$user->user_nicename}</ins>", $message );
+						$nicename = esc_html( $user->user_nicename );
+						$message  = str_ireplace( $prop_html, "<del class='replace'>{$prop_html}</del><ins>{$nicename}</ins>", $message );
 					} else {
 						// All else.
 						$tag     = $user ? 'ins' : 'del';
-						$message = str_ireplace( $prop, "<{$tag}>{$prop}</{$tag}>", $message );
+						$message = str_ireplace( $prop_html, "<{$tag}>{$prop_html}</{$tag}>", $message );
 					}
 				}
 
@@ -362,7 +369,7 @@ class Commits_List_Table extends WP_List_Table {
 					$prop_display_name_different = ( $user && $user->display_name != $prop );
 
 					$output .= $avatar;
-					$output .= $user ? $user->display_name : $prop;
+					$output .= esc_html( $user ? $user->display_name : $prop );
 
 					if ( $prop_is_different_from_user ) {
 						$output .= " <em>typo</em>";

--- a/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/admin/list-table.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/admin/list-table.php
@@ -348,7 +348,8 @@ class Commits_List_Table extends WP_List_Table {
 				return "<div>{$message}</div>";
 
 			case 'props':
-				$can_edit = current_user_can( 'publish_posts' );
+				// Must match what the handlers in admin/post.php require, see the note there.
+				$can_edit = current_user_can( 'edit_others_posts' );
 				$output   = '<div class="propslist">';
 
 				foreach ( $item->props as $prop => $user_id ) {

--- a/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/admin/post.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/admin/post.php
@@ -4,7 +4,8 @@ namespace WordPressdotorg\Trac\Watcher;
 add_action( 'admin_post_svn_save', function() {
 	global $wpdb;
 
-	if ( ! current_user_can( 'publish_posts' ) ) {
+	// Not publish_posts or edit_posts: o2 Posting Access grants both to any logged-in non-member.
+	if ( ! current_user_can( 'edit_others_posts' ) ) {
 		die( '-1' );
 	}
 	check_admin_referer( 'edit_svn_prop' );
@@ -139,7 +140,8 @@ add_action( 'admin_post_svn_save', function() {
 add_action( 'admin_post_svn_reparse', function() {
 	global $wpdb;
 
-	if ( ! current_user_can( 'publish_posts' ) ) {
+	// Reparsing rewrites the same records; see the note on the save handler above.
+	if ( ! current_user_can( 'edit_others_posts' ) ) {
 		die( '-1' );
 	}
 	check_admin_referer( 'reparse_svn' );

--- a/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/admin/post.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/admin/post.php
@@ -46,7 +46,7 @@ add_action( 'admin_post_svn_save', function() {
 			die( -1 );
 		}
 
-		$prop_name = wp_unslash( $_REQUEST['prop_name'] );
+		$prop_name = sanitize_text_field( wp_unslash( $_REQUEST['prop_name'] ) );
 		if ( ! $user && $prop_name != $the_prop->prop_name ) {
 			$user = Props\find_user_id( $prop_name );
 		}
@@ -92,9 +92,9 @@ add_action( 'admin_post_svn_save', function() {
 		// Adding one?
 
 		// Use the 'prop name' field first, otherwise fall back to the user_id field if the former is blank
-		$prop_name = wp_unslash( $_REQUEST['prop_name'] ?? '' );
+		$prop_name = sanitize_text_field( wp_unslash( $_REQUEST['prop_name'] ?? '' ) );
 		if ( ! $prop_name ) {
-			$prop_name = wp_unslash( $_REQUEST['user_id'] ?? '' );
+			$prop_name = sanitize_text_field( wp_unslash( $_REQUEST['user_id'] ?? '' ) );
 		};
 
 		if ( ! $prop_name ) {

--- a/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/admin/reports-page.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/admin/reports-page.php
@@ -78,7 +78,7 @@ function display_reports_page( $details ) {
 
 		// Revisions.
 		if ( ! empty( $revisions ) ) {
-			if (  preg_match( '!(?P<start>\d+)[:-](?P<end>(HEAD|\d+))!', $args['revisions'], $m ) ) {
+			if (  preg_match( '!(?P<start>\d+)[:-](?P<end>(HEAD|\d+))!', $revisions, $m ) ) {
 				if ( 'HEAD' === $m['end'] ) {
 					$where .= $wpdb->prepare( ' AND r.id > %d', $m['start'] );
 				} else {

--- a/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/admin/reports-page.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/admin/reports-page.php
@@ -78,7 +78,7 @@ function display_reports_page( $details ) {
 
 		// Revisions.
 		if ( ! empty( $revisions ) ) {
-			if (  preg_match( '!(?P<start>\d+)[:-](?P<end>(HEAD|\d+))!', $revisions, $m ) ) {
+			if ( preg_match( '!(?P<start>\d+)[:-](?P<end>(HEAD|\d+))!', $revisions, $m ) ) {
 				if ( 'HEAD' === $m['end'] ) {
 					$where .= $wpdb->prepare( ' AND r.id > %d', $m['start'] );
 				} else {

--- a/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/admin/reports-page.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/admin/reports-page.php
@@ -439,8 +439,8 @@ function display_reports_page( $details ) {
 						esc_html( $c->display_name ),
 						esc_html( $c->count ),
 						wp_kses_post( make_clickable( $c->user_nicename ? 'https://profile.wordpress.org/' . $c->user_nicename . '/' : '' ) ),
-						$c->ID ? get_avatar( $c->ID, min( 96, absint( $_GET['size'] ?? 32 ) ) ) : '',
-						wp_kses_post( make_clickable( $c->ID ? get_avatar_url( $c->ID, [ 'size' => absint( $_GET['size'] ?? 64 ) ] ) : '' ) )
+						$c->ID ? get_avatar( $c->ID, min( 96, absint( $_GET['size'] ?? 0 ) ?: 32 ) ) : '',
+						wp_kses_post( make_clickable( $c->ID ? get_avatar_url( $c->ID, [ 'size' => absint( $_GET['size'] ?? 0 ) ?: 64 ] ) : '' ) )
 					);
 				}
 				echo '</table>';

--- a/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/admin/reports-page.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/admin/reports-page.php
@@ -20,15 +20,15 @@ function display_reports_page( $details ) {
 	<div class="wrap">
 		<h2>Reports: <?php echo esc_html( $details['name'] ); ?></h2>
 		<ol>
-			<li><a href="<?php echo $url; ?>&what=contributors">All props matching filter</a></li>
-			<li><a href="<?php echo $url; ?>&what=committers">All Committers matching filter</a></li>
-			<li><a href="<?php echo $url; ?>&what=cloud">Cloud of Props matching filter</a></li>
-			<li><a href="<?php echo $url; ?>&what=typos">Props typos matching filter</a></li>
-			<li><a href="<?php echo $url; ?>&what=unknown-props">Unknown Props/typos matching filter</a></li>
-			<li><a href="<?php echo $url; ?>&what=raw-contributors-and-committers">All Props+Committers matching filter grouped together</a></li>
-			
+			<li><a href="<?php echo esc_url( $url . '&what=contributors' ); ?>">All props matching filter</a></li>
+			<li><a href="<?php echo esc_url( $url . '&what=committers' ); ?>">All Committers matching filter</a></li>
+			<li><a href="<?php echo esc_url( $url . '&what=cloud' ); ?>">Cloud of Props matching filter</a></li>
+			<li><a href="<?php echo esc_url( $url . '&what=typos' ); ?>">Props typos matching filter</a></li>
+			<li><a href="<?php echo esc_url( $url . '&what=unknown-props' ); ?>">Unknown Props/typos matching filter</a></li>
+			<li><a href="<?php echo esc_url( $url . '&what=raw-contributors-and-committers' ); ?>">All Props+Committers matching filter grouped together</a></li>
+
 			<?php if ( $is_core ) { ?>
-			<li><a href="<?php echo $url; ?>&what=versions-contributed">Versions which users have contributed to. Ignores filter.</a></li>
+			<li><a href="<?php echo esc_url( $url . '&what=versions-contributed' ); ?>">Versions which users have contributed to. Ignores filter.</a></li>
 			<?php } ?>
 		</ol>
 
@@ -136,11 +136,11 @@ function display_reports_page( $details ) {
 					);
 
 					printf(
-						'<tr><td><a href="%s">%s</a></td><td><a href="%s">%s</a></td></tr>',
-						'https://profiles.wordpress.org/' . $c->user_nicename . '/',
-						get_avatar( $c->ID, 32 ) . ' ' . ( $c->display_name ?: $c->user_nicename ),
-						$link,
-						$c->count,
+						'<tr><td><a href="%1$s">%2$s</a></td><td><a href="%3$s">%4$s</a></td></tr>',
+						esc_url( 'https://profiles.wordpress.org/' . $c->user_nicename . '/' ),
+						get_avatar( $c->ID, 32 ) . ' ' . esc_html( $c->display_name ?: $c->user_nicename ),
+						esc_url( $link ),
+						esc_html( $c->count ),
 					);
 				}
 				echo '</table>';
@@ -172,21 +172,21 @@ function display_reports_page( $details ) {
 					);
 					if ( ! $c->ID ) {
 						printf(
-							'<tr><td>%s</td><td>%s</td><td><a href="%s">%s</a></td></tr>',
-							$c->prop_name,
-							$c->count,
-							$link,
-							'[' . str_replace( ',', '] [', $c->revisions ) . ']'
+							'<tr><td>%1$s</td><td>%2$s</td><td><a href="%3$s">%4$s</a></td></tr>',
+							esc_html( $c->prop_name ),
+							esc_html( $c->count ),
+							esc_url( $link ),
+							esc_html( '[' . str_replace( ',', '] [', $c->revisions ) . ']' )
 						);
 						continue;
 					}
 					printf(
-						'<tr><td><a href="%s">%s</a></td><td>%s</td><td><a href="%s">%s</a></td></tr>',
-						'https://profiles.wordpress.org/' . $c->user_nicename . '/',
-						get_avatar( $c->ID, 32 ) . ' ' . ($c->display_name ?: $c->user_nicename),
-						$c->count,
-						$link,
-						'[' . str_replace( ',', '] [', $c->revisions ) . ']'
+						'<tr><td><a href="%1$s">%2$s</a></td><td>%3$s</td><td><a href="%4$s">%5$s</a></td></tr>',
+						esc_url( 'https://profiles.wordpress.org/' . $c->user_nicename . '/' ),
+						get_avatar( $c->ID, 32 ) . ' ' . esc_html( $c->display_name ?: $c->user_nicename ),
+						esc_html( $c->count ),
+						esc_url( $link ),
+						esc_html( '[' . str_replace( ',', '] [', $c->revisions ) . ']' )
 					);
 				}
 				echo '</table>';
@@ -298,18 +298,22 @@ function display_reports_page( $details ) {
 							admin_url( 'admin.php' )
 						);
 	
-						$profile = $p->prop_name;
+						$profile = esc_html( $p->prop_name );
 						if ( $p->user_id ) {
-							$u = get_user_by( 'ID', $p->user_id );
-							$profile = "<A href='https://profiles.wordpress.org/{$u->user_nicename}/'>" . ( $u->display_name ?: $u->user_login ) . "</a>";
+							$u       = get_user_by( 'ID', $p->user_id );
+							$profile = sprintf(
+								'<a href="%s">%s</a>',
+								esc_url( 'https://profiles.wordpress.org/' . $u->user_nicename . '/' ),
+								esc_html( $u->display_name ?: $u->user_login )
+							);
 						}
 
 						printf(
-							'<tr><td>%s</td><td>%s</td><td title="%s">%s</td></tr>',
-							$profile,
-							$p->count,
+							'<tr><td>%1$s</td><td>%2$s</td><td title="%3$s">%4$s</td></tr>',
+							$profile, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped when built above.
+							esc_html( $p->count ),
 							esc_attr( $p->versions ),
-							$compress( $p->versions )
+							esc_html( $compress( $p->versions ) )
 						);
 					}
 					echo '</table>';
@@ -342,13 +346,13 @@ function display_reports_page( $details ) {
 						admin_url( 'admin.php' )
 					);
 					printf(
-						'<tr><td><a href="%s">%s</a></td><td>%s</td><td>%s</td><td><a href="%s">%s</a></td></tr>',
-						'https://profiles.wordpress.org/' . $c->user_nicename . '/',
-						$c->display_name ?: $c->user_nicename,
-						$c->typos,
-						$c->count,
-						$link,
-						'[' . str_replace( ',', '] [', $c->revisions ) . ']'
+						'<tr><td><a href="%1$s">%2$s</a></td><td>%3$s</td><td>%4$s</td><td><a href="%5$s">%6$s</a></td></tr>',
+						esc_url( 'https://profiles.wordpress.org/' . $c->user_nicename . '/' ),
+						esc_html( $c->display_name ?: $c->user_nicename ),
+						esc_html( $c->typos ),
+						esc_html( $c->count ),
+						esc_url( $link ),
+						esc_html( '[' . str_replace( ',', '] [', $c->revisions ) . ']' )
 					);
 				}
 				echo '</table>';
@@ -377,11 +381,11 @@ function display_reports_page( $details ) {
 						admin_url( 'admin.php' )
 					);
 					printf(
-						'<tr><td>%s</td><td>%s</td><td><a href="%s">%s</a></td></tr>',
+						'<tr><td>%1$s</td><td>%2$s</td><td><a href="%3$s">%4$s</a></td></tr>',
 						esc_html( $c->prop_name ),
-						$c->count,
-						$link,
-						'[' . str_replace( ',', '] [', $c->revisions ) . ']'
+						esc_html( $c->count ),
+						esc_url( $link ),
+						esc_html( '[' . str_replace( ',', '] [', $c->revisions ) . ']' )
 					);
 				}
 				echo '</table>';
@@ -413,21 +417,21 @@ function display_reports_page( $details ) {
 
 
 				echo "<p>Props (Contributors + Committers bunched together) designed to be copy-pasted elsewhere.<br>
-				Set gravatar size via adding <a href='$url&size=96'>&size=96</a> to this URL.<br>
+				Set gravatar size via adding <a href='" . esc_url( $url . '&size=96' ) . "'>&size=96</a> to this URL.<br>
 				Note: A committer prop'ing themselves only counts for 1 here.</p>";
 
 				echo '<table class="widefat striped">';
 				echo '<thead><tr><th>ID</th><th>Name</th><th>DisplayName</th><th>Count</th><th>Profile URL</th><th>Gravatar</th><th>GravURL</th></tr></thead>';
 				foreach ( $details as $c ) {
 					printf(
-						'<tr><td>%s</td><td>%s</td><td>%s</td><td>%s</td><td>%s</td><td>%s</td><td>%s</td></tr>',
-						$c->ID,
-						$c->prop_name,
-						$c->display_name,
-						$c->count,
-						make_clickable( $c->user_nicename ? 'https://profile.wordpress.org/' . $c->user_nicename . '/' : '' ),
-						$c->ID ? get_avatar( $c->ID, min( 96, $_GET['size'] ?? 32 ) ) : '',
-						make_clickable( $c->ID ? get_avatar_url( $c->ID, [ 'size' => $_GET['size'] ?? 64 ] ) : '' )
+						'<tr><td>%1$s</td><td>%2$s</td><td>%3$s</td><td>%4$s</td><td>%5$s</td><td>%6$s</td><td>%7$s</td></tr>',
+						esc_html( $c->ID ),
+						esc_html( $c->prop_name ),
+						esc_html( $c->display_name ),
+						esc_html( $c->count ),
+						make_clickable( $c->user_nicename ? esc_url( 'https://profile.wordpress.org/' . $c->user_nicename . '/' ) : '' ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- URL escaped, make_clickable() returns markup.
+						$c->ID ? get_avatar( $c->ID, min( 96, absint( $_GET['size'] ?? 32 ) ) ) : '',
+						make_clickable( $c->ID ? get_avatar_url( $c->ID, [ 'size' => absint( $_GET['size'] ?? 64 ) ] ) : '' ) // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Generated URL, and the anchor text is meant to be copy-pasted as-is.
 					);
 				}
 				echo '</table>';

--- a/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/admin/reports-page.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/admin/reports-page.php
@@ -105,8 +105,9 @@ function display_reports_page( $details ) {
 				$counts = [];
 				foreach ( $details as $r ) {
 					$counts[] = (object)[
-						'id' => $r->id,
+						'id' => $r->ID,
 						'name' => $r->display_name ?: $r->user_nicename,
+						'slug' => $r->user_nicename,
 						'link' => 'https://profiles.wordpress.org/' . $r->user_nicename . '/',
 						'count' => $r->count
 					];
@@ -321,7 +322,7 @@ function display_reports_page( $details ) {
 					break;
 			case 'typos':
 				$details = $wpdb->get_results(
-					"SELECT u.user_login, u.user_nicename,
+					"SELECT u.user_login, u.user_nicename, u.display_name,
 						COUNT( * ) as count,
 						group_concat( distinct p.prop_name SEPARATOR ', ' ) as typos,
 						group_concat( p.revision ORDER BY p.revision ASC ) as revisions

--- a/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/admin/reports-page.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/admin/reports-page.php
@@ -10,8 +10,8 @@ function display_reports_page( $details ) {
 	$branch    = $_REQUEST['branch'] ?? '';
 	$is_core   = ( 'core' === $details['slug'] );
 
-	// Default to the latest version for core.
-	if ( $is_core && is_null( $version ) ) {
+	// Default to the latest version for core. The constant is optional, as it is everywhere else in the plugin.
+	if ( $is_core && is_null( $version ) && defined( 'WP_CORE_LATEST_RELEASE' ) ) {
 		$version = sprintf( '%.1f', floatval( WP_CORE_LATEST_RELEASE ) + 0.1 );
 	}
 
@@ -300,8 +300,10 @@ function display_reports_page( $details ) {
 						);
 	
 						$profile = esc_html( $p->prop_name );
-						if ( $p->user_id ) {
-							$u       = get_user_by( 'ID', $p->user_id );
+						$u       = $p->user_id ? get_user_by( 'ID', $p->user_id ) : false;
+
+						// The account a prop points at may since have been deleted; fall back to the stored name.
+						if ( $u ) {
 							$profile = sprintf(
 								'<a href="%s">%s</a>',
 								esc_url( 'https://profiles.wordpress.org/' . $u->user_nicename . '/' ),

--- a/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/admin/reports-page.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/admin/reports-page.php
@@ -194,134 +194,140 @@ function display_reports_page( $details ) {
 
 				break;
 			case 'versions-contributed':
-					$details = $wpdb->get_results(
-						"SELECT prop_name, user_id, COUNT( distinct version ) as count,
-							group_concat( distinct version ORDER BY version ASC  SEPARATOR ', ' ) as versions,
-							ifnull(user_id,prop_name) as _groupby
-						FROM (
-							SELECT distinct LEFT(version, 3) as version, prop_name, p.user_id
-							FROM {$details['props_table']} p
-								JOIN {$details['rev_table']} r ON p.revision = r.id
-							GROUP BY prop_name, version
-							UNION
-							SELECT distinct LEFT(version, 3) as version, r.author as prop_name, u.ID as user_id
-							FROM {$details['rev_table']} r
-								JOIN {$wpdb->users} u ON r.author = u.user_login
-							GROUP BY r.author, version
-						) a
-						WHERE version != ''
-						group by _groupby HAVING COUNT(*) > 1
-						ORDER BY `count` DESC"
+				// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names come from get_svns(), and an identifier cannot be a placeholder.
+				$details = $wpdb->get_results(
+					"SELECT prop_name, user_id, COUNT( distinct version ) as count,
+						group_concat( distinct version ORDER BY version ASC  SEPARATOR ', ' ) as versions,
+						ifnull(user_id,prop_name) as _groupby
+					FROM (
+						SELECT distinct LEFT(version, 3) as version, prop_name, p.user_id
+						FROM {$details['props_table']} p
+							JOIN {$details['rev_table']} r ON p.revision = r.id
+						GROUP BY prop_name, version
+						UNION
+						SELECT distinct LEFT(version, 3) as version, r.author as prop_name, u.ID as user_id
+						FROM {$details['rev_table']} r
+							JOIN {$wpdb->users} u ON r.author = u.user_login
+						GROUP BY r.author, version
+					) a
+					WHERE version != ''
+					group by _groupby HAVING COUNT(*) > 1
+					ORDER BY `count` DESC"
+				);
+				// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+				// Compress the versions list down to a smaller range.
+				$compress = function ( $versions ) {
+					$in = $versions;
+					$out = [];
+					if ( ! is_array( $versions ) ) {
+						$versions = preg_split( '![,\s]+!', $versions );
+					}
+
+					// Don't try to compress only a few versions.
+					if ( count( $versions ) <= 2 ) {
+						return $in;
+					}
+
+					// [ X.Y => 0, X.Y+1 => 1, ... ]
+					$versions = array_flip( $versions );
+
+					$not_a_version = [
+						'0.9', '1.1', '1.2', '1.4', '1.7', '1.8', '1.9',
+					];
+
+					// 2.4 + 2.5 are special. 2.4 was skipped, and many users only have a 2.4 or a 2.5 prop. Give them both versions if they have either.
+					if ( isset( $versions['2.5'] ) || isset( $versions['2.4'] ) ) {
+						$versions['2.5'] = 1;
+						$versions['2.4'] = 1;
+					}
+
+					$i = 0; // This counter is just here to protect against infinite loops should something go wrong.
+					while ( $versions && $i++ < 40 ) {
+						$min   = sprintf( '%.1f', min( array_keys( $versions ) ) );
+						$max   = sprintf( '%.1f', max( array_keys( $versions ) ) );
+						if ( $min === $max ) {
+							$out[] = $min;
+							break;
+						} elseif ( $max - $min < 0.2 ) {
+							$out[] = "{$min}-{$max}";
+							break;
+						}
+
+						foreach ( range( $min, $max + 0.1, 0.1 ) as $v ) {
+							$v = sprintf( '%.1f', $v );
+
+							if ( in_array( $v, $not_a_version ) ) {
+								unset( $versions[ $v ] );
+								continue;
+							}
+
+							if ( ! isset( $versions[ $v ] ) ) {
+								$last = sprintf( '%.1f', $v - 0.1 );
+
+								if ( $last == $min ) {
+									$out[] = $last;
+									unset( $versions[ $v ] );
+									break;
+								} elseif ( $last - $min < 0.15 ) {
+									// No point doing 1-2, just do 1, 2
+									$out[] = $min;
+									$out[] = $last;
+								} else {
+									$out[] = "{$min}-{$last}";
+								}
+								break;
+							} elseif ( $v == $max ) {
+								$out[] = "{$min}-{$max}"; // (5)";
+								unset( $versions[ $v ] );
+								break;
+							}
+
+							// No break above: we are between a start and an end version.
+							unset( $versions[ $v ] );
+						}
+					}
+
+					return implode( ', ', $out );
+				};
+
+				echo '<table class="widefat striped">';
+				echo '<thead><tr><th>Prop</th><th>Count</th><th>Versions</th></tr></thead>';
+				foreach ( $details as $p ) {
+					$link = add_query_arg(
+						[
+							'page' => str_replace( 'reports', 'edit', $_REQUEST['page'] ),
+							's' => $p->prop_name,
+						],
+						admin_url( 'admin.php' )
 					);
 
-					// Compress the versions list down to a smaller range.
-					$compress = function( $versions ) {
-						$in = $versions;
-						$out = [];
-						if ( ! is_array( $versions ) ) {
-							$versions = preg_split( '![,\s]+!', $versions );
-						}
+					$u = $p->user_id ? get_user_by( 'ID', $p->user_id ) : false;
 
-						// Don't try to compress only a few versions.
-						if ( count( $versions ) <= 2 ) {
-							return $in;
-						}
-
-						// [ X.Y => 0, X.Y+1 => 1, ... ]
-						$versions = array_flip( $versions );
-
-						$not_a_version = [
-							'0.9', '1.1', '1.2', '1.4', '1.7', '1.8', '1.9',
-						];
-
-						// 2.4 + 2.5 are special. 2.4 was skipped, and many users only have a 2.4 or a 2.5 prop. Give them both versions if they have either.
-						if ( isset( $versions['2.5'] ) || isset( $versions['2.4'] ) ) {
-							$versions['2.5'] = $version['2.4'] = 1;
-						}
-
-						$i = 0; // This counter is just here to protect against infinite loops should something go wrong.
-						while ( $versions && $i++ < 40 ) {
-							$min   = sprintf( '%.1f', min( array_keys( $versions ) ) );
-							$max   = sprintf( '%.1f', max( array_keys( $versions ) ) );
-							if ( $min === $max ) {
-								$out[] = $min;
-								break;
-							} elseif ( $max - $min < 0.2 ) {
-								$out[] = "{$min}-{$max}";
-								break;
-							}
-
-							foreach ( range( $min, $max+0.1, 0.1 ) as $v ) {
-								$v = sprintf( '%.1f', $v );
-
-								if ( in_array( $v, $not_a_version ) ) {
-									unset( $versions[ $v ] );
-									continue;
-								}
-
-								if ( ! isset( $versions[ $v ] ) ) {
-									$last = sprintf( '%.1f', $v - 0.1 );
-
-									if ( $last == $min ) {
-										$out[] = $last;
-										unset( $versions[ $v ] );
-										break;
-									} elseif ( $last - $min < 0.15 ) {
-										// No point doing 1-2, just do 1, 2
-										$out[] = $min;
-										$out[] = $last;
-									} else {
-										$out[] = "{$min}-{$last}";
-									}
-									break;
-								} elseif ( $v == $max ) {
-									$out[] = "{$min}-{$max}"; // (5)";
-									unset( $versions[ $v ] );
-									break;
-								} else {
-									// no break. We're between a start, and end version.
-								}
-								unset( $versions[ $v ] );
-							}
-						}
-
-						return implode( ', ', $out );
-					};
-
-					echo '<table class="widefat striped">';
-					echo '<thead><tr><th>Prop</th><th>Count</th><th>Versions</th></tr></thead>';
-					foreach ( $details as $p ) {
-						$link = add_query_arg(
-							[
-								'page' => str_replace( 'reports', 'edit', $_REQUEST['page'] ),
-								's' => $p->prop_name,
-							],
-							admin_url( 'admin.php' )
-						);
-	
-						$profile = esc_html( $p->prop_name );
-						$u       = $p->user_id ? get_user_by( 'ID', $p->user_id ) : false;
-
-						// The account a prop points at may since have been deleted; fall back to the stored name.
-						if ( $u ) {
-							$profile = sprintf(
-								'<a href="%s">%s</a>',
-								esc_url( 'https://profiles.wordpress.org/' . $u->user_nicename . '/' ),
-								esc_html( $u->display_name ?: $u->user_login )
-							);
-						}
-
+					// The account a prop points at may since have been deleted; fall back to the stored name.
+					if ( ! $u ) {
 						printf(
 							'<tr><td>%1$s</td><td>%2$s</td><td title="%3$s">%4$s</td></tr>',
-							$profile, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped when built above.
+							esc_html( $p->prop_name ),
 							esc_html( $p->count ),
 							esc_attr( $p->versions ),
 							esc_html( $compress( $p->versions ) )
 						);
+						continue;
 					}
-					echo '</table>';
 
-					break;
+					printf(
+						'<tr><td><a href="%1$s">%2$s</a></td><td>%3$s</td><td title="%4$s">%5$s</td></tr>',
+						esc_url( 'https://profiles.wordpress.org/' . $u->user_nicename . '/' ),
+						esc_html( $u->display_name ?: $u->user_login ),
+						esc_html( $p->count ),
+						esc_attr( $p->versions ),
+						esc_html( $compress( $p->versions ) )
+					);
+				}
+				echo '</table>';
+
+				break;
 			case 'typos':
 				$details = $wpdb->get_results(
 					"SELECT u.user_login, u.user_nicename, u.display_name,
@@ -432,9 +438,9 @@ function display_reports_page( $details ) {
 						esc_html( $c->prop_name ),
 						esc_html( $c->display_name ),
 						esc_html( $c->count ),
-						make_clickable( $c->user_nicename ? esc_url( 'https://profile.wordpress.org/' . $c->user_nicename . '/' ) : '' ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- URL escaped, make_clickable() returns markup.
+						wp_kses_post( make_clickable( $c->user_nicename ? 'https://profile.wordpress.org/' . $c->user_nicename . '/' : '' ) ),
 						$c->ID ? get_avatar( $c->ID, min( 96, absint( $_GET['size'] ?? 32 ) ) ) : '',
-						make_clickable( $c->ID ? get_avatar_url( $c->ID, [ 'size' => absint( $_GET['size'] ?? 64 ) ] ) : '' ) // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Generated URL, and the anchor text is meant to be copy-pasted as-is.
+						wp_kses_post( make_clickable( $c->ID ? get_avatar_url( $c->ID, [ 'size' => absint( $_GET['size'] ?? 64 ) ] ) : '' ) )
 					);
 				}
 				echo '</table>';

--- a/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/phpunit.xml.dist
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/phpunit.xml.dist
@@ -1,0 +1,11 @@
+<phpunit
+	bootstrap="phpunit/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	>
+	<testsuites>
+		<testsuite name="wporg-trac-watcher">
+			<directory suffix=".php">./phpunit/tests/</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/phpunit/bootstrap.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/phpunit/bootstrap.php
@@ -5,6 +5,8 @@
  * @package wporg-trac-watcher
  */
 
+declare( strict_types=1 );
+
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
 
 if ( ! $_tests_dir && file_exists( '/wordpress-phpunit/includes/functions.php' ) ) {
@@ -50,20 +52,6 @@ require_once dirname( __DIR__ ) . '/admin/ui.php';
  * call the same function register_activation_hook() would.
  */
 WordPressdotorg\Trac\Watcher\create_tables();
-
-/*
- * find_user_id() falls back to a GitHub username lookup against a table owned
- * by another part of dotorg. It isn't under test, but it has to exist or every
- * lookup emits a database error.
- */
-global $wpdb;
-$wpdb->query(
-	'CREATE TABLE IF NOT EXISTS `wporg_github_users` (
-		`user_id` bigint(20) NOT NULL,
-		`github_user` varchar(255) NOT NULL DEFAULT "",
-		PRIMARY KEY (`user_id`)
-	) ENGINE=InnoDB DEFAULT CHARSET=latin1;'
-);
 
 // Include the base test case.
 require __DIR__ . '/includes/testcase.php';

--- a/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/phpunit/bootstrap.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/phpunit/bootstrap.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * PHPUnit bootstrap file.
+ *
+ * @package wporg-trac-watcher
+ */
+
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
+
+if ( ! $_tests_dir && file_exists( '/wordpress-phpunit/includes/functions.php' ) ) {
+	// wp-env mounts the WordPress test suite here.
+	$_tests_dir = '/wordpress-phpunit/';
+} elseif ( ! $_tests_dir ) {
+	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib/tests/phpunit/';
+}
+
+if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
+	echo 'Could not find the WordPress test suite. Set WP_TESTS_DIR to its path.' . PHP_EOL;
+	exit( 1 );
+}
+
+// Set polyfills path if available (required by WP test suite).
+if ( ! defined( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' ) && file_exists( $_tests_dir . '/vendor/yoast/phpunit-polyfills' ) ) {
+	define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', $_tests_dir . '/vendor/yoast/phpunit-polyfills' );
+}
+
+// Give access to tests_add_filter() function.
+require_once $_tests_dir . '/includes/functions.php';
+
+/**
+ * Manually loads the plugin being tested.
+ */
+function wporg_trac_watcher_manually_load_plugin() {
+	require_once dirname( __DIR__ ) . '/trac-watch.php';
+}
+tests_add_filter( 'muplugins_loaded', 'wporg_trac_watcher_manually_load_plugin' );
+
+// Start up the WP testing environment.
+require $_tests_dir . '/includes/bootstrap.php';
+
+/*
+ * trac-watch.php only pulls the admin UI in under WP_ADMIN, and list-table.php
+ * needs WP_List_Table, so load the admin includes and then the UI directly.
+ */
+require_once ABSPATH . 'wp-admin/includes/admin.php';
+require_once dirname( __DIR__ ) . '/admin/ui.php';
+
+/*
+ * The plugin's own tables. Activation hooks don't run in the test suite, so
+ * call the same function register_activation_hook() would.
+ */
+WordPressdotorg\Trac\Watcher\create_tables();
+
+/*
+ * find_user_id() falls back to a GitHub username lookup against a table owned
+ * by another part of dotorg. It isn't under test, but it has to exist or every
+ * lookup emits a database error.
+ */
+global $wpdb;
+$wpdb->query(
+	'CREATE TABLE IF NOT EXISTS `wporg_github_users` (
+		`user_id` bigint(20) NOT NULL,
+		`github_user` varchar(255) NOT NULL DEFAULT "",
+		PRIMARY KEY (`user_id`)
+	) ENGINE=InnoDB DEFAULT CHARSET=latin1;'
+);
+
+// Include the base test case.
+require __DIR__ . '/includes/testcase.php';

--- a/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/phpunit/includes/testcase.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/phpunit/includes/testcase.php
@@ -1,0 +1,252 @@
+<?php
+/**
+ * Base test case for the Trac Watcher plugin.
+ *
+ * WordPress ships `WP_UnitTestCase`, but its `set_up()` calls
+ * `PHPUnit\Util\Test::parseTestMethodAnnotations()`, which PHPUnit 10 removed.
+ * WordPress has no PHPUnit 10+ compatible release, so extending it fails every
+ * test before a single assertion runs. This mirrors the approach the o2 Posting
+ * Access and handbook suites take.
+ *
+ * @package wporg-trac-watcher
+ */
+
+use PHPUnit\Framework\TestCase;
+use function WordPressdotorg\Trac\Watcher\SVN\get_svns;
+
+/**
+ * Provides WordPress fixtures plus revision and props seeding helpers.
+ */
+abstract class WPorg_Trac_Watcher_TestCase extends TestCase {
+
+	/**
+	 * Revision the seeding helpers operate on.
+	 */
+	const REVISION = 60001;
+
+	/**
+	 * Shared fixture factory.
+	 *
+	 * @var WP_UnitTest_Factory|null
+	 */
+	protected static $factory_instance = null;
+
+	/**
+	 * Hook globals captured before the first test, restored after each test.
+	 *
+	 * @var array
+	 */
+	protected static $hooks_saved = array();
+
+	/**
+	 * Fixture factory.
+	 *
+	 * @var WP_UnitTest_Factory
+	 */
+	protected $factory;
+
+	/**
+	 * Details for the core SVN, which every test uses.
+	 *
+	 * @var array
+	 */
+	protected $svn;
+
+	/**
+	 * Returns the fixture factory, creating it on first use.
+	 *
+	 * @return WP_UnitTest_Factory
+	 */
+	protected static function factory() {
+		if ( ! self::$factory_instance ) {
+			self::$factory_instance = new WP_UnitTest_Factory();
+		}
+
+		return self::$factory_instance;
+	}
+
+	/**
+	 * Prepares a clean WordPress state before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->factory = static::factory();
+		$this->svn     = get_svns()['core'];
+
+		if ( ! self::$hooks_saved ) {
+			$this->backup_hooks();
+		}
+
+		wp_cache_flush();
+
+		$this->start_transaction();
+
+		/*
+		 * The list table reads per_page off the current screen, and constructing
+		 * it at all needs a screen to convert. Without the option registered the
+		 * per_page lookup returns null and prepare_items() builds an invalid LIMIT.
+		 */
+		set_current_screen( 'toplevel_page_props-edit-core' );
+		get_current_screen()->add_option( 'per_page', array( 'default' => 100 ) );
+	}
+
+	/**
+	 * Rolls back database and global state after each test.
+	 */
+	public function tearDown(): void {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Transaction control has no caching or API equivalent.
+		$wpdb->query( 'ROLLBACK' );
+
+		$this->restore_hooks();
+
+		wp_set_current_user( 0 );
+
+		$_REQUEST = array();
+		$_POST    = array();
+		$_GET     = array();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Wraps the test in a transaction so database writes never persist.
+	 */
+	protected function start_transaction() {
+		global $wpdb;
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Transaction control has no caching or API equivalent.
+		$wpdb->query( 'SET autocommit = 0;' );
+		$wpdb->query( 'START TRANSACTION;' );
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+	}
+
+	/**
+	 * Snapshots the hook globals.
+	 */
+	protected function backup_hooks() {
+		self::$hooks_saved['wp_filter'] = array();
+
+		foreach ( $GLOBALS['wp_filter'] as $hook_name => $hook_object ) {
+			self::$hooks_saved['wp_filter'][ $hook_name ] = clone $hook_object;
+		}
+
+		foreach ( array( 'wp_actions', 'wp_filters', 'wp_current_filter' ) as $key ) {
+			self::$hooks_saved[ $key ] = $GLOBALS[ $key ] ?? array();
+		}
+	}
+
+	/**
+	 * Restores the hook globals from the snapshot.
+	 */
+	protected function restore_hooks() {
+		if ( ! isset( self::$hooks_saved['wp_filter'] ) ) {
+			return;
+		}
+
+		$GLOBALS['wp_filter'] = array();
+
+		foreach ( self::$hooks_saved['wp_filter'] as $hook_name => $hook_object ) {
+			$GLOBALS['wp_filter'][ $hook_name ] = clone $hook_object;
+		}
+
+		foreach ( array( 'wp_actions', 'wp_filters', 'wp_current_filter' ) as $key ) {
+			if ( isset( self::$hooks_saved[ $key ] ) ) {
+				$GLOBALS[ $key ] = self::$hooks_saved[ $key ];
+			}
+		}
+	}
+
+	/**
+	 * Inserts a revision for the tests to hang props off.
+	 *
+	 * @param string $message The commit message.
+	 * @return void
+	 */
+	protected function seed_revision( $message ) {
+		global $wpdb;
+
+		$wpdb->insert(
+			$this->svn['rev_table'],
+			array(
+				'id'      => self::REVISION,
+				'author'  => 'admin',
+				'date'    => '2026-07-01 12:00:00',
+				'summary' => 'Seeded revision.',
+				'message' => $message,
+				'branch'  => 'trunk',
+				'version' => '7.1',
+			)
+		);
+	}
+
+	/**
+	 * Inserts props against the seeded revision.
+	 *
+	 * @param array $props Map of prop name to user ID, or null when unresolved.
+	 * @return void
+	 */
+	protected function seed_props( array $props ) {
+		global $wpdb;
+
+		foreach ( $props as $prop_name => $user_id ) {
+			$wpdb->insert(
+				$this->svn['props_table'],
+				array(
+					'revision'  => self::REVISION,
+					'prop_name' => $prop_name,
+					'user_id'   => $user_id,
+				)
+			);
+		}
+	}
+
+	/**
+	 * Builds the item the list table renders, without going through the database.
+	 *
+	 * @param string $message The commit message.
+	 * @param array  $props   Map of prop name to user ID, or null when unresolved.
+	 * @return object
+	 */
+	protected function make_item( $message, array $props ) {
+		return (object) array(
+			'id'      => self::REVISION,
+			'author'  => 'admin',
+			'date'    => '2026-07-01 12:00:00',
+			'summary' => 'Seeded revision.',
+			'message' => $message,
+			'branch'  => 'trunk',
+			'version' => '7.1',
+			'props'   => $props,
+		);
+	}
+
+	/**
+	 * Renders a single column of the commits list table.
+	 *
+	 * @param object $item   The revision being rendered.
+	 * @param string $column The column name.
+	 * @return string
+	 */
+	protected function render_column( $item, $column ) {
+		$table = new WordPressdotorg\Trac\Watcher\Commits_List_Table( $this->svn );
+
+		return $table->column_default( $item, $column );
+	}
+
+	/**
+	 * Asserts that a value appears in the output as text rather than as live markup.
+	 *
+	 * Escaping only rewrites the angle brackets and the ampersand, so asserting on
+	 * the payload as a whole would match the escaped form too and pass either way.
+	 *
+	 * @param string $html The rendered output.
+	 * @return void
+	 */
+	protected function assertMarkupIsInert( $html ) {
+		$this->assertStringNotContainsString( '<img', $html, 'The stored value rendered as a live tag.' );
+		$this->assertStringContainsString( '&lt;img', $html, 'The stored value is missing, so the escaping assertion above would pass vacuously.' );
+	}
+}

--- a/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/phpunit/includes/testcase.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/phpunit/includes/testcase.php
@@ -11,6 +11,8 @@
  * @package wporg-trac-watcher
  */
 
+declare( strict_types=1 );
+
 use PHPUnit\Framework\TestCase;
 use function WordPressdotorg\Trac\Watcher\SVN\get_svns;
 
@@ -29,35 +31,35 @@ abstract class WPorg_Trac_Watcher_TestCase extends TestCase {
 	 *
 	 * @var WP_UnitTest_Factory|null
 	 */
-	protected static $factory_instance = null;
+	protected static ?WP_UnitTest_Factory $factory_instance = null;
 
 	/**
 	 * Hook globals captured before the first test, restored after each test.
 	 *
 	 * @var array
 	 */
-	protected static $hooks_saved = array();
+	protected static array $hooks_saved = array();
 
 	/**
 	 * Fixture factory.
 	 *
 	 * @var WP_UnitTest_Factory
 	 */
-	protected $factory;
+	protected WP_UnitTest_Factory $factory;
 
 	/**
 	 * Details for the core SVN, which every test uses.
 	 *
 	 * @var array
 	 */
-	protected $svn;
+	protected array $svn;
 
 	/**
 	 * Returns the fixture factory, creating it on first use.
 	 *
 	 * @return WP_UnitTest_Factory
 	 */
-	protected static function factory() {
+	protected static function factory(): WP_UnitTest_Factory {
 		if ( ! self::$factory_instance ) {
 			self::$factory_instance = new WP_UnitTest_Factory();
 		}
@@ -114,7 +116,7 @@ abstract class WPorg_Trac_Watcher_TestCase extends TestCase {
 	/**
 	 * Wraps the test in a transaction so database writes never persist.
 	 */
-	protected function start_transaction() {
+	protected function start_transaction(): void {
 		global $wpdb;
 
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Transaction control has no caching or API equivalent.
@@ -126,7 +128,7 @@ abstract class WPorg_Trac_Watcher_TestCase extends TestCase {
 	/**
 	 * Snapshots the hook globals.
 	 */
-	protected function backup_hooks() {
+	protected function backup_hooks(): void {
 		self::$hooks_saved['wp_filter'] = array();
 
 		foreach ( $GLOBALS['wp_filter'] as $hook_name => $hook_object ) {
@@ -141,7 +143,7 @@ abstract class WPorg_Trac_Watcher_TestCase extends TestCase {
 	/**
 	 * Restores the hook globals from the snapshot.
 	 */
-	protected function restore_hooks() {
+	protected function restore_hooks(): void {
 		if ( ! isset( self::$hooks_saved['wp_filter'] ) ) {
 			return;
 		}
@@ -165,9 +167,10 @@ abstract class WPorg_Trac_Watcher_TestCase extends TestCase {
 	 * @param string $message The commit message.
 	 * @return void
 	 */
-	protected function seed_revision( $message ) {
+	protected function seed_revision( string $message ): void {
 		global $wpdb;
 
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Seeding the plugin's own table, which has no API or caching layer.
 		$wpdb->insert(
 			$this->svn['rev_table'],
 			array(
@@ -188,10 +191,11 @@ abstract class WPorg_Trac_Watcher_TestCase extends TestCase {
 	 * @param array $props Map of prop name to user ID, or null when unresolved.
 	 * @return void
 	 */
-	protected function seed_props( array $props ) {
+	protected function seed_props( array $props ): void {
 		global $wpdb;
 
 		foreach ( $props as $prop_name => $user_id ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Seeding the plugin's own table, which has no API or caching layer.
 			$wpdb->insert(
 				$this->svn['props_table'],
 				array(
@@ -210,7 +214,7 @@ abstract class WPorg_Trac_Watcher_TestCase extends TestCase {
 	 * @param array  $props   Map of prop name to user ID, or null when unresolved.
 	 * @return object
 	 */
-	protected function make_item( $message, array $props ) {
+	protected function make_item( string $message, array $props ): object {
 		return (object) array(
 			'id'      => self::REVISION,
 			'author'  => 'admin',
@@ -230,7 +234,7 @@ abstract class WPorg_Trac_Watcher_TestCase extends TestCase {
 	 * @param string $column The column name.
 	 * @return string
 	 */
-	protected function render_column( $item, $column ) {
+	protected function render_column( object $item, string $column ): string {
 		$table = new WordPressdotorg\Trac\Watcher\Commits_List_Table( $this->svn );
 
 		return $table->column_default( $item, $column );
@@ -245,7 +249,7 @@ abstract class WPorg_Trac_Watcher_TestCase extends TestCase {
 	 * @param string $html The rendered output.
 	 * @return void
 	 */
-	protected function assertMarkupIsInert( $html ) {
+	protected function assertMarkupIsInert( string $html ): void {
 		$this->assertStringNotContainsString( '<img', $html, 'The stored value rendered as a live tag.' );
 		$this->assertStringContainsString( '&lt;img', $html, 'The stored value is missing, so the escaping assertion above would pass vacuously.' );
 	}

--- a/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/phpunit/includes/testcase.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/phpunit/includes/testcase.php
@@ -104,6 +104,7 @@ abstract class WPorg_Trac_Watcher_TestCase extends TestCase {
 
 		$this->restore_hooks();
 
+		set_current_screen( 'front' );
 		wp_set_current_user( 0 );
 
 		$_REQUEST = array();

--- a/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/phpunit/tests/WPorg_Trac_Watcher_Props_Save_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/phpunit/tests/WPorg_Trac_Watcher_Props_Save_Test.php
@@ -1,0 +1,127 @@
+<?php // phpcs:disable WordPress.Files.FileName.NotHyphenatedLowercase -- PHPUnit only finds a test class in a file named after it.
+/**
+ * Tests for the props save handler.
+ *
+ * The handler's rejection paths call die() rather than wp_die(), so they cannot
+ * be exercised in process -- a refused request would take the test runner down
+ * with it. What the capability actually gates is covered from the rendering side
+ * instead, in WPorg_Trac_Watcher_Rendering_Test.
+ *
+ * @package wporg-trac-watcher
+ */
+
+defined( 'ABSPATH' ) || die();
+
+/**
+ * Covers what reaches the database when a prop is added or edited.
+ */
+class WPorg_Trac_Watcher_Props_Save_Test extends WPorg_Trac_Watcher_TestCase {
+
+	/**
+	 * Signs the request in as someone the handler will accept.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$this->seed_revision( 'Fix the thing.' );
+	}
+
+	/**
+	 * Runs the save handler with the given request.
+	 *
+	 * @param array $request Request arguments, merged over the required ones.
+	 * @return void
+	 */
+	protected function save( array $request ) {
+		$_REQUEST = array_merge(
+			array(
+				'svn'      => 'core',
+				'revision' => self::REVISION,
+				'user_id'  => '',
+				'_wpnonce' => wp_create_nonce( 'edit_svn_prop' ),
+			),
+			$request
+		);
+
+		// The handler ends by echoing the replacement row.
+		ob_start();
+		do_action( 'admin_post_svn_save' );
+		ob_end_clean();
+	}
+
+	/**
+	 * Returns the prop names stored against the seeded revision.
+	 *
+	 * @return string[]
+	 */
+	protected function stored_prop_names() {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Table name comes from get_svns(), and the plugin's tables have no caching layer.
+		return $wpdb->get_col( $wpdb->prepare( "SELECT prop_name FROM {$this->svn['props_table']} WHERE revision = %d", self::REVISION ) );
+	}
+
+	/**
+	 * Markup submitted as a new prop name is stripped before it is stored.
+	 */
+	public function test_adding_a_prop_strips_markup_from_the_name() {
+		$this->save(
+			array(
+				'what'      => 'add',
+				'prop_name' => 'alice<img src=x onerror=alert(1)>',
+			)
+		);
+
+		$this->assertSame( array( 'alice' ), $this->stored_prop_names() );
+	}
+
+	/**
+	 * The name also falls back to the user_id field when the first is left blank,
+	 * which is a second way the same value reaches the table.
+	 */
+	public function test_adding_a_prop_strips_markup_from_the_fallback_field() {
+		$this->save(
+			array(
+				'what'      => 'add',
+				'prop_name' => '',
+				'user_id'   => 'bobby<b>x</b>',
+			)
+		);
+
+		$this->assertSame( array( 'bobbyx' ), $this->stored_prop_names() );
+	}
+
+	/**
+	 * Editing an existing prop goes through a separate assignment.
+	 */
+	public function test_editing_a_prop_strips_markup_from_the_name() {
+		$this->seed_props( array( 'bobby' => null ) );
+
+		$this->save(
+			array(
+				'what'           => 'edit',
+				'prop_name_orig' => 'bobby',
+				'prop_name'      => 'robert<img src=x onerror=alert(1)>',
+			)
+		);
+
+		$this->assertSame( array( 'robert' ), $this->stored_prop_names() );
+	}
+
+	/**
+	 * Sanitising on the way in does not make the output escaping redundant: rows
+	 * predating it are still in the table, so the renderer has to hold on its own.
+	 */
+	public function test_a_row_that_predates_sanitisation_still_renders_inert() {
+		$this->seed_props( array( '<img src=x onerror=alert(1)>' => null ) );
+
+		$table = new WordPressdotorg\Trac\Watcher\Commits_List_Table( $this->svn );
+		$table->prepare_items( array( 'revision' => self::REVISION ) );
+
+		$this->assertNotEmpty( $table->items, 'The seeded revision was not loaded, so nothing was rendered.' );
+
+		$this->assertMarkupIsInert( $table->column_default( $table->items[0], 'props' ) );
+	}
+}

--- a/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/phpunit/tests/WPorg_Trac_Watcher_Props_Save_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/phpunit/tests/WPorg_Trac_Watcher_Props_Save_Test.php
@@ -10,6 +10,8 @@
  * @package wporg-trac-watcher
  */
 
+declare( strict_types=1 );
+
 defined( 'ABSPATH' ) || die();
 
 /**
@@ -34,7 +36,7 @@ class WPorg_Trac_Watcher_Props_Save_Test extends WPorg_Trac_Watcher_TestCase {
 	 * @param array $request Request arguments, merged over the required ones.
 	 * @return void
 	 */
-	protected function save( array $request ) {
+	protected function save( array $request ): void {
 		$_REQUEST = array_merge(
 			array(
 				'svn'      => 'core',
@@ -56,7 +58,7 @@ class WPorg_Trac_Watcher_Props_Save_Test extends WPorg_Trac_Watcher_TestCase {
 	 *
 	 * @return string[]
 	 */
-	protected function stored_prop_names() {
+	protected function stored_prop_names(): array {
 		global $wpdb;
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Table name comes from get_svns(), and the plugin's tables have no caching layer.
@@ -66,7 +68,7 @@ class WPorg_Trac_Watcher_Props_Save_Test extends WPorg_Trac_Watcher_TestCase {
 	/**
 	 * Markup submitted as a new prop name is stripped before it is stored.
 	 */
-	public function test_adding_a_prop_strips_markup_from_the_name() {
+	public function test_adding_a_prop_strips_markup_from_the_name(): void {
 		$this->save(
 			array(
 				'what'      => 'add',
@@ -81,7 +83,7 @@ class WPorg_Trac_Watcher_Props_Save_Test extends WPorg_Trac_Watcher_TestCase {
 	 * The name also falls back to the user_id field when the first is left blank,
 	 * which is a second way the same value reaches the table.
 	 */
-	public function test_adding_a_prop_strips_markup_from_the_fallback_field() {
+	public function test_adding_a_prop_strips_markup_from_the_fallback_field(): void {
 		$this->save(
 			array(
 				'what'      => 'add',
@@ -96,7 +98,7 @@ class WPorg_Trac_Watcher_Props_Save_Test extends WPorg_Trac_Watcher_TestCase {
 	/**
 	 * Editing an existing prop goes through a separate assignment.
 	 */
-	public function test_editing_a_prop_strips_markup_from_the_name() {
+	public function test_editing_a_prop_strips_markup_from_the_name(): void {
 		$this->seed_props( array( 'bobby' => null ) );
 
 		$this->save(
@@ -114,7 +116,7 @@ class WPorg_Trac_Watcher_Props_Save_Test extends WPorg_Trac_Watcher_TestCase {
 	 * Sanitising on the way in does not make the output escaping redundant: rows
 	 * predating it are still in the table, so the renderer has to hold on its own.
 	 */
-	public function test_a_row_that_predates_sanitisation_still_renders_inert() {
+	public function test_a_row_that_predates_sanitisation_still_renders_inert(): void {
 		$this->seed_props( array( '<img src=x onerror=alert(1)>' => null ) );
 
 		$table = new WordPressdotorg\Trac\Watcher\Commits_List_Table( $this->svn );

--- a/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/phpunit/tests/WPorg_Trac_Watcher_Rendering_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/phpunit/tests/WPorg_Trac_Watcher_Rendering_Test.php
@@ -1,0 +1,176 @@
+<?php // phpcs:disable WordPress.Files.FileName.NotHyphenatedLowercase -- PHPUnit only finds a test class in a file named after it.
+/**
+ * Tests for how the commits list table renders stored props.
+ *
+ * @package wporg-trac-watcher
+ */
+
+defined( 'ABSPATH' ) || die();
+
+/**
+ * Covers the props and message columns, which interpolate a stored prop name
+ * that anyone able to reach the save handler controls.
+ */
+class WPorg_Trac_Watcher_Rendering_Test extends WPorg_Trac_Watcher_TestCase {
+
+	/**
+	 * A prop name carrying markup.
+	 *
+	 * @var string
+	 */
+	const MARKUP_PROP = '<img src=x onerror=alert(1)>';
+
+	/**
+	 * A user the props resolve to.
+	 *
+	 * @var int
+	 */
+	protected $alice;
+
+	/**
+	 * Creates the user the resolvable props map to.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->alice = $this->factory()->user->create(
+			array(
+				'user_login'   => 'alice',
+				'display_name' => 'Alice Example',
+				'role'         => 'editor',
+			)
+		);
+	}
+
+	/*
+	 * The props column.
+	 */
+
+	/**
+	 * An unresolved prop is the case the screen exists to let people fix, so it is
+	 * the branch a stored value is most likely to reach.
+	 */
+	public function test_props_column_escapes_an_unresolved_prop_name() {
+		$item = $this->make_item( 'Fix the thing.', array( self::MARKUP_PROP => null ) );
+
+		$this->assertMarkupIsInert( $this->render_column( $item, 'props' ) );
+	}
+
+	/**
+	 * The name is also written into a data attribute the edit dialog reads back.
+	 */
+	public function test_props_column_escapes_the_prop_data_attribute() {
+		$item = $this->make_item( 'Fix the thing.', array( self::MARKUP_PROP => null ) );
+
+		$this->assertStringContainsString(
+			'data-prop="&lt;img src=x onerror=alert(1)&gt;"',
+			$this->render_column( $item, 'props' )
+		);
+	}
+
+	/**
+	 * A resolved prop renders the account's display name instead of the stored name.
+	 */
+	public function test_props_column_escapes_a_display_name() {
+		global $wpdb;
+
+		/*
+		 * wp_insert_user() runs display_name through sanitize_text_field(), so the
+		 * fixture has to be written directly to represent data that predates it or
+		 * arrived from profiles.
+		 */
+		$wpdb->update( $wpdb->users, array( 'display_name' => '<b>Alice</b>' ), array( 'ID' => $this->alice ) );
+		clean_user_cache( $this->alice );
+
+		$this->assertSame(
+			'<b>Alice</b>',
+			get_user_by( 'ID', $this->alice )->display_name,
+			'The fixture did not take, so the escaping assertion below would pass vacuously.'
+		);
+
+		$output = $this->render_column( $this->make_item( 'Fix the thing.', array( 'alice' => $this->alice ) ), 'props' );
+
+		$this->assertStringNotContainsString( '<b>Alice</b>', $output );
+		$this->assertStringContainsString( '&lt;b&gt;Alice&lt;/b&gt;', $output );
+	}
+
+	/*
+	 * The message column.
+	 */
+
+	/**
+	 * A prop absent from the commit message is appended as a "missed" note, which
+	 * happens after format_trac_markup() has already escaped the message.
+	 */
+	public function test_message_column_escapes_a_missed_prop() {
+		$item = $this->make_item( 'Fix the thing.', array( self::MARKUP_PROP => null ) );
+
+		$output = $this->render_column( $item, 'message' );
+
+		$this->assertStringContainsString( 'Missed Prop:', $output, 'The prop did not take the missed-prop branch.' );
+		$this->assertMarkupIsInert( $output );
+	}
+
+	/**
+	 * Guards the escaping change in the message column: the prop is escaped before
+	 * it is matched against the message, so an ordinary name has to still match.
+	 */
+	public function test_message_column_still_highlights_a_matching_prop() {
+		$item = $this->make_item( 'Fix the thing. Props alice.', array( 'alice' => $this->alice ) );
+
+		$this->assertStringContainsString( '<ins>alice</ins>', $this->render_column( $item, 'message' ) );
+	}
+
+	/**
+	 * A prop that resolves to an account under a different name is shown as a typo.
+	 */
+	public function test_message_column_marks_a_mis_propped_name() {
+		$item = $this->make_item( 'Fix the thing. Props Aliec.', array( 'Aliec' => $this->alice ) );
+
+		$this->assertStringContainsString(
+			"<del class='replace'>Aliec</del><ins>alice</ins>",
+			$this->render_column( $item, 'message' )
+		);
+	}
+
+	/**
+	 * An unresolved prop that does appear in the message is struck through in place,
+	 * which is the other branch that interpolates the stored name.
+	 */
+	public function test_message_column_escapes_a_prop_present_in_the_message() {
+		$item = $this->make_item( 'Fix the thing. Props ' . self::MARKUP_PROP . '.', array( self::MARKUP_PROP => null ) );
+
+		$this->assertMarkupIsInert( $this->render_column( $item, 'message' ) );
+	}
+
+	/*
+	 * The edit affordances.
+	 */
+
+	/**
+	 * The edit links have to track what the save handler will actually accept,
+	 * otherwise the UI offers an action that fails.
+	 */
+	public function test_props_column_offers_editing_to_a_user_who_can_edit_others_posts() {
+		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$output = $this->render_column( $this->make_item( 'Fix the thing.', array( 'bobby' => null ) ), 'props' );
+
+		$this->assertStringContainsString( 'class="edit dashicons', $output );
+	}
+
+	/**
+	 * An author holds publish_posts, which is what the handler used to require.
+	 */
+	public function test_props_column_withholds_editing_from_an_author() {
+		$author = $this->factory()->user->create( array( 'role' => 'author' ) );
+		wp_set_current_user( $author );
+
+		$this->assertTrue( user_can( $author, 'publish_posts' ), 'The fixture no longer represents the role that used to pass the old check.' );
+
+		$output = $this->render_column( $this->make_item( 'Fix the thing.', array( 'bobby' => null ) ), 'props' );
+
+		$this->assertStringNotContainsString( 'class="edit dashicons', $output );
+		$this->assertStringNotContainsString( 'class="reparse"', $output );
+	}
+}

--- a/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/phpunit/tests/WPorg_Trac_Watcher_Rendering_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/phpunit/tests/WPorg_Trac_Watcher_Rendering_Test.php
@@ -5,6 +5,8 @@
  * @package wporg-trac-watcher
  */
 
+declare( strict_types=1 );
+
 defined( 'ABSPATH' ) || die();
 
 /**
@@ -25,7 +27,7 @@ class WPorg_Trac_Watcher_Rendering_Test extends WPorg_Trac_Watcher_TestCase {
 	 *
 	 * @var int
 	 */
-	protected $alice;
+	protected int $alice;
 
 	/**
 	 * Creates the user the resolvable props map to.
@@ -50,7 +52,7 @@ class WPorg_Trac_Watcher_Rendering_Test extends WPorg_Trac_Watcher_TestCase {
 	 * An unresolved prop is the case the screen exists to let people fix, so it is
 	 * the branch a stored value is most likely to reach.
 	 */
-	public function test_props_column_escapes_an_unresolved_prop_name() {
+	public function test_props_column_escapes_an_unresolved_prop_name(): void {
 		$item = $this->make_item( 'Fix the thing.', array( self::MARKUP_PROP => null ) );
 
 		$this->assertMarkupIsInert( $this->render_column( $item, 'props' ) );
@@ -59,7 +61,7 @@ class WPorg_Trac_Watcher_Rendering_Test extends WPorg_Trac_Watcher_TestCase {
 	/**
 	 * The name is also written into a data attribute the edit dialog reads back.
 	 */
-	public function test_props_column_escapes_the_prop_data_attribute() {
+	public function test_props_column_escapes_the_prop_data_attribute(): void {
 		$item = $this->make_item( 'Fix the thing.', array( self::MARKUP_PROP => null ) );
 
 		$this->assertStringContainsString(
@@ -71,7 +73,7 @@ class WPorg_Trac_Watcher_Rendering_Test extends WPorg_Trac_Watcher_TestCase {
 	/**
 	 * A resolved prop renders the account's display name instead of the stored name.
 	 */
-	public function test_props_column_escapes_a_display_name() {
+	public function test_props_column_escapes_a_display_name(): void {
 		global $wpdb;
 
 		/*
@@ -79,6 +81,7 @@ class WPorg_Trac_Watcher_Rendering_Test extends WPorg_Trac_Watcher_TestCase {
 		 * fixture has to be written directly to represent data that predates it or
 		 * arrived from profiles.
 		 */
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Deliberately bypassing wp_update_user(), which would sanitise the fixture away.
 		$wpdb->update( $wpdb->users, array( 'display_name' => '<b>Alice</b>' ), array( 'ID' => $this->alice ) );
 		clean_user_cache( $this->alice );
 
@@ -102,7 +105,7 @@ class WPorg_Trac_Watcher_Rendering_Test extends WPorg_Trac_Watcher_TestCase {
 	 * A prop absent from the commit message is appended as a "missed" note, which
 	 * happens after format_trac_markup() has already escaped the message.
 	 */
-	public function test_message_column_escapes_a_missed_prop() {
+	public function test_message_column_escapes_a_missed_prop(): void {
 		$item = $this->make_item( 'Fix the thing.', array( self::MARKUP_PROP => null ) );
 
 		$output = $this->render_column( $item, 'message' );
@@ -115,7 +118,7 @@ class WPorg_Trac_Watcher_Rendering_Test extends WPorg_Trac_Watcher_TestCase {
 	 * Guards the escaping change in the message column: the prop is escaped before
 	 * it is matched against the message, so an ordinary name has to still match.
 	 */
-	public function test_message_column_still_highlights_a_matching_prop() {
+	public function test_message_column_still_highlights_a_matching_prop(): void {
 		$item = $this->make_item( 'Fix the thing. Props alice.', array( 'alice' => $this->alice ) );
 
 		$this->assertStringContainsString( '<ins>alice</ins>', $this->render_column( $item, 'message' ) );
@@ -124,7 +127,7 @@ class WPorg_Trac_Watcher_Rendering_Test extends WPorg_Trac_Watcher_TestCase {
 	/**
 	 * A prop that resolves to an account under a different name is shown as a typo.
 	 */
-	public function test_message_column_marks_a_mis_propped_name() {
+	public function test_message_column_marks_a_mis_propped_name(): void {
 		$item = $this->make_item( 'Fix the thing. Props Aliec.', array( 'Aliec' => $this->alice ) );
 
 		$this->assertStringContainsString(
@@ -137,7 +140,7 @@ class WPorg_Trac_Watcher_Rendering_Test extends WPorg_Trac_Watcher_TestCase {
 	 * An unresolved prop that does appear in the message is struck through in place,
 	 * which is the other branch that interpolates the stored name.
 	 */
-	public function test_message_column_escapes_a_prop_present_in_the_message() {
+	public function test_message_column_escapes_a_prop_present_in_the_message(): void {
 		$item = $this->make_item( 'Fix the thing. Props ' . self::MARKUP_PROP . '.', array( self::MARKUP_PROP => null ) );
 
 		$this->assertMarkupIsInert( $this->render_column( $item, 'message' ) );
@@ -151,7 +154,7 @@ class WPorg_Trac_Watcher_Rendering_Test extends WPorg_Trac_Watcher_TestCase {
 	 * The edit links have to track what the save handler will actually accept,
 	 * otherwise the UI offers an action that fails.
 	 */
-	public function test_props_column_offers_editing_to_a_user_who_can_edit_others_posts() {
+	public function test_props_column_offers_editing_to_a_user_who_can_edit_others_posts(): void {
 		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'editor' ) ) );
 
 		$output = $this->render_column( $this->make_item( 'Fix the thing.', array( 'bobby' => null ) ), 'props' );
@@ -162,7 +165,7 @@ class WPorg_Trac_Watcher_Rendering_Test extends WPorg_Trac_Watcher_TestCase {
 	/**
 	 * An author holds publish_posts, which is what the handler used to require.
 	 */
-	public function test_props_column_withholds_editing_from_an_author() {
+	public function test_props_column_withholds_editing_from_an_author(): void {
 		$author = $this->factory()->user->create( array( 'role' => 'author' ) );
 		wp_set_current_user( $author );
 

--- a/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/svn.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/svn.php
@@ -101,8 +101,11 @@ function import_revisions( $svn ) {
 		(int) MAX_REVISIONS
 	);
 
+	// shell_exec() returns null when the command can't be run at all, which simplexml_load_string() won't accept.
+	$log = shell_exec( $command );
+
 	$xml_internal_errors = libxml_use_internal_errors( true );
-	$xml                 = simplexml_load_string( shell_exec( $command ) );
+	$xml                 = $log ? simplexml_load_string( $log ) : false;
 	libxml_use_internal_errors( $xml_internal_errors );
 
 	if ( ! $xml ) {

--- a/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/trac-watch.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/trac-watch.php
@@ -48,6 +48,8 @@ add_action( 'admin_init', function() {
  */
 register_activation_hook( __FILE__, __NAMESPACE__ . '\create_tables' );
 function create_tables() {
+	global $wpdb;
+
 	$trac_table = "CREATE TABLE IF NOT EXISTS `%s` (
 		`id` int(11) NOT NULL AUTO_INCREMENT,
 		`description` longtext NOT NULL,


### PR DESCRIPTION
An escaping and tidy-up pass over the Trac Watcher admin screens, plus the test coverage the plugin was missing. 

### Escape output in the list table and reports

The props and message columns, and most of the reports, interpolated stored prop names, display names and profile URLs into HTML unescaped — in several cases alongside a sibling `esc_attr()` on the same value in the same `sprintf()`.

The message column needed a little care rather than a blanket wrap: `format_trac_markup()` has already run the message through `esc_html()` by the time the props loop runs, so the prop is now escaped *before* it is matched against the message and before it is inserted. For ordinary alphanumeric prop names `esc_html()` is a no-op, so matching and highlighting are unchanged; names containing markup never matched before either.

Prop names also now go through `sanitize_text_field()` on save. That only helps new rows, so the output escaping is doing the real work.

### Require `edit_others_posts` to alter props records

The save and reparse handlers, and the edit affordances in the props column, checked `publish_posts`. On the make sites o2 Posting Access grants that to every logged-in account that isn't a member of the blog, so it wasn't gating much. Editing props rewrites attribution on someone else's commit, which feeds the release credits and profile badges.

Viewing the screen still only needs `edit_posts`.

> **Before this deploys:** anyone doing props wrangling without Editor on the make site loses write access unless the capability is granted to them first. The previous check was broad enough that the working set was never expressed as a role, so it isn't derivable from the repo.

### Fix several PHP warnings

- `create_tables()` used `$wpdb` without importing it, so activation fatalled outright.
- `import_revisions()` passed `shell_exec()`'s return straight to `simplexml_load_string()`, which is `null` whenever the command can't run.
- The props cloud read `$r->id` and never set a slug, both of which `wp_generate_tag_cloud()` expects.
- The typos report rendered `$c->display_name` without selecting the column — the `WHERE` clause already referenced it.

### Add a PHPUnit suite

Follows the layout the o2 Posting Access suite uses and runs off the same make wp-env config. Covers both branches that interpolate a stored prop name, that an ordinary prop is still matched and highlighted after the escaping change, that names are stripped on all three write paths, and that the edit affordances track the capability the handler enforces.

The handler's rejection paths call `die()` rather than `wp_die()`, so a refused request would take the runner down with it; what the capability gates is asserted from the rendering side instead.

`environments/make/.wp-env.test.json` picks up the plugin and defines `WP_CORE_LATEST_RELEASE`, which the reports page reads unguarded when choosing its default version filter.

### Testing

- 13 tests, 23 assertions, green.
- Mutation-checked rather than just run: reverting each change individually fails the suite — props column escaping (3 failures), the message-column escaping order (2), `sanitize_text_field()` (3), and the capability (1). Three tests carry explicit guards against passing vacuously.
- Existing o2 Posting Access suite still passes (32 tests) against the shared config.
- Manually exercised on wp-env across all seven report views and all four props screens: no PHP notices, an unresolved prop containing markup renders inert, and an Author-role account can view the screen but sees no edit affordances and gets `-1` from a direct POST.
- `phpcs` on the touched files drops from 160 to 118 pre-existing violations; nothing new introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
