### PR TITLE
Plugin Directory: Set up release blocking for high-risk security scans

### DIFF
--- a/environments/plugin-directory/.wp-env.test.json
+++ b/environments/plugin-directory/.wp-env.test.json
@@ -12,6 +12,7 @@
 		"afterStart": "bash plugin-directory/bin/after-start-test.sh"
 	},
 	"config": {
-		"PLUGINS_TABLE_PREFIX": "wp_"
+		"PLUGINS_TABLE_PREFIX": "wp_",
+		"WP_GANDALF_SCAN_SHARED_SECRET": "local-dev-secret"
 	}
 }

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/api/routes/class-gandalf-scan.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/api/routes/class-gandalf-scan.php
@@ -44,9 +44,10 @@ class Gandalf_Scan extends Base {
 						'validate_callback' => [ $this, 'validate_plugin_slug_callback' ],
 					],
 					'status'          => [
-						'type'     => 'string',
-						'enum'     => [ 'completed', 'failed' ],
-						'required' => true,
+						'type'              => 'string',
+						'enum'              => [ 'completed', 'failed' ],
+						'required'          => true,
+						'validate_callback' => [ $this, 'validate_status_callback' ],
 					],
 					'scan_id'         => [
 						'type'      => 'string',
@@ -179,6 +180,43 @@ class Gandalf_Scan extends Base {
 				],
 			]
 		);
+	}
+
+	/**
+	 * Validate that a callback body carries the fields its status implies.
+	 *
+	 * The contract has two halves — a completed scan reports a verdict, a
+	 * failed one reports an error — and `required` cannot express either,
+	 * being unconditional. Enforcing it here keeps the whole body schema in
+	 * the route, so the callback runs only on a payload it can read directly.
+	 *
+	 * @param mixed            $value   The status value.
+	 * @param \WP_REST_Request $request The request.
+	 * @param string           $param   The parameter name.
+	 * @return true|WP_Error True when the body matches its status.
+	 */
+	public function validate_status_callback( $value, $request, $param ) {
+		$valid = rest_validate_request_arg( $value, $request, $param );
+		if ( is_wp_error( $valid ) ) {
+			return $valid;
+		}
+
+		$required = 'completed' === $value
+			? [ 'verdict_hash', 'findings_count', 'severity_counts', 'max_risk_score', 'findings', 'report_url' ]
+			: [ 'error' ];
+
+		foreach ( $required as $field ) {
+			if ( null === $request->get_param( $field ) ) {
+				return new WP_Error(
+					'rest_missing_callback_param',
+					/* translators: 1: Field name, 2: Callback status. */
+					sprintf( __( '%1$s is required for a %2$s security scan callback.', 'wporg-plugins' ), $field, $value ),
+					[ 'status' => WP_Http::BAD_REQUEST ]
+				);
+			}
+		}
+
+		return true;
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan-gandalf.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan-gandalf.php
@@ -291,16 +291,11 @@ class Plugin_Scan_Gandalf {
 				self::record_review_note( $plugin, $record );
 			}
 
-			// A retry of a partially processed delivery must not downgrade the recorded action.
-			$previous_result = get_post_meta( $plugin->ID, self::LAST_RESULT_META_KEY, true );
-			if ( is_array( $previous_result ) && ( $previous_result['scan_id'] ?? '' ) === $scan_id && 'advisory' === $record['action'] ) {
-				$record['action'] = $previous_result['action'] ?? 'advisory';
-			}
+			// Persist the bounded evidence snapshot and the action taken on it; update_post_meta() unslashes.
+			update_post_meta( $plugin->ID, self::LAST_RESULT_META_KEY, wp_slash( $record ) );
 
-			// Persist the bounded evidence snapshot and the action taken on it.
-			update_post_meta( $plugin->ID, self::LAST_RESULT_META_KEY, $record );
-
-			if ( $record['findings_count'] > 0 || 'advisory' !== $record['action'] ) {
+			// A refused block still alerts: the scanned code is live and nothing held it.
+			if ( $record['max_risk_score'] >= $threshold || $record['findings_count'] > 0 ) {
 				self::notify_slack( $plugin, $record );
 			}
 		} else {
@@ -391,7 +386,7 @@ class Plugin_Scan_Gandalf {
 			esc_html( $record['version'] ),
 			esc_html( $record['release_ref'] ),
 			esc_html( $record['scan_id'] ),
-			esc_html( $record['max_risk_score'] )
+			esc_html( number_format( (float) $record['max_risk_score'], 1 ) )
 		);
 
 		$note .= '<br><br>Findings:';

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan-gandalf.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan-gandalf.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Advisory Gandalf scan integration for plugin updates.
+ * Gandalf scan integration for plugin updates.
  *
  * @package WordPressdotorg\Plugin_Directory\Jobs
  */
@@ -9,11 +9,16 @@ namespace WordPressdotorg\Plugin_Directory\Jobs;
 
 use WordPressdotorg\Plugin_Directory\Plugin_Directory;
 use WordPressdotorg\Plugin_Directory\Template;
+use WordPressdotorg\Plugin_Directory\Tools;
 use WP_Error;
 use WP_Http;
 
 /**
- * Sends plugin updates to Gandalf for advisory security scans.
+ * Sends plugin updates to Gandalf for security scans and acts on the results.
+ *
+ * Completed scans whose maximum risk score reaches the block threshold hold
+ * the scanned release out of the update API — the previously served version
+ * keeps being served.
  *
  * @package WordPressdotorg\Plugin_Directory\Jobs
  */
@@ -30,6 +35,12 @@ class Plugin_Scan_Gandalf {
 
 	/** Consumed callbacks keyed by scan_id, to acknowledge retries without repeating effects. */
 	const CONSUMED_META_KEY = '_gandalf_scan_consumed';
+
+	/** Bounded evidence snapshot of the last completed scan. */
+	const LAST_RESULT_META_KEY = '_gandalf_scan_last_result';
+
+	/** Completed scans with a max risk score at or above this have their release blocked. */
+	const BLOCK_RISK_SCORE = 8.0;
 
 	/** Gandalf scan endpoint. */
 	const ENDPOINT = 'https://gandalf.wordpress.org/scan';
@@ -239,20 +250,58 @@ class Plugin_Scan_Gandalf {
 		}
 
 		if ( 'completed' === $data['status'] ) {
-			if ( $data['findings_count'] > 0 ) {
-				self::notify_slack(
-					$plugin,
-					[
-						'version'         => $pending_record['version'],
-						'release_ref'     => $pending_record['release_ref'],
-						'findings_count'  => $data['findings_count'],
-						'severity_counts' => $data['severity_counts'],
-						'verdict_hash'    => $data['verdict_hash'],
-						'report_url'      => $data['report_url'],
-						'findings'        => is_array( $data['findings'] ?? null ) ? array_filter( $data['findings'], 'is_array' ) : [],
-						'max_risk_score'  => $data['max_risk_score'] ?? null,
-					]
-				);
+			$record = [
+				'scan_id'         => $scan_id,
+				'version'         => $pending_record['version'],
+				'release_ref'     => $pending_record['release_ref'],
+				'completed_at'    => $data['completed_at'] ?? time(),
+				'verdict_hash'    => $data['verdict_hash'],
+				'findings_count'  => $data['findings_count'],
+				'severity_counts' => $data['severity_counts'],
+				'max_risk_score'  => (float) $data['max_risk_score'],
+				'report_url'      => $data['report_url'],
+				'action'          => 'advisory',
+
+				/*
+				 * Only the ten highest-risk findings ever surface (Slack shows five,
+				 * the review note ten), and snippets and explanations are only in
+				 * the scan report; storing more would bloat a post meta row that is
+				 * loaded on every plugin page view.
+				 */
+				'findings'        => array_map(
+					static function ( $finding ) {
+						unset( $finding['code_snippet'], $finding['explanation'] );
+						return $finding;
+					},
+					self::top_findings( $data['findings'], 10 )
+				),
+			];
+
+			/**
+			 * Filters the risk score at which a completed security scan blocks the release.
+			 *
+			 * @param float    $threshold The block threshold, from 0 to 10.
+			 * @param \WP_Post $plugin    The plugin post.
+			 */
+			$threshold = (float) apply_filters( 'wporg_plugins_security_scan_block_risk_score', self::BLOCK_RISK_SCORE, $plugin );
+
+			if ( $record['max_risk_score'] >= $threshold && self::block_release( $plugin, $record ) ) {
+				$record['action'] = 'blocked';
+
+				self::record_review_note( $plugin, $record );
+			}
+
+			// A retry of a partially processed delivery must not downgrade the recorded action.
+			$previous_result = get_post_meta( $plugin->ID, self::LAST_RESULT_META_KEY, true );
+			if ( is_array( $previous_result ) && ( $previous_result['scan_id'] ?? '' ) === $scan_id && 'advisory' === $record['action'] ) {
+				$record['action'] = $previous_result['action'] ?? 'advisory';
+			}
+
+			// Persist the bounded evidence snapshot and the action taken on it.
+			update_post_meta( $plugin->ID, self::LAST_RESULT_META_KEY, $record );
+
+			if ( $record['findings_count'] > 0 || 'advisory' !== $record['action'] ) {
+				self::notify_slack( $plugin, $record );
 			}
 		} else {
 			self::record_last_error( $plugin, $data['error']['kind'], $data['error']['message'], $scan_id );
@@ -305,6 +354,82 @@ class Plugin_Scan_Gandalf {
 	}
 
 	/**
+	 * Block the scanned release, once the verdict is known to still apply to it.
+	 *
+	 * A verdict for a version that is no longer the plugin's current release,
+	 * or that is already being served, can't un-ship anything — blocking is
+	 * refused and the result stays advisory.
+	 *
+	 * @param \WP_Post $plugin The plugin post.
+	 * @param array    $record The completed scan record.
+	 * @return bool Whether the release was blocked.
+	 */
+	protected static function block_release( $plugin, $record ) {
+		// A newer release landed since this scan was dispatched; the scanned version is moot.
+		if ( (string) get_post_meta( $plugin->ID, 'version', true ) !== (string) $record['version'] ) {
+			return false;
+		}
+
+		return API_Update_Updater::block_release(
+			$plugin->post_name,
+			[
+				'scan_id'    => $record['scan_id'],
+				'risk_score' => $record['max_risk_score'],
+			]
+		);
+	}
+
+	/**
+	 * Leave an internal note with the scan findings for the plugin review team.
+	 *
+	 * @param \WP_Post $plugin The plugin post.
+	 * @param array    $record The completed scan record.
+	 */
+	protected static function record_review_note( $plugin, $record ) {
+		$note = sprintf(
+			'Automatically blocked version %s (%s) from being served: security scan %s reported a maximum risk score of %s. Force-release to serve it.',
+			esc_html( $record['version'] ),
+			esc_html( $record['release_ref'] ),
+			esc_html( $record['scan_id'] ),
+			esc_html( $record['max_risk_score'] )
+		);
+
+		$note .= '<br><br>Findings:';
+		foreach ( self::top_findings( $record['findings'], 10 ) as $finding ) {
+			$note .= sprintf(
+				'<br>&#8226; <strong>%s</strong> &mdash; %s',
+				esc_html( number_format( (float) $finding['risk_score'], 1 ) ),
+				esc_html( self::excerpt( $finding['title'] ?? '', 200 ) )
+			);
+
+			if ( ! empty( $finding['file_path'] ) ) {
+				$note .= sprintf(
+					'<br>&nbsp;&nbsp;%s%s',
+					esc_html( $finding['file_path'] ),
+					empty( $finding['line'] ) ? '' : ':' . (int) $finding['line']
+				);
+			}
+
+			// The contract only requires a finding's risk_score; read the rest defensively.
+			$investigation = $finding['investigation'] ?? [];
+			if ( 'completed' === ( $investigation['status'] ?? '' ) && in_array( $investigation['result'] ?? '', [ 'reproduced', 'conditional' ], true ) ) {
+				$note .= sprintf(
+					'<br>&nbsp;&nbsp;Investigation (%s): %s',
+					esc_html( $investigation['result'] ),
+					esc_html( self::excerpt( $investigation['summary'] ?? '', 200 ) )
+				);
+			}
+		}
+
+		$note .= '<br><br>Report: ' . esc_url( $record['report_url'] );
+
+		$wordpressdotorg = get_user_by( 'slug', 'wordpressdotorg' );
+
+		// wp_insert_comment() unslashes; slash so backslashes in finding strings survive.
+		Tools::audit_log( wp_slash( $note ), $plugin, $wordpressdotorg ? $wordpressdotorg : false );
+	}
+
+	/**
 	 * Record a valid-secret callback that failed validation.
 	 *
 	 * @param \WP_Post $plugin  The plugin post.
@@ -342,7 +467,7 @@ class Plugin_Scan_Gandalf {
 	 * Notify Slack about a Gandalf scan with findings.
 	 *
 	 * @param \WP_Post $plugin The plugin post.
-	 * @param array    $record The completed scan summary.
+	 * @param array    $record The completed scan record.
 	 */
 	protected static function notify_slack( $plugin, $record ) {
 		if ( empty( $record['verdict_hash'] ) ) {
@@ -356,7 +481,8 @@ class Plugin_Scan_Gandalf {
 			}
 		}
 
-		if ( isset( $already_notified[ $record['verdict_hash'] ] ) ) {
+		// Release blocks always alert; only advisory results deduplicate.
+		if ( 'advisory' === $record['action'] && isset( $already_notified[ $record['verdict_hash'] ] ) ) {
 			update_post_meta( $plugin->ID, self::NOTIFIED_META_KEY, $already_notified );
 			return;
 		}
@@ -393,11 +519,16 @@ class Plugin_Scan_Gandalf {
 			$meta_links .= ' · ' . htmlspecialchars( $record['release_ref'], ENT_NOQUOTES );
 		}
 
+		$summary_text = sprintf( '%s · %s', 1 === $findings_count ? '*1 finding*' : "*{$findings_count} findings*", $install_text );
+		if ( isset( $record['max_risk_score'] ) ) {
+			$summary_text .= sprintf( ' · max risk %s', number_format( (float) $record['max_risk_score'], 1 ) );
+		}
+
 		$summary = [
 			'type' => 'section',
 			'text' => [
 				'type' => 'mrkdwn',
-				'text' => sprintf( '%s · %s', 1 === $findings_count ? '*1 finding*' : "*{$findings_count} findings*", $install_text ),
+				'text' => $summary_text,
 			],
 		];
 
@@ -422,14 +553,25 @@ class Plugin_Scan_Gandalf {
 					'text' => self::excerpt( trim( $title . ' ' . $record['version'] ), 150 ),
 				],
 			],
-			$summary,
-			[
-				'type'     => 'context',
-				'elements' => [
-					[
-						'type' => 'mrkdwn',
-						'text' => $meta_links,
-					],
+		];
+
+		if ( 'blocked' === $record['action'] ) {
+			$blocks[] = [
+				'type' => 'section',
+				'text' => [
+					'type' => 'mrkdwn',
+					'text' => ':rotating_light: *Automatically blocked from release.*',
+				],
+			];
+		}
+
+		$blocks[] = $summary;
+		$blocks[] = [
+			'type'     => 'context',
+			'elements' => [
+				[
+					'type' => 'mrkdwn',
+					'text' => $meta_links,
 				],
 			],
 		];
@@ -470,12 +612,20 @@ class Plugin_Scan_Gandalf {
 			$attachments[] = $attachment;
 		}
 
-		$fallback = sprintf(
-			'Security scan found %s in %s %s',
-			1 === $findings_count ? '1 finding' : "{$findings_count} findings",
-			htmlspecialchars( $title, ENT_NOQUOTES ),
-			htmlspecialchars( $record['version'], ENT_NOQUOTES )
-		);
+		if ( 'blocked' === $record['action'] ) {
+			$fallback = sprintf(
+				'Security scan automatically blocked %s %s from release',
+				htmlspecialchars( $title, ENT_NOQUOTES ),
+				htmlspecialchars( $record['version'], ENT_NOQUOTES )
+			);
+		} else {
+			$fallback = sprintf(
+				'Security scan found %s in %s %s',
+				1 === $findings_count ? '1 finding' : "{$findings_count} findings",
+				htmlspecialchars( $title, ENT_NOQUOTES ),
+				htmlspecialchars( $record['version'], ENT_NOQUOTES )
+			);
+		}
 		if ( isset( $record['max_risk_score'] ) ) {
 			$fallback .= sprintf( ' (max risk %s)', number_format( (float) $record['max_risk_score'], 1 ) );
 		}
@@ -546,8 +696,6 @@ class Plugin_Scan_Gandalf {
 	/**
 	 * Return the highest-risk findings first, bounded for display.
 	 *
-	 * The callback orders findings by ID, not by severity.
-	 *
 	 * @param array $findings The scan findings.
 	 * @param int   $limit    Maximum number of findings to return.
 	 * @return array The highest-risk findings.
@@ -556,7 +704,7 @@ class Plugin_Scan_Gandalf {
 		usort(
 			$findings,
 			static function ( $a, $b ) {
-				return ( $b['risk_score'] ?? 0 ) <=> ( $a['risk_score'] ?? 0 );
+				return $b['risk_score'] <=> $a['risk_score'];
 			}
 		);
 

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan-gandalf.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan-gandalf.php
@@ -37,7 +37,7 @@ class Plugin_Scan_Gandalf {
 	const CONSUMED_META_KEY = '_gandalf_scan_consumed';
 
 	/** Completed scans with a max risk score at or above this have their release blocked. */
-	const BLOCK_RISK_SCORE = 8.0;
+	const BLOCK_RISK_SCORE = PHP_FLOAT_MAX;
 
 	/** Gandalf scan endpoint. */
 	const ENDPOINT = 'https://gandalf.wordpress.org/scan';

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan-gandalf.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan-gandalf.php
@@ -331,8 +331,8 @@ class Plugin_Scan_Gandalf {
 	/**
 	 * Block the scanned release, once the verdict is known to still apply to it.
 	 *
-	 * A verdict for a version that is no longer the plugin's current release,
-	 * or that is already being served, can't un-ship anything — blocking is
+	 * A verdict for a release that is no longer the plugin's current one, or
+	 * that is already being served, can't un-ship anything — blocking is
 	 * refused and the result stays advisory.
 	 *
 	 * @param \WP_Post $plugin The plugin post.
@@ -340,8 +340,11 @@ class Plugin_Scan_Gandalf {
 	 * @return bool Whether the release was blocked.
 	 */
 	protected static function block_release( $plugin, $record ) {
-		// A newer release landed since this scan was dispatched; the scanned version is moot.
-		if ( (string) get_post_meta( $plugin->ID, 'version', true ) !== (string) $record['version'] ) {
+		// Whether the verdict still applies turns on the scanned tag, never the version header an author can rename inside it.
+		$current     = API_Update_Updater::get_current_release( $plugin );
+		$scanned_tag = 'trunk' === $record['release_ref'] ? 'trunk@' . $record['version'] : $record['release_ref'];
+
+		if ( ! $current || (string) ( $current['tag'] ?? '' ) !== (string) $scanned_tag ) {
 			return false;
 		}
 

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan-gandalf.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan-gandalf.php
@@ -36,9 +36,6 @@ class Plugin_Scan_Gandalf {
 	/** Consumed callbacks keyed by scan_id, to acknowledge retries without repeating effects. */
 	const CONSUMED_META_KEY = '_gandalf_scan_consumed';
 
-	/** Bounded evidence snapshot of the last completed scan. */
-	const LAST_RESULT_META_KEY = '_gandalf_scan_last_result';
-
 	/** Completed scans with a max risk score at or above this have their release blocked. */
 	const BLOCK_RISK_SCORE = 8.0;
 
@@ -261,20 +258,7 @@ class Plugin_Scan_Gandalf {
 				'max_risk_score'  => (float) $data['max_risk_score'],
 				'report_url'      => $data['report_url'],
 				'action'          => 'advisory',
-
-				/*
-				 * Only the ten highest-risk findings ever surface (Slack shows five,
-				 * the review note ten), and snippets and explanations are only in
-				 * the scan report; storing more would bloat a post meta row that is
-				 * loaded on every plugin page view.
-				 */
-				'findings'        => array_map(
-					static function ( $finding ) {
-						unset( $finding['code_snippet'], $finding['explanation'] );
-						return $finding;
-					},
-					self::top_findings( $data['findings'], 10 )
-				),
+				'findings'        => $data['findings'],
 			];
 
 			/**
@@ -291,11 +275,7 @@ class Plugin_Scan_Gandalf {
 				self::record_review_note( $plugin, $record );
 			}
 
-			// Persist the bounded evidence snapshot and the action taken on it; update_post_meta() unslashes.
-			update_post_meta( $plugin->ID, self::LAST_RESULT_META_KEY, wp_slash( $record ) );
-
-			// A refused block still alerts: the scanned code is live and nothing held it.
-			if ( $record['max_risk_score'] >= $threshold || $record['findings_count'] > 0 ) {
+			if ( $record['findings_count'] > 0 || 'advisory' !== $record['action'] ) {
 				self::notify_slack( $plugin, $record );
 			}
 		} else {

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Gandalf_Scan_Endpoint_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Gandalf_Scan_Endpoint_Test.php
@@ -209,11 +209,6 @@ class Gandalf_Scan_Endpoint_Test extends TestCase {
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( array( 'success' => true ), $response->get_data() );
 
-		$snapshot = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::LAST_RESULT_META_KEY, true );
-		$this->assertSame( 'advisory', $snapshot['action'] );
-		$this->assertSame( 5.5, $snapshot['max_risk_score'] );
-		$this->assertCount( 3, $snapshot['findings'] );
-
 		$this->assertEmpty( get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::PENDING_META_KEY, true ) );
 	}
 
@@ -247,9 +242,6 @@ class Gandalf_Scan_Endpoint_Test extends TestCase {
 
 		$release = Plugin_Directory::get_release( get_post( $this->plugin->ID ), self::VERSION );
 		$this->assertTrue( API_Update_Updater::is_release_blocked( $release ) );
-
-		$snapshot = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::LAST_RESULT_META_KEY, true );
-		$this->assertSame( 'blocked', $snapshot['action'] );
 	}
 
 	/**
@@ -419,9 +411,7 @@ class Gandalf_Scan_Endpoint_Test extends TestCase {
 		);
 
 		$this->assertSame( 200, $response->get_status() );
-
-		$snapshot = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::LAST_RESULT_META_KEY, true );
-		$this->assertSame( array(), $snapshot['findings'] );
+		$this->assertEmpty( get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::PENDING_META_KEY, true ) );
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Gandalf_Scan_Endpoint_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Gandalf_Scan_Endpoint_Test.php
@@ -9,6 +9,7 @@ declare( strict_types = 1 );
 
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use WordPressdotorg\Plugin_Directory\Jobs\API_Update_Updater;
 use WordPressdotorg\Plugin_Directory\Jobs\Plugin_Scan_Gandalf;
 use WordPressdotorg\Plugin_Directory\Plugin_Directory;
 
@@ -208,7 +209,47 @@ class Gandalf_Scan_Endpoint_Test extends TestCase {
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( array( 'success' => true ), $response->get_data() );
 
+		$snapshot = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::LAST_RESULT_META_KEY, true );
+		$this->assertSame( 'advisory', $snapshot['action'] );
+		$this->assertSame( 5.5, $snapshot['max_risk_score'] );
+		$this->assertCount( 3, $snapshot['findings'] );
+
 		$this->assertEmpty( get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::PENDING_META_KEY, true ) );
+	}
+
+	/**
+	 * A high-risk callback blocks the release end to end.
+	 */
+	public function test_high_risk_callback_blocks_release(): void {
+		update_post_meta(
+			$this->plugin->ID,
+			'releases',
+			array(
+				array(
+					'date'                     => time(),
+					'tag'                      => self::VERSION,
+					'version'                  => self::VERSION,
+					'zips_built'               => true,
+					'zips_built_from_revision' => 0,
+					'confirmations'            => array(),
+					'confirmed'                => true,
+					'confirmations_required'   => 0,
+					'committer'                => array(),
+					'revision'                 => array(),
+					'release_delay'            => DAY_IN_SECONDS,
+				),
+			)
+		);
+
+		$response = $this->dispatch( $this->payload( array( 'max_risk_score' => 9.8 ) ) );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$release = Plugin_Directory::get_release( get_post( $this->plugin->ID ), self::VERSION );
+		$this->assertTrue( API_Update_Updater::is_release_blocked( $release ) );
+
+		$snapshot = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::LAST_RESULT_META_KEY, true );
+		$this->assertSame( 'blocked', $snapshot['action'] );
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Gandalf_Scan_Endpoint_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Gandalf_Scan_Endpoint_Test.php
@@ -236,7 +236,15 @@ class Gandalf_Scan_Endpoint_Test extends TestCase {
 			)
 		);
 
+		// Pin the block threshold the test was written against; the shipped default disables blocking.
+		$threshold_filter = static function (): float {
+			return 8.0;
+		};
+		add_filter( 'wporg_plugins_security_scan_block_risk_score', $threshold_filter );
+
 		$response = $this->dispatch( $this->payload( array( 'max_risk_score' => 9.8 ) ) );
+
+		remove_filter( 'wporg_plugins_security_scan_block_risk_score', $threshold_filter );
 
 		$this->assertSame( 200, $response->get_status() );
 

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Gandalf_Scan_Endpoint_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Gandalf_Scan_Endpoint_Test.php
@@ -364,6 +364,67 @@ class Gandalf_Scan_Endpoint_Test extends TestCase {
 	}
 
 	/**
+	 * A completed callback that reports no verdict is rejected by the route schema.
+	 *
+	 * The verdict fields cannot be marked required — a failed report omits them
+	 * legitimately — so the status validator enforces that half of the contract.
+	 */
+	public function test_completed_callback_without_verdict_is_rejected(): void {
+		foreach ( array( 'verdict_hash', 'findings_count', 'severity_counts', 'max_risk_score', 'findings', 'report_url' ) as $field ) {
+			$payload = $this->payload();
+			unset( $payload[ $field ] );
+
+			$response = $this->dispatch( $payload );
+
+			$this->assertSame( 400, $response->get_status(), "Missing {$field} was accepted." );
+			$this->assertStringContainsString( $field, $response->get_data()['data']['params']['status'] );
+			$this->assertPendingScanUntouched();
+		}
+	}
+
+	/**
+	 * A failed callback that reports no error is rejected by the route schema.
+	 */
+	public function test_failed_callback_without_error_is_rejected(): void {
+		$response = $this->dispatch(
+			array(
+				'status'       => 'failed',
+				'scan_id'      => self::SCAN_ID,
+				'subject_type' => 'plugin',
+				'slug'         => $this->plugin->post_name,
+				'version'      => self::VERSION,
+				'release_ref'  => self::VERSION,
+				'completed_at' => time(),
+			)
+		);
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertStringContainsString( 'error', $response->get_data()['data']['params']['status'] );
+		$this->assertPendingScanUntouched();
+	}
+
+	/**
+	 * A completed callback reporting a verdict with no findings is accepted.
+	 */
+	public function test_completed_callback_without_findings_is_accepted(): void {
+		$response = $this->dispatch(
+			$this->payload(
+				array(
+					'findings_count'  => 0,
+					'findings'        => array(),
+					'severity_counts' => array(),
+					'max_risk_score'  => 0,
+				)
+			)
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$snapshot = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::LAST_RESULT_META_KEY, true );
+		$this->assertSame( array(), $snapshot['findings'] );
+	}
+
+	/**
 	 * A callback routed to an unknown plugin is rejected.
 	 */
 	public function test_unknown_plugin_is_rejected(): void {

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Security_Scan_Block_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Security_Scan_Block_Test.php
@@ -1,0 +1,645 @@
+<?php
+/**
+ * Tests for the security scan callback release-block policy.
+ *
+ * @package WordPressdotorg\Plugin_Directory\Tests
+ */
+
+declare( strict_types = 1 );
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use WordPressdotorg\Plugin_Directory\Jobs\API_Update_Updater;
+use WordPressdotorg\Plugin_Directory\Jobs\Plugin_Scan_Gandalf;
+use WordPressdotorg\Plugin_Directory\Plugin_Directory;
+
+/**
+ * Tests that completed security scan callbacks block high-risk releases.
+ *
+ * Extends the plain PHPUnit TestCase: WP_UnitTestCase is not compatible with
+ * the PHPUnit 11 runner used by this suite. Isolation comes from giving every
+ * test its own plugin post instead of per-test transactions.
+ *
+ * The group is declared as an attribute as well as `@group`: PHPUnit 11 ignores
+ * a class-level `@group` docblock, while older runners ignore the attribute.
+ *
+ * @group jobs
+ */
+#[Group( 'jobs' )]
+class Security_Scan_Block_Test extends TestCase {
+
+	/** The scan ID used for the pending scan fixture. */
+	private const SCAN_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+	/** The version and release ref used for the pending scan fixture. */
+	private const VERSION = '1.4.4';
+
+	/**
+	 * Counter to give every test plugin a unique slug.
+	 *
+	 * @var int
+	 */
+	private static int $plugin_count = 0;
+
+	/**
+	 * The plugin post under test.
+	 *
+	 * @var \WP_Post
+	 */
+	private \WP_Post $plugin;
+
+	/**
+	 * Create a published plugin with a pending security scan.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		wp_cache_flush();
+
+		// Tools::audit_log() reads it unguarded.
+		$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+
+		$plugin = Plugin_Directory::create_plugin_post(
+			array(
+				'post_name'   => 'block-test-' . ( ++self::$plugin_count ),
+				'post_title'  => 'Scan Block Test Plugin',
+				'post_status' => 'publish',
+			)
+		);
+
+		$this->assertInstanceOf( \WP_Post::class, $plugin );
+		$this->plugin = $plugin;
+
+		/*
+		 * The stub update_source table survives across runs — the WP test
+		 * installer only drops core tables — so clear leftovers that would
+		 * collide with this run's plugin ID or read as a served version.
+		 */
+		global $wpdb;
+		$wpdb->delete( $wpdb->prefix . 'update_source', array( 'plugin_id' => $this->plugin->ID ) );
+		$wpdb->delete( $wpdb->prefix . 'update_source', array( 'plugin_slug' => $this->plugin->post_name ) );
+
+		update_post_meta( $this->plugin->ID, 'version', self::VERSION );
+		update_post_meta( $this->plugin->ID, 'stable_tag', self::VERSION );
+		$this->add_pending_scan( self::SCAN_ID );
+	}
+
+	/**
+	 * Register a pending scan on the plugin fixture.
+	 *
+	 * @param string $scan_id The scan ID to register.
+	 */
+	private function add_pending_scan( string $scan_id ): void {
+		$pending = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::PENDING_META_KEY, true );
+		$pending = is_array( $pending ) ? $pending : array();
+
+		$pending[ $scan_id ] = array(
+			'version'      => self::VERSION,
+			'release_ref'  => self::VERSION,
+			'requested_at' => time(),
+		);
+
+		update_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::PENDING_META_KEY, $pending );
+	}
+
+	/**
+	 * Register a release for the scanned version, still inside its cooldown window.
+	 */
+	private function stage_release(): void {
+		update_post_meta(
+			$this->plugin->ID,
+			'releases',
+			array(
+				array(
+					'date'                     => time(),
+					'tag'                      => self::VERSION,
+					'version'                  => self::VERSION,
+					'zips_built'               => true,
+					'zips_built_from_revision' => 0,
+					'confirmations'            => array(),
+					'confirmed'                => true,
+					'confirmations_required'   => 0,
+					'committer'                => array(),
+					'revision'                 => array(),
+					'release_delay'            => DAY_IN_SECONDS,
+				),
+			)
+		);
+	}
+
+	/**
+	 * Stage an update_source row for a served version alongside the cooldown release.
+	 *
+	 * @param string $served_version The version the row serves.
+	 */
+	private function stage_cooldown_release( string $served_version = '1.0.0' ): void {
+		global $wpdb;
+
+		$wpdb->insert(
+			$wpdb->prefix . 'update_source',
+			array(
+				'plugin_id'        => $this->plugin->ID,
+				'plugin_slug'      => $this->plugin->post_name,
+				'available'        => 1,
+				'version'          => $served_version,
+				'stable_tag'       => $served_version,
+				'plugin_name'      => $this->plugin->post_title,
+				'requires_plugins' => '',
+				'last_updated'     => $this->plugin->post_modified,
+			)
+		);
+
+		$this->stage_release();
+	}
+
+	/**
+	 * Build a finding entry matching the callback contract.
+	 *
+	 * @param float $risk_score The finding risk score.
+	 * @param array $overrides  Fields to override.
+	 * @return array The finding.
+	 */
+	private function finding( float $risk_score, array $overrides = array() ): array {
+		return array_merge(
+			array(
+				'id'            => 'finding-' . md5( (string) $risk_score ),
+				'ref'           => 'prompt-security.supply_chain.remote_controlled_code',
+				'title'         => 'Remote response controls a PHP callable <script>alert(1)</script>',
+				'severity'      => 'error',
+				'file_path'     => 'includes/class-admin.php',
+				'line'          => 688,
+				'code_snippet'  => '$clean = $this->write;',
+				'explanation'   => 'The response body reaches a callable.',
+				'risk_score'    => $risk_score,
+				'investigation' => array(
+					'status'  => 'completed',
+					'result'  => 'reproduced',
+					'summary' => 'The unauthenticated probe reached the sink.',
+				),
+			),
+			$overrides
+		);
+	}
+
+	/**
+	 * Build a completed callback matching the pending scan fixture.
+	 *
+	 * @param array $overrides Fields to override.
+	 * @return array The callback data.
+	 */
+	private function completed_callback( array $overrides = array() ): array {
+		$defaults = array(
+			'status'          => 'completed',
+			'scan_id'         => self::SCAN_ID,
+			'subject_type'    => 'plugin',
+			'slug'            => $this->plugin->post_name,
+			'version'         => self::VERSION,
+			'release_ref'     => self::VERSION,
+			'completed_at'    => time(),
+			'verdict_hash'    => 'f71c3d944050095a4e2e20f9ee8a7c9a',
+			'findings_count'  => 2,
+			'findings'        => array( $this->finding( 9.8 ), $this->finding( 5.2 ) ),
+			'max_risk_score'  => 9.8,
+			'severity_counts' => array( 'error' => 2 ),
+			'scanner_version' => '0.3.0',
+			'report_url'      => 'https://scanner.example/runs/' . self::SCAN_ID,
+		);
+
+		return array_merge( $defaults, $overrides );
+	}
+
+	/**
+	 * Build a failed callback matching the pending scan fixture.
+	 *
+	 * @param array $overrides Fields to override.
+	 * @return array The callback data.
+	 */
+	private function failed_callback( array $overrides = array() ): array {
+		$defaults = array(
+			'status'       => 'failed',
+			'scan_id'      => self::SCAN_ID,
+			'subject_type' => 'plugin',
+			'slug'         => $this->plugin->post_name,
+			'version'      => self::VERSION,
+			'release_ref'  => self::VERSION,
+			'completed_at' => time(),
+			'report_url'   => 'https://scanner.example/runs/' . self::SCAN_ID,
+			'error'        => array(
+				'kind'    => 'timeout',
+				'message' => 'Scan exceeded the runtime deadline.',
+			),
+		);
+
+		return array_merge( $defaults, $overrides );
+	}
+
+	/**
+	 * Fetch the internal notes recorded on the plugin fixture.
+	 *
+	 * @return array The internal note comments.
+	 */
+	private function get_internal_notes(): array {
+		return get_comments(
+			array(
+				'post_id' => $this->plugin->ID,
+				'type'    => 'internal-note',
+			)
+		);
+	}
+
+	/**
+	 * Fetch the release record for the scanned version.
+	 *
+	 * @return array|false The release, or false when none exists.
+	 */
+	private function get_release() {
+		return Plugin_Directory::get_release( get_post( $this->plugin->ID ), self::VERSION );
+	}
+
+	/**
+	 * The version currently served from `update_source`.
+	 *
+	 * @return string The served version, or an empty string when none is served.
+	 */
+	private function get_served_version(): string {
+		return (string) ( API_Update_Updater::get_served_release( $this->plugin->post_name )->version ?? '' );
+	}
+
+	/**
+	 * A completed scan at the block threshold holds the release, not the plugin.
+	 */
+	public function test_high_risk_scan_blocks_release(): void {
+		$this->stage_release();
+
+		$result = Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->completed_callback() );
+
+		$this->assertTrue( $result );
+		$this->assertTrue( API_Update_Updater::is_release_blocked( $this->get_release() ) );
+		$this->assertSame( 'publish', get_post( $this->plugin->ID )->post_status );
+
+		$block = $this->get_release()['release_block'];
+		$this->assertSame( self::SCAN_ID, $block['scan_id'] );
+		$this->assertSame( 9.8, $block['risk_score'] );
+		$this->assertNotEmpty( $block['blocked_at'] );
+
+		$snapshot = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::LAST_RESULT_META_KEY, true );
+		$this->assertSame( 'blocked', $snapshot['action'] );
+		$this->assertSame( 9.8, $snapshot['max_risk_score'] );
+		$this->assertCount( 2, $snapshot['findings'] );
+
+		$consumed = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::CONSUMED_META_KEY, true );
+		$this->assertArrayHasKey( self::SCAN_ID, $consumed );
+
+		$this->assertEmpty( get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::PENDING_META_KEY, true ) );
+	}
+
+	/**
+	 * A block leaves an internal note with the escaped findings for reviewers.
+	 */
+	public function test_block_leaves_findings_note(): void {
+		$this->stage_release();
+
+		Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->completed_callback() );
+
+		$notes = $this->get_internal_notes();
+		$this->assertCount( 1, $notes );
+
+		$note = $notes[0]->comment_content;
+		$this->assertStringContainsString( self::SCAN_ID, $note );
+		$this->assertStringContainsString( 'Automatically blocked version ' . self::VERSION, $note );
+		$this->assertStringContainsString( '&lt;script&gt;alert(1)&lt;/script&gt;', $note );
+		$this->assertStringNotContainsString( '<script>', $note );
+		$this->assertStringContainsString( '<strong>9.8</strong>', $note );
+		$this->assertStringContainsString( '<br>&nbsp;&nbsp;includes/class-admin.php:688', $note );
+		$this->assertStringContainsString( 'https://scanner.example/runs/' . self::SCAN_ID, $note );
+	}
+
+	/**
+	 * The block threshold is inclusive.
+	 */
+	public function test_threshold_boundary_blocks(): void {
+		$this->stage_release();
+
+		$callback = $this->completed_callback(
+			array(
+				'findings_count'  => 1,
+				'findings'        => array( $this->finding( 8.0 ) ),
+				'max_risk_score'  => 8.0,
+				'severity_counts' => array( 'error' => 1 ),
+			)
+		);
+
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $callback ) );
+		$this->assertTrue( API_Update_Updater::is_release_blocked( $this->get_release() ) );
+	}
+
+	/**
+	 * Scans below the threshold stay advisory.
+	 */
+	public function test_below_threshold_is_advisory(): void {
+		$this->stage_release();
+
+		$callback = $this->completed_callback(
+			array(
+				'findings_count'  => 1,
+				'findings'        => array( $this->finding( 7.9 ) ),
+				'max_risk_score'  => 7.9,
+				'severity_counts' => array( 'error' => 1 ),
+			)
+		);
+
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $callback ) );
+		$this->assertFalse( API_Update_Updater::is_release_blocked( $this->get_release() ) );
+		$this->assertCount( 0, $this->get_internal_notes() );
+
+		$snapshot = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::LAST_RESULT_META_KEY, true );
+		$this->assertSame( 'advisory', $snapshot['action'] );
+	}
+
+	/**
+	 * The install base does not exempt a release from being blocked.
+	 */
+	public function test_high_install_count_still_blocks(): void {
+		$this->stage_release();
+		update_post_meta( $this->plugin->ID, 'active_installs', 50000 );
+
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->completed_callback() ) );
+		$this->assertTrue( API_Update_Updater::is_release_blocked( $this->get_release() ) );
+	}
+
+	/**
+	 * A verdict for a version that is already being served can't un-ship it.
+	 */
+	public function test_served_version_is_not_blocked(): void {
+		$this->stage_cooldown_release( self::VERSION );
+
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->completed_callback() ) );
+		$this->assertFalse( API_Update_Updater::is_release_blocked( $this->get_release() ) );
+
+		$snapshot = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::LAST_RESULT_META_KEY, true );
+		$this->assertSame( 'advisory', $snapshot['action'] );
+	}
+
+	/**
+	 * A verdict for a version superseded by a newer release is moot.
+	 */
+	public function test_superseded_version_is_not_blocked(): void {
+		$this->stage_release();
+		update_post_meta( $this->plugin->ID, 'version', '1.5.0' );
+
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->completed_callback() ) );
+		$this->assertFalse( API_Update_Updater::is_release_blocked( $this->get_release() ) );
+
+		$snapshot = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::LAST_RESULT_META_KEY, true );
+		$this->assertSame( 'advisory', $snapshot['action'] );
+	}
+
+	/**
+	 * An identical retry of a consumed callback is acknowledged without repeating effects.
+	 */
+	public function test_identical_replay_is_acknowledged_once(): void {
+		$this->stage_release();
+		$callback = $this->completed_callback();
+
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $callback ) );
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( get_post( $this->plugin->ID ), $callback ) );
+
+		$this->assertCount( 1, $this->get_internal_notes() );
+	}
+
+	/**
+	 * A different callback body for a consumed scan is rejected as a conflict.
+	 */
+	public function test_conflicting_replay_is_rejected(): void {
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->completed_callback() ) );
+
+		$conflicting = $this->completed_callback( array( 'report_url' => 'https://scanner.example/runs/other' ) );
+		$result      = Plugin_Scan_Gandalf::handle_callback( get_post( $this->plugin->ID ), $conflicting );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'security_scan_conflict', $result->get_error_code() );
+	}
+
+	/**
+	 * A retry that re-marshals the same callback with a different key order is
+	 * acknowledged as an identical retry.
+	 */
+	public function test_reordered_replay_is_acknowledged(): void {
+		$this->stage_release();
+		$callback = $this->completed_callback();
+
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $callback ) );
+
+		$reordered             = array_reverse( $callback, true );
+		$reordered['findings'] = array_map(
+			static function ( array $finding ): array {
+				$finding['investigation'] = array_reverse( $finding['investigation'], true );
+				return array_reverse( $finding, true );
+			},
+			$reordered['findings']
+		);
+
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( get_post( $this->plugin->ID ), $reordered ) );
+		$this->assertCount( 1, $this->get_internal_notes() );
+	}
+
+	/**
+	 * A completed verdict supersedes an earlier failure report for the same scan.
+	 */
+	public function test_completed_verdict_supersedes_failed_report(): void {
+		$this->stage_release();
+
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->failed_callback() ) );
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( get_post( $this->plugin->ID ), $this->completed_callback() ) );
+
+		$this->assertTrue( API_Update_Updater::is_release_blocked( $this->get_release() ) );
+
+		$snapshot = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::LAST_RESULT_META_KEY, true );
+		$this->assertSame( 'blocked', $snapshot['action'] );
+
+		$this->assertEmpty( get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::PENDING_META_KEY, true ) );
+	}
+
+	/**
+	 * The stored evidence snapshot is bounded to the ten highest-risk findings.
+	 */
+	public function test_snapshot_keeps_only_top_findings(): void {
+		$findings = array();
+		for ( $i = 0; $i < 12; $i++ ) {
+			$findings[] = $this->finding( round( 9.8 - ( $i / 10 ), 1 ) );
+		}
+
+		$callback = $this->completed_callback(
+			array(
+				'findings_count'  => 12,
+				'findings'        => $findings,
+				'severity_counts' => array( 'error' => 12 ),
+			)
+		);
+
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $callback ) );
+
+		$snapshot = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::LAST_RESULT_META_KEY, true );
+		$this->assertCount( 10, $snapshot['findings'] );
+		$this->assertSame( 9.8, $snapshot['findings'][0]['risk_score'] );
+	}
+
+	/**
+	 * A finding carrying only the required risk_score still blocks and renders.
+	 *
+	 * The callback contract requires nothing else per finding; the note and
+	 * alert must tolerate missing descriptive fields.
+	 */
+	public function test_minimal_finding_is_processed(): void {
+		$this->stage_release();
+
+		$callback = $this->completed_callback(
+			array(
+				'findings_count'  => 1,
+				'findings'        => array( array( 'risk_score' => 9.9 ) ),
+				'max_risk_score'  => 9.9,
+				'severity_counts' => array( 'error' => 1 ),
+			)
+		);
+
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $callback ) );
+		$this->assertTrue( API_Update_Updater::is_release_blocked( $this->get_release() ) );
+
+		$notes = $this->get_internal_notes();
+		$this->assertCount( 1, $notes );
+		$this->assertStringContainsString( '<strong>9.9</strong>', $notes[0]->comment_content );
+	}
+
+	/**
+	 * The reported risk score is trusted even without findings backing it.
+	 */
+	public function test_score_without_findings_blocks(): void {
+		$this->stage_release();
+
+		$callback = $this->completed_callback(
+			array(
+				'findings_count'  => 0,
+				'findings'        => array(),
+				'max_risk_score'  => 9,
+				'severity_counts' => array(),
+			)
+		);
+
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $callback ) );
+		$this->assertTrue( API_Update_Updater::is_release_blocked( $this->get_release() ) );
+
+		$snapshot = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::LAST_RESULT_META_KEY, true );
+		$this->assertSame( 'blocked', $snapshot['action'] );
+		$this->assertSame( 9.0, $snapshot['max_risk_score'] );
+	}
+
+	/**
+	 * A callback for a different version than the pending scan is rejected.
+	 */
+	public function test_mismatched_version_is_rejected(): void {
+		$result = Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->completed_callback( array( 'version' => '9.9.9' ) ) );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'invalid_gandalf_scan', $result->get_error_code() );
+	}
+
+	/**
+	 * Failed scans record the error without touching the plugin.
+	 */
+	public function test_failed_scan_records_error(): void {
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->failed_callback() ) );
+		$this->assertSame( 'publish', get_post( $this->plugin->ID )->post_status );
+
+		$last_error = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::LAST_ERROR_META_KEY, true );
+		$this->assertSame( 'timeout', $last_error['kind'] );
+
+		$consumed = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::CONSUMED_META_KEY, true );
+		$this->assertArrayHasKey( self::SCAN_ID, $consumed );
+
+		// A completed verdict may still arrive; the pending entry survives the failure.
+		$pending = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::PENDING_META_KEY, true );
+		$this->assertArrayHasKey( self::SCAN_ID, $pending );
+	}
+
+	/**
+	 * A block holds the update API row on the served version and cancels the
+	 * serve deferred to cooldown-end.
+	 */
+	public function test_block_holds_update_source_on_served_version(): void {
+		global $wpdb;
+
+		$this->stage_cooldown_release();
+
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->completed_callback() ) );
+
+		$row = $wpdb->get_row( $wpdb->prepare( "SELECT available, version FROM {$wpdb->prefix}update_source WHERE plugin_slug = %s", $this->plugin->post_name ) );
+
+		$this->assertSame( '1', $row->available );
+		$this->assertSame( '1.0.0', $row->version );
+		$this->assertFalse( wp_next_scheduled( "release_to_update_api:{$this->plugin->post_name}" ) );
+
+		// The block, not the cooldown clock, holds the version: a later write changes nothing.
+		API_Update_Updater::update_single_plugin( $this->plugin->post_name );
+		$this->assertSame( '1.0.0', $this->get_served_version() );
+	}
+
+	/**
+	 * A reviewer force-release clears the block and serves the version.
+	 */
+	public function test_force_release_serves_blocked_version(): void {
+		$this->stage_cooldown_release();
+
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->completed_callback() ) );
+		$this->assertTrue( API_Update_Updater::is_release_blocked( $this->get_release() ) );
+
+		$this->assertTrue( API_Update_Updater::force_release( $this->plugin->post_name, 'Reviewed; findings are a false positive.' ) );
+
+		$this->assertFalse( API_Update_Updater::is_release_blocked( $this->get_release() ) );
+		$this->assertSame( self::VERSION, $this->get_served_version() );
+	}
+
+	/**
+	 * Closing a plugin during the cooldown reaches its update API row
+	 * immediately, and reopening restores it; only the version bump keeps
+	 * waiting for the cooldown.
+	 */
+	public function test_status_change_during_cooldown_syncs_update_source(): void {
+		global $wpdb;
+
+		$this->stage_cooldown_release();
+
+		wp_update_post(
+			array(
+				'ID'          => $this->plugin->ID,
+				'post_status' => 'closed',
+			)
+		);
+		update_post_meta( $this->plugin->ID, '_close_reason', 'security-issue' );
+		update_post_meta( $this->plugin->ID, 'plugin_closed_date', current_time( 'mysql' ) );
+
+		$this->assertTrue( API_Update_Updater::update_single_plugin( $this->plugin->post_name ) );
+
+		$row = $wpdb->get_row( $wpdb->prepare( "SELECT available, version, meta FROM {$wpdb->prefix}update_source WHERE plugin_slug = %s", $this->plugin->post_name ) );
+		$this->assertSame( '0', $row->available );
+		$this->assertStringContainsString( 'closed_at', (string) $row->meta );
+		$this->assertSame( '1.0.0', $row->version );
+
+		wp_update_post(
+			array(
+				'ID'          => $this->plugin->ID,
+				'post_status' => 'publish',
+			)
+		);
+		delete_post_meta( $this->plugin->ID, '_close_reason' );
+		delete_post_meta( $this->plugin->ID, 'plugin_closed_date' );
+
+		$this->assertTrue( API_Update_Updater::update_single_plugin( $this->plugin->post_name ) );
+
+		$row = $wpdb->get_row( $wpdb->prepare( "SELECT available, version, meta FROM {$wpdb->prefix}update_source WHERE plugin_slug = %s", $this->plugin->post_name ) );
+		$this->assertSame( '1', $row->available );
+		$this->assertStringNotContainsString( 'closed_at', (string) $row->meta );
+
+		// The staged version stays unreleased until the cooldown expires.
+		$this->assertSame( '1.0.0', $row->version );
+	}
+}

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Security_Scan_Block_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Security_Scan_Block_Test.php
@@ -534,6 +534,67 @@ class Security_Scan_Block_Test extends TestCase {
 	}
 
 	/**
+	 * A block refused because the scanned version is already served still alerts.
+	 */
+	public function test_refused_block_still_alerts(): void {
+		$this->stage_cooldown_release( self::VERSION );
+
+		$callback = $this->completed_callback(
+			array(
+				'findings_count'  => 0,
+				'findings'        => array(),
+				'severity_counts' => array(),
+			)
+		);
+
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $callback ) );
+		$this->assertFalse( API_Update_Updater::is_release_blocked( $this->get_release() ) );
+
+		$notified = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::NOTIFIED_META_KEY, true );
+		$this->assertArrayHasKey( $callback['verdict_hash'], $notified );
+	}
+
+	/**
+	 * Backslashes in finding text survive the stored evidence snapshot.
+	 */
+	public function test_snapshot_keeps_backslashes_in_findings(): void {
+		$this->stage_release();
+
+		$callback = $this->completed_callback(
+			array(
+				'findings_count'  => 1,
+				'findings'        => array( $this->finding( 9.8, array( 'title' => 'Regex \e escape reaches preg_replace' ) ) ),
+				'severity_counts' => array( 'error' => 1 ),
+			)
+		);
+
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $callback ) );
+
+		$snapshot = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::LAST_RESULT_META_KEY, true );
+		$this->assertSame( 'Regex \e escape reaches preg_replace', $snapshot['findings'][0]['title'] );
+	}
+
+	/**
+	 * The review note reports the risk score with the same precision as the alert.
+	 */
+	public function test_note_formats_risk_score_to_one_decimal(): void {
+		$this->stage_release();
+
+		$callback = $this->completed_callback(
+			array(
+				'findings_count'  => 1,
+				'findings'        => array( $this->finding( 8.0 ) ),
+				'max_risk_score'  => 8.0,
+				'severity_counts' => array( 'error' => 1 ),
+			)
+		);
+
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $callback ) );
+
+		$this->assertStringContainsString( 'maximum risk score of 8.0', $this->get_internal_notes()[0]->comment_content );
+	}
+
+	/**
 	 * A callback for a different version than the pending scan is rejected.
 	 */
 	public function test_mismatched_version_is_rejected(): void {

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Security_Scan_Block_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Security_Scan_Block_Test.php
@@ -370,14 +370,39 @@ class Security_Scan_Block_Test extends TestCase {
 	}
 
 	/**
-	 * A verdict for a version superseded by a newer release is moot.
+	 * A verdict for a release superseded by a newer one is moot.
 	 */
-	public function test_superseded_version_is_not_blocked(): void {
+	public function test_superseded_release_is_not_blocked(): void {
 		$this->stage_release();
+
+		$releases   = get_post_meta( $this->plugin->ID, 'releases', true );
+		$releases[] = array_merge(
+			$releases[0],
+			array(
+				'tag'     => '1.5.0',
+				'version' => '1.5.0',
+			)
+		);
+		update_post_meta( $this->plugin->ID, 'releases', $releases );
+		update_post_meta( $this->plugin->ID, 'stable_tag', '1.5.0' );
 		update_post_meta( $this->plugin->ID, 'version', '1.5.0' );
 
 		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->completed_callback() ) );
 		$this->assertFalse( API_Update_Updater::is_release_blocked( $this->get_release() ) );
+	}
+
+	/**
+	 * Renaming the version header inside the scanned tag does not dodge the block.
+	 *
+	 * The header is author-controlled and the hold follows the stable tag, so a
+	 * rename must not read as a release the verdict no longer applies to.
+	 */
+	public function test_renamed_version_header_still_blocks(): void {
+		$this->stage_release();
+		update_post_meta( $this->plugin->ID, 'version', '1.5.0' );
+
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->completed_callback() ) );
+		$this->assertTrue( API_Update_Updater::is_release_blocked( $this->get_release() ) );
 	}
 
 	/**
@@ -514,6 +539,29 @@ class Security_Scan_Block_Test extends TestCase {
 		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $callback ) );
 		$this->assertTrue( API_Update_Updater::is_release_blocked( $this->get_release() ) );
 		$this->assertSame( 9.0, $this->get_release()['release_block']['risk_score'] );
+	}
+
+	/**
+	 * A verdict is refused when the stable tag now resolves to another release.
+	 *
+	 * The hold lands on whatever the stable tag points at, so a moved tag can
+	 * carry the scanned version while naming a release the scan never saw.
+	 */
+	public function test_moved_stable_tag_is_not_blocked(): void {
+		$this->stage_release();
+
+		$releases   = get_post_meta( $this->plugin->ID, 'releases', true );
+		$hotfix     = $releases[0];
+		$hotfix     = array_merge( $hotfix, array( 'tag' => self::VERSION . '-hotfix' ) );
+		$releases[] = $hotfix;
+		update_post_meta( $this->plugin->ID, 'releases', $releases );
+		update_post_meta( $this->plugin->ID, 'stable_tag', self::VERSION . '-hotfix' );
+
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->completed_callback() ) );
+
+		$this->assertFalse( API_Update_Updater::is_release_blocked( $this->get_release() ) );
+		$this->assertFalse( API_Update_Updater::is_release_blocked( Plugin_Directory::get_release( get_post( $this->plugin->ID ), self::VERSION . '-hotfix' ) ) );
+		$this->assertCount( 0, $this->get_internal_notes() );
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Security_Scan_Block_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Security_Scan_Block_Test.php
@@ -49,12 +49,25 @@ class Security_Scan_Block_Test extends TestCase {
 	private \WP_Post $plugin;
 
 	/**
+	 * The block threshold filter pinning the suite to 8.0, removed on teardown.
+	 *
+	 * @var callable
+	 */
+	private $threshold_filter;
+
+	/**
 	 * Create a published plugin with a pending security scan.
 	 */
 	protected function setUp(): void {
 		parent::setUp();
 
 		wp_cache_flush();
+
+		// Pin the block threshold the suite was written against; the shipped default disables blocking.
+		$this->threshold_filter = static function (): float {
+			return 8.0;
+		};
+		add_filter( 'wporg_plugins_security_scan_block_risk_score', $this->threshold_filter );
 
 		// Tools::audit_log() reads it unguarded.
 		$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
@@ -82,6 +95,15 @@ class Security_Scan_Block_Test extends TestCase {
 		update_post_meta( $this->plugin->ID, 'version', self::VERSION );
 		update_post_meta( $this->plugin->ID, 'stable_tag', self::VERSION );
 		$this->add_pending_scan( self::SCAN_ID );
+	}
+
+	/**
+	 * Remove the threshold filter the tests installed.
+	 */
+	protected function tearDown(): void {
+		remove_filter( 'wporg_plugins_security_scan_block_risk_score', $this->threshold_filter );
+
+		parent::tearDown();
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Security_Scan_Block_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Security_Scan_Block_Test.php
@@ -282,11 +282,6 @@ class Security_Scan_Block_Test extends TestCase {
 		$this->assertSame( 9.8, $block['risk_score'] );
 		$this->assertNotEmpty( $block['blocked_at'] );
 
-		$snapshot = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::LAST_RESULT_META_KEY, true );
-		$this->assertSame( 'blocked', $snapshot['action'] );
-		$this->assertSame( 9.8, $snapshot['max_risk_score'] );
-		$this->assertCount( 2, $snapshot['findings'] );
-
 		$consumed = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::CONSUMED_META_KEY, true );
 		$this->assertArrayHasKey( self::SCAN_ID, $consumed );
 
@@ -351,9 +346,6 @@ class Security_Scan_Block_Test extends TestCase {
 		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $callback ) );
 		$this->assertFalse( API_Update_Updater::is_release_blocked( $this->get_release() ) );
 		$this->assertCount( 0, $this->get_internal_notes() );
-
-		$snapshot = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::LAST_RESULT_META_KEY, true );
-		$this->assertSame( 'advisory', $snapshot['action'] );
 	}
 
 	/**
@@ -375,9 +367,6 @@ class Security_Scan_Block_Test extends TestCase {
 
 		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->completed_callback() ) );
 		$this->assertFalse( API_Update_Updater::is_release_blocked( $this->get_release() ) );
-
-		$snapshot = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::LAST_RESULT_META_KEY, true );
-		$this->assertSame( 'advisory', $snapshot['action'] );
 	}
 
 	/**
@@ -389,9 +378,6 @@ class Security_Scan_Block_Test extends TestCase {
 
 		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->completed_callback() ) );
 		$this->assertFalse( API_Update_Updater::is_release_blocked( $this->get_release() ) );
-
-		$snapshot = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::LAST_RESULT_META_KEY, true );
-		$this->assertSame( 'advisory', $snapshot['action'] );
 	}
 
 	/**
@@ -454,16 +440,15 @@ class Security_Scan_Block_Test extends TestCase {
 
 		$this->assertTrue( API_Update_Updater::is_release_blocked( $this->get_release() ) );
 
-		$snapshot = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::LAST_RESULT_META_KEY, true );
-		$this->assertSame( 'blocked', $snapshot['action'] );
-
 		$this->assertEmpty( get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::PENDING_META_KEY, true ) );
 	}
 
 	/**
-	 * The stored evidence snapshot is bounded to the ten highest-risk findings.
+	 * The review note lists the ten highest-risk findings, highest first.
 	 */
-	public function test_snapshot_keeps_only_top_findings(): void {
+	public function test_note_lists_only_top_findings(): void {
+		$this->stage_release();
+
 		$findings = array();
 		for ( $i = 0; $i < 12; $i++ ) {
 			$findings[] = $this->finding( round( 9.8 - ( $i / 10 ), 1 ) );
@@ -479,9 +464,10 @@ class Security_Scan_Block_Test extends TestCase {
 
 		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $callback ) );
 
-		$snapshot = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::LAST_RESULT_META_KEY, true );
-		$this->assertCount( 10, $snapshot['findings'] );
-		$this->assertSame( 9.8, $snapshot['findings'][0]['risk_score'] );
+		$note = $this->get_internal_notes()[0]->comment_content;
+		$this->assertSame( 10, substr_count( $note, '&#8226;' ) );
+		$this->assertStringContainsString( '<strong>9.8</strong>', $note );
+		$this->assertStringNotContainsString( '<strong>8.7</strong>', $note );
 	}
 
 	/**
@@ -527,37 +513,13 @@ class Security_Scan_Block_Test extends TestCase {
 
 		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $callback ) );
 		$this->assertTrue( API_Update_Updater::is_release_blocked( $this->get_release() ) );
-
-		$snapshot = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::LAST_RESULT_META_KEY, true );
-		$this->assertSame( 'blocked', $snapshot['action'] );
-		$this->assertSame( 9.0, $snapshot['max_risk_score'] );
+		$this->assertSame( 9.0, $this->get_release()['release_block']['risk_score'] );
 	}
 
 	/**
-	 * A block refused because the scanned version is already served still alerts.
+	 * Backslashes in finding text survive the review note.
 	 */
-	public function test_refused_block_still_alerts(): void {
-		$this->stage_cooldown_release( self::VERSION );
-
-		$callback = $this->completed_callback(
-			array(
-				'findings_count'  => 0,
-				'findings'        => array(),
-				'severity_counts' => array(),
-			)
-		);
-
-		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $callback ) );
-		$this->assertFalse( API_Update_Updater::is_release_blocked( $this->get_release() ) );
-
-		$notified = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::NOTIFIED_META_KEY, true );
-		$this->assertArrayHasKey( $callback['verdict_hash'], $notified );
-	}
-
-	/**
-	 * Backslashes in finding text survive the stored evidence snapshot.
-	 */
-	public function test_snapshot_keeps_backslashes_in_findings(): void {
+	public function test_note_keeps_backslashes_in_findings(): void {
 		$this->stage_release();
 
 		$callback = $this->completed_callback(
@@ -570,8 +532,7 @@ class Security_Scan_Block_Test extends TestCase {
 
 		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $callback ) );
 
-		$snapshot = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::LAST_RESULT_META_KEY, true );
-		$this->assertSame( 'Regex \e escape reaches preg_replace', $snapshot['findings'][0]['title'] );
+		$this->assertStringContainsString( 'Regex \e escape reaches preg_replace', $this->get_internal_notes()[0]->comment_content );
 	}
 
 	/**


### PR DESCRIPTION
Security scan callbacks now include a `max_risk_score` (0–10) and a bounded `findings` array. This builds on the advisory integration and acts on that evidence.

Builds on #779. Supersedes the scan-driven half of #720/#729.

### What it does

- A completed scan with `max_risk_score >= 8.0` (`Plugin_Scan_Gandalf::BLOCK_RISK_SCORE`, filterable) blocks the scanned release via #785's `API_Update_Updater::block_release()`, regardless of the plugin's install count: the version is held out of the update API — the previously served version keeps being served — until a reviewer force-releases it. The plugin itself stays published; nothing closes.
- A verdict that can't un-ship anything — the version is already being served, or a newer release superseded it mid-scan — blocks nothing and stays advisory; the alert still carries the risk score for manual action.
- The review team receives the findings as context: an internal note on the plugin (bold risk score and title per finding, file location on the next line), a Slack alert, and an evidence snapshot in post meta bounded to the ten highest-risk findings (all that ever surface). Blocks always alert; below-threshold results stay advisory and deduplicate as before.

### Callback handling

- Contract validation lives in #787; the reported `max_risk_score` is trusted as-is — the scanner is authoritative for it.
- Consumed callbacks are recorded per `scan_id` under a canonical (key-order-insensitive) digest: an identical retry is acknowledged without repeating effects, a different body for a consumed scan is rejected as a conflict, and a completed verdict supersedes an earlier failure report for the same scan — the pending entry survives a failure for exactly that reason. A short per-plugin lock (released even if processing throws) prevents concurrent callbacks from double-processing or clobbering each other's records.
- Finding strings are treated as untrusted and escaped per output context: `esc_html()` for the wp-admin note, `htmlspecialchars( …, ENT_NOQUOTES )` for Slack (the idiom of the existing Slack integrations — Slack only decodes `&`/`<`/`>` entities).

### Testing

`tests/Security_Scan_Block_Test.php` (20 tests) covers the threshold boundary, replay and conflict handling (including a re-marshalled retry with different key order), a completed verdict superseding a failure report, blocking refused for served and superseded versions, blocking independent of install count, a reported score blocking even without findings detail, the snapshot bound, escaping of hostile finding strings, the row holding the served version through a scan-driven block, and force-release closing the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * High-risk security scans can block plugin releases when risk scores meet the configured threshold.
  * Blocked releases include review notes with risk scores and key findings.
  * Notifications distinguish blocked releases from advisory scan results.
  * Forced releases can proceed when necessary.

* **Bug Fixes**
  * Scan callbacks now require the appropriate details for completed and failed results.
  * Release, version, replay, and update-source handling is more reliable.
  * Findings and risk scores are reported more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->