### PR TITLE
Plugin Directory: Use wporg-plugins textdomain for sidebar review links

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/inc/block-bindings.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/inc/block-bindings.php
@@ -43,13 +43,13 @@ function get_meta_block_value( $args, $block ) {
 			return sprintf(
 				'<a href="%s">%s</a>',
 				esc_url( 'https://wordpress.org/support/plugin/' . $plugin_post->post_name . '/reviews/' ),
-				__( 'See all<span class="screen-reader-text"> reviews</span>', 'wporg-themes' )
+				__( 'See all<span class="screen-reader-text"> reviews</span>', 'wporg-plugins' )
 			);
 		case 'submit-review-link':
 			return sprintf(
 				'<a href="%s">%s</a>',
 				esc_url( 'https://wordpress.org/support/plugin/' . $plugin_post->post_name . '/reviews/#new-post' ),
-				__( 'Your review', 'wporg-themes' )
+				__( 'Your review', 'wporg-plugins' )
 			);
 	}
 }


### PR DESCRIPTION
## Summary
- The plugin sidebar **Your review** / **See all reviews** links used the `wporg-themes` textdomain, so **Your review** stayed in English on locale sites even though it is already translated in [meta/plugins-v3](https://translate.wordpress.org/projects/meta/plugins-v3/).
- Both strings now use `wporg-plugins`. No new GlotPress strings.

Fixes #792.

## Test plan
- [ ] On https://de.wordpress.org/plugins/synced-pattern-popups/ (after deploy), the Ratings sidebar shows **Deine Rezension** instead of **Your review**.
- [ ] **Alle Rezensionen anzeigen** still translates.
- [ ] English plugin pages are unchanged.
