### PR TITLE
Fix unit tests after GitHub outage

### DIFF
--- a/environments/plugin-directory/.wp-env.test.json
+++ b/environments/plugin-directory/.wp-env.test.json
@@ -4,7 +4,13 @@
 	"plugins": [
 		"../wordpress.org/public_html/wp-content/plugins/plugin-directory"
 	],
+	"mappings": {
+		"wp-content/env-bin": "./plugin-directory/bin"
+	},
 	"lifecycleScripts": {
 		"afterStart": "bash plugin-directory/bin/after-start-test.sh"
+	},
+	"config": {
+		"PLUGINS_TABLE_PREFIX": "wp_"
 	}
 }

--- a/environments/plugin-directory/bin/after-start-test.sh
+++ b/environments/plugin-directory/bin/after-start-test.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 #
 # Runs after wp-env start for the test environment.
-# Installs PHPUnit 11 and Yoast polyfills in the test container.
+# Installs PHPUnit 11 and Yoast polyfills in the test container, and creates the
+# stub tables that live outside WordPress on production.
 #
 
 CONFIG="--config plugin-directory/.wp-env.test.json"
@@ -10,3 +11,8 @@ RUN="npx wp-env $CONFIG run tests-cli"
 echo "Installing PHPUnit 11 and polyfills..."
 $RUN composer global require -W phpunit/phpunit:^11.0 2>&1
 $RUN composer require --dev yoast/phpunit-polyfills:^4.0 --working-dir=/wordpress-phpunit 2>&1
+
+# The file only uses CREATE TABLE IF NOT EXISTS, so re-importing it on every
+# start is safe.
+echo "Creating stub database tables..."
+$RUN -- wp db import wp-content/env-bin/database-tables.sql 2>&1


### PR DESCRIPTION
The unit test workflow has been failing on every trunk push and PR since [r15044](https://github.com/WordPress/wordpress.org/commit/6e29a0ef9) (#767): the new `Capabilities_Committer_Identity_Test` reads the `PLUGINS_TABLE_PREFIX` constant and inserts rows into the `svn_access` stub table, both of which were only provisioned in the development environment — the tests environment (`.wp-env.test.json`) had neither, so all nine tests error with `Undefined constant "PLUGINS_TABLE_PREFIX"`.

This defines the constant and imports the existing `database-tables.sql` stubs in the tests environment, mirroring how the Make environment already handles it.

Verified locally with `npm run plugins:test`: 164 tests, 265 assertions, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)