### PR TITLE
Trac: Restore WP.org color scheme for tickets

### DIFF
--- a/wordpress.org/public_html/style/trac/wp-trac.css
+++ b/wordpress.org/public_html/style/trac/wp-trac.css
@@ -325,26 +325,22 @@ form#search input {
 }
 
 #tabs {
-	-webkit-border-radius: 3px;
 	border-radius: 3px;
 	-webkit-box-shadow: none;
 	box-shadow: none;
 }
 
 #tabs li li.active {
-	-webkit-border-radius: 0;
 	border-radius: 0;
 	-webkit-box-shadow: none;
 	box-shadow: none;
 }
 
 .plugin {
-	-webkit-border-radius: 3px;
 	border-radius: 3px;
 }
 
 .plugin .foldable > :link, .plugin .foldable > :visited {
-	-webkit-border-radius: 3px;
 	border-radius: 3px;
 }
 
@@ -376,7 +372,6 @@ table.code td {
 }
 
 div.code {
-	-webkit-border-radius: 3px;
 	border-radius: 3px;
 }
 
@@ -483,13 +478,20 @@ table.progress td.closed {
 }
 
 #ticket {
-	background: #f9f9f9;
-	border: 1px solid #ccc;
 	padding: 0;
 }
 
-#ticket > h2 {
+#ticketbox {
+	background: #f9f9f9;
+	border: 1px solid #ccc;
+}
+
+#ticketbox > h2 {
 	font-size: 16px;
+}
+
+#ticketbox > h1 {
+	color: inherit;
 }
 
 #ticket .date {
@@ -524,7 +526,7 @@ table.progress td.closed {
 	color: #666;
 }
 
-#ticket div.description h3 {
+#ticket div.description h2 {
 	border-bottom: 1px solid #ddd;
 	color: #666;
 }
@@ -584,18 +586,15 @@ table.progress td.closed {
 	padding: .2em 0; /* breathing room */
 }
 
-#ticket {
-	-webkit-border-radius: 3px;
+#ticketbox {
 	border-radius: 3px;
 }
 
 .ticketdraft {
-	-webkit-border-radius: 3px;
 	border-radius: 3px;
 }
 
 ul.children > li.child {
-	-webkit-border-radius: 3px;
 	border-radius: 3px;
 }
 
@@ -715,7 +714,6 @@ blockquote.citation {
 	font: 400 10px "Open Sans",sans-serif;
 	background: none;
 	border: 0;
-	-webkit-border-radius: 0;
 	border-radius: 0;
 	line-height: 1;
 	margin-top: 8px;
@@ -726,7 +724,6 @@ blockquote.citation {
 
 #mainnav .first, #mainnav .first :link,
 #mainnav .last, #mainnav .last :link {
-	-webkit-border-radius: 0;
 	border-radius: 0;
 }
 
@@ -867,7 +864,6 @@ span:target {
 }
 
 input[type="button"], input[type="submit"], input[type="reset"] {
-	-webkit-border-radius: 3px;
 	border-radius: 3px;
 	text-shadow: none;
 	-webkit-box-shadow: none;
@@ -895,7 +891,6 @@ input[type="reset"]:focus:active {
 }
 
 input[type="text"], input.textwidget, textarea {
-	-webkit-border-radius: 3px;
 	border-radius: 3px;
 	font-size: 13px;
 }
@@ -905,14 +900,12 @@ input[name="description"] {
 }
 
 fieldset {
-	-webkit-border-radius: 3px;
 	border-radius: 3px;
 	-webkit-box-shadow: none;
 	box-shadow: none;
 }
 
 .inlinebuttons input {
-	-webkit-border-radius: 3px;
 	border-radius: 3px;
 }
 
@@ -952,7 +945,6 @@ div.trac-content {
 }
 
 #prefs {
-	-webkit-border-radius: 3px;
 	border-radius: 3px;
 }
 
@@ -967,7 +959,6 @@ pre.wiki, pre.literal-block {
 }
 
 tt {
-	-webkit-border-radius: 3px;
 	border-radius: 3px;
 }
 
@@ -983,7 +974,6 @@ table.listing {
 
 span.system-message,
 div.system-message {
-	-webkit-border-radius: 3px;
 	border-radius: 3px;
 	-webkit-box-shadow: none;
 	box-shadow: none;
@@ -1004,7 +994,6 @@ div.system-message {
 }
 
 div.system-message .trac-close-msg {
-	-webkit-border-radius: 3px;
 	border-radius: 3px;
 }
 
@@ -1060,7 +1049,6 @@ div.trac-content {
 span.avatar img,
 table.properties img.avatar {
 	float: left;
-	-webkit-border-radius: 3px;
 	border-radius: 3px;
 }
 
@@ -1186,7 +1174,6 @@ div.change > .trac-ticket-buttons {
 }
 
 div.trac-ticket-buttons input[type="submit"] {
-	-webkit-border-radius: 0;
 	border-radius: 0;
 	background: none;
 	padding: 0 5px;


### PR DESCRIPTION
Fixes #8391

## Summary

Trac 1.6 changed the ticket page markup: content is now wrapped in a new `#ticketbox` div nested inside `#ticket`, and the description heading was renamed from `h3` to `h2`. `wp-trac.css`'s overrides were still written against the pre-1.6 structure, so several selectors silently stopped matching:

- `#ticket > h2` no longer matched the id/status/type badge line (it's now a grandchild of `#ticket`, not a direct child), losing its `font-size` override.
- `#ticket`'s background/border no longer reached the actual box — Trac's own `ticket.css` now colors the nested `#ticketbox` (yellow background, double border).
- Trac's `ticket.css` now also colors the ticket title (`#trac-ticket-title`, an `h1` wrapping the summary) via a grouped `#ticketbox > h1, #ticketbox > h2 { color: #844 }` rule. That `h1` target didn't exist pre-1.6, so the summary text picked up Trac's maroon color with no WP.org override in place.
- `#ticket div.description h3` stopped matching the description heading, which Trac renamed to `h2`, losing its color/border-bottom override.

## Changes

- Move the box background/border/radius and badge-line `font-size` overrides from `#ticket` to `#ticketbox`.
- Add a color reset for `#ticketbox > h1` (the ticket title/summary).
- Update the description heading selector from `h3` to `h2`.
- Drop the unrelated but noticed-along-the-way dead `-webkit-border-radius` declarations throughout the file (unprefixed `border-radius` has been supported everywhere since ~2012).

## Test plan

- [ ] Load a ticket page and confirm the ticket box has a single gray border with no yellow background.
- [ ] Confirm the ticket summary/title text is no longer maroon.
- [ ] Confirm the "Description" section heading uses the neutral WP.org gray, not the native Trac color/border.