### PR TITLE
Plugin Directory: Mark only the ZIPs that actually built, in the import path too

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/bin/rebuild-zip.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/bin/rebuild-zip.php
@@ -115,20 +115,22 @@ try {
 			$stable_tag
 		);
 
-		// Mark the ZIPs as being built, trunk has no release record.
-		foreach ( (array) $built_versions as $built_tag ) {
-			if ( 'trunk' === $built_tag ) {
-				continue;
-			}
+		// Mark the built ZIPs; trunk has no release record. build() returns false when unconfigured.
+		if ( is_array( $built_versions ) ) {
+			foreach ( $built_versions as $built_tag => $built_revision ) {
+				if ( 'trunk' === $built_tag ) {
+					continue;
+				}
 
-			Plugin_Directory::add_release(
-				$plugin_post,
-				array(
-					'tag'                      => $built_tag,
-					'zips_built'               => true,
-					'zips_built_from_revision' => $zip_builder->plugins_revision,
-				)
-			);
+				Plugin_Directory::add_release(
+					$plugin_post,
+					array(
+						'tag'                      => $built_tag,
+						'zips_built'               => true,
+						'zips_built_from_revision' => $built_revision,
+					)
+				);
+			}
 		}
 	}
 

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/bin/rebuild-zip.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/bin/rebuild-zip.php
@@ -104,7 +104,10 @@ try {
 	if ( ! $plugin_post ) {
 		throw new Exception( 'Could not locate plugin post' );
 	}
-	$stable_tag = get_post_meta( $plugin_post->ID, 'stable_tag', true ) ?: 'trunk';
+	$stable_tag = get_post_meta( $plugin_post->ID, 'stable_tag', true );
+	if ( ! $stable_tag ) {
+		$stable_tag = 'trunk';
+	}
 
 	// (re)Build & Commit 5 Zips at a time to avoid limitations.
 	foreach ( array_chunk( $versions, 5 ) as $versions_to_build ) {

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/bin/rebuild-zip.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/bin/rebuild-zip.php
@@ -104,7 +104,7 @@ try {
 	if ( ! $plugin_post ) {
 		throw new Exception( 'Could not locate plugin post' );
 	}
-	$stable_tag = get_post_meta( $plugin_post->ID, 'stable_tag', true ) ?? 'trunk';
+	$stable_tag = get_post_meta( $plugin_post->ID, 'stable_tag', true ) ?: 'trunk';
 
 	// (re)Build & Commit 5 Zips at a time to avoid limitations.
 	foreach ( array_chunk( $versions, 5 ) as $versions_to_build ) {

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/bin/rebuild-zip.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/bin/rebuild-zip.php
@@ -115,23 +115,8 @@ try {
 			$stable_tag
 		);
 
-		// Mark the built ZIPs; trunk has no release record. build() returns false when unconfigured.
-		if ( is_array( $built_versions ) ) {
-			foreach ( $built_versions as $built_tag => $built_revision ) {
-				if ( 'trunk' === $built_tag ) {
-					continue;
-				}
-
-				Plugin_Directory::add_release(
-					$plugin_post,
-					array(
-						'tag'                      => $built_tag,
-						'zips_built'               => true,
-						'zips_built_from_revision' => $built_revision,
-					)
-				);
-			}
-		}
+		// Mark only the ZIPs that actually built, each with its export revision.
+		Plugin_Directory::mark_zips_built( $plugin_post, $built_versions );
 	}
 
 	echo 'OK. Took ' . round( microtime( 1 ) - $start_time, 2 ) . "s\n";

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-plugin-directory.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-plugin-directory.php
@@ -1816,9 +1816,6 @@ class Plugin_Directory {
 	 * @return bool
 	 */
 	public static function remove_release( $plugin, $tag ) {
-		// PHP coerces numeric-string array keys to integers; release tags are strings.
-		$tag = (string) $tag;
-
 		$result   = false;
 		$plugin   = self::get_plugin_post( $plugin );
 		$releases = self::get_releases( $plugin );

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-plugin-directory.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-plugin-directory.php
@@ -1776,6 +1776,39 @@ class Plugin_Directory {
 	}
 
 	/**
+	 * Mark built ZIPs as such on their release records.
+	 *
+	 * @param string|\WP_Post $plugin            Plugin slug or post object.
+	 * @param array|false     $built_versions    Map of built version => SVN revision, as returned by Zip\Builder::build().
+	 * @param int             $fallback_revision Optional. Revision to record when the build revision is empty. Default 0.
+	 * @return void
+	 */
+	public static function mark_zips_built( $plugin, $built_versions, $fallback_revision = 0 ) {
+		if ( ! is_array( $built_versions ) ) {
+			return;
+		}
+
+		foreach ( $built_versions as $tag => $revision ) {
+			// PHP coerces numeric-string array keys to integers; release tags are strings.
+			$tag = (string) $tag;
+
+			// Trunk has no release record.
+			if ( 'trunk' === $tag ) {
+				continue;
+			}
+
+			self::add_release(
+				$plugin,
+				[
+					'tag'                      => $tag,
+					'zips_built'               => true,
+					'zips_built_from_revision' => $revision ? $revision : $fallback_revision,
+				]
+			);
+		}
+	}
+
+	/**
 	 * Remove a Plugin Release from the internal storage.
 	 *
 	 * @param string $plugin Plugin slug.

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-plugin-directory.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-plugin-directory.php
@@ -1716,6 +1716,10 @@ class Plugin_Directory {
 		if ( ! isset( $data['tag'] ) ) {
 			return false;
 		}
+
+		// PHP coerces numeric-string array keys to integers; release tags are strings.
+		$data['tag'] = (string) $data['tag'];
+
 		$plugin = self::get_plugin_post( $plugin );
 
 		$release = self::get_release( $plugin, $data['tag'] ) ?: [
@@ -1778,20 +1782,16 @@ class Plugin_Directory {
 	/**
 	 * Mark built ZIPs as such on their release records.
 	 *
-	 * @param string|\WP_Post $plugin            Plugin slug or post object.
-	 * @param array|false     $built_versions    Map of built version => SVN revision, as returned by Zip\Builder::build().
-	 * @param int             $fallback_revision Optional. Revision to record when the build revision is empty. Default 0.
+	 * @param string|\WP_Post $plugin         Plugin slug or post object.
+	 * @param array|false     $built_versions Map of built version => SVN revision, as returned by Zip\Builder::build().
 	 * @return void
 	 */
-	public static function mark_zips_built( $plugin, $built_versions, $fallback_revision = 0 ) {
+	public static function mark_zips_built( $plugin, $built_versions ) {
 		if ( ! is_array( $built_versions ) ) {
 			return;
 		}
 
 		foreach ( $built_versions as $tag => $revision ) {
-			// PHP coerces numeric-string array keys to integers; release tags are strings.
-			$tag = (string) $tag;
-
 			// Trunk has no release record.
 			if ( 'trunk' === $tag ) {
 				continue;
@@ -1802,7 +1802,7 @@ class Plugin_Directory {
 				[
 					'tag'                      => $tag,
 					'zips_built'               => true,
-					'zips_built_from_revision' => $revision ? $revision : $fallback_revision,
+					'zips_built_from_revision' => $revision,
 				]
 			);
 		}
@@ -1816,6 +1816,9 @@ class Plugin_Directory {
 	 * @return bool
 	 */
 	public static function remove_release( $plugin, $tag ) {
+		// PHP coerces numeric-string array keys to integers; release tags are strings.
+		$tag = (string) $tag;
+
 		$result   = false;
 		$plugin   = self::get_plugin_post( $plugin );
 		$releases = self::get_releases( $plugin );

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
@@ -651,8 +651,8 @@ class Import {
 		// Rebuild/Build $build_zips
 		try {
 			// This will rebuild the ZIP.
-			$zip_builder = new Builder();
-			$zip_builder->build(
+			$zip_builder    = new Builder();
+			$built_versions = $zip_builder->build(
 				$plugin_slug,
 				array_unique( $versions_to_build ),
 				$svn_revision_triggered ?
@@ -675,20 +675,22 @@ class Import {
 			return false;
 		}
 
-		// Mark the ZIPs as being built.
-		foreach ( $versions_to_build as $tag ) {
-			if ( 'trunk' === $tag ) {
-				continue;
-			}
+		// Mark only the ZIPs that actually built, each with its export revision.
+		if ( is_array( $built_versions ) ) {
+			foreach ( $built_versions as $tag => $revision ) {
+				if ( 'trunk' === $tag ) {
+					continue;
+				}
 
-			Plugin_Directory::add_release(
-				$plugin,
-				[
-					'tag'                      => $tag,
-					'zips_built'               => true,
-					'zips_built_from_revision' => ( $zip_builder->plugins_revision ?? 0 ) ?: $svn_revision_triggered,
-				]
-			);
+				Plugin_Directory::add_release(
+					$plugin,
+					[
+						'tag'                      => $tag,
+						'zips_built'               => true,
+						'zips_built_from_revision' => $revision ? $revision : $svn_revision_triggered,
+					]
+				);
+			}
 		}
 
 		return true;

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
@@ -676,22 +676,7 @@ class Import {
 		}
 
 		// Mark only the ZIPs that actually built, each with its export revision.
-		if ( is_array( $built_versions ) ) {
-			foreach ( $built_versions as $tag => $revision ) {
-				if ( 'trunk' === $tag ) {
-					continue;
-				}
-
-				Plugin_Directory::add_release(
-					$plugin,
-					[
-						'tag'                      => $tag,
-						'zips_built'               => true,
-						'zips_built_from_revision' => $revision ? $revision : $svn_revision_triggered,
-					]
-				);
-			}
-		}
+		Plugin_Directory::mark_zips_built( $plugin, $built_versions, $svn_revision_triggered );
 
 		return true;
 	}

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
@@ -676,7 +676,7 @@ class Import {
 		}
 
 		// Mark only the ZIPs that actually built, each with its export revision.
-		Plugin_Directory::mark_zips_built( $plugin, $built_versions, $svn_revision_triggered );
+		Plugin_Directory::mark_zips_built( $plugin, $built_versions );
 
 		return true;
 	}

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/zip/class-builder.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/zip/class-builder.php
@@ -39,9 +39,10 @@ class Builder {
 	/**
 	 * Generate a ZIP for a provided Plugin tags.
 	 *
-	 * @param string $slug     The plugin slug.
-	 * @param array  $versions The versions of the plugin to build ZIPs for.
-	 * @param string $context  The context of this Builder instance (commit #, etc)
+	 * @param string $slug       The plugin slug.
+	 * @param array  $versions   The versions of the plugin to build ZIPs for.
+	 * @param string $context    Optional. The context of this Builder instance (commit #, etc). Default empty string.
+	 * @param string $stable_tag Optional. The stable tag of the plugin, used to determine whether checksums are generated. Default empty string.
 	 * @return array|false Map of successfully-built version (as requested) => SVN revision it was built from, false in unconfigured environments.
 	 */
 	public function build( $slug, $versions, $context = '', $stable_tag = '' ) {

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/zip/class-builder.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/zip/class-builder.php
@@ -38,7 +38,7 @@ class Builder {
 	 * @param string $slug     The plugin slug.
 	 * @param array  $versions The versions of the plugin to build ZIPs for.
 	 * @param string $context  The context of this Builder instance (commit #, etc)
-	 * @return array|false The versions that were successfully built, false in unconfigured environments.
+	 * @return array|false Map of successfully-built version => SVN revision it was built from, false in unconfigured environments.
 	 */
 	public function build( $slug, $versions, $context = '', $stable_tag = '' ) {
 		// Bail when in an unconfigured environment.
@@ -161,7 +161,8 @@ class Builder {
 				SVN::add( $this->signature_file );
 			}
 
-			$built_versions[] = $version;
+			// Record each built version with the revision it was exported from.
+			$built_versions[ $version ] = $this->plugins_revision;
 		}
 
 		// If no versions could be built, an empty commit would incorrectly report success.

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/zip/class-builder.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/zip/class-builder.php
@@ -29,8 +29,12 @@ class Builder {
 	// The SVN url of the plugin version being packaged.
 	protected $plugin_version_svn_url = '';
 
-	// The revision of the plugin that was just packaged.
-	public $plugins_revision = 0;
+	/**
+	 * The revision of the plugin that was just packaged.
+	 *
+	 * @var int
+	 */
+	protected $plugins_revision = 0;
 
 	/**
 	 * Generate a ZIP for a provided Plugin tags.
@@ -38,7 +42,7 @@ class Builder {
 	 * @param string $slug     The plugin slug.
 	 * @param array  $versions The versions of the plugin to build ZIPs for.
 	 * @param string $context  The context of this Builder instance (commit #, etc)
-	 * @return array|false Map of successfully-built version => SVN revision it was built from, false in unconfigured environments.
+	 * @return array|false Map of successfully-built version (as requested) => SVN revision it was built from, false in unconfigured environments.
 	 */
 	public function build( $slug, $versions, $context = '', $stable_tag = '' ) {
 		// Bail when in an unconfigured environment.
@@ -95,8 +99,9 @@ class Builder {
 
 		// Build the requested ZIPs
 		$built_versions = [];
-		foreach ( $versions as $version ) {
+		foreach ( $versions as $requested_version ) {
 			// Incase .1 was passed, treat it as 0.1
+			$version = $requested_version;
 			if ( '.' == substr( $version, 0, 1 ) ) {
 				$version = "0{$version}";
 			}
@@ -161,8 +166,8 @@ class Builder {
 				SVN::add( $this->signature_file );
 			}
 
-			// Record each built version with the revision it was exported from.
-			$built_versions[ $version ] = $this->plugins_revision;
+			// Key by the requested version, as release records store the raw tag name.
+			$built_versions[ $requested_version ] = $this->plugins_revision;
 		}
 
 		// If no versions could be built, an empty commit would incorrectly report success.


### PR DESCRIPTION
## Summary

Follow-up to the merged `zips_built` accuracy work ([a1303ea] "Mark releases as built when manually rebuilding ZIPs", [f19b1c0] "Emit a PHP warning when a ZIP fails to build"). That change taught `Builder::build()` to skip per-version export failures (`continue`) and return only the versions it actually built — but only `bin/rebuild-zip.php` was updated to consume that return value.

This PR closes the gap in the **primary automated path** and tightens two accuracy issues.

## The gap

`Import::rebuild_affected_zips()` — the caller that runs on every SVN commit import — still ignored `build()`'s return value and looped over the full `$versions_to_build`, marking every requested tag `zips_built => true`. So when a chunk built, say, 3 of 5 versions, the 2 that failed to export were still recorded as built. That is the exact condition the earlier change set out to prevent, left unfixed on the path that matters most.

It now consumes the return value and marks only the versions that actually built.

## Provenance and the `false` return

Two smaller fixes ride along, both enabled by reshaping the return value:

- **`build()` now returns a `version => revision` map** instead of a flat list. Previously `zips_built_from_revision` was stamped from `$zip_builder->plugins_revision`, which only ever holds the *last* built version's revision — so every tag in a 5-version chunk got the final version's revision. Each entry is now recorded with the revision it was actually exported from. With that map being the only external contract, `$plugins_revision` drops to `protected`.
- **Both call sites route through the new `Plugin_Directory::mark_zips_built()`**, which owns the mark-built contract in one place next to `add_release()`. It guards on `is_array()` — `build()` returns `false` in an unconfigured environment, and `(array) false` is `[ false ]`, not `[]`, so the old `foreach ( (array) $built_versions ... )` would have written a bogus `tag => false` release record.

## Map keys are the requested (raw) tags

`build()` normalizes `.1` → `0.1` internally for building, but the returned map is keyed by the version the caller requested. Release records store the raw SVN tag name (`prefill_releases_meta()` and the import both store the tag as-is; only the `version` field is normalized) and `get_release()` matches the tag exactly, so a normalized key would create a phantom release row while the real one stays unmarked. `mark_zips_built()` also casts each key back to string: PHP coerces numeric-string array keys (`'2'`) to integers, which would defeat the strict `===` tag comparisons in `add_release()`/`remove_release()` and leave duplicate release rows.

## Not changed

The relaxed commit-error check (`! $res['result'] && $res['errors']`) is intentional and left as-is: `SVN::commit()` only yields empty `errors` when `parse_svn_errors()` finds no `svn: E###` lines — i.e. genuinely "nothing to commit," which is a successful no-op build. Real commit failures (auth/network) always emit parseable `svn: E###` output and still throw.

## Testing

Verified by code inspection and phpcs (changed lines clean). No automated test is added: `Builder` has no existing test coverage and is tightly coupled to static `SVN::*` calls with no injection seam, so exercising `rebuild_affected_zips()` would require SVN mocking infrastructure that doesn't exist here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
