### PR TITLE
Unit Tests: Remove the results aggregate job

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -39,7 +39,6 @@ This folder contains the repository's configuration for GitHub, automated CI/CD 
   - **`changes`**: Loads the suite definitions, detects which paths changed, and builds the matrices for the suites that need to run.
   - **`php-standalone`**: Runs PHPUnit on modules that do not depend on WordPress or a database (Serve Happy, Browse Happy, Events API, Slack Trac Bot, and Slack Props Library).
   - **`php-wordpress`**: Sets up Node.js, installs Docker-based `@wordpress/env` (`wp-env`), spins up the local container environment, injects PHPUnit polyfills, and runs unit tests for the Handbook, Plugin Directory, Theme Directory, and Make plugins.
-  - **`results`**: Always-run aggregate job that fails if any suite failed — the stable status check to require in branch protection.
 
 ### 3. [Events API (live) Checks](workflows/events-api-live.yml) (`events-api-live.yml`)
 - **Trigger:** Runs daily at 14:00 UTC and on manual workflow dispatch.

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -173,15 +173,3 @@ jobs:
       # and the polyfills, and then run each suite it holds.
       - name: Run PHPUnit
         run: npm run ${{ matrix.script }}
-
-  # Stable status check for branch protection — always runs, unlike the conditional matrix-named suite jobs.
-  results:
-    name: Test results
-    needs: [ changes, php-standalone, php-wordpress ]
-    if: always()
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Fail if a suite failed
-        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
-        run: exit 1


### PR DESCRIPTION
The `results` job added in #774 exists to give branch protection a stable check name — matrix suite jobs have dynamic names and don't always run, so they can't be required. But this repository is a read-only SVN mirror: PRs are never merged on GitHub, so no required-status-check rule will ever consume it. Committers reviewing a PR see failed suites directly in the check list.

Removes the job and its mention in `.github/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)