### PR TITLE
Theme Directory: Normalize file types after SVN export

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
@@ -256,9 +256,10 @@ class WPORG_Themes_Upload {
 
 		// Check out from SVN.
 		$this->create_tmp_dirs( $slug . '.' . $version );
-		$esc_svn = escapeshellarg( "https://themes.svn.wordpress.org/{$slug}/{$version}/" );
+		$esc_svn       = escapeshellarg( "https://themes.svn.wordpress.org/{$slug}/{$version}/" );
+		$esc_theme_dir = escapeshellarg( $this->theme_dir );
 		$this->exec_with_notify(
-			self::SVN . ' export ' . $esc_svn . ' ' . escapeshellarg( $this->theme_dir ) . ' --force', // force as we've created the directory already.
+			self::SVN . " export {$esc_svn} {$esc_theme_dir} --force", // force as we've created the directory already.
 			$output,
 			$return_var
 		);
@@ -270,7 +271,7 @@ class WPORG_Themes_Upload {
 		}
 
 		// Remove any unexpected entries, we only need basic files and directories, anything else will cause problems when installed onto a site.
-		$this->exec_with_notify( 'find ' . escapeshellarg( $this->theme_dir ) . ' -not -type f -not -type d -delete' );
+		$this->exec_with_notify( "find {$esc_theme_dir} -not -type f -not -type d -delete" );
 
 		// Fetch data from SVN if not known.
 		if ( ! $changeset ) {

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
@@ -258,7 +258,7 @@ class WPORG_Themes_Upload {
 		$this->create_tmp_dirs( $slug . '.' . $version );
 		$esc_svn = escapeshellarg( "https://themes.svn.wordpress.org/{$slug}/{$version}/" );
 		$this->exec_with_notify(
-			self::SVN . " export {$esc_svn} {$this->theme_dir} --force", // force as we've created the directory already.
+			self::SVN . ' export ' . $esc_svn . ' ' . escapeshellarg( $this->theme_dir ) . ' --force', // force as we've created the directory already.
 			$output,
 			$return_var
 		);

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
@@ -270,7 +270,7 @@ class WPORG_Themes_Upload {
 		}
 
 		// Remove any unexpected entries, we only need basic files and directories, anything else will cause problems when installed onto a site.
-		$this->exec_with_notify( "find {$this->theme_dir} -not -type f -not -type d -delete" );
+		$this->exec_with_notify( 'find ' . escapeshellarg( $this->theme_dir ) . ' -not -type f -not -type d -delete' );
 
 		// Fetch data from SVN if not known.
 		if ( ! $changeset ) {

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
@@ -269,6 +269,9 @@ class WPORG_Themes_Upload {
 			);
 		}
 
+		// Remove any unexpected entries, we only need basic files and directories, anything else will cause problems when installed onto a site.
+		$this->exec_with_notify( "find {$this->theme_dir} -not -type f -not -type d -delete" );
+
 		// Fetch data from SVN if not known.
 		if ( ! $changeset ) {
 			$changeset = (int) trim( $this->exec_with_notify( self::SVN . " info --show-item=last-changed-revision {$esc_svn}" ) );


### PR DESCRIPTION
## Summary
- `process_update_from_svn()` exports a theme revision straight from SVN, but unlike `unzip_package()` (used for ZIP uploads) it never scrubbed the resulting tree down to plain files and directories.
- Applies the same `find -not -type f -not -type d -delete` pass used for uploads, so both import paths only ever see plain files and directories.

## Test plan
- [ ] Confirm `process_update_from_svn()` still imports a normal theme update unaffected by the new scrub.
- [ ] Confirm an SVN-exported tree containing a symlink or other non-regular entry has it removed before `WP_Theme` is built over it.