### PR TITLE
Plugin Directory: Rebuild the security scan alert with Block Kit

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan-gandalf.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan-gandalf.php
@@ -273,8 +273,8 @@ class Plugin_Scan_Gandalf {
 			$install_text = "*{$install_text}*";
 		}
 
-		// Escaping &, <, and > neutralizes Slack control sequences like <!channel> in untrusted strings.
-		$title = htmlspecialchars( $plugin->post_title, ENT_NOQUOTES );
+		// Post titles are stored entity-encoded; the header block is plain text, so only decode.
+		$title = html_entity_decode( $plugin->post_title, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
 		if ( 'closed' === $plugin->post_status ) {
 			$title .= ' (closed)';
 		}
@@ -282,47 +282,135 @@ class Plugin_Scan_Gandalf {
 		$findings_count = (int) $record['findings_count'];
 		$top_findings   = self::top_findings( $record['findings'], 5 );
 
-		$body = sprintf(
-			'Security scan found *%s* in *<https://wordpress.org/plugins/%s/|%s>* %s',
+		$meta_links = sprintf(
+			'<https://wordpress.org/plugins/wp-admin/post.php?post=%d&action=edit|wp-admin> · <https://wordpress.org/plugins/%s/|Plugin page>',
+			$plugin->ID,
+			$plugin->post_name
+		);
+		if ( $record['release_ref'] !== $record['version'] ) {
+			// Escaping &, <, and > neutralizes Slack control sequences like <!channel> in untrusted strings.
+			$meta_links .= ' · ' . htmlspecialchars( $record['release_ref'], ENT_NOQUOTES );
+		}
+
+		$summary = [
+			'type' => 'section',
+			'text' => [
+				'type' => 'mrkdwn',
+				'text' => sprintf( '%s · %s', 1 === $findings_count ? '*1 finding*' : "*{$findings_count} findings*", $install_text ),
+			],
+		];
+
+		$report_url = esc_url_raw( $record['report_url'] ?? '' );
+		if ( $report_url ) {
+			$summary['accessory'] = [
+				'type'  => 'button',
+				'text'  => [
+					'type' => 'plain_text',
+					'text' => 'View report',
+				],
+				'url'   => $report_url,
+				'style' => 'primary',
+			];
+		}
+
+		$blocks = [
+			[
+				'type' => 'header',
+				'text' => [
+					'type' => 'plain_text',
+					'text' => self::excerpt( trim( $title . ' ' . $record['version'] ), 150 ),
+				],
+			],
+			$summary,
+			[
+				'type'     => 'context',
+				'elements' => [
+					[
+						'type' => 'mrkdwn',
+						'text' => $meta_links,
+					],
+				],
+			],
+		];
+
+		$attachments = [];
+		foreach ( $top_findings as $finding ) {
+			$risk_score = (float) ( $finding['risk_score'] ?? 0 );
+
+			$attachment = [
+				'color'  => self::risk_color( $risk_score ),
+				'blocks' => [
+					[
+						'type' => 'section',
+						'text' => [
+							'type' => 'mrkdwn',
+							'text' => sprintf(
+								'*%s* — %s',
+								number_format( $risk_score, 1 ),
+								htmlspecialchars( self::excerpt( $finding['title'] ?? '', 150 ), ENT_NOQUOTES )
+							),
+						],
+					],
+				],
+			];
+
+			if ( ! empty( $finding['file_path'] ) ) {
+				$attachment['blocks'][] = [
+					'type'     => 'context',
+					'elements' => [
+						[
+							'type' => 'mrkdwn',
+							'text' => 'File: ' . self::file_link( $plugin, $record['release_ref'], $finding['file_path'], (int) ( $finding['line'] ?? 0 ) ),
+						],
+					],
+				];
+			}
+
+			$attachments[] = $attachment;
+		}
+
+		$fallback = sprintf(
+			'Security scan found %s in %s %s',
 			1 === $findings_count ? '1 finding' : "{$findings_count} findings",
-			$plugin->post_name,
-			$title,
+			htmlspecialchars( $title, ENT_NOQUOTES ),
 			htmlspecialchars( $record['version'], ENT_NOQUOTES )
 		);
-
-		if ( $record['release_ref'] !== $record['version'] ) {
-			$body .= sprintf( ' (`%s`)', htmlspecialchars( $record['release_ref'], ENT_NOQUOTES ) );
+		if ( isset( $record['max_risk_score'] ) ) {
+			$fallback .= sprintf( ' (max risk %s)', number_format( (float) $record['max_risk_score'], 1 ) );
 		}
 
-		$body .= "\n" . $install_text . "\n";
-
-		if ( $top_findings ) {
-			$body .= "\n";
-			foreach ( $top_findings as $finding ) {
-				$body .= sprintf(
-					"*%s*: %s\n",
-					htmlspecialchars( trim( ( $finding['risk_score'] ?? 0 ) . ' ' . trim( (string) ( $finding['severity'] ?? '' ) ) ), ENT_NOQUOTES ),
-					htmlspecialchars( self::excerpt( $finding['title'] ?? '', 150 ), ENT_NOQUOTES )
-				);
-
-				if ( ! empty( $finding['file_path'] ) ) {
-					$body .= '↳ ' . self::file_link( $plugin, $record['release_ref'], $finding['file_path'], (int) ( $finding['line'] ?? 0 ) ) . "\n";
-				}
-			}
-
-			if ( $findings_count > count( $top_findings ) ) {
-				$body .= sprintf( "…and %d more in the full report.\n", $findings_count - count( $top_findings ) );
-			}
-		}
-
-		// A | would end the URL portion of the Slack link early; htmlspecialchars() covers < and >.
-		$body .= "\n" . sprintf(
-			'<https://wordpress.org/plugins/wp-admin/post.php?post=%d&action=edit|wp-admin> · <%s|Gandalf report>',
-			$plugin->ID,
-			htmlspecialchars( str_replace( '|', '%7C', $record['report_url'] ), ENT_NOQUOTES )
+		slack_dm(
+			[
+				'text'        => $fallback,
+				'username'    => 'Gandalf',
+				'blocks'      => $blocks,
+				'attachments' => $attachments,
+			],
+			PLUGIN_REVIEW_ALERT_SLACK_CHANNEL,
+			true
 		);
+	}
 
-		slack_dm( $body, PLUGIN_REVIEW_ALERT_SLACK_CHANNEL, true );
+	/**
+	 * Return the attachment bar color for a risk score.
+	 *
+	 * @param float $risk_score The finding's risk score, 0-10.
+	 * @return string A hex color.
+	 */
+	protected static function risk_color( $risk_score ) {
+		if ( $risk_score >= 9 ) {
+			return '#D0342C';
+		}
+
+		if ( $risk_score >= 6 ) {
+			return '#E8912D';
+		}
+
+		if ( $risk_score >= 4 ) {
+			return '#ECB22E';
+		}
+
+		return '#808080';
 	}
 
 	/**


### PR DESCRIPTION
Follow-up to #779 and #781, superseding the earlier text-mrkdwn restyle on this branch. The alert becomes a structured Block Kit message, designed iteratively against rendered mockups of real callback payloads:

- **Header block** — plugin name and version as Slack's large heading (`Accordion and Accordion Slider 1.4.4`), with ` (closed)` appended for closed plugins. Header blocks are plain text, so entity-encoded titles are decoded (fixes the literal `&amp;` visible in current alerts) and control sequences like `<!channel>` are inert without escaping.
- **Summary section** — `*3 findings* · 3,000+ active installs` (installs bold at ≥10,000), with a primary **View report** link button as the section accessory. The button URL is `esc_url_raw()`-sanitized and omitted entirely if the callback carries no report URL, so the block set stays valid.
- **Context links** — small `wp-admin · Plugin page` line; the scanned ref is appended (escaped) only when it differs from the version, e.g. `· trunk`.
- **One color-barred attachment per finding** (top 5 by risk score): the bar encodes the risk band — red ≥9, orange ≥6, yellow ≥4, gray below. Each card is a section with `*9.8* — <title>` (score padded to one decimal, title excerpted to 150 chars) plus a small `File:` context line linking to the plugins Trac browser at the scanned ref and line.
- **Sender** — displays as **Gandalf** via the new `username` override, instead of the dispatching web host (`web2.dca.wordpress.org`).
- **Fallback text** — `Security scan found 3 findings in <plugin> <version> (max risk 9.8)`, escaped, keeping push notifications and non-block surfaces informative.

Verified in a rendering harness against the example callback payload, an entity-encoded Jetpack-style title with 17 findings, and hostile strings (`<!channel>`/`<!here>` in titles, `|` and `<`/`>` in file paths and the report URL) — mrkdwn escaping, link syntax, and block validity hold in all cases. `phpcs-changed` against trunk reports no new violations.

**Deploy-order dependency:** this requires the `notify_slack()`/`slack_dm()` array-message support (`text`/`blocks`/`attachments`/`username` keys) in the private dotorg repository to land **first**. Against an un-upgraded `slack_dm()`, the array would be JSON-encoded into the webhook `text` field and Slack would reject the payload, silently dropping the alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)