### PR TITLE
Escape values interpolated into HTML attributes

### DIFF
--- a/global.wordpress.org/public_html/wp-content/themes/rosetta/front-page.php
+++ b/global.wordpress.org/public_html/wp-content/themes/rosetta/front-page.php
@@ -140,7 +140,7 @@ if ( false === $latest_release && $rosetta->rosetta->get_latest_release() ) :
 	while (have_posts()) : the_post();
 ?>
 							<div class="post" id="post-<?php the_ID(); ?>">
-								<h4><a href="<?php the_permalink() ?>" rel="bookmark" title="<?php printf( esc_attr__('Permanent Link to %s', 'rosetta'), get_the_title()); ?>"><?php the_title(); ?></a></h4>
+								<h4><a href="<?php the_permalink(); ?>" rel="bookmark" title="<?php echo esc_attr( sprintf( __( 'Permanent Link to %s', 'rosetta' ), get_the_title() ) ); ?>"><?php the_title(); ?></a></h4>
 								<div class="entry">
 									<?php the_excerpt(); ?>
 								</div>

--- a/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-hooks.php
+++ b/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-hooks.php
@@ -55,7 +55,16 @@ class Hooks {
 		remove_filter( 'bbp_get_topic_author_link', 'bbp_rel_nofollow' );
 		remove_filter( 'bbp_get_reply_author_link', 'bbp_rel_nofollow' );
 
-		// add ugc to links in topics and replies. These already have nofollow, this adds ugc as well
+		/*
+		 * Remove the nofollow filter from topic and reply content. It parses attributes with
+		 * shortcode_parse_atts(), which runs stripcslashes() over every value, and then re-emits
+		 * them without escaping. add_rel_ugc() below adds nofollow via wp_rel_callback(), which
+		 * escapes, so dropping this loses no behaviour.
+		 */
+		remove_filter( 'bbp_get_reply_content', 'bbp_rel_nofollow', 60 );
+		remove_filter( 'bbp_get_topic_content', 'bbp_rel_nofollow', 60 );
+
+		// add nofollow and ugc to links in topics and replies
 		add_filter( 'bbp_get_reply_content', array( $this, 'add_rel_ugc' ), 80 );
 		add_filter( 'bbp_get_topic_content', array( $this, 'add_rel_ugc' ), 80 );
 

--- a/wordpress.org/public_html/wp-content/plugins/wp-i18n-teams/views/locale-details.php
+++ b/wordpress.org/public_html/wp-content/plugins/wp-i18n-teams/views/locale-details.php
@@ -80,7 +80,7 @@
 					?></a>
 				<?php
 				if ( $locale_manager['slack'] ) {
-					printf( '<span class="user-slack">@%s on <a href="%s">Slack</a></span>', $locale_manager['slack'], 'https://make.wordpress.org/chat/' );
+					printf( '<span class="user-slack">@%s on <a href="%s">Slack</a></span>', esc_html( $locale_manager['slack'] ), 'https://make.wordpress.org/chat/' );
 				}
 				?>
 			</li>
@@ -101,7 +101,7 @@
 				?></a>
 				<?php
 				if ( $validator['slack'] ) {
-					printf( '<span class="user-slack">@%s on <a href="%s">Slack</a></span>', $validator['slack'], 'https://make.wordpress.org/chat/' );
+					printf( '<span class="user-slack">@%s on <a href="%s">Slack</a></span>', esc_html( $validator['slack'] ), 'https://make.wordpress.org/chat/' );
 				}
 				?>
 			</li>
@@ -122,7 +122,7 @@
 				?></a>
 				<?php
 				if ( $validator['slack'] ) {
-					printf( '<span class="user-slack">@%s on <a href="%s">Slack</a></span>', $validator['slack'], 'https://make.wordpress.org/chat/' );
+					printf( '<span class="user-slack">@%s on <a href="%s">Slack</a></span>', esc_html( $validator['slack'] ), 'https://make.wordpress.org/chat/' );
 				}
 				?>
 			</li>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/404.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/404.php
@@ -38,10 +38,18 @@ $wp_query = new WP_Query( array( 'no_found_rows' => true, 'post_type' => 'post',
 											$image_src = substr($value, 0, $space);
 											$image_desc = substr($value, $space+1);
 
+											$thumb_src = add_query_arg(
+												array(
+													'w' => 155,
+													'h' => 155,
+												),
+												$image_src
+											);
+
 											$output .= "<dl class='gallery-item'>";
 											$output .= "
 												<dt class='gallery-icon'>
-													<a href='$image_src' title='$image_desc'><img src='$image_src?w=155&h=155' /></a>
+													<a href='" . esc_url( $image_src ) . "' title='" . esc_attr( $image_desc ) . "'><img src='" . esc_url( $thumb_src ) . "' /></a>
 												</dt>";
 											$output .= "</dl>";
 											if ( $key > 0 && $key+1 % 2 == 0 )

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/functions.php
@@ -56,7 +56,7 @@ function site_screenshot_src( $width = '', $echo = true ) {
 	$screenshot = str_replace( 'http://', 'https://', $screenshot );
 
 	if ( $echo ) {
-		echo $screenshot;
+		echo esc_url( $screenshot );
 	} else {
 		return $screenshot;
 	}
@@ -77,9 +77,15 @@ function site_screenshot_tag( $width = '', $classes='screenshot' ) {
 	// mshot images have a 4/3 ratio
 	$height = (int)( $width * (3/4) );
 
-	$img = "<img src='{$screenshot}' srcset='$srcset 2x' width='{$width}' height='{$height}' alt='". the_title_attribute(array('echo'=>false)) . "' class='{$classes}' />";
-
-	echo $img;
+	printf(
+		'<img src="%s" srcset="%s 2x" width="%s" height="%s" alt="%s" class="%s" />',
+		esc_url( $screenshot ),
+		esc_url( $srcset ),
+		esc_attr( $width ),
+		esc_attr( $height ),
+		the_title_attribute( array( 'echo' => false ) ),
+		esc_attr( $classes )
+	);
 }
 
 function wp_flavors() {

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/js/fancyzoom.js
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/js/fancyzoom.js
@@ -79,7 +79,9 @@ function prepZooms() {
 	if (! document.getElementsByTagName) {
 		return;
 	}
-	var links = document.getElementsByTagName("a");
+	// Only the theme's own gallery is zoomable; unrelated anchors (comment links) must not be bound.
+	var gallery = document.querySelector(".gallery");
+	var links = gallery ? gallery.getElementsByTagName("a") : [];
 	for (i = 0; i < links.length; i++) {
 		if (links[i].getAttribute("href")) {
 			if (links[i].getAttribute("href").search(/(.*)\.(jpg|jpeg|gif|png|bmp|tif|tiff)/gi) != -1) {
@@ -239,10 +241,10 @@ function zoomIn(from, shift) {
 		if (includeCaption) {
 			document.getElementById(zoomCaptionDiv).style.visibility = "hidden";
 			if (from.getAttribute('title') && includeCaption) {
-				// Yes, there's a caption, set it up
-				document.getElementById(zoomCaption).innerHTML = from.getAttribute('title');
+				// Yes, there's a caption, set it up. The title is untrusted, so it is written as text.
+				document.getElementById(zoomCaption).textContent = from.getAttribute('title');
 			} else {
-				document.getElementById(zoomCaption).innerHTML = "";
+				document.getElementById(zoomCaption).textContent = "";
 			}
 		}
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/single.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/single.php
@@ -31,10 +31,18 @@
 											$image_src = substr($value, 0, $space);
 											$image_desc = substr($value, $space+1);
 
+											$thumb_src = add_query_arg(
+												array(
+													'w' => 155,
+													'h' => 155,
+												),
+												$image_src
+											);
+
 											$output .= "<dl class='gallery-item'>";
 											$output .= "
 												<dt class='gallery-icon'>
-													<a href='$image_src' title='$image_desc'><img src='$image_src?w=155&h=155' /></a>
+													<a href='" . esc_url( $image_src ) . "' title='" . esc_attr( $image_desc ) . "'><img src='" . esc_url( $thumb_src ) . "' /></a>
 												</dt>";
 											$output .= "</dl>";
 											if ( $key > 0 && $key+1 % 2 == 0 )

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/user-profile.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/user-profile.php
@@ -74,7 +74,7 @@ do_action( 'bbp_template_before_user_profile' ); ?>
 				/* translators: 1: user's WordPress.org profile link, 2: user's Slack username, 3: make.wordpress.org/chat URL */
 				printf( __( '%1$s on WordPress.org, %2$s on <a href="%3$s">Slack</a>', 'wporg-forums' ),
 					wporg_support_get_wporg_profile_link(),
-					'@' . $slack_username,
+					'@' . esc_html( $slack_username ),
 					'https://make.wordpress.org/chat/'
 				);
 			} elseif( $slack_username ) {


### PR DESCRIPTION
A sweep of templates that build HTML attributes by interpolation without an escaper, or with one that does not match the context. Each change is a straightforward output-escaping correction.

### Rosetta

`front-page.php`'s blog list applied `esc_attr__()` to the `printf()` format string — a hardcoded developer constant with nothing to escape — while the post title passed as the argument was interpolated raw. Reworked to escape the composed string.

### Showcase

- `single.php` / `404.php`: the gallery loop interpolated the two halves of the `image` custom field into single-quoted `href` and `title` attributes with no escaper. Now `esc_url()` / `esc_attr()`. The `?w=155&h=155` cache-buster was also being concatenated onto a URL that may already carry a query string, so it now goes through `add_query_arg()`.
- `functions.php`: `site_screenshot_tag()` escaped `alt` but not `src`, `srcset`, `width`, `height` or `class`. `site_screenshot_src()` echoed its URL raw.
- `js/fancyzoom.js`: the caption is a plain string, so it is now written with `textContent` rather than `innerHTML`. `prepZooms()` also scanned every anchor in the document; it is now scoped to the theme's own `.gallery` container, so unrelated links are not given zoom handlers.

### Support forums

bbPress registers `bbp_rel_nofollow` on `bbp_get_topic_content` and `bbp_get_reply_content` at priority 60. It parses attributes with `shortcode_parse_atts()`, which runs `stripcslashes()` over every value, and then re-emits them with no escaping. `class-hooks.php` already removes this filter from the author-link hooks, and adds its own `add_rel_ugc()` at priority 80 — which builds attributes via core's `wp_rel_callback()` and escapes them. Removing the priority-60 filter from the two content hooks therefore loses no behaviour.

This one is a mitigation, not the root fix: the defect is in `bbp_rel_nofollow_callback()` in bbPress itself, which is unfixed upstream and affects every bbPress site. That needs a separate fix there — `wp_kses_hair()` in place of `shortcode_parse_atts()`, plus `esc_attr()` on re-emission. Note an escaper alone is not sufficient upstream, since the decode has already happened by that point. Removing the filter here is worth doing regardless, because on WordPress.org it is pure redundancy.

### i18n teams / support profiles

Slack display names are synced from an external source and were printed raw into markup on support profiles and locale team pages. Escaped at the three `wp-i18n-teams` sinks and at the `wporg-support-2024` profile sink.

The getters are deliberately left returning the raw value. `sanitize_text_field()` there would be the wrong tool — it is a sanitiser in a read position, and it is lossy for legitimate names, since it strips percent-encoded sequences (`50%20off` → `50off`). If a defence-in-depth layer is wanted it belongs at import, where `slack_users.profiledata` is written.

### Notes

- `wporg-learn-2024`'s `search-results-context` block has the same class of issue — `esc_attr()` used for an element-name position. It is mirrored here from `WordPress/Learn`, so the fix goes there instead and will arrive on the next sync: WordPress/Learn#3586.
- `wporg-showcase` appears superseded by [wporg-showcase-2022](https://github.com/WordPress/wporg-showcase-2022) and has had no commits since June 2022; the fixes are included since the theme is still in the tree, but removing the theme would be the better close. That would also drop `fancyzoom.js`, which carries a licence requiring a per-domain fee for commercial use and forbidding sale of derived works.
- Linted with `./vendor/bin/phpcs`; no new violations on the changed lines. Pre-existing violations in these files are left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)