### PR TITLE
Global Header & Footer: Remove unused wporg_get_global_footer() and feature flag

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/.wp-env.json
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/.wp-env.json
@@ -6,8 +6,5 @@
   ],
   "mappings": {
     "wp-content/mu-plugins": "./mu-plugins"
-  },
-  "config": {
-    "FEATURE_2021_GLOBAL_HEADER_FOOTER": true
   }
 }

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/functions.php
@@ -665,15 +665,6 @@ function wporg_support_pre_get_document_title( $title ) {
 add_filter( 'pre_get_document_title', 'wporg_support_pre_get_document_title' );
 
 /**
- * The Footer for our theme.
- *
- * @package WPBBP
- */
-function wporg_get_global_footer() {
-	require WPORGPATH . 'footer.php';
-}
-
-/**
  * Append an optimized site name.
  *
  * @param array $title Parts of the page title.


### PR DESCRIPTION
Part of the post-launch cleanup for the 2021 global header/footer: https://github.com/WordPress/wporg-mu-plugins/issues/55 (companion to https://github.com/WordPress/wporg-mu-plugins/pull/753, which removes the flag itself from mu-plugins).

- Removes `wporg_get_global_footer()` from the wporg-support-2024 theme. It has no callers anywhere in the repo and only wrapped a `require` of the retired `footer.php`.
- Removes the `FEATURE_2021_GLOBAL_HEADER_FOOTER` constant from wporg-openverse's `.wp-env.json` — the flag is being removed from mu-plugins, so the override no longer does anything.

No other references to either symbol remain in the repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)