### PR TITLE
Give Copilot repo context so its PR reviews stop flagging intentional patterns

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,28 @@
+# WordPress.org Meta
+
+This repository powers production WordPress.org sites (wordpress.org, api.wordpress.org, login, forums, translate, and others). It runs on WordPress `trunk` and targets PHP 8.4 compatibility. For broader architecture and workspace context, see [AGENTS.md](../AGENTS.md).
+
+## Security practices
+
+Most code here handles untrusted input on a high-traffic, high-value target. Hold every change to these expectations:
+
+- **Late escaping.** Output must be escaped at the point of echo, with the context-appropriate function (`esc_html()`, `esc_attr()`, `esc_url()`, `wp_kses()`). Escaping at save time is not a substitute.
+- **Prepared SQL.** Any variable interpolated into a query must go through `$wpdb->prepare()`. Table names concatenated from constants are acceptable; user-influenced values never are.
+- **Sanitized superglobals.** `$_GET`, `$_POST`, `$_REQUEST`, `$_COOKIE`, and `$_SERVER` values must be sanitized on read (`sanitize_text_field()`, `absint()`, `wp_unslash()`, type casts). Cookie and header values may be arrays or absent — watch for type confusion.
+- **Nonce and capability checks.** State-changing actions need both a nonce verification and a `current_user_can()` check. A nonce alone is not authorization.
+- **REST endpoints.** Every route needs an explicit `permission_callback`. Argument definitions should validate and sanitize; note that a custom `sanitize_callback` disables the default schema validation.
+- **SSRF and remote requests.** URLs passed to `wp_remote_*()` that derive from user input need validation against expected hosts.
+- **Object injection.** `unserialize()` on any value that could be user-influenced is a vulnerability; prefer JSON.
+- **Signature and secret comparison.** Webhook handlers and API callbacks that verify shared secrets or HMAC signatures must compare with `hash_equals()`, never `==` or `===` — string comparison leaks timing information.
+- **Test isolation.** In PHPUnit tests, `remove_all_filters()` and `remove_all_actions()` strip production callbacks along with test ones. Tests must remove the specific callback they added.
+
+## Repository quirks
+
+- `wp-init-ondemand.php` is required by many API endpoints but lives in a private repository. Its absence here is expected; do not report the include as broken or suggest creating the file.
+- Code that overrides `$wp_object_cache->blog_prefix` or switches blogs before cache/database access is an intentional multisite pattern, not a bug.
+- Direct database queries and low-level cache manipulation are common and accepted in the `api.wordpress.org` endpoints, which run outside a full WordPress bootstrap.
+
+## When reviewing pull requests
+
+- Do not comment on formatting, alignment, Yoda conditions, or other mechanical style issues. Code style is enforced by a PHP_CodeSniffer CI job against the repository's `phpcs.xml.dist`.
+- This Git repository is a read-only mirror of `meta.svn.wordpress.org`. PRs are not merged on GitHub; a Meta committer commits the patch to SVN, which closes the PR automatically. Do not suggest merge-related workflow steps.


### PR DESCRIPTION
Copilot code review currently runs with zero repository-specific context. Its reviews summarize diffs competently but comment on style that the PHPCS CI job already enforces, and it has no way to know that patterns like the `wp-init-ondemand.php` include (private repository) or `$wp_object_cache->blog_prefix` overrides are intentional rather than bugs.

This adds `.github/copilot-instructions.md`, which Copilot injects into every request — code review, chat, and the coding agent ([docs](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions/add-repository-instructions)). It contains:

- **Security practices** — the cross-cutting expectations for this codebase: late escaping, `$wpdb->prepare()`, superglobal sanitization, nonce + capability checks, REST `permission_callback`, SSRF validation, `unserialize()`, timing-safe secret comparison with `hash_equals()`, and test isolation (`remove_all_filters()` stripping production callbacks).
- **Repository quirks** — the known false-positive traps: the private bootstrap file, multisite cache prefix switching, and direct queries in `api.wordpress.org` endpoints.
- **Review guidance** — leave style to PHPCS, and don't suggest GitHub merge steps since this repository is a read-only SVN mirror.

Custom instructions were chosen over a `.github/skills/code-review/` agent skill because instructions are injected deterministically on every request, while skills are loaded conditionally.

The file takes effect for any PR whose head branch contains it, so it applies to new PRs once committed to trunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)