### PR TITLE
Trac Watcher: Cover the reports page escaping with tests

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/phpunit/bootstrap.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/phpunit/bootstrap.php
@@ -5,7 +5,7 @@
  * @package wporg-trac-watcher
  */
 
-declare( strict_types=1 );
+declare( strict_types = 1 );
 
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
 

--- a/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/phpunit/bootstrap.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/phpunit/bootstrap.php
@@ -46,6 +46,7 @@ require $_tests_dir . '/includes/bootstrap.php';
  */
 require_once ABSPATH . 'wp-admin/includes/admin.php';
 require_once dirname( __DIR__ ) . '/admin/ui.php';
+require_once dirname( __DIR__ ) . '/admin/reports-page.php';
 
 /*
  * The plugin's own tables. Activation hooks don't run in the test suite, so

--- a/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/phpunit/includes/testcase.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/phpunit/includes/testcase.php
@@ -11,7 +11,7 @@
  * @package wporg-trac-watcher
  */
 
-declare( strict_types=1 );
+declare( strict_types = 1 );
 
 use PHPUnit\Framework\TestCase;
 use function WordPressdotorg\Trac\Watcher\SVN\get_svns;

--- a/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/phpunit/tests/WPorg_Trac_Watcher_Props_Save_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/phpunit/tests/WPorg_Trac_Watcher_Props_Save_Test.php
@@ -10,7 +10,7 @@
  * @package wporg-trac-watcher
  */
 
-declare( strict_types=1 );
+declare( strict_types = 1 );
 
 defined( 'ABSPATH' ) || die();
 

--- a/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/phpunit/tests/WPorg_Trac_Watcher_Rendering_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/phpunit/tests/WPorg_Trac_Watcher_Rendering_Test.php
@@ -5,7 +5,7 @@
  * @package wporg-trac-watcher
  */
 
-declare( strict_types=1 );
+declare( strict_types = 1 );
 
 defined( 'ABSPATH' ) || die();
 

--- a/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/phpunit/tests/WPorg_Trac_Watcher_Reports_Page_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/phpunit/tests/WPorg_Trac_Watcher_Reports_Page_Test.php
@@ -1,0 +1,163 @@
+<?php // phpcs:disable WordPress.Files.FileName.NotHyphenatedLowercase -- PHPUnit only finds a test class in a file named after it.
+/**
+ * Tests for how the reports page renders request data into its own links.
+ *
+ * @package wporg-trac-watcher
+ */
+
+declare( strict_types = 1 );
+
+defined( 'ABSPATH' ) || die();
+
+use function WordPressdotorg\Trac\Watcher\display_reports_page;
+
+/**
+ * Covers the report links, which are built out of the request with
+ * add_query_arg() and then echoed into an href.
+ *
+ * Only the query string already on the base URL gets encoded on the way through:
+ * the arguments handed to add_query_arg() reach build_query(), which calls
+ * _http_build_query() with $urlencode false, and that skips urlencode() on keys
+ * and values alike. What comes back is as tainted as what went in, so it still
+ * needs escaping at the sink.
+ */
+class WPorg_Trac_Watcher_Reports_Page_Test extends WPorg_Trac_Watcher_TestCase {
+
+	/**
+	 * A request value that closes the href and opens a tag of its own.
+	 *
+	 * @var string
+	 */
+	const MARKUP_VALUE = '"><img src=x onerror=alert(1)>';
+
+	/**
+	 * The slug the reports screen is registered under for core.
+	 *
+	 * @var string
+	 */
+	const PAGE = 'props-reports-core';
+
+	/**
+	 * Renders the reports page for core.
+	 *
+	 * @return string
+	 */
+	protected function render_reports_page(): string {
+		ob_start();
+		display_reports_page( $this->svn );
+
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * Returns the href of every report link on the page.
+	 *
+	 * The report links are the ones carrying a `what` argument, which separates
+	 * them from the profile links the individual reports render.
+	 *
+	 * @param string $html The rendered page.
+	 * @return string[]
+	 */
+	protected function get_report_hrefs( string $html ): array {
+		preg_match_all( '/href="([^"]*what=[^"]*)"/', $html, $matches );
+
+		return $matches[1];
+	}
+
+	/*
+	 * The report links.
+	 */
+
+	/**
+	 * The version is the only free-form argument that reaches the links, so it is
+	 * the one an attacker-supplied URL would carry.
+	 */
+	public function test_report_links_escape_a_version_from_the_request(): void {
+		$_REQUEST['page']    = self::PAGE;
+		$_REQUEST['version'] = self::MARKUP_VALUE;
+
+		$output = $this->render_reports_page();
+
+		/*
+		 * The guard has to hold whether or not the escaping does, otherwise it fails
+		 * first on the very output it exists to rule out and reports the wrong thing.
+		 * The label is in the template either way; only the ampersand before it moves.
+		 */
+		$this->assertStringContainsString(
+			'what=contributors',
+			$output,
+			'The page rendered no report links, so the assertions below would pass vacuously.'
+		);
+		$this->assertStringNotContainsString( '<img', $output, 'The version broke out of the href and became a live tag.' );
+		$this->assertStringNotContainsString( 'onerror=alert(1)>', $output, 'The version kept a usable event handler.' );
+	}
+
+	/**
+	 * Guards the test above against passing because the version never reaches the
+	 * links at all: an ordinary version has to still survive into every one of them.
+	 */
+	public function test_report_links_carry_an_ordinary_version(): void {
+		$_REQUEST['page']    = self::PAGE;
+		$_REQUEST['version'] = '7.1';
+
+		$hrefs = $this->get_report_hrefs( $this->render_reports_page() );
+
+		$this->assertNotEmpty( $hrefs );
+
+		foreach ( $hrefs as $href ) {
+			$this->assertStringContainsString( 'version=7.1', $href );
+		}
+	}
+
+	/**
+	 * The page slug reaches the same URL, and a hidden input below it. Neither is
+	 * reachable in practice: wp-admin/admin.php resolves the slug against the
+	 * registered menus and dies on a miss, and the version call re-parses the page
+	 * call's argument as part of the query string it inherits, so urlencode_deep()
+	 * catches it on the way through. Both sinks should still hold on their own.
+	 */
+	public function test_report_links_escape_a_page_from_the_request(): void {
+		$_REQUEST['page'] = self::MARKUP_VALUE;
+
+		$output = $this->render_reports_page();
+
+		$this->assertStringNotContainsString( '<img', $output );
+		$this->assertStringContainsString(
+			'value="&quot;&gt;&lt;img src=x onerror=alert(1)&gt;"',
+			$output,
+			'The page slug is missing from the form, so the assertion above would pass vacuously.'
+		);
+	}
+
+	/*
+	 * The links inside an individual report.
+	 */
+
+	/**
+	 * Each row of a report links back to the edit screen through a URL built the
+	 * same way, from the same request data.
+	 */
+	public function test_contributors_report_escapes_a_page_in_the_row_links(): void {
+		$user = $this->factory()->user->create(
+			array(
+				'user_login'   => 'alice',
+				'display_name' => 'Alice Example',
+			)
+		);
+
+		$this->seed_revision( 'Fix the thing. Props alice.' );
+		$this->seed_props( array( 'alice' => $user ) );
+
+		$_REQUEST['page'] = self::MARKUP_VALUE;
+		$_REQUEST['what'] = 'contributors';
+
+		$output = $this->render_reports_page();
+
+		$this->assertStringContainsString(
+			'Alice Example',
+			$output,
+			'The report rendered no rows, so the assertion below would pass vacuously.'
+		);
+		$this->assertStringNotContainsString( '<img src=x', $output, 'The page slug broke out of a row link and became a live tag.' );
+	}
+}


### PR DESCRIPTION
Follow-up to r15022, which escaped the admin output in `wporg-trac-watcher` but only added tests for the list table. The reports page has no coverage at all, so the escaping there can regress without anything failing.

### What the reports page does

`display_reports_page()` builds its own report links out of the request and echoes them into an `href`:

```php
$url = add_query_arg( 'page', $_REQUEST['page'], admin_url( 'admin.php' ) );
$version = $_REQUEST['version'] ?? null;
$url = add_query_arg( 'version', $version, $url );
```

`add_query_arg()` runs `urlencode_deep()` over the query string already on the base URL, but the arguments handed to it reach `build_query()`, which calls `_http_build_query()` with `$urlencode` false — and that skips `urlencode()` on keys and values alike. Its return value is therefore as tainted as what went in, and needs escaping at the sink. r15022 added the `esc_url()` calls; this pins them.

Worth noting for anyone reading the code: `version` is the only argument that actually arrives raw. Because `page` is added by the first call, it becomes part of the query string the *second* call parses, so `urlencode_deep()` catches it on the way through. It is also gated by `wp-admin/admin.php`, which resolves the slug against the registered menus and dies on a miss. It is covered here as defence in depth, and the test docblock says so rather than implying a reachable sink.

### Tests

Four cases in a new `WPorg_Trac_Watcher_Reports_Page_Test`:

- the version, rendered into every report link
- an ordinary version, which has to still survive into those links — this is what keeps the case above from passing because the value never arrives at all
- the page slug, in both the links and the hidden input below them
- the page slug in the row links of an individual report, which are built the same way from the same request data

Each escaping assertion is paired with a guard that holds whether or not the escaping does. That distinction matters: the first draft guarded by matching `href="…"` with a regex, which stops matching once a payload closes the attribute early, so a regression failed on the guard instead of on the assertion that names it. The guards now key off text that is present either way.

Verified by reverting the `esc_url()` calls locally and confirming the suite goes red, then restoring them. 17 tests / 38 assertions pass against `trunk`, via `npm run make:test:trac-watcher`.

The bootstrap gains one `require_once` for `admin/reports-page.php`, which `admin/ui.php` otherwise only pulls in when the submenu renders.

No production code changes.