### PR TITLE
Theme Directory: Read theme headers without loading the theme's text domain

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
@@ -197,6 +197,62 @@ class WPORG_Themes_Upload {
 	}
 
 	/**
+	 * Reads a header from the theme being imported.
+	 *
+	 * The third argument to WP_Theme::display() must stay false. With translation
+	 * enabled, display() calls WP_Theme::load_textdomain(), which loads translation
+	 * files from the theme's own directory, and WordPress loads PHP translation
+	 * files (.l10n.php) by including them. The theme being imported is unreviewed
+	 * upload content, so no file from it may be included while it is validated.
+	 *
+	 * Headers are still marked up and sanitized exactly as display() would do, so
+	 * this is only a change of translation behavior and not of output.
+	 *
+	 * The same applies to casting a WP_Theme to a string or reading it as an array:
+	 * WP_Theme::__toString() and WP_Theme::offsetGet() both call display() with
+	 * translation left enabled. Read headers through this method instead.
+	 *
+	 * @param string $header The header to read, for example 'Name' or 'Version'.
+	 * @return string|false The header value, or false if the header is not set.
+	 */
+	public function get_theme_header( $header ) {
+		return $this->theme->display( $header, true, false );
+	}
+
+	/**
+	 * Refuses to load any translation file that resolves inside the extracted upload.
+	 *
+	 * `get_theme_header()` keeps the deliberate header reads from engaging
+	 * translation at all; this is the backstop for any path that does not, such as
+	 * casting a WP_Theme to a string. Paths outside the extracted upload, including
+	 * this plugin's own text domain, are left to load normally.
+	 *
+	 * @param bool   $override Whether the load was already overridden.
+	 * @param string $domain   Text domain being loaded. Unused; the check is by path.
+	 * @param string $mofile   Absolute path to the candidate translation file.
+	 * @return bool True to refuse a load from inside the extracted upload, otherwise $override.
+	 */
+	public function block_upload_textdomain( $override, $domain, $mofile ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- Signature is set by the filter.
+		if ( ! $this->tmp_dir ) {
+			return $override;
+		}
+
+		$root = realpath( $this->tmp_dir );
+		if ( ! $root ) {
+			// Nothing left to guard: remove_files() deletes the tree while this filter is still attached.
+			return $override;
+		}
+
+		// An unresolvable path while a tree is on disk is refused rather than guessed at.
+		$dir = realpath( dirname( (string) $mofile ) );
+		if ( ! $dir ) {
+			return true;
+		}
+
+		return str_starts_with( trailingslashit( $dir ), trailingslashit( $root ) ) ? true : $override;
+	}
+
+	/**
 	 * Validate that a theme upload succeeded and was a valid file.
 	 */
 	public function validate_upload( $file ) {
@@ -335,7 +391,7 @@ class WPORG_Themes_Upload {
 		return sprintf(
 			/* translators: 1: theme name, 2: Trac ticket URL */
 			__( 'Thank you for uploading %1$s to the WordPress Theme Directory. We&rsquo;ve sent you an email verifying that we&rsquo;ve received it. Feedback will be provided at <a href="%2$s">%2$s</a>', 'wporg-themes' ),
-			$this->theme->display( 'Name' ),
+			$this->get_theme_header( 'Name' ),
 			esc_url( 'https://themes.trac.wordpress.org/ticket/' . $this->trac_ticket->id )
 		);
 	}
@@ -398,6 +454,9 @@ class WPORG_Themes_Upload {
 
 		// We have a stylesheet, let's set up the theme, theme post, and author.
 		$this->theme = new WP_Theme( basename( dirname( $style_css ) ), dirname( dirname( $style_css ) ) );
+
+		// The theme's files are unreviewed: nothing in its tree may load as a translation file.
+		add_filter( 'override_load_textdomain', array( $this, 'block_upload_textdomain' ), 10, 3 );
 
 		// We need a screen shot. People love screen shots.
 		if ( ! $this->has_screenshot( $theme_files ) ) {
@@ -600,7 +659,8 @@ class WPORG_Themes_Upload {
 				sprintf(
 					/* translators: %s: parent theme */
 					__( 'There is no theme called %s in the directory. For child themes, you must use a parent theme that already exists in the directory.', 'wporg-themes' ),
-					'<code>' . $this->theme->parent() . '</code>'
+					// The slug, not the parent object: casting a WP_Theme to a string loads translations from its directory.
+					'<code>' . esc_html( $this->theme->get_template() ) . '</code>'
 				)
 			);
 		}
@@ -688,7 +748,7 @@ class WPORG_Themes_Upload {
 				sprintf(
 					/* translators: 1: theme name, 2: theme version, 3: style.css */
 					__( 'You need to upload a version of %1$s higher than %2$s. Increase the theme version number in %3$s, then upload your zip file again.', 'wporg-themes' ),
-					$this->theme->display( 'Name' ),
+					$this->get_theme_header( 'Name' ),
 					'<code>' . $this->theme_post->max_version . '</code>',
 					'<code>style.css</code>'
 				)
@@ -1134,7 +1194,7 @@ class WPORG_Themes_Upload {
 	 * Sets up all Trac ticket information that we need later.
 	 */
 	public function prepare_trac_ticket() {
-		$this->trac_ticket->summary = sprintf( 'THEME: %1$s – %2$s', $this->theme->display( 'Name' ), $this->theme->display( 'Version' ) );
+		$this->trac_ticket->summary = sprintf( 'THEME: %1$s – %2$s', $this->get_theme_header( 'Name' ), $this->get_theme_header( 'Version' ) );
 
 		// Keywords
 		$this->trac_ticket->keywords[] = 'theme-' . $this->theme_slug;
@@ -1179,34 +1239,34 @@ class WPORG_Themes_Upload {
 
 		// Diff line.
 		if ( ! empty( $this->theme_post->max_version ) ) {
-			$this->trac_ticket->diff_line = "\nDiff with previous version: [{$this->trac_changeset}] https://themes.trac.wordpress.org/changeset?old_path={$this->theme_slug}/{$this->theme_post->max_version}&new_path={$this->theme_slug}/{$this->theme->display( 'Version' )}\n";
+			$this->trac_ticket->diff_line = "\nDiff with previous version: [{$this->trac_changeset}] https://themes.trac.wordpress.org/changeset?old_path={$this->theme_slug}/{$this->theme_post->max_version}&new_path={$this->theme_slug}/{$this->get_theme_header( 'Version' )}\n";
 		}
 
 		// Description
-		$theme_description = $this->strip_non_utf8( (string) $this->theme->display( 'Description' ) );
+		$theme_description = $this->strip_non_utf8( (string) $this->get_theme_header( 'Description' ) );
 
 		// ZIP location
-		$theme_zip_link = "https://downloads.wordpress.org/theme/{$this->theme_slug}.{$this->theme->display( 'Version' )}.zip?nostats=1";
+		$theme_zip_link = "https://downloads.wordpress.org/theme/{$this->theme_slug}.{$this->get_theme_header( 'Version' )}.zip?nostats=1";
 
 		$live_preview_link = add_query_arg(
 			'blueprint-url',
-			urlencode( rest_url( 'themes/v1/review-blueprint/' . $this->theme_post->ID . '-' . $this->theme_slug . '/' . $this->theme->display( 'Version' ) ) ),
+			urlencode( rest_url( 'themes/v1/review-blueprint/' . $this->theme_post->ID . '-' . $this->theme_slug . '/' . $this->get_theme_header( 'Version' ) ) ),
 			'https://playground.wordpress.net/'
 		);
 
 		// Hacky way to prevent a problem with xml-rpc.
 		$this->trac_ticket->description = <<<TICKET
-{$this->theme->display( 'Name' )} - {$this->theme->display( 'Version' )}
+{$this->get_theme_header( 'Name' )} - {$this->get_theme_header( 'Version' )}
 
 {$theme_description}
 
-Theme URL - {$this->theme->display( 'ThemeURI' )}
-Author URL - {$this->theme->display( 'AuthorURI' )}
+Theme URL - {$this->get_theme_header( 'ThemeURI' )}
+Author URL - {$this->get_theme_header( 'AuthorURI' )}
 
-Trac Browser - https://themes.trac.wordpress.org/browser/{$this->theme_slug}/{$this->theme->display( 'Version' )}
+Trac Browser - https://themes.trac.wordpress.org/browser/{$this->theme_slug}/{$this->get_theme_header( 'Version' )}
 WordPress.org - https://wordpress.org/themes/{$this->theme_slug}/
 
-SVN - https://themes.svn.wordpress.org/{$this->theme_slug}/{$this->theme->display( 'Version' )}
+SVN - https://themes.svn.wordpress.org/{$this->theme_slug}/{$this->get_theme_header( 'Version' )}
 ZIP - {$theme_zip_link}
 Live preview – [[{$live_preview_link}|https://playground.wordpress.net/#…]]
 
@@ -1215,7 +1275,7 @@ Live preview – [[{$live_preview_link}|https://playground.wordpress.net/#…]]
 History:
 [[TicketQuery(format=table, keywords=~theme-{$this->theme_slug}, col=id|summary|status|resolution|owner)]]
 
-[[Image(https://themes.svn.wordpress.org/{$this->theme_slug}/{$this->theme->display( 'Version' )}/{$this->theme->screenshot}, width=640)]]
+[[Image(https://themes.svn.wordpress.org/{$this->theme_slug}/{$this->get_theme_header( 'Version' )}/{$this->theme->screenshot}, width=640)]]
 TICKET;
 
 		$theme_check_results = $this->generate_themecheck_results_for_trac();
@@ -1497,7 +1557,7 @@ TICKET;
 				return trim( $line, "/\r\n\t " );
 			}, $output );
 
-			if ( in_array( $this->theme->display( 'Version' ), $svn_versions, true ) ) {
+			if ( in_array( $this->get_theme_header( 'Version' ), $svn_versions, true ) ) {
 				return new WP_Error( 'version_exists_in_svn', 'version_exists_in_svn' ); // Intentionally not translated or human-readable-text.
 			}
 		}
@@ -1509,7 +1569,7 @@ TICKET;
 		}
 
 		// Try to copy the previous version over.
-		$new_version_dir = escapeshellarg( "{$this->tmp_svn_dir}/{$this->theme->display( 'Version' )}" );
+		$new_version_dir = escapeshellarg( "{$this->tmp_svn_dir}/{$this->get_theme_header( 'Version' )}" );
 		$prev_version    = escapeshellarg( "https://themes.svn.wordpress.org/{$this->theme_slug}/{$this->theme_post->max_version}" );
 		$this->exec_with_notify( self::SVN . " cp $prev_version $new_version_dir", $output, $return_var );
 		if ( $return_var > 0 ) {
@@ -1530,8 +1590,8 @@ TICKET;
 		$password = escapeshellarg( THEME_DROPBOX_PASSWORD );
 		$message  = escapeshellarg( sprintf(
 			'New version of %1$s - %2$s', // Intentionally not translated.
-			$this->theme->display( 'Name' ),
-			$this->theme->display( 'Version' )
+			$this->get_theme_header( 'Name' ),
+			$this->get_theme_header( 'Version' )
 		) );
 
 		/* DEBUGGING
@@ -1560,8 +1620,8 @@ TICKET;
 		}
 
 		$import_msg = empty( $this->theme_post ) ?  'New theme: %1$s - %2$s' : 'New version of %1$s - %2$s'; // Intentionally not translated
-		$import_msg = escapeshellarg( sprintf( $import_msg, $this->theme->display( 'Name' ), $this->theme->display( 'Version' ) ) );
-		$svn_path   = escapeshellarg( "https://themes.svn.wordpress.org/{$this->theme_slug}/{$this->theme->display( 'Version' )}" );
+		$import_msg = escapeshellarg( sprintf( $import_msg, $this->get_theme_header( 'Name' ), $this->get_theme_header( 'Version' ) ) );
+		$svn_path   = escapeshellarg( "https://themes.svn.wordpress.org/{$this->theme_slug}/{$this->get_theme_header( 'Version' )}" );
 		$theme_path = escapeshellarg( $this->theme_dir );
 		$password   = escapeshellarg( THEME_DROPBOX_PASSWORD );
 
@@ -1592,13 +1652,13 @@ TICKET;
 			return false;
 		}
 
-		$svn_path = "{$this->theme_slug}/{$this->theme->display( 'Version' )}";
-		if ( ! $this->theme_slug || ! $this->theme->display( 'Version' ) || strlen( $svn_path ) < 3 ) {
+		$svn_path = "{$this->theme_slug}/{$this->get_theme_header( 'Version' )}";
+		if ( ! $this->theme_slug || ! $this->get_theme_header( 'Version' ) || strlen( $svn_path ) < 3 ) {
 			return false;
 		}
 
 		$import_msg = 'Removing theme %1$s - %2$s: %3$s';
-		$import_msg = escapeshellarg( sprintf( $import_msg, $this->theme->display( 'Name' ), $this->theme->display( 'Version' ), $reason ) );
+		$import_msg = escapeshellarg( sprintf( $import_msg, $this->get_theme_header( 'Name' ), $this->get_theme_header( 'Version' ), $reason ) );
 		$svn_path   = escapeshellarg( "https://themes.svn.wordpress.org/{$svn_path}" );
 		$password   = escapeshellarg( THEME_DROPBOX_PASSWORD );
 
@@ -1631,8 +1691,8 @@ TICKET;
 			$email_subject = sprintf(
 				/* translators: 1: theme name, 2: theme version */
 				__( '[WordPress Themes] %1$s, new version %2$s', 'wporg-themes' ),
-				$this->theme->display( 'Name' ),
-				$this->theme->display( 'Version' )
+				$this->get_theme_header( 'Name' ),
+				$this->get_theme_header( 'Version' )
 			);
 
 			$email_content = sprintf(
@@ -1644,15 +1704,15 @@ Feedback will be provided at %3$s
 --
 The WordPress.org Themes Team
 https://make.wordpress.org/themes', 'wporg-themes' ),
-				$this->theme->display( 'Version' ),
-				$this->theme->display( 'Name' ),
+				$this->get_theme_header( 'Version' ),
+				$this->get_theme_header( 'Name' ),
 				'https://themes.trac.wordpress.org/ticket/' . $this->trac_ticket->id
 			);
 		} else {
 			$email_subject = sprintf(
 				/* translators: %s: theme name */
 				__( '[WordPress Themes] New Theme - %s', 'wporg-themes' ),
-				$this->theme->display( 'Name' )
+				$this->get_theme_header( 'Name' )
 			);
 
 			$email_content = sprintf(
@@ -1690,7 +1750,7 @@ Subscribe to the Themes Team blog to stay up to date with the latest requirement
 
 Thank you.
 The WordPress Themes Team', 'wporg-themes' ),
-				$this->theme->display( 'Name' ),
+				$this->get_theme_header( 'Name' ),
 				'https://themes.trac.wordpress.org/ticket/' . $this->trac_ticket->id
 			);
 		}
@@ -1717,13 +1777,13 @@ The WordPress Themes Team', 'wporg-themes' ),
 			json_encode([
 				'event_type'     => sprintf(
 					"%s %s %s",
-					$this->theme->display( 'Name' ),
-					$this->theme->display( 'Version' ),
+					$this->get_theme_header( 'Name' ),
+					$this->get_theme_header( 'Version' ),
 					$this->trac_ticket->priority
 				),
 				'client_payload' => [
 					'theme_slug'       => $this->theme_slug,
-					'theme_zip'        => "https://wordpress.org/themes/download/{$this->theme_slug}.{$this->theme->display( 'Version' )}.zip?nostats=1",
+					'theme_zip'        => "https://wordpress.org/themes/download/{$this->theme_slug}.{$this->get_theme_header( 'Version' )}.zip?nostats=1",
 					'accessible_ready' => in_array( 'accessibility-ready', $this->theme->get( 'Tags' ) ),
 					'trac_ticket_id'   => $this->trac_ticket->id,
 					'trac_priority'    => $this->trac_ticket->priority,
@@ -1930,7 +1990,7 @@ The WordPress Themes Team', 'wporg-themes' ),
 						(
 							// When importing from SVN, include a 'Compare' link as the Changeset likely won't show a Diff unless the author did a `svn cp`.
 							'svn' === $this->importing_from && ! empty( $this->theme_post->max_version ) ?
-							"<https://themes.trac.wordpress.org/changeset?old_path={$this->theme_slug}/{$this->theme_post->_last_live_version}&new_path={$this->theme_slug}/{$this->theme->display( 'Version' )}|Compare>" :
+							"<https://themes.trac.wordpress.org/changeset?old_path={$this->theme_slug}/{$this->theme_post->_last_live_version}&new_path={$this->theme_slug}/{$this->get_theme_header( 'Version' )}|Compare>" :
 							''
 						),
 				];
@@ -1950,7 +2010,7 @@ The WordPress Themes Team', 'wporg-themes' ),
 						'https://ts.w.org/wp-content/themes/%1$s/%2$s?ver=%3$s',
 						$this->theme_slug,
 						$this->theme->screenshot,
-						$this->theme->display( 'Version' )
+						$this->get_theme_header( 'Version' )
 					),
 				],
 				'fields' => $fields

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/jobs/class-svn-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/jobs/class-svn-import.php
@@ -162,7 +162,7 @@ class SVN_Import {
 						"----\nWordPress Theme Directory",
 					),
 					esc_html( $uploader->author->display_name ?: $uploader->author->user_login ),
-					$uploader->theme->display('Name') . ' ' . $uploader->theme->display('Version'),
+					$uploader->get_theme_header( 'Name' ) . ' ' . $uploader->get_theme_header( 'Version' ),
 					'<div style="margin-left: 30px">' . $error_message . '</div>',
 					'https://make.wordpress.org/themes/handbook/review/required/'
 				),

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Theme_Header_Translation_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Theme_Header_Translation_Test.php
@@ -1,0 +1,334 @@
+<?php
+/**
+ * Tests that theme headers are read without engaging the translation system.
+ *
+ * `WP_Theme::display()` loads the theme's own text domain before translating a
+ * header, and WordPress loads PHP translation files by including them. A theme
+ * being imported is unreviewed upload content, so
+ * `WPORG_Themes_Upload::get_theme_header()` reads headers with translation
+ * disabled, and `block_upload_textdomain()` backs that up by refusing any
+ * translation load that resolves inside the extracted upload. These tests pin
+ * both behaviors.
+ *
+ * @package theme-directory
+ */
+
+declare( strict_types = 1 );
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for `WPORG_Themes_Upload::get_theme_header()`.
+ *
+ * @group upload
+ */
+class Theme_Header_Translation_Test extends TestCase {
+
+	/**
+	 * Text domain declared by the fixture theme.
+	 *
+	 * @var string
+	 */
+	const FIXTURE_DOMAIN = 'wporg-fixture-theme-domain';
+
+	/**
+	 * Absolute path of the temporary theme root holding the fixture.
+	 *
+	 * @var string
+	 */
+	protected $theme_root = '';
+
+	/**
+	 * Directory name of the fixture theme within the theme root.
+	 *
+	 * @var string
+	 */
+	protected $stylesheet = 'fixture-theme';
+
+	/**
+	 * Number of translation lookups made against the fixture's text domain.
+	 *
+	 * @var int
+	 */
+	protected $translation_lookups = 0;
+
+	/**
+	 * The `gettext` callback, kept so it can be removed again.
+	 *
+	 * @var callable|null
+	 */
+	protected $gettext_callback = null;
+
+	/**
+	 * Uploads created during a test.
+	 *
+	 * An import registers hooks bound to the extraction directory; they are removed
+	 * again on teardown so they cannot affect a later test.
+	 *
+	 * @var array
+	 */
+	protected $uploads = array();
+
+	/**
+	 * Writes the fixture theme and starts counting translation lookups.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		// A unique root per test, so WP_Theme's header cache cannot be reused.
+		$this->theme_root = untrailingslashit( get_temp_dir() ) . '/wporg-theme-header-' . uniqid();
+		wp_mkdir_p( $this->theme_root . '/' . $this->stylesheet );
+
+		$style_css = "/*\nTheme Name: Fixture Theme\nVersion: 1.0\nText Domain: " . self::FIXTURE_DOMAIN . "\n*/\n";
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test fixture in a temporary directory.
+		file_put_contents( $this->theme_root . '/' . $this->stylesheet . '/style.css', $style_css );
+
+		// A lookup against the fixture's domain means the translation system was engaged.
+		$this->translation_lookups = 0;
+		$this->gettext_callback    = function ( $translation, $text, $domain ) {
+			if ( self::FIXTURE_DOMAIN === $domain ) {
+				++$this->translation_lookups;
+
+				return 'TRANSLATED';
+			}
+
+			return $translation;
+		};
+
+		add_filter( 'gettext', $this->gettext_callback, 10, 3 );
+	}
+
+	/**
+	 * Removes the filter and the fixture theme.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		remove_filter( 'gettext', $this->gettext_callback, 10 );
+		$this->gettext_callback = null;
+
+		foreach ( $this->uploads as $upload ) {
+			remove_filter( 'override_load_textdomain', array( $upload, 'block_upload_textdomain' ), 10 );
+			remove_action( 'shutdown', array( $upload, 'remove_files' ), 10 );
+
+			if ( $upload->tmp_dir ) {
+				$this->remove_fixture( $upload->tmp_dir );
+			}
+		}
+		$this->uploads = array();
+
+		$this->remove_fixture( $this->theme_root );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Recursively removes a fixture directory.
+	 *
+	 * @param string $path Absolute path to remove.
+	 * @return void
+	 */
+	protected function remove_fixture( string $path ): void {
+		if ( ! is_dir( $path ) ) {
+			return;
+		}
+
+		foreach ( (array) glob( $path . '/*' ) as $item ) {
+			if ( is_dir( $item ) ) {
+				$this->remove_fixture( $item );
+			} else {
+				wp_delete_file( $item );
+			}
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- Test fixture in a temporary directory.
+		rmdir( $path );
+	}
+
+	/**
+	 * Builds an upload whose theme is the fixture.
+	 *
+	 * @return WPORG_Themes_Upload
+	 */
+	protected function create_upload(): WPORG_Themes_Upload {
+		$upload        = new WPORG_Themes_Upload();
+		$upload->theme = new WP_Theme( $this->stylesheet, $this->theme_root );
+
+		$this->uploads[] = $upload;
+
+		return $upload;
+	}
+
+	/**
+	 * Absolute path of the fixture theme's own directory, which exists on disk.
+	 *
+	 * @return string
+	 */
+	protected function theme_dir(): string {
+		return $this->theme_root . '/' . $this->stylesheet;
+	}
+
+	/**
+	 * Reading a header must return the value as written in style.css, without
+	 * the theme's own text domain being consulted.
+	 *
+	 * @return void
+	 */
+	public function test_get_theme_header_does_not_translate(): void {
+		$upload = $this->create_upload();
+
+		$name = $upload->get_theme_header( 'Name' );
+
+		$this->assertSame( 'Fixture Theme', $name );
+		$this->assertSame(
+			0,
+			$this->translation_lookups,
+			'Reading a header from an imported theme must not engage the translation system.'
+		);
+	}
+
+	/**
+	 * The same holds for every header the importer reads, not just the name.
+	 *
+	 * @return void
+	 */
+	public function test_get_theme_header_does_not_translate_version(): void {
+		$upload = $this->create_upload();
+
+		$version = $upload->get_theme_header( 'Version' );
+
+		$this->assertSame( '1.0', $version );
+		$this->assertSame( 0, $this->translation_lookups );
+	}
+
+	/**
+	 * Characterizes the behavior the third argument of `WP_Theme::display()`
+	 * guards against: left at its default, `display()` runs the theme's own text
+	 * domain through the translation system, which is what loads translation
+	 * files out of the theme directory.
+	 *
+	 * If this ever stops holding, `get_theme_header()` can be re-evaluated.
+	 *
+	 * @return void
+	 */
+	public function test_display_with_translation_enabled_engages_translation(): void {
+		$theme = new WP_Theme( $this->stylesheet, $this->theme_root );
+
+		$name = $theme->display( 'Name' );
+
+		$this->assertSame( 'TRANSLATED', $name );
+		$this->assertGreaterThan(
+			0,
+			$this->translation_lookups,
+			'display() with translation enabled is expected to consult the theme text domain.'
+		);
+	}
+
+	/**
+	 * Importing attaches the backstop, before any of the theme's own files are read.
+	 *
+	 * `import()` is protected, so it is invoked by reflection. Reaching the
+	 * registration needs nothing but an extracted style.css: Trac and SVN are gated
+	 * off by their password constants, and the import returns the style.css errors
+	 * shortly afterwards, so no network or repository work runs.
+	 *
+	 * @return void
+	 */
+	public function test_import_registers_the_backstop(): void {
+		$upload = $this->create_upload();
+		$upload->create_tmp_dirs( 'fixture' );
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_copy -- Test fixture in a temporary directory.
+		copy( $this->theme_dir() . '/style.css', $upload->theme_dir . '/style.css' );
+
+		$import = new ReflectionMethod( WPORG_Themes_Upload::class, 'import' );
+		$result = $import->invoke( $upload );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertTrue(
+			apply_filters(
+				'override_load_textdomain',
+				false,
+				self::FIXTURE_DOMAIN,
+				$upload->theme_dir . '/en_US.mo'
+			)
+		);
+	}
+
+	/**
+	 * A translation file resolving inside the extraction directory is refused.
+	 *
+	 * @return void
+	 */
+	public function test_blocks_translation_load_from_inside_the_upload(): void {
+		$upload          = $this->create_upload();
+		$upload->tmp_dir = $this->theme_root;
+
+		$this->assertTrue(
+			$upload->block_upload_textdomain( false, self::FIXTURE_DOMAIN, $this->theme_dir() . '/en_US.mo' )
+		);
+	}
+
+	/**
+	 * A translation file outside the extraction directory loads normally, so the
+	 * backstop cannot break unrelated text domains.
+	 *
+	 * @return void
+	 */
+	public function test_allows_translation_load_from_outside_the_upload(): void {
+		$upload          = $this->create_upload();
+		$upload->tmp_dir = $this->theme_root;
+
+		$outside = untrailingslashit( get_temp_dir() ) . '/en_US.mo';
+
+		$this->assertFalse( $upload->block_upload_textdomain( false, 'wporg-themes', $outside ) );
+	}
+
+	/**
+	 * With no extraction directory in play, every load passes through.
+	 *
+	 * @return void
+	 */
+	public function test_backstop_is_inert_without_an_extraction_directory(): void {
+		$upload = $this->create_upload();
+
+		$this->assertSame( '', $upload->tmp_dir );
+		$this->assertFalse(
+			$upload->block_upload_textdomain( false, 'wporg-themes', $this->theme_dir() . '/en_US.mo' )
+		);
+	}
+
+	/**
+	 * Once the extraction directory is gone there is nothing left to protect, and
+	 * the backstop must not start refusing unrelated loads: `remove_files()`
+	 * deletes that directory on shutdown while this filter is still attached.
+	 *
+	 * @return void
+	 */
+	public function test_backstop_is_inert_once_the_extraction_directory_is_gone(): void {
+		$upload          = $this->create_upload();
+		$upload->tmp_dir = $this->theme_root . '/already-removed';
+
+		$this->assertFalse(
+			$upload->block_upload_textdomain( false, 'wporg-themes', $this->theme_dir() . '/en_US.mo' )
+		);
+	}
+
+	/**
+	 * A path that cannot be resolved while the extraction directory is on disk is
+	 * refused rather than guessed at.
+	 *
+	 * @return void
+	 */
+	public function test_refuses_an_unresolvable_path_while_the_upload_is_on_disk(): void {
+		$upload          = $this->create_upload();
+		$upload->tmp_dir = $this->theme_root;
+
+		$this->assertTrue(
+			$upload->block_upload_textdomain( false, self::FIXTURE_DOMAIN, $this->theme_root . '/missing/en_US.mo' )
+		);
+	}
+}


### PR DESCRIPTION
`WP_Theme::display()` resolves a header through the theme's own text domain, which means reading a header from a theme that is being imported initializes translations out of that theme's directory. The importer only needs the literal header values, so it should not be asking the theme to translate them.

## Changes

**A single accessor for header reads.** `WPORG_Themes_Upload::get_theme_header()` wraps `display( $header, true, false )`, and the 37 call sites in the importer plus the one in `jobs/class-svn-import.php` now go through it. The third argument is the whole point — with it, `display()` returns before `WP_Theme::load_textdomain()` is reached. Output is unchanged: `markup_header()` still runs, so `wptexturize()` is still applied to `Description` and `esc_url()` to the URI headers, and `get()` still applies `sanitize_header()`.

This also removes a mismatch: validation compared `get( 'Version' )` while the SVN paths and shell commands used `display( 'Version' )`, so an imported theme could make the two differ. They are now the same string everywhere.

**The invalid-parent notice.** It interpolated the parent `WP_Theme` object, and `WP_Theme::__toString()` is `(string) $this->display( 'Name' )` with translation left on. It now prints `get_template()` — the slug that `is_parent_available()` actually looked up — escaped with `esc_html()`. That is also more useful output, since the previous version rendered an empty `<code></code>` whenever the parent object carried errors.

**A backstop.** `block_upload_textdomain()` is hooked to `override_load_textdomain` at the point the theme object is constructed, and declines any load whose path resolves inside the extraction directory. Paths outside it, including this plugin's own text domain, are untouched. It stays inert once the extraction directory is gone, since `remove_files()` deletes that on shutdown while the filter is still attached.

## Tests

`tests/Theme_Header_Translation_Test.php`, 9 tests. Coverage is a `gettext` filter scoped to a fixture theme's domain, which fires precisely when the translation system is engaged — more robust than hooking the loader, since modern core defers the actual load until `translate()`.

Included is a characterization test asserting that `display()` *with* translation enabled does consult the text domain, so the guard is re-evaluated if that ever stops being true. Registration is covered by invoking the protected `import()` by reflection; it reaches the hook using nothing but an extracted `style.css`, and returns the style.css errors shortly after.

Each test was mutation-checked: reverting the third argument, dropping the registration, inverting the path check, and flipping the inert-when-removed branch each produce failures.

## Verification

- `phpunit` for `theme-directory`: 45 tests, 86 assertions, passing.
- `phpcs`: the new test file is clean; `class-wporg-themes-upload.php` is unchanged against its pre-existing baseline, with no new violations introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)