### PR TITLE
Official WordPress Events: Remove use of retired Meetup API key

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/official-wordpress-events/official-wordpress-events.php
+++ b/wordpress.org/public_html/wp-content/plugins/official-wordpress-events/official-wordpress-events.php
@@ -919,7 +919,7 @@ class Official_WordPress_Events {
 	 */
 	protected function log( $message, $write_to_disk = false ) {
 		$limit = 500;
-		$api_keys = array( MEETUP_API_KEY, OFFICIAL_WP_EVENTS_GOOGLE_MAPS_API_KEY );
+		$api_keys = array( OFFICIAL_WP_EVENTS_GOOGLE_MAPS_API_KEY );
 
 		if ( 'cli' === php_sapi_name() ) {
 			echo "\n" . $message;


### PR DESCRIPTION
The Meetup.com API is no longer active, so the `MEETUP_API_KEY` constant no longer needs to be redacted from log messages. This removes its only remaining use in the plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)