### PR TITLE
Plugin Directory, Photo Directory: Escape output consistently

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/admin.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/admin.php
@@ -653,8 +653,8 @@ class Admin {
 
 		echo '<dl class="photos-flagged">';
 		foreach ( $flags as $flag => $class ) {
-			echo '<dt>' . ucfirst( $flag ) . ':</dt>';
-			echo '<dd>' . ucwords( str_replace( '_', ' ', $class ) ) . '</dd>';
+			echo '<dt>' . esc_html( ucfirst( $flag ) ) . ':</dt>';
+			echo '<dd>' . esc_html( ucwords( str_replace( '_', ' ', $class ) ) ) . '</dd>';
 		}
 		echo "</dl>\n";
 

--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/head.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/head.php
@@ -104,8 +104,11 @@ class Head {
 		// Print the schema.
 		if ( $schema ) {
 			echo PHP_EOL, '<script type="application/ld+json">', PHP_EOL;
-			// Output URLs without escaping the slashes, and print it human readable.
-			echo wp_json_encode( $schema, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT );
+			// Output URLs without escaping the slashes, and print it human readable. JSON_HEX_* keeps a stored '</script>' from closing the element.
+			echo wp_json_encode(
+				$schema,
+				JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
+			);
 			echo PHP_EOL, '</script>', PHP_EOL;
 		}
 	}

--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/moderation.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/moderation.php
@@ -376,6 +376,8 @@ class Moderation {
 	/**
 	 * Formats flags into a list for display.
 	 *
+	 * Flag names can originate from post meta, so no caller may pass markup through them.
+	 *
 	 * @param array $flags  Associative array of flags names (as keys) and
 	 *                      severity (as values). Severity can be one of
 	 *                      ['possible', 'likely', 'very_likely'].
@@ -391,9 +393,13 @@ class Moderation {
 			$formatted .= sprintf(
 				'<li class="dashicons-before dashicons-flag %s" title="%s">%s</li>' . "\n",
 				esc_attr( $class ),
-				/* translators: 1: Moderation category, 2: Likelihood of the image being of the given moderation category */
-				sprintf( __( 'This image is flagged as potentially containing %1$s content: %2$s', 'wporg-photos' ), $flag, ucwords( str_replace( '_', ' ', $class ) ) ),
-				ucwords( $flag )
+				esc_attr( sprintf(
+					/* translators: 1: Moderation category, 2: Likelihood of the image being of the given moderation category */
+					__( 'This image is flagged as potentially containing %1$s content: %2$s', 'wporg-photos' ),
+					$flag,
+					ucwords( str_replace( '_', ' ', $class ) )
+				) ),
+				esc_html( ucwords( $flag ) )
 			);
 		}
 		$formatted .= "</ul>\n";
@@ -682,15 +688,15 @@ https://wordpress.org/photos/
 				else {
 					if ( $rejections_percentage >= self::FLAG_REJECTION_CRITICAL_THRESHOLD_PERCENTAGE ) {
 						$rejections_level = 'very_likely';
-						$message = __( 'very high rejection rate (<strong>%d%%</strong>)', 'wporg-photos' );
+						$message = __( 'very high rejection rate (%d%%)', 'wporg-photos' );
 					}
 					elseif ( $rejections_percentage >= self::FLAG_REJECTION_ALERT_THRESHOLD_PERCENTAGE ) {
 						$rejections_level = 'likely';
-						$message = __( 'high rejection rate (<strong>%d%%</strong>)', 'wporg-photos' );
+						$message = __( 'high rejection rate (%d%%)', 'wporg-photos' );
 					}
 					elseif ( $rejections_percentage >= self::FLAG_REJECTION_WARNING_THRESHOLD_PERCENTAGE ) {
 						$rejections_level = 'possible';
-						$message = __( 'rejection rate (<strong>%d%%</strong>)', 'wporg-photos' );
+						$message = __( 'rejection rate (%d%%)', 'wporg-photos' );
 					}
 				}
 

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/list-table/class-plugin-posts.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/list-table/class-plugin-posts.php
@@ -685,15 +685,19 @@ class Plugin_Posts extends \WP_Posts_List_Table {
 		$reviewer_time = (int) ( $post->assigned_reviewer_time ?? 0 );
 
 		if ( $reviewer ) {
+			$args = [
+				'post_type' => $post->post_type,
+				'reviewer'  => $reviewer_id,
+			];
+
 			printf(
-				"<a href='%s'>%s</a><br><span>%s</span>",
-				add_query_arg( [ 'reviewer' => $reviewer_id ] ),
-				$reviewer->display_name ?: $reviewer->user_login,
-				sprintf(
+				'%s<br><span>%s</span>',
+				$this->get_edit_link( $args, esc_html( $reviewer->display_name ?: $reviewer->user_login ) ),
+				esc_html( sprintf(
 					/* translators: %s The time/date different, '1 hour' */
 					__( '%s ago', 'wporg-plugins' ),
 					human_time_diff( $reviewer_time )
-				)
+				) )
 			);
 		} else {
 			echo '-';

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/list-table/class-plugin-posts.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/list-table/class-plugin-posts.php
@@ -692,6 +692,7 @@ class Plugin_Posts extends \WP_Posts_List_Table {
 
 			printf(
 				'%s<br><span>%s</span>',
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_edit_link() runs the URL through esc_url(), and the link text is escaped here.
 				$this->get_edit_link( $args, esc_html( $reviewer->display_name ?: $reviewer->user_login ) ),
 				esc_html( sprintf(
 					/* translators: %s The time/date different, '1 hour' */

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/metabox/class-controls.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/metabox/class-controls.php
@@ -353,7 +353,7 @@ class Controls {
 			<?php if ( $post->tested ) : ?>
 			<tr>
 				<td><?php _e( 'Tested With:', 'wporg-plugins' ); ?></td>
-				<td><strong><?php printf( 'WordPress %s', $post->tested ); ?></strong></td>
+				<td><strong><?php printf( 'WordPress %s', esc_html( $post->tested ) ); ?></strong></td>
 			</tr>
 			<?php endif; ?>
 		</table><!-- .misc-pub-section -->

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-template.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-template.php
@@ -48,8 +48,11 @@ class Template {
 		// Print the schema.
 		if ( $schema ) {
 			echo PHP_EOL, '<script type="application/ld+json">', PHP_EOL;
-			// Output URLs without escaping the slashes, and print it human readable.
-			echo wp_json_encode( $schema, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT );
+			// Output URLs without escaping the slashes, and print it human readable. JSON_HEX_* keeps a stored '</script>' from closing the element.
+			echo wp_json_encode(
+				$schema,
+				JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
+			);
 			echo PHP_EOL, '</script>', PHP_EOL;
 		}
 	}
@@ -448,9 +451,13 @@ class Template {
 			case 'html':
 
 				if ( $icon_2x && $icon_2x !== $icon ) {
-					return "<img class='plugin-icon' srcset='{$icon}, {$icon_2x} 2x' src='{$icon_2x}' alt=''>";
+					return sprintf(
+						'<img class="plugin-icon" srcset="%1$s, %2$s 2x" src="%2$s" alt="">',
+						esc_url( $icon ),
+						esc_url( $icon_2x )
+					);
 				} else {
-					return "<img class='plugin-icon' src='{$icon}' alt=''>";
+					return sprintf( '<img class="plugin-icon" src="%s" alt="">', esc_url( $icon ) );
 				}
 				break;
 

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/js/commit-subscription.js
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/js/commit-subscription.js
@@ -1,0 +1,24 @@
+/**
+ * Confirmation for the commit-subscription link in the [wporg-plugins-developers] shortcode.
+ *
+ * The prompt is read from the parsed `data-confirm` attribute, so the plugin title
+ * it contains is never handed to the JavaScript parser as source text.
+ */
+
+( function () {
+	document.addEventListener( 'click', function ( event ) {
+		if ( ! event.target || ! event.target.closest ) {
+			return;
+		}
+
+		var link = event.target.closest( 'a.plugin-commit-subscribe' );
+
+		if ( ! link ) {
+			return;
+		}
+
+		if ( ! window.confirm( link.dataset.confirm ) ) {
+			event.preventDefault();
+		}
+	} );
+} )();

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-developers.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-developers.php
@@ -4,6 +4,9 @@ namespace WordPressdotorg\Plugin_Directory\Shortcodes;
 use WordPressdotorg\Plugin_Directory\Plugin_I18n;
 use WordPressdotorg\Plugin_Directory\Tools;
 
+use const WordPressdotorg\Plugin_Directory\PLUGIN_DIR;
+use const WordPressdotorg\Plugin_Directory\PLUGIN_FILE;
+
 /**
  * The [wporg-plugins-developers] shortcode handler to display developer information.
  *
@@ -24,7 +27,7 @@ class Developers {
 		$output .= '<p>' . sprintf(
 			/* translators: %s: plugin name */
 			__( '&#8220;%s&#8221; is open source software. The following people have contributed to this plugin.', 'wporg-plugins' ),
-			$title
+			esc_html( $title )
 		) . '</p>';
 
 		ob_start();
@@ -63,7 +66,7 @@ class Developers {
 						$locales_count,
 						'wporg-plugins'
 					),
-					$title,
+					esc_html( $title ),
 					number_format_i18n( $locales_count )
 				) . ' ';
 
@@ -82,7 +85,7 @@ class Developers {
 			sprintf(
 				/* translators: %s: plugin name */
 				__( 'Translate &#8220;%s&#8221; into your language.', 'wporg-plugins' ),
-				$title
+				esc_html( $title )
 			)
 		) . '</p>';
 
@@ -111,14 +114,23 @@ class Developers {
 					$email_url
 				) . '</p></div>';
 			} else {
+				wp_enqueue_script(
+					'wporg-plugins-commit-subscription',
+					plugins_url( 'js/commit-subscription.js', PLUGIN_FILE ),
+					array(),
+					(string) filemtime( PLUGIN_DIR . '/js/commit-subscription.js' ),
+					true
+				);
+
 				$output .= '<p>' . sprintf(
 					/* translators: 1: email subscription URL, 2: Confirm of subscribe-by-email */
-					__( 'You can also subscribe to emails for each plugin commit by <a href="%1$s" onclick="confirm(%2$s)">clicking here</a>.', 'wporg-plugins' ),
+					__( 'You can also subscribe to emails for each plugin commit by <a href="%1$s" class="plugin-commit-subscribe" data-confirm="%2$s">clicking here</a>.', 'wporg-plugins' ),
 					$email_url,
-					esc_attr( wp_json_encode( sprintf(
+					esc_attr( sprintf(
+						/* translators: %s: plugin name */
 						__( 'Are you sure you want to subscribe to email notifications for each commit to %s?', 'wporg-plugins' ),
 						$title
-					) ) )
+					) )
 				) . '</p>';
 			}
 		}


### PR DESCRIPTION
Both directories have a handful of spots that build markup by interpolation with no escaper, or with one whose guarantees don't match the context the value lands in. This brings them in line with the code immediately around them.

### Plugin Directory

- **`admin/list-table/class-plugin-posts.php`** — the Assigned Reviewer column builds its link with `get_edit_link()` and an explicit args array, the way core's `column_author()` does, and escapes the reviewer name and the relative time. The link now points at `edit.php?post_type=plugin&reviewer=<id>`; like core's author column, it no longer carries the current view's search/status/paging over.
- **`class-template.php`** — the plugin icon `<img>` uses double-quoted attributes and `esc_url()`. It was interpolating `esc_url_raw()` into single quotes; the raw variant is for storage and redirects and deliberately leaves `'` alone. `get_asset_url()` still returns the raw form for its non-markup callers, and the banner markup beside it already did this.
- **`admin/metabox/class-controls.php`** — the Tested With row escapes its value, matching the three sibling rows above it, and the same value as rendered by `class-custom-fields.php`.
- **`class-template.php`** and **`photo-directory/inc/head.php`** — the JSON-LD schema is encoded with the `JSON_HEX_*` flags so nothing in it can close the `<script>` element. `JSON_UNESCAPED_SLASHES` stays, so the readable-URL intent is unchanged. `esc_html()` on the encoded JSON is not an option: entities aren't decoded inside a script element, so it would only corrupt the schema for consumers.
- **`shortcodes/class-developers.php`** — the commit-subscription confirmation moves out of an inline `onclick` into a `data-confirm` attribute read by a small script (`js/commit-subscription.js`), so the plugin title is only ever parsed as HTML. `esc_attr()` can't cover the inline form: it doesn't double-encode, so an entity already in the title survives it intact. The title is also escaped at its three other uses in the same shortcode.

### Photo Directory

- **`inc/moderation.php`**, **`inc/admin.php`** — moderation flag names and severities are escaped in both the list-table column and the metabox. `format_flags()` escaped the severity where it lands in `class` and then re-emitted it raw inside `title`, with the flag name raw in both remaining positions.
- `Moderation::show_flags()` no longer passes markup through the flag names, so the shared formatter can escape unconditionally. The rejection-rate percentages lose their `<strong>` as a result — they were rendering their tags literally inside the `title` attribute anyway.

### Notes

- Four translatable strings change: the three rejection-rate strings and the commit-subscription sentence.
- `js/commit-subscription.js` is enqueued only in the branch that renders the link, following `shortcodes/class-screenshots.php`.
- No new `phpcs` violations in any touched file; `php -l` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
