### PR TITLE
Plugin Directory: Rebuild the Plugin Check Slack alert with Block Kit

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan.php
@@ -232,13 +232,6 @@ class Plugin_Scan {
 			return;
 		}
 
-		$totals = sprintf(
-			"Found %d errors in %s %s.\n\n",
-			$results[ 'totals' ][ 'errors' ],
-			$plugin->post_name,
-			$tag
-		);
-
 		$summary = [];
 		foreach ( $results[ 'files' ] as $filename => $file ) {
 			foreach ( $file as $message ) {
@@ -256,48 +249,120 @@ class Plugin_Scan {
 			return;
 		}
 
-		$active_installs = (int) get_post_meta( $plugin->ID, 'active_installs', true );
-
-		$body = sprintf( "Detected errors in *%s*\n", $plugin->post_title );
-		if ( $active_installs >= 10000 ) {
-			$body .= sprintf( ":bangbang::bangbang::bangbang: %s+ active installs :bangbang::bangbang::bangbang:\n", number_format_i18n( $active_installs ) );
-		} else {
-			$body .= sprintf( "%s+ active installs\n", number_format_i18n( $active_installs ) );
-		}
-
-		$body .= $totals . "\n";
-		$body .= sprintf( "Details: https://wordpress.org/plugins/wp-admin/post.php?post=%s&action=edit\n", $plugin->ID );
-		$body .= sprintf( "Source: https://plugins.trac.wordpress.org/browser/%s/%s/\n",
-			$plugin->post_name,
-			( 'trunk' === $tag ? 'trunk' : 'tags/' . $tag )
-		);
-		$body .= sprintf( "Plugin: https://wordpress.org/plugins/%s/\n", $plugin->post_name );
-
-		$body .= "\n\n```\n";
-		$body .= sprintf( "%-80s %8s %8s\n", 'Type', 'Errors', 'Files' );
-		$body .= sprintf( "%-80s %8s %8s\n", '----', '------', '-----' );
+		$codes = [];
 		foreach ( $summary as $error_code => $file_errors ) {
-			$file_count  = count( $file_errors );
-			$error_count = count( $file_errors, COUNT_RECURSIVE ) - $file_count;
+			$file_count = count( $file_errors );
 
-			$body .= sprintf(
-				"%-80s %8d %8d\n",
-				$error_code,
-				$error_count,
-				$file_count
-			);
+			$codes[] = [
+				'code'   => $error_code,
+				'errors' => count( $file_errors, COUNT_RECURSIVE ) - $file_count,
+				'files'  => $file_count,
+			];
 		}
-		$body .= '```';
+
+		usort(
+			$codes,
+			static function ( $a, $b ) {
+				return $b['errors'] <=> $a['errors'];
+			}
+		);
+
+		$total_errors = array_sum( array_column( $codes, 'errors' ) );
+
+		// Keep the table scannable and well below the 3,000-character section block limit.
+		$more = count( $codes ) - 10;
+		if ( $more > 0 ) {
+			$codes = array_slice( $codes, 0, 10 );
+		}
+
+		foreach ( $codes as $i => $code ) {
+			// Escaping &, <, and > neutralizes Slack control sequences in scanner-supplied codes.
+			$codes[ $i ]['code'] = htmlspecialchars( $code['code'], ENT_NOQUOTES );
+		}
+
+		$width = max( array_map( 'strlen', array_merge( [ 'Type' ], array_column( $codes, 'code' ) ) ) );
+
+		$table  = sprintf( "%-{$width}s %8s %8s\n", 'Type', 'Errors', 'Files' );
+		$table .= sprintf( "%-{$width}s %8s %8s\n", '----', '------', '-----' );
+		foreach ( $codes as $code ) {
+			$table .= sprintf( "%-{$width}s %8d %8d\n", $code['code'], $code['errors'], $code['files'] );
+		}
+		if ( $more > 0 ) {
+			$table .= sprintf( "…and %d more error types.\n", $more );
+		}
+
+		$active_installs = (int) get_post_meta( $plugin->ID, 'active_installs', true );
+		$install_text    = sprintf( '%s+ active installs', number_format_i18n( $active_installs ) );
+		if ( $active_installs >= 10000 ) {
+			$install_text = "*{$install_text}*";
+		}
+
+		// Post titles are stored entity-encoded; the header block is plain text, so only decode.
+		$title = html_entity_decode( $plugin->post_title, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+
+		$blocks = [
+			[
+				'type' => 'header',
+				'text' => [
+					'type' => 'plain_text',
+					'text' => mb_strimwidth( preg_replace( '/\s+/u', ' ', trim( $title . ' ' . $tag ) ), 0, 150, '…' ),
+				],
+			],
+			[
+				'type' => 'section',
+				'text' => [
+					'type' => 'mrkdwn',
+					'text' => sprintf( '%s · %s', 1 === $total_errors ? '*1 error*' : "*{$total_errors} errors*", $install_text ),
+				],
+			],
+			[
+				'type'     => 'context',
+				'elements' => [
+					[
+						'type' => 'mrkdwn',
+						'text' => sprintf(
+							'<https://wordpress.org/plugins/wp-admin/post.php?post=%d&action=edit|wp-admin> · <https://plugins.trac.wordpress.org/browser/%s/%s/|Source> · <https://wordpress.org/plugins/%s/|Plugin page>',
+							$plugin->ID,
+							$plugin->post_name,
+							'trunk' === $tag ? 'trunk' : 'tags/' . rawurlencode( $tag ),
+							$plugin->post_name
+						),
+					],
+				],
+			],
+			[
+				'type' => 'divider',
+			],
+			[
+				'type' => 'section',
+				'text' => [
+					'type' => 'mrkdwn',
+					'text' => "```\n{$table}```",
+				],
+			],
+		];
+
+		$fallback = sprintf(
+			'Plugin Check found %s in %s %s',
+			1 === $total_errors ? '1 error' : "{$total_errors} errors",
+			htmlspecialchars( $title, ENT_NOQUOTES ),
+			htmlspecialchars( $tag, ENT_NOQUOTES )
+		);
 
 		if ( wp_doing_cron() ) {
 			// During cron, output the body to the log.
 			echo "\n==== Plugin Check Results for {$plugin->post_name} {$tag} SLACK LOG ====\n";
-			echo $body;
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- CLI cron log output, not HTML.
+			echo $fallback . "\n" . $table;
 		}
 
 		if ( defined( 'PLUGIN_REVIEW_ALERT_SLACK_CHANNEL' ) && function_exists( 'slack_dm' ) ) {
 			slack_dm(
-				$body,
+				[
+					'text'     => $fallback,
+					'username' => 'Plugin Check',
+					'blocks'   => $blocks,
+				],
 				PLUGIN_REVIEW_ALERT_SLACK_CHANNEL,
 				true
 			);

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan.php
@@ -276,8 +276,10 @@ class Plugin_Scan {
 		}
 
 		foreach ( $codes as $i => $code ) {
-			// Escaping &, <, and > neutralizes Slack control sequences in scanner-supplied codes.
-			$codes[ $i ]['code'] = htmlspecialchars( $code['code'], ENT_NOQUOTES );
+			// Keep untrusted codes from escaping the code block or exceeding Slack's block size limit.
+			$clean = preg_replace( '/\s+/u', ' ', trim( str_replace( '`', '', (string) $code['code'] ) ) );
+
+			$codes[ $i ]['code'] = htmlspecialchars( mb_strimwidth( $clean, 0, 80, '…' ), ENT_NOQUOTES );
 		}
 
 		$width = max( array_map( 'strlen', array_merge( [ 'Type' ], array_column( $codes, 'code' ) ) ) );


### PR DESCRIPTION
Companion to #782. The Plugin Check (PCP) alert in the review channel still used the original text format: raw labeled URLs, the `:bangbang:` install wall, and a fixed 80-column table. This rebuilds it in the same Block Kit design language as the Gandalf alert while keeping the two feeds visually distinguishable:

- **Sender** — displays as **Plugin Check** (Gandalf alerts show as **Gandalf**), so the channel tells the feeds apart by name.
- **Header block** — plugin name and scanned ref (`Flex Fields trunk`), entity-decoded, capped at Slack's 150-char header limit.
- **Summary section** — `*9 errors* · 10+ active installs` (installs bold at ≥10,000). No button on this feed.
- **Context links** — `wp-admin · Source · Plugin page`, replacing the three raw labeled URLs.
- **Error table** — a divider, then the error-code table in a code block, with the code column sized to the longest name instead of a fixed 80 characters (typically half as wide), rows sorted by error count, capped at 10 with an `…and N more error types.` trailer — staying well inside the 3,000-char section limit. Codes are escaped; the scanned tag is URL-encoded in the Source link.
- **Pure blocks, no attachments** — PCP errors carry no risk score, so nothing needs a color bar; this also avoids Slack's "Added by" attribution label entirely.
- **Accurate count** — the headline derives from the displayed summary instead of `totals.errors`, which could disagree with the table (the current alert can say "Found 1 errors" above a table listing 9).
- **Fallback text** — `Plugin Check found 9 errors in Flex Fields trunk`, escaped, for notifications; the cron log echo keeps the same content in plain text.

Verified in a rendering harness against the current alert's real-world example (Flex Fields), an entity-encoded title with 18 error codes (row cap + bold installs + tag-based Source URL), hostile strings (`<!channel>` in titles and codes, `<`/`>`/`|` in the tag), and the closed-plugin no-op. `phpcs-changed` against trunk reports no new violations on changed lines.

**Deploy-order dependency:** same as #782 — requires the `notify_slack()` array-message support in the private dotorg repository first; an un-upgraded `slack_dm()` would JSON-encode the array into `text` and Slack would reject the payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
