### PR TITLE
Translate: link Meta project pages to their per-locale contributor pages

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/projects-meta.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/projects-meta.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Project page for the Meta project family.
+ *
+ * Mirrors GlotPress's project template, except that the locale name links to
+ * the locale's contributors page rather than into the editor, matching what
+ * the wp-plugins and wp-themes project pages already do.
+ *
+ * @see https://meta.trac.wordpress.org/ticket/8396
+ *
+ * @package wporg-gp-customizations
+ */
+
+gp_title(
+	sprintf(
+		/* translators: %s: Project name. */
+		__( '%s project < GlotPress', 'glotpress' ),
+		esc_html( $project->name )
+	)
+);
+gp_breadcrumb_project( $project );
+gp_enqueue_scripts( array( 'gp-common', 'tablesorter' ) );
+gp_tmpl_header();
+?>
+
+<h2 class="project-name"><?php echo esc_html( $project->name ); ?></h2>
+
+<?php if ( $project->description ) : ?>
+	<div class="project-description"><?php echo $project->description; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Project descriptions allow markup. ?></div>
+<?php endif; ?>
+
+<?php if ( $translation_sets ) : ?>
+<div id="translation-sets">
+	<table class="gp-table translation-sets">
+		<thead>
+			<tr>
+				<th><?php esc_html_e( 'Locale', 'glotpress' ); ?></th>
+				<th class="stats percent"><?php esc_html_e( 'Percent', 'glotpress' ); ?></th>
+				<th class="stats translated"><?php esc_html_e( 'Translated', 'glotpress' ); ?></th>
+				<th class="stats fuzzy"><?php esc_html_e( 'Fuzzy', 'glotpress' ); ?></th>
+				<th class="stats untranslated"><?php esc_html_e( 'Untranslated', 'glotpress' ); ?></th>
+				<th class="stats waiting"><?php esc_html_e( 'Waiting', 'glotpress' ); ?></th>
+			</tr>
+		</thead>
+		<tbody>
+		<?php
+		foreach ( $translation_sets as $set ) :
+			// The contributors page for this locale. It is generated for every
+			// project path, Meta included, and is what this template exists to
+			// surface -- see #8396.
+			$contributors_url = gp_url( gp_url_join( 'locale', $set->locale, $set->slug, $project->path ) );
+			$editor_url       = gp_url_project( $project, gp_url_join( $set->locale, $set->slug ) );
+			?>
+			<tr>
+				<td>
+					<strong><?php gp_link( $contributors_url, $set->name_with_locale ); ?></strong>
+					<?php if ( $set->current_count && $set->all_count && $set->current_count >= $set->all_count * 0.9 ) : ?>
+						<span class="bubble morethan90"><?php echo esc_html( number_format_i18n( floor( $set->current_count / $set->all_count * 100 ) ) ); ?>%</span>
+					<?php endif; ?>
+				</td>
+				<td class="stats percent"><?php echo esc_html( number_format_i18n( $set->percent_translated ) ); ?>%</td>
+				<td class="stats translated" title="<?php esc_attr_e( 'translated', 'glotpress' ); ?>">
+					<?php gp_link( gp_url_join( $editor_url, array( 'filters[status]' => 'current' ) ), number_format_i18n( $set->current_count ) ); ?>
+				</td>
+				<td class="stats fuzzy" title="<?php esc_attr_e( 'fuzzy', 'glotpress' ); ?>">
+					<?php gp_link( gp_url_join( $editor_url, array( 'filters[status]' => 'fuzzy' ) ), number_format_i18n( $set->fuzzy_count ) ); ?>
+				</td>
+				<td class="stats untranslated" title="<?php esc_attr_e( 'untranslated', 'glotpress' ); ?>">
+					<?php gp_link( gp_url_join( $editor_url, array( 'filters[status]' => 'untranslated' ) ), number_format_i18n( $set->untranslated_count ) ); ?>
+				</td>
+				<td class="stats waiting">
+					<?php gp_link( gp_url_join( $editor_url, array( 'filters[status]' => 'waiting' ) ), number_format_i18n( $set->waiting_count ) ); ?>
+				</td>
+			</tr>
+		<?php endforeach; ?>
+		</tbody>
+	</table>
+</div>
+<?php endif; ?>
+
+<?php if ( $sub_projects ) : ?>
+<div id="sub-projects">
+	<h3><?php esc_html_e( 'Projects', 'glotpress' ); ?></h3>
+	<ul>
+		<?php foreach ( $sub_projects as $sub_project ) : ?>
+			<li>
+				<?php gp_link_project( $sub_project, esc_html( $sub_project->name ) ); ?>
+				<?php if ( $sub_project->description ) : ?>
+					<span class="description"><?php echo esc_html( gp_html_excerpt( $sub_project->description, 111 ) ); ?></span>
+				<?php endif; ?>
+			</li>
+		<?php endforeach; ?>
+	</ul>
+</div>
+<?php endif; ?>
+
+<script type="text/javascript">
+	jQuery( function( $ ) {
+		$( '.translation-sets' ).tablesorter( { sortList: [ [ 1, 1 ] ] } );
+	} );
+</script>
+
+<?php gp_tmpl_footer(); ?>

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-routes/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-routes/inc/class-plugin.php
@@ -167,6 +167,7 @@ class Plugin {
 			GP::$router->prepend( "/projects/wp-themes/$project", array( __NAMESPACE__ . '\Routes\WP_Themes', 'get_theme_projects' ) );
 			GP::$router->prepend( "/projects/wp-themes/$project/contributors", array( __NAMESPACE__ . '\Routes\WP_Themes', 'get_theme_contributors' ) );
 			GP::$router->prepend( "/projects/wp-themes/$project/language-packs", array( __NAMESPACE__ . '\Routes\WP_Themes', 'get_theme_language_packs' ) );
+			GP::$router->prepend( "/projects/meta/$project", array( __NAMESPACE__ . '\Routes\Meta', 'get_meta_projects' ) );
 
 			// Add Robots.txt support
 			GP::$router->prepend( '/robots\.txt', 'do_robots' );

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-routes/inc/routes/class-meta.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-routes/inc/routes/class-meta.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Project pages for the Meta project family.
+ *
+ * @package wporg-gp-routes
+ */
+
+namespace WordPressdotorg\GlotPress\Routes\Routes;
+
+use GP;
+use GP_Locales;
+use GP_Route;
+
+/**
+ * Project pages for the Meta project family.
+ *
+ * Identical in output to GlotPress's own project page, with one difference:
+ * each locale links to its contributors page under /locale/ rather than
+ * straight into the editor. Those pages already exist and already render for
+ * Meta projects -- nothing linked to them, which is what this route fixes.
+ *
+ * Meta projects are leaves rather than containers, so this cannot reuse
+ * WP_Plugins::get_plugin_projects(): that builds its table from child projects
+ * (dev, stable, ...), and a Meta project has none. The numbers here come from
+ * the project's own translation sets, the same source GlotPress uses.
+ *
+ * @see https://meta.trac.wordpress.org/ticket/8396
+ */
+class Meta extends GP_Route {
+
+	/**
+	 * Prints the project page for a Meta project.
+	 *
+	 * @param string $project_slug Slug of a project below meta/.
+	 */
+	public function get_meta_projects( $project_slug ) {
+		$project = GP::$project->by_path( 'meta/' . $project_slug );
+
+		if ( ! $project ) {
+			return $this->die_with_404();
+		}
+
+		$sub_projects     = $project->sub_projects();
+		$translation_sets = GP::$translation_set->by_project_id( $project->id );
+
+		foreach ( $translation_sets as $set ) {
+			$locale = GP_Locales::by_slug( $set->locale );
+
+			$set->name_with_locale   = $set->name_with_locale();
+			$set->current_count      = $set->current_count();
+			$set->untranslated_count = $set->untranslated_count();
+			$set->waiting_count      = $set->waiting_count();
+			$set->fuzzy_count        = $set->fuzzy_count();
+			$set->percent_translated = $set->percent_translated();
+			$set->all_count          = $set->all_count();
+			$set->wp_locale          = $locale ? $locale->wp_locale : '';
+		}
+
+		usort(
+			$translation_sets,
+			function ( $a, $b ) {
+				return ( $b->current_count <=> $a->current_count );
+			}
+		);
+
+		$title = sprintf(
+			/* translators: %s: project name */
+			__( '%s project', 'glotpress' ),
+			esc_html( $project->name )
+		);
+
+		$this->tmpl( 'projects-meta', get_defined_vars() );
+	}
+}


### PR DESCRIPTION
Ticket: https://meta.trac.wordpress.org/ticket/8396

### What this fixes

The per-locale contributor pages already exist for Meta projects and already render. `/locale/pl/default/meta/wordcamp/` returns 200 and lists 54 contributors with real per-project totals, plus the Translation Editors block, in the same `locale-project-contributors` markup the plugin pages use.

Nothing links to them. Measured on the rendered HTML:

| Page | links to `/locale/…` |
| --- | --- |
| `/projects/wp-plugins/codepress-admin-columns/` | 410 |
| `/projects/meta/wordcamp/` | 0 |

`inc/class-plugin.php` registers wporg project routes for `wp-plugins` and `wp-themes` only, so those get `templates/projects-wp-plugins.php`, whose locale column links to `gp_url_join( 'locale', $locale, $set_slug, $project->path )`. Meta has no route, so it falls through to GlotPress core's `gp-templates/project.php`, whose locale column links into the editor instead. Core has no filter around that link, and wporg does not override `project.php`.

### Approach

A `Routes\Meta` route plus a `projects-meta.php` template rendering the same translation-set table, with the locale name linking to its contributor page. The per-status counts (translated / fuzzy / untranslated / waiting) keep linking into the editor, so the path a translator actually uses is unchanged.

**Why this does not reuse `WP_Plugins::get_plugin_projects()`**, which was my first instinct: that method builds its table from `WHERE p.parent_project_id = $project->id`, which is right for `wp-plugins/<slug>` because that is a container over `dev` / `stable` / `dev-readme` / `stable-readme`. Meta projects are leaves. `/projects/meta/wordcamp/` has 0 sub-projects and 179 locale rows of its own, 140 with non-zero counts. A copy of that query would have returned an empty table. The data GlotPress core already renders is correct; only the destination of the locale link differs.

The template still renders a sub-projects list, so Meta projects that do have children are unaffected.

### Open question for reviewers

The ticket raises this and I did not want to decide it unilaterally: this makes the locale name link to contributors, matching the wp-plugins precedent. The alternative is to leave the locale name pointing at the editor and add a separate "Contributors" link per row. Happy to switch, it is a two-line change in the template.

There is also a more general option, noted in the ticket: add a hook to GlotPress's `gp-templates/project.php` so any install can append per-locale links, rather than wporg carrying a near-copy of that template. That is the better long-term shape but needs a GlotPress release, so this is the version that can ship now. If you would rather wait for the upstream hook, say so and I will close this and open the GlotPress issue instead.

### Checks

`php -l` clean on all three files. PHPCS against `phpcs.xml.dist` reports 0 issues on both new files; `class-plugin.php` has 15 pre-existing issues, none on the line this adds (line 170).

Not verified in a running environment: I do not have a translate.wordpress.org instance to load the route against, so this is verified by reading the routing, autoloading (`register_class_path` resolves `Routes\Meta` to `inc/routes/class-meta.php`) and the core route it mirrors, not by hitting the page. Worth someone loading `/projects/meta/wordcamp/` on sandbox before this goes near production.

Props motylanogha
