### PR TITLE
Trac: Read the asset cache-busting version from common.ini

### DIFF
--- a/trac.wordpress.org/conf/common.ini
+++ b/trac.wordpress.org/conf/common.ini
@@ -14,7 +14,7 @@ trac.admin.web_ui.BasicsAdminPanel = disabled
 trac.admin.web_ui.LoggingAdminPanel = disabled
 
 [wporg]
-scripts_version = 240
+scripts_version = 243
 
 [inherit]
 file = common-extended.ini

--- a/trac.wordpress.org/templates/site_footer.html
+++ b/trac.wordpress.org/templates/site_footer.html
@@ -1,9 +1,8 @@
 {# WordPress.org Trac customizations — content injected at the end of <body>.
 
-  Jinja2 replacement for the tail of the old Genshi site.html <body> match.
   Trac auto-includes this file (see TracInterfaceCustomization).
 #}
-# set scripts_version = '242'
+# set scripts_version = env.config.get('wporg', 'scripts_version')
 # set project_slug = req.environ['HTTP_HOST'].split(':')[0].split('.')[0]
 # set wporg_endpoint = 'https://make.wordpress.org/' + project_slug + '/'
 # set notifications_enabled = project_slug in ['core', 'meta']

--- a/trac.wordpress.org/templates/site_head.html
+++ b/trac.wordpress.org/templates/site_head.html
@@ -1,10 +1,8 @@
 {# WordPress.org Trac customizations — content injected into <head>.
 
-  Jinja2 replacement for the `head` matches in the old Genshi site.html.
-  Trac auto-includes this file (see TracInterfaceCustomization). Only additive
-  markup belongs here; DOM rewrites now live in wp-trac.js / wp-trac.css.
+  Trac auto-includes this file (see TracInterfaceCustomization).
 #}
-# set scripts_version = '242'
+# set scripts_version = env.config.get('wporg', 'scripts_version')
 # set project_slug = req.environ['HTTP_HOST'].split(':')[0].split('.')[0]
 
 ## WP.org global <head> markup (kept in sync by update-headers.php)


### PR DESCRIPTION
## Summary

- `site_head.html` and `site_footer.html` each hardcoded their own `scripts_version`, so every wp-trac.css/js cache bump required editing both files in lockstep.
- Both templates now read `scripts_version` from a new `[wporg]` section in `common.ini` via `env.config.get('wporg', 'scripts_version')`, giving a single source of truth.

## Test plan

- [ ] Deploy to the dotorg sandbox and confirm `wp-trac.css`/`wp-trac.js`/`trac-security.js` URLs render with `?243`
- [ ] Confirm bumping `[wporg] scripts_version` in `common.ini` alone updates both templates' asset URLs