### PR TITLE
PHPCS: Color changed-lines output and annotate violations on the PR diff

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -19,6 +19,7 @@ This folder contains the repository's configuration for GitHub, automated CI/CD 
 - **Mechanism:**
   - Runs standard `phpcs` on newly added files (`diff-filter=A`).
   - Runs `phpcs-changed` on modified files (`diff-filter=M`), creating temporary files/diffs to calculate only the errors introduced on the changed lines.
+  - In GitHub Actions, also emits each violation as an inline annotation on the PR diff.
 - **Usage:**
   ```bash
   BASE_REF=trunk php .github/bin/phpcs-branch.php

--- a/.github/bin/phpcs-branch.php
+++ b/.github/bin/phpcs-branch.php
@@ -12,12 +12,73 @@
 namespace WordPressOrg\Bin\PHPCS_Changed;
 
 /*
+ * Restore the ANSI colors that phpcs-changed's reporter drops, matching the
+ * colored report phpcs itself produces for new files.
+ */
+function colorize_report( $lines ) {
+	return array_map(
+		function ( $line ) {
+			return preg_replace(
+				array( '/^(\s*\d+ \| )(ERROR)( \| )/', '/^(\s*\d+ \| )(WARNING)( \| )/', '/^(FILE: .+|FOUND .+)$/' ),
+				array( "$1\033[31m$2\033[0m$3", "$1\033[33m$2\033[0m$3", "\033[1m$1\033[0m" ),
+				$line
+			);
+		},
+		$lines
+	);
+}
+
+/*
+ * Escape data for GitHub workflow commands; property values additionally
+ * escape the property separators.
+ */
+function annotation_escape( $value, $is_property = false ) {
+	$value = str_replace( array( '%', "\r", "\n" ), array( '%25', '%0D', '%0A' ), $value );
+	if ( $is_property ) {
+		$value = str_replace( array( ':', ',' ), array( '%3A', '%2C' ), $value );
+	}
+	return $value;
+}
+
+/*
+ * Surface each violation of a phpcs/phpcs-changed JSON report as an inline
+ * annotation on the PR diff. No-op outside of GitHub Actions.
+ */
+function emit_annotations( $report, $file_override = null ) {
+	if ( ! getenv( 'GITHUB_ACTIONS' ) || empty( $report['files'] ) ) {
+		return;
+	}
+
+	foreach ( $report['files'] as $path => $details ) {
+		foreach ( $details['messages'] ?? array() as $message ) {
+			$type       = ( 'ERROR' === $message['type'] ) ? 'error' : 'warning';
+			$properties = 'file=' . annotation_escape( $file_override ?? $path, true ) . ',line=' . (int) $message['line'];
+			if ( ! empty( $message['column'] ) ) {
+				$properties .= ',col=' . (int) $message['column'];
+			}
+			$text = $message['message'] . ( empty( $message['source'] ) ? '' : " ({$message['source']})" );
+			echo "\n::{$type} {$properties}::" . annotation_escape( $text );
+		}
+	}
+	echo "\n";
+}
+
+/*
  * New files are scanned in a single invocation, so that the parallel processing
  * configured in phpcs.xml.dist can scan them concurrently.
  */
 function run_phpcs( $files, $bin_dir ) {
-	exec( "$bin_dir/phpcs " . implode( ' ', array_map( 'escapeshellarg', $files ) ) . ' -snq', $output, $exec_exit_status );
+	$json_report = '.phpcs-branch.json';
+	$json_arg    = escapeshellarg( $json_report );
+
+	exec( "$bin_dir/phpcs " . implode( ' ', array_map( 'escapeshellarg', $files ) ) . " -snq --report-full --report-json=$json_arg", $output, $exec_exit_status );
 	echo implode( "\n", $output );
+
+	if ( file_exists( $json_report ) ) {
+		emit_annotations( (array) json_decode( file_get_contents( $json_report ), true ) );
+		exec( "rm -f $json_arg" );
+	}
+
 	return $exec_exit_status;
 }
 
@@ -51,8 +112,12 @@ function run_phpcs_changed( $file, $git, $base_branch, $bin_dir ) {
 
 	$cmd = "$bin_dir/phpcs-changed -s --diff $diff --phpcs-orig $orig_json --phpcs-new $new_json";
 	exec( $cmd, $output, $exec_exit_status );
-	echo implode( "\n", $output );
+	echo implode( "\n", colorize_report( $output ) );
 	echo "\n";
+
+	// The report is keyed by the temporary path, so annotate the real file instead.
+	exec( "$cmd --report json", $json_output );
+	emit_annotations( (array) json_decode( implode( '', $json_output ), true ), $file );
 
 	exec( "rm $diff $test_file $orig_json $new_json" );
 	return $exec_exit_status;

--- a/.github/bin/phpcs-branch.php
+++ b/.github/bin/phpcs-branch.php
@@ -68,15 +68,20 @@ function emit_annotations( $report, $file_override = null ) {
  * configured in phpcs.xml.dist can scan them concurrently.
  */
 function run_phpcs( $files, $bin_dir ) {
-	$json_report = '.phpcs-branch.json';
-	$json_arg    = escapeshellarg( $json_report );
+	$args = implode( ' ', array_map( 'escapeshellarg', $files ) ) . ' -snq';
 
-	exec( "$bin_dir/phpcs " . implode( ' ', array_map( 'escapeshellarg', $files ) ) . " -snq --report-full --report-json=$json_arg", $output, $exec_exit_status );
+	// Only produce the JSON report when there are annotations to feed.
+	if ( getenv( 'GITHUB_ACTIONS' ) ) {
+		$json_report = '.phpcs-branch.json';
+		$args       .= ' --report-full --report-json=' . escapeshellarg( $json_report );
+	}
+
+	exec( "$bin_dir/phpcs $args", $output, $exec_exit_status );
 	echo implode( "\n", $output );
 
-	if ( file_exists( $json_report ) ) {
+	if ( ! empty( $json_report ) && file_exists( $json_report ) ) {
 		emit_annotations( (array) json_decode( file_get_contents( $json_report ), true ) );
-		exec( "rm -f $json_arg" );
+		unlink( $json_report );
 	}
 
 	return $exec_exit_status;
@@ -116,8 +121,10 @@ function run_phpcs_changed( $file, $git, $base_branch, $bin_dir ) {
 	echo "\n";
 
 	// The report is keyed by the temporary path, so annotate the real file instead.
-	exec( "$cmd --report json", $json_output );
-	emit_annotations( (array) json_decode( implode( '', $json_output ), true ), $file );
+	if ( getenv( 'GITHUB_ACTIONS' ) ) {
+		exec( "$cmd --report json", $json_output );
+		emit_annotations( (array) json_decode( implode( '', $json_output ), true ), $file );
+	}
 
 	exec( "rm $diff $test_file $orig_json $new_json" );
 	return $exec_exit_status;


### PR DESCRIPTION
The phpcs check renders its two sections differently: new files are reported by `phpcs` itself, which honors the `colors` arg in `phpcs.xml.dist`, while modified files are reported by `phpcs-changed`, whose reporter has no color support at all — so the changed-lines section prints plain.

- **Colorize the `phpcs-changed` output in `phpcs-branch.php`** to match phpcs's look: red/yellow `ERROR`/`WARNING` labels, bold `FILE:`/`FOUND` header lines.
- **Emit inline PR annotations from both sections.** Every violation is also printed as a `::error`/`::warning` workflow command with file, line, and column, so it shows up directly on the PR diff view. Modified files annotate under their real path (the report itself is keyed by the temporary scan copy). Outside of GitHub Actions the annotations are skipped, so local runs are unchanged.

Verified locally against seeded violations in a new and a modified file: changed-lines output now carries the same ANSI styling as the phpcs section, and both sections emit correctly escaped workflow commands with accurate paths/lines/columns. Note GitHub caps inline annotations at 10 per type per step; overflow violations still appear in the log output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)