### PR TITLE
Honor registered post statuses across the plugin/theme REST route and support forums

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-plugin-directory.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-plugin-directory.php
@@ -204,7 +204,7 @@ class Plugin_Directory {
 			'menu_icon'    => 'dashicons-admin-plugins',
 			'capabilities' => array(
 				'edit_post'          => 'plugin_edit',
-				'read_post'          => 'read',
+				'read_post'          => 'plugin_admin_view',
 				'edit_posts'         => 'plugin_dashboard_access',
 				'edit_others_posts'  => 'plugin_edit_others',
 				'publish_posts'      => 'plugin_approve',

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Plugin_Read_Permission_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Plugin_Read_Permission_Test.php
@@ -1,0 +1,275 @@
+<?php
+/**
+ * Tests that the `plugin` post type's `read_post` capability keeps non-public
+ * submissions out of the single-item REST route.
+ *
+ * @package WordPressdotorg\Plugin_Directory\Tests
+ */
+
+declare( strict_types = 1 );
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers single-item REST read permission for the `plugin` post type.
+ *
+ * @group capabilities
+ */
+class Plugin_Read_Permission_Test extends TestCase {
+
+	/**
+	 * Slug of the plugin under test.
+	 *
+	 * @var string
+	 */
+	const PLUGIN_SLUG = 'read-permission-fixture';
+
+	/**
+	 * REST controller for the `plugin` post type.
+	 *
+	 * @var WP_REST_Posts_Controller
+	 */
+	protected WP_REST_Posts_Controller $controller;
+
+	/**
+	 * Plugin post IDs created by the running test, removed on tear down.
+	 *
+	 * @var int[]
+	 */
+	protected array $plugin_ids = array();
+
+	/**
+	 * User IDs created by the running test, removed on tear down.
+	 *
+	 * @var int[]
+	 */
+	protected array $user_ids = array();
+
+	/**
+	 * Prepares the REST controller shared by each test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->controller = new WP_REST_Posts_Controller( 'plugin' );
+	}
+
+	/**
+	 * Removes every fixture the test created.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		global $wpdb;
+
+		wp_set_current_user( 0 );
+
+		foreach ( $this->user_ids as $user_id ) {
+			wp_delete_user( $user_id );
+		}
+		$this->user_ids = array();
+
+		foreach ( $this->plugin_ids as $plugin_id ) {
+			wp_delete_post( $plugin_id, true );
+		}
+		$this->plugin_ids = array();
+
+		$wpdb->delete(
+			PLUGINS_TABLE_PREFIX . 'svn_access',
+			array( 'path' => '/' . self::PLUGIN_SLUG )
+		);
+		wp_cache_delete( self::PLUGIN_SLUG, 'plugin-committers' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Inserts a plugin post in the given status.
+	 *
+	 * `Plugin_Directory::filter_wp_insert_post_data()` dereferences `post_modified`
+	 * unconditionally, so it is supplied explicitly or the insert is rejected.
+	 *
+	 * @param string $post_status Status to create the plugin in.
+	 * @param int    $author_id   Optional. Post author. Default 0.
+	 * @return WP_Post The created plugin post.
+	 */
+	protected function create_plugin( string $post_status, int $author_id = 0 ): WP_Post {
+		$plugin_id = wp_insert_post(
+			array(
+				'post_type'         => 'plugin',
+				'post_title'        => 'Read Permission Fixture',
+				'post_name'         => self::PLUGIN_SLUG,
+				'post_status'       => $post_status,
+				'post_author'       => $author_id,
+				'post_modified'     => current_time( 'mysql' ),
+				'post_modified_gmt' => current_time( 'mysql', 1 ),
+			),
+			true
+		);
+
+		$this->assertNotInstanceOf( WP_Error::class, $plugin_id, "The '{$post_status}' plugin fixture could not be created." );
+
+		$this->plugin_ids[] = (int) $plugin_id;
+
+		return get_post( (int) $plugin_id );
+	}
+
+	/**
+	 * Creates a subscriber and registers it for removal on tear down.
+	 *
+	 * @param string $user_login Login for the new account.
+	 * @return int User ID.
+	 */
+	protected function create_user( string $user_login ): int {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => $user_login,
+				'user_pass'  => wp_generate_password( 24 ),
+				'user_email' => $user_login . '@example.invalid',
+				'role'       => 'subscriber',
+			)
+		);
+
+		$this->assertNotInstanceOf( WP_Error::class, $user_id, "Could not create the user '{$user_login}'." );
+
+		$this->user_ids[] = (int) $user_id;
+
+		return (int) $user_id;
+	}
+
+	/**
+	 * Grants a login commit access to the plugin under test.
+	 *
+	 * @param string $user_login Login to record as a committer.
+	 * @return void
+	 */
+	protected function add_committer( string $user_login ): void {
+		global $wpdb;
+
+		$wpdb->insert(
+			PLUGINS_TABLE_PREFIX . 'svn_access',
+			array(
+				'path'   => '/' . self::PLUGIN_SLUG,
+				'user'   => $user_login,
+				'access' => 'rw',
+			)
+		);
+		wp_cache_delete( self::PLUGIN_SLUG, 'plugin-committers' );
+	}
+
+	/**
+	 * Statuses the directory serves publicly, which stay readable over REST.
+	 *
+	 * @return array<string, string[]>
+	 */
+	public static function data_public_statuses(): array {
+		return array(
+			'publish'  => array( 'publish' ),
+			'closed'   => array( 'closed' ),
+			'disabled' => array( 'disabled' ),
+		);
+	}
+
+	/**
+	 * Non-public plugin statuses that must never be exposed over REST.
+	 *
+	 * @return array<string, string[]>
+	 */
+	public static function data_non_public_statuses(): array {
+		return array(
+			'new'      => array( 'new' ),
+			'pending'  => array( 'pending' ),
+			'approved' => array( 'approved' ),
+			'rejected' => array( 'rejected' ),
+			'draft'    => array( 'draft' ),
+		);
+	}
+
+	/**
+	 * Public statuses stay readable to both anonymous and logged-in visitors.
+	 *
+	 * @dataProvider data_public_statuses
+	 *
+	 * @param string $post_status Public plugin status under test.
+	 * @return void
+	 */
+	public function test_public_statuses_are_readable( string $post_status ): void {
+		$plugin = $this->create_plugin( $post_status );
+
+		wp_set_current_user( 0 );
+		$this->assertTrue(
+			$this->controller->check_read_permission( $plugin ),
+			"A logged-out visitor should read a '{$post_status}' plugin over REST."
+		);
+
+		$subscriber = $this->create_user( 'plainsubscriber' );
+		wp_set_current_user( $subscriber );
+		$this->assertTrue(
+			$this->controller->check_read_permission( $plugin ),
+			"A subscriber should read a '{$post_status}' plugin over REST."
+		);
+	}
+
+	/**
+	 * A plain subscriber cannot read a submission still in the review pipeline.
+	 *
+	 * This is the regression guard for the `read_post => plugin_admin_view` mapping;
+	 * with `read_post => read` each of these returned true.
+	 *
+	 * @dataProvider data_non_public_statuses
+	 *
+	 * @param string $post_status Non-public plugin status under test.
+	 * @return void
+	 */
+	public function test_non_public_statuses_are_hidden_from_subscribers( string $post_status ): void {
+		$plugin     = $this->create_plugin( $post_status );
+		$subscriber = $this->create_user( 'plainsubscriber' );
+
+		wp_set_current_user( $subscriber );
+
+		$this->assertFalse(
+			$this->controller->check_read_permission( $plugin ),
+			"A subscriber must not read a '{$post_status}' plugin over REST."
+		);
+	}
+
+	/**
+	 * A committer keeps REST read access to their own non-public submission.
+	 *
+	 * @return void
+	 */
+	public function test_committer_can_read_non_public_submission(): void {
+		$committer = $this->create_user( 'pluginowner' );
+		$plugin    = $this->create_plugin( 'pending', $committer );
+		$this->add_committer( 'pluginowner' );
+
+		wp_set_current_user( $committer );
+
+		$this->assertTrue(
+			$this->controller->check_read_permission( $plugin ),
+			'A committer should retain read access to their pending submission.'
+		);
+	}
+
+	/**
+	 * A reviewer keeps REST read access to non-public submissions.
+	 *
+	 * @return void
+	 */
+	public function test_reviewer_can_read_non_public_submission(): void {
+		$plugin   = $this->create_plugin( 'pending' );
+		$reviewer = $this->create_user( 'pluginreviewer' );
+
+		$user = get_user_by( 'id', $reviewer );
+		$user->add_cap( 'plugin_review' );
+
+		wp_set_current_user( $reviewer );
+
+		$this->assertTrue(
+			$this->controller->check_read_permission( $plugin ),
+			'A plugin reviewer should retain read access to a pending submission.'
+		);
+	}
+}

--- a/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-directory-compat.php
+++ b/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-directory-compat.php
@@ -772,7 +772,7 @@ abstract class Directory_Compat {
 	}
 
 	/**
-	 * Reject review submissions aimed at objects the directory does not serve publicly.
+	 * Reject review submissions the create-topic form would not offer.
 	 *
 	 * The create-topic-form filter only decides whether the review form is displayed; bbPress's
 	 * topic handlers never consult it, so the same rule is enforced here on the write path.
@@ -789,16 +789,20 @@ abstract class Directory_Compat {
 			return;
 		}
 
-		// Prefer the resolved compat slug; otherwise fall back to this compat's query var.
+		// The resolved slug, or this compat's query var.
 		$slug = $this->slug() ? $this->slug() : get_query_var( $this->query_var() );
 		if ( ! $slug ) {
 			return;
 		}
 
-		if ( ! self::get_object_by_slug_and_type( $slug, $this->compat() ) ) {
+		// Mirror the create-topic form: a published plugin, or a publicly-served theme.
+		$object     = self::get_object_by_slug_and_type( $slug, $this->compat() );
+		$reviewable = $object && ( 'plugin' !== $this->compat() || 'publish' === $object->post_status );
+
+		if ( ! $reviewable ) {
 			bbp_add_error(
-				'wporg_compat_unpublished_review',
-				__( '<strong>Error</strong>: Reviews are only available for published plugins and themes.', 'wporg-forums' )
+				'wporg_compat_unavailable_review',
+				__( '<strong>Error:</strong> This item is not available for reviews.', 'wporg-forums' )
 			);
 		}
 	}

--- a/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-directory-compat.php
+++ b/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-directory-compat.php
@@ -60,6 +60,9 @@ abstract class Directory_Compat {
 			// Always check to see if a topic title needs a compat prefix.
 			add_filter( 'bbp_get_topic_title', array( $this, 'get_topic_title' ), 9, 2 );
 
+			// Enforce the published-status rule on the write path; priority 0 beats bbPress's handlers (1 and 10).
+			add_action( 'bbp_post_request', array( $this, 'block_unpublished_object_review' ), 0 );
+
 			// Always check to see if a new topic is being posted; this must run
 			// before subscriptions go out for `bbp_new_topic` at priority 10.
 			add_action( 'bbp_new_topic', array( $this, 'new_topic' ), 9, 4 );
@@ -769,6 +772,38 @@ abstract class Directory_Compat {
 	}
 
 	/**
+	 * Reject review submissions aimed at objects the directory does not serve publicly.
+	 *
+	 * The create-topic-form filter only decides whether the review form is displayed; bbPress's
+	 * topic handlers never consult it, so the same rule is enforced here on the write path.
+	 *
+	 * @param string $action The bbPress POST action being handled.
+	 */
+	public function block_unpublished_object_review( $action = '' ) {
+		if ( 'bbp-new-topic' !== $action && 'bbp-edit-topic' !== $action ) {
+			return;
+		}
+
+		// Only guard submissions to the reviews forum.
+		if ( (int) Plugin::REVIEWS_FORUM_ID !== (int) bbp_get_form_topic_forum() ) {
+			return;
+		}
+
+		// Prefer the resolved compat slug; otherwise fall back to this compat's query var.
+		$slug = $this->slug() ? $this->slug() : get_query_var( $this->query_var() );
+		if ( ! $slug ) {
+			return;
+		}
+
+		if ( ! self::get_object_by_slug_and_type( $slug, $this->compat() ) ) {
+			bbp_add_error(
+				'wporg_compat_unpublished_review',
+				__( '<strong>Error</strong>: Reviews are only available for published plugins and themes.', 'wporg-forums' )
+			);
+		}
+	}
+
+	/**
 	 * Filter the template fetch to avoid displaying a new topic form in the reviews forum.
 	 *
 	 * @param array $templates The templates to load
@@ -969,12 +1004,11 @@ abstract class Directory_Compat {
 		$cache_group = $type . '-objects';
 		$compat_object = wp_cache_get( $cache_key, $cache_group );
 		if ( false === $compat_object ) {
-
-			// Get the object information from the correct table.
+			// Only resolve publicly-served records; the other statuses are the private review pipeline.
 			if ( $type == 'theme' ) {
-				$compat_object = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->base_prefix}%d_posts WHERE post_name = %s AND post_type = 'repopackage' LIMIT 1", WPORG_THEME_DIRECTORY_BLOGID, $slug ) );
+				$compat_object = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->base_prefix}%d_posts WHERE post_name = %s AND post_type = 'repopackage' AND post_status IN ( 'publish', 'delist' ) LIMIT 1", WPORG_THEME_DIRECTORY_BLOGID, $slug ) );
 			} elseif ( $type == 'plugin' ) {
-				$compat_object = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->base_prefix}%d_posts WHERE post_name = %s AND post_type = 'plugin' LIMIT 1", WPORG_PLUGIN_DIRECTORY_BLOGID, $slug ) );
+				$compat_object = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->base_prefix}%d_posts WHERE post_name = %s AND post_type = 'plugin' AND post_status IN ( 'publish', 'closed', 'disabled' ) LIMIT 1", WPORG_PLUGIN_DIRECTORY_BLOGID, $slug ) );
 			}
 
 			wp_cache_set( $cache_key, $compat_object, $cache_group, HOUR_IN_SECONDS );

--- a/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-users.php
+++ b/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-users.php
@@ -407,7 +407,16 @@ class Users {
 	 * @return array Filtered query arguments.
 	 */
 	public function parse_user_replies_query_args( $args ) {
-		if ( get_query_var( 'wporg_single_user_reported_topics' ) ) {
+		/*
+		 * The marker is a public query var, so it can be set on any request. Gate the switch to
+		 * the private reported_topics type on the same check as the reports template: the profile
+		 * owner, or a user who may edit that profile.
+		 */
+		if (
+			get_query_var( 'wporg_single_user_reported_topics' )
+			&&
+			( bbp_is_user_home() || current_user_can( 'edit_user', bbp_get_displayed_user_id() ) )
+		) {
 			$args['post_type'] = 'reported_topics';
 			unset( $args['meta_key'] );
 			unset( $args['meta_type'] );


### PR DESCRIPTION
Aligns a few plugin/theme directory read and write paths with the post statuses those directories actually serve publicly, so each path applies the same visibility rules the rest of the directory already does.

### Plugin Directory
- Map the `plugin` post type's `read_post` capability to the directory's status-aware `plugin_admin_view` meta capability instead of the generic `read`. Publicly-served statuses stay readable over the single-item REST route; the remaining statuses follow the directory's existing access rules.
- Adds `Plugin_Read_Permission_Test`, covering `WP_REST_Posts_Controller::check_read_permission()` across statuses (`publish`/`closed`/`disabled` vs `new`/`pending`/`approved`/`rejected`/`draft`) and roles (subscriber, committer, reviewer).

### Support Forums
- Scope the plugin/theme compat lookup (`Directory_Compat::get_object_by_slug_and_type()`) to the statuses the directories serve publicly — `publish`/`closed`/`disabled` for plugins, `publish`/`delist` for themes.
- Enforce the published-status requirement for reviews on the submission handler (`bbp_post_request`), matching the rule the create-topic form already applies on display, so the check no longer depends solely on whether the form is rendered.
- Limit the profile "Reports Submitted" query switch to the profile owner and users who can edit that profile, matching the reports template's own gate.

### Testing
`npm run plugins:test` — full plugin-directory suite green (190 tests), including the new coverage. Support Forums changes verified manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
