### PR TITLE
Plugin Directory: Email committers the outcome of a security scan

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-security-scan-findings.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-security-scan-findings.php
@@ -248,10 +248,11 @@ class Security_Scan_Findings extends Markdown_Base {
 	 * Backticks become apostrophes: a line-leading backtick pair would turn
 	 * into a code block (Markdown::code_trick()). Line indents go for the
 	 * same reason, and brackets can't form Markdown links or images. A
-	 * line-leading heading or rule marker is emitted as a numeric entity, so
-	 * it displays as typed but can't forge a heading or horizontal rule; a
-	 * lone carriage return is folded first, since the Markdown processor
-	 * treats it as a newline and would otherwise expose a marker mid-text.
+	 * line-leading block marker — heading, rule, list, table, definition
+	 * list, or fence — is emitted as a numeric entity, so it displays as
+	 * typed but can't forge a block element; a lone carriage return is folded
+	 * first, since the Markdown processor treats it as a newline and would
+	 * otherwise expose a marker mid-text.
 	 *
 	 * @param string $text   The text to bound.
 	 * @param int    $length Maximum length in characters.
@@ -265,10 +266,20 @@ class Security_Scan_Findings extends Markdown_Base {
 		$text = str_replace( [ '[', ']', '`' ], [ '(', ')', "'" ], $text );
 		$text = htmlspecialchars( $text, ENT_NOQUOTES | ENT_SUBSTITUTE, 'UTF-8' );
 
-		return preg_replace_callback(
-			'/^([#=*_-])/m',
+		// A line-leading heading, rule, list, table, definition-list, or fence marker.
+		$text = preg_replace_callback(
+			'/^([#=*_+~|:-])/m',
 			static function ( array $matches ): string {
 				return '&#' . ord( $matches[1] ) . ';';
+			},
+			$text
+		);
+
+		// An ordered-list marker, whose opener is the digits' trailing punctuation followed by a space; a version like 9.9 is left alone.
+		return preg_replace_callback(
+			'/^(\d+)([.)])(?=\s)/m',
+			static function ( array $matches ): string {
+				return $matches[1] . '&#' . ord( $matches[2] ) . ';';
 			},
 			$text
 		);

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-security-scan-findings.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-security-scan-findings.php
@@ -59,15 +59,15 @@ class Security_Scan_Findings extends Markdown_Base {
 		);
 
 		$intro = sprintf(
-			/* translators: 1: Plugin name. 2: Plugin version. 3: Maximum risk score, from 0 to 10. */
-			__( 'An automated security scan of %1$s %2$s reported findings with a maximum risk score of %3$s out of 10.', 'wporg-plugins' ),
+			/* translators: 1: Plugin name. 2: Plugin version. 3: URL to the automated security review documentation. */
+			__( 'An automated security review of %1$s %2$s reported the following findings. Learn more about these reviews in the [plugin developer handbook](%3$s).', 'wporg-plugins' ),
 			$this->plugin_title(),
 			$record['version'],
-			number_format_i18n( (float) $record['max_risk_score'], 1 )
+			'https://developer.wordpress.org/plugins/wordpress-org/automated-security-review/'
 		);
 
 		if ( 'blocked' === $record['action'] ) {
-			$action = __( 'A security review of this version found issues severe enough to block it from being offered as an update, protecting sites from receiving it. Sites running a previous version keep receiving that version. Please address the findings and release a new version.', 'wporg-plugins' );
+			$action = __( 'The issues found were severe enough to block this version from being offered as an update. Sites running a previous version keep receiving that version. Please address the findings and release a new version.', 'wporg-plugins' );
 		} else {
 			$action = __( 'Please review the findings and address them in an upcoming release.', 'wporg-plugins' );
 		}
@@ -79,7 +79,7 @@ class Security_Scan_Findings extends Markdown_Base {
 			array_push( $parts, $findings, '---' );
 		}
 
-		$parts[] = __( 'If you have questions or believe these findings to be in error, please reply to this email or contact plugins@wordpress.org.', 'wporg-plugins' );
+		$parts[] = __( 'If you have questions or believe a finding does not apply, please reply to this email with the details.', 'wporg-plugins' );
 
 		return implode( "\n\n", $parts );
 	}

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-security-scan-findings.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-security-scan-findings.php
@@ -69,7 +69,7 @@ class Security_Scan_Findings extends Markdown_Base {
 		if ( 'blocked' === $record['action'] ) {
 			$action = __( 'A security review of this version found issues severe enough to block it from being offered as an update, protecting sites from receiving it. Sites running a previous version keep receiving that version. Please address the findings and release a new version; the block applies only to this version.', 'wporg-plugins' );
 		} else {
-			$action = __( 'No action has been taken against this version. Please review the findings and address them in an upcoming release.', 'wporg-plugins' );
+			$action = __( 'Please review the findings and address them in an upcoming release.', 'wporg-plugins' );
 		}
 
 		$outro = __( 'If you have questions or believe these findings to be in error, please reply to this email or contact plugins@wordpress.org.', 'wporg-plugins' );

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-security-scan-findings.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-security-scan-findings.php
@@ -67,7 +67,7 @@ class Security_Scan_Findings extends Markdown_Base {
 		);
 
 		if ( 'blocked' === $record['action'] ) {
-			$action = __( 'A security review of this version found issues severe enough to block it from being offered as an update, protecting sites from receiving it. Sites running a previous version keep receiving that version. Please address the findings and release a new version; the block applies only to this version.', 'wporg-plugins' );
+			$action = __( 'A security review of this version found issues severe enough to block it from being offered as an update, protecting sites from receiving it. Sites running a previous version keep receiving that version. Please address the findings and release a new version.', 'wporg-plugins' );
 		} else {
 			$action = __( 'Please review the findings and address them in an upcoming release.', 'wporg-plugins' );
 		}
@@ -78,13 +78,25 @@ class Security_Scan_Findings extends Markdown_Base {
 	}
 
 	/**
-	 * Format the findings as a list, highest risk first.
+	 * The plain-text content for the email template.
+	 *
+	 * Decodes the entities prose() encodes into the Markdown source.
+	 *
+	 * @return string The plain-text content.
+	 */
+	public function body(): string {
+		return html_entity_decode( $this->markdown(), ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+	}
+
+	/**
+	 * Format the findings, highest risk first.
 	 *
 	 * Finding strings are untrusted scanner output; only the risk score is
-	 * contractually guaranteed. Lines end in two spaces to hard-break in Markdown.
+	 * contractually guaranteed. The title line ends in two spaces to
+	 * hard-break in Markdown.
 	 *
 	 * @param array $record The completed scan record.
-	 * @return string The findings list, or an empty string without findings.
+	 * @return string The findings, or an empty string without findings.
 	 */
 	private function findings_text( array $record ): string {
 		$items = [];
@@ -93,7 +105,7 @@ class Security_Scan_Findings extends Markdown_Base {
 			$title = $this->excerpt( (string) ( $finding['title'] ?? '' ), 300 );
 
 			$item = sprintf(
-				'* **%1$s** — %2$s',
+				'**%1$s** — %2$s',
 				number_format_i18n( (float) ( $finding['risk_score'] ?? 0 ), 1 ),
 				$title ?: __( '(no summary provided)', 'wporg-plugins' )
 			);
@@ -102,8 +114,22 @@ class Security_Scan_Findings extends Markdown_Base {
 				$file_path = $this->excerpt( (string) $finding['file_path'], 200 );
 				$line      = (int) ( $finding['line'] ?? 0 );
 
-				$item .= "  \n  " . $file_path . ( $line ? ':' . $line : '' );
-				$item .= "  \n  " . $this->file_url( (string) $record['release_ref'], (string) $finding['file_path'], $line );
+				// The excerpted label can't contain a `]`, the URL is percent-encoded; the link syntax stays intact.
+				$item .= sprintf(
+					"  \n[%1\$s](%2\$s)",
+					$file_path . ( $line ? ':' . $line : '' ),
+					$this->file_url( (string) $record['release_ref'], (string) $finding['file_path'], $line )
+				);
+			}
+
+			$snippet = $this->snippet_text( (string) ( $finding['code_snippet'] ?? '' ) );
+			if ( '' !== $snippet ) {
+				$item .= "\n\n" . $snippet;
+			}
+
+			$explanation = $this->prose( (string) ( $finding['explanation'] ?? '' ), 2000 );
+			if ( '' !== $explanation ) {
+				$item .= "\n\n" . $explanation;
 			}
 
 			$items[] = $item;
@@ -113,7 +139,7 @@ class Security_Scan_Findings extends Markdown_Base {
 			return '';
 		}
 
-		return __( 'Findings:', 'wporg-plugins' ) . "\n\n" . implode( "\n", $items );
+		return '### ' . __( 'Findings', 'wporg-plugins' ) . "\n\n" . implode( "\n\n---\n\n", $items );
 	}
 
 	/**
@@ -140,6 +166,49 @@ class Security_Scan_Findings extends Markdown_Base {
 	}
 
 	/**
+	 * Format an untrusted code snippet as an indented Markdown code block.
+	 *
+	 * Unlike a fence, an indented code block cannot be broken out of, and
+	 * Markdown escapes its content in the HTML variant.
+	 *
+	 * @param string $snippet The code snippet.
+	 * @return string The code block, or an empty string for an empty snippet.
+	 */
+	private function snippet_text( string $snippet ): string {
+		$snippet = str_replace( "\r\n", "\n", trim( $snippet, "\n\r" ) );
+		$snippet = mb_strimwidth( implode( "\n", array_slice( explode( "\n", $snippet ), 0, 10 ) ), 0, 1000, '…' );
+
+		if ( '' === trim( $snippet ) ) {
+			return '';
+		}
+
+		return '    ' . str_replace( "\n", "\n    ", $snippet );
+	}
+
+	/**
+	 * Bound untrusted prose, preserving paragraphs, without live markup.
+	 *
+	 * Angle brackets are encoded rather than stripped, so text like `<slug>`
+	 * or `<?php` survives as text; body() decodes the plain-text variant.
+	 * Backticks become apostrophes: a line-leading backtick pair would turn
+	 * into a code block (Markdown::code_trick()). Line indents go for the
+	 * same reason, and brackets can't form Markdown links or images.
+	 *
+	 * @param string $text   The text to bound.
+	 * @param int    $length Maximum length in characters.
+	 * @return string The bounded text.
+	 */
+	private function prose( string $text, int $length ): string {
+		$text = str_replace( "\r\n", "\n", trim( $text ) );
+		$text = preg_replace( '/^[ \t]+/m', '', $text );
+		$text = preg_replace( "/\n{3,}/", "\n\n", $text );
+		$text = mb_strimwidth( $text, 0, $length, '…' );
+		$text = str_replace( [ '[', ']', '`' ], [ '(', ')', "'" ], $text );
+
+		return htmlspecialchars( $text, ENT_NOQUOTES, 'UTF-8' );
+	}
+
+	/**
 	 * Collapse untrusted text onto a single bounded line, without markup.
 	 *
 	 * @param string $text   The text to excerpt.
@@ -147,11 +216,6 @@ class Security_Scan_Findings extends Markdown_Base {
 	 * @return string The excerpted text.
 	 */
 	private function excerpt( string $text, int $length ): string {
-		$text = wp_strip_all_tags( $text );
-
-		// Neutralize Markdown link and image syntax; the HTML variant renders Markdown.
-		$text = str_replace( [ '[', ']' ], [ '(', ')' ], $text );
-
-		return mb_strimwidth( preg_replace( '/\s+/u', ' ', trim( $text ) ), 0, $length, '…' );
+		return preg_replace( '/\s+/u', ' ', $this->prose( $text, $length ) );
 	}
 }

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-security-scan-findings.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-security-scan-findings.php
@@ -247,20 +247,31 @@ class Security_Scan_Findings extends Markdown_Base {
 	 * or `<?php` survives as text; body() decodes the plain-text variant.
 	 * Backticks become apostrophes: a line-leading backtick pair would turn
 	 * into a code block (Markdown::code_trick()). Line indents go for the
-	 * same reason, and brackets can't form Markdown links or images.
+	 * same reason, and brackets can't form Markdown links or images. A
+	 * line-leading heading or rule marker is emitted as a numeric entity, so
+	 * it displays as typed but can't forge a heading or horizontal rule; a
+	 * lone carriage return is folded first, since the Markdown processor
+	 * treats it as a newline and would otherwise expose a marker mid-text.
 	 *
 	 * @param string $text   The text to bound.
 	 * @param int    $length Maximum length in characters.
 	 * @return string The bounded text.
 	 */
 	private function prose( string $text, int $length ): string {
-		$text = str_replace( "\r\n", "\n", trim( $text ) );
+		$text = str_replace( [ "\r\n", "\r" ], "\n", trim( $text ) );
 		$text = preg_replace( '/^[ \t]+/m', '', $text );
 		$text = preg_replace( "/\n{3,}/", "\n\n", $text );
 		$text = mb_strimwidth( $text, 0, $length, '…' );
 		$text = str_replace( [ '[', ']', '`' ], [ '(', ')', "'" ], $text );
+		$text = htmlspecialchars( $text, ENT_NOQUOTES, 'UTF-8' );
 
-		return htmlspecialchars( $text, ENT_NOQUOTES, 'UTF-8' );
+		return preg_replace_callback(
+			'/^([#=*_-])/m',
+			static function ( array $matches ): string {
+				return '&#' . ord( $matches[1] ) . ';';
+			},
+			$text
+		);
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-security-scan-findings.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-security-scan-findings.php
@@ -61,8 +61,8 @@ class Security_Scan_Findings extends Markdown_Base {
 		$intro = sprintf(
 			/* translators: 1: Plugin name. 2: Plugin version. 3: URL to the automated security review documentation. */
 			__( 'An automated security review of %1$s %2$s reported the following findings. Learn more about these reviews in the [plugin developer handbook](%3$s).', 'wporg-plugins' ),
-			$this->plugin_title(),
-			$record['version'],
+			$this->excerpt( $this->plugin_title(), 200 ),
+			$this->excerpt( (string) $record['version'], 32 ),
 			'https://developer.wordpress.org/plugins/wordpress-org/automated-security-review/'
 		);
 

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-security-scan-findings.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-security-scan-findings.php
@@ -183,13 +183,60 @@ class Security_Scan_Findings extends Markdown_Base {
 	 */
 	private function snippet_text( string $snippet ): string {
 		$snippet = str_replace( "\r\n", "\n", trim( $snippet, "\n\r" ) );
-		$snippet = mb_strimwidth( implode( "\n", array_slice( explode( "\n", $snippet ), 0, 10 ) ), 0, 1000, '…' );
+		$lines   = array_slice( explode( "\n", $snippet ), 0, 10 );
+		$snippet = mb_strimwidth( implode( "\n", $this->outdent( $lines ) ), 0, 1000, '…' );
 
 		if ( '' === trim( $snippet ) ) {
 			return '';
 		}
 
 		return '    ' . str_replace( "\n", "\n    ", $snippet );
+	}
+
+	/**
+	 * Strip the whitespace prefix shared by all non-blank lines, keeping
+	 * the block's relative indentation.
+	 *
+	 * @param array $lines The lines to outdent.
+	 * @return array The outdented lines.
+	 */
+	private function outdent( array $lines ): array {
+		$prefix = null;
+
+		foreach ( $lines as $line ) {
+			if ( '' === trim( $line ) ) {
+				continue;
+			}
+
+			$indent = substr( $line, 0, strspn( $line, " \t" ) );
+
+			if ( null === $prefix ) {
+				$prefix = $indent;
+				continue;
+			}
+
+			$length     = 0;
+			$max_length = min( strlen( $prefix ), strlen( $indent ) );
+			while ( $length < $max_length && $prefix[ $length ] === $indent[ $length ] ) {
+				++$length;
+			}
+			$prefix = substr( $prefix, 0, $length );
+
+			if ( '' === $prefix ) {
+				break;
+			}
+		}
+
+		if ( ! $prefix ) {
+			return $lines;
+		}
+
+		return array_map(
+			static function ( string $line ) use ( $prefix ): string {
+				return str_starts_with( $line, $prefix ) ? substr( $line, strlen( $prefix ) ) : $line;
+			},
+			$lines
+		);
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-security-scan-findings.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-security-scan-findings.php
@@ -35,7 +35,7 @@ class Security_Scan_Findings extends Markdown_Base {
 
 		if ( 'blocked' === $record['action'] ) {
 			/* translators: 1: Plugin name. 2: Plugin version. */
-			$subject = __( '%1$s %2$s has been blocked pending a security review', 'wporg-plugins' );
+			$subject = __( '%1$s %2$s has been blocked due to security findings', 'wporg-plugins' );
 		} else {
 			/* translators: 1: Plugin name. 2: Plugin version. */
 			$subject = __( 'Security scan findings in %1$s %2$s', 'wporg-plugins' );
@@ -67,7 +67,7 @@ class Security_Scan_Findings extends Markdown_Base {
 		);
 
 		if ( 'blocked' === $record['action'] ) {
-			$action = __( 'To protect sites, this version has been blocked from being offered as an update while the WordPress Plugin Review Team takes a closer look. Sites running a previous version keep receiving that version in the meantime. The team will release this version if it finds no cause for concern; you can also address the findings in a new version, which is not affected by this block.', 'wporg-plugins' );
+			$action = __( 'A security review of this version found issues severe enough to block it from being offered as an update, protecting sites from receiving it. Sites running a previous version keep receiving that version. Please address the findings and release a new version; the block applies only to this version.', 'wporg-plugins' );
 		} else {
 			$action = __( 'No action has been taken against this version. Please review the findings and address them in an upcoming release.', 'wporg-plugins' );
 		}

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-security-scan-findings.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-security-scan-findings.php
@@ -72,9 +72,16 @@ class Security_Scan_Findings extends Markdown_Base {
 			$action = __( 'Please review the findings and address them in an upcoming release.', 'wporg-plugins' );
 		}
 
-		$outro = __( 'If you have questions or believe these findings to be in error, please reply to this email or contact plugins@wordpress.org.', 'wporg-plugins' );
+		$parts = [ $greeting, $intro, $action ];
 
-		return implode( "\n\n", array_filter( [ $greeting, $intro, $action, $this->findings_text( $record ), $outro ] ) );
+		$findings = $this->findings_text( $record );
+		if ( '' !== $findings ) {
+			array_push( $parts, $findings, '---' );
+		}
+
+		$parts[] = __( 'If you have questions or believe these findings to be in error, please reply to this email or contact plugins@wordpress.org.', 'wporg-plugins' );
+
+		return implode( "\n\n", $parts );
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-security-scan-findings.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-security-scan-findings.php
@@ -182,7 +182,8 @@ class Security_Scan_Findings extends Markdown_Base {
 	 * @return string The code block, or an empty string for an empty snippet.
 	 */
 	private function snippet_text( string $snippet ): string {
-		$snippet = str_replace( "\r\n", "\n", trim( $snippet, "\n\r" ) );
+		// Normalize every newline the Markdown processor recognizes (it maps \r\n and lone \r to \n): an unindented line it splits out later escapes the code block.
+		$snippet = str_replace( [ "\r\n", "\r" ], "\n", trim( $snippet, "\n\r" ) );
 		$lines   = array_slice( explode( "\n", $snippet ), 0, 10 );
 		$snippet = mb_strimwidth( implode( "\n", $this->outdent( $lines ) ), 0, 1000, '…' );
 

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-security-scan-findings.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-security-scan-findings.php
@@ -263,7 +263,7 @@ class Security_Scan_Findings extends Markdown_Base {
 		$text = preg_replace( "/\n{3,}/", "\n\n", $text );
 		$text = mb_strimwidth( $text, 0, $length, '…' );
 		$text = str_replace( [ '[', ']', '`' ], [ '(', ')', "'" ], $text );
-		$text = htmlspecialchars( $text, ENT_NOQUOTES, 'UTF-8' );
+		$text = htmlspecialchars( $text, ENT_NOQUOTES | ENT_SUBSTITUTE, 'UTF-8' );
 
 		return preg_replace_callback(
 			'/^([#=*_-])/m',

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-security-scan-findings.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/email/class-security-scan-findings.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * Email to plugin committers about the outcome of a security scan.
+ *
+ * @package WordPressdotorg\Plugin_Directory\Email
+ */
+
+declare( strict_types = 1 );
+
+namespace WordPressdotorg\Plugin_Directory\Email;
+
+/**
+ * Notifies plugin committers of a completed security scan's findings, and
+ * whether the scanned release was blocked from being served pending review.
+ *
+ * Expects a `record` arg: the completed scan record built by
+ * `Plugin_Scan_Gandalf`, with findings ordered highest risk first.
+ */
+class Security_Scan_Findings extends Markdown_Base {
+
+	/**
+	 * The completed scan record is required.
+	 *
+	 * @var array
+	 */
+	protected $required_args = [ 'record' ];
+
+	/**
+	 * The email subject.
+	 *
+	 * @return string The subject.
+	 */
+	public function subject(): string {
+		$record = $this->args['record'];
+
+		if ( 'blocked' === $record['action'] ) {
+			/* translators: 1: Plugin name. 2: Plugin version. */
+			$subject = __( '%1$s %2$s has been blocked pending a security review', 'wporg-plugins' );
+		} else {
+			/* translators: 1: Plugin name. 2: Plugin version. */
+			$subject = __( 'Security scan findings in %1$s %2$s', 'wporg-plugins' );
+		}
+
+		return sprintf( $subject, $this->plugin_title(), $record['version'] );
+	}
+
+	/**
+	 * The Markdown content of the email.
+	 *
+	 * @return string The email content.
+	 */
+	public function markdown(): string {
+		$record = $this->args['record'];
+
+		$greeting = sprintf(
+			/* translators: %s: Committer's display name. */
+			__( 'Howdy %s,', 'wporg-plugins' ),
+			$this->user_text( $this->user )
+		);
+
+		$intro = sprintf(
+			/* translators: 1: Plugin name. 2: Plugin version. 3: Maximum risk score, from 0 to 10. */
+			__( 'An automated security scan of %1$s %2$s reported findings with a maximum risk score of %3$s out of 10.', 'wporg-plugins' ),
+			$this->plugin_title(),
+			$record['version'],
+			number_format_i18n( (float) $record['max_risk_score'], 1 )
+		);
+
+		if ( 'blocked' === $record['action'] ) {
+			$action = __( 'To protect sites, this version has been blocked from being offered as an update while the WordPress Plugin Review Team takes a closer look. Sites running a previous version keep receiving that version in the meantime. The team will release this version if it finds no cause for concern; you can also address the findings in a new version, which is not affected by this block.', 'wporg-plugins' );
+		} else {
+			$action = __( 'No action has been taken against this version. Please review the findings and address them in an upcoming release.', 'wporg-plugins' );
+		}
+
+		$outro = __( 'If you have questions or believe these findings to be in error, please reply to this email or contact plugins@wordpress.org.', 'wporg-plugins' );
+
+		return implode( "\n\n", array_filter( [ $greeting, $intro, $action, $this->findings_text( $record ), $outro ] ) );
+	}
+
+	/**
+	 * Format the findings as a list, highest risk first.
+	 *
+	 * Finding strings are untrusted scanner output; only the risk score is
+	 * contractually guaranteed. Lines end in two spaces to hard-break in Markdown.
+	 *
+	 * @param array $record The completed scan record.
+	 * @return string The findings list, or an empty string without findings.
+	 */
+	private function findings_text( array $record ): string {
+		$items = [];
+
+		foreach ( $record['findings'] as $finding ) {
+			$title = $this->excerpt( (string) ( $finding['title'] ?? '' ), 300 );
+
+			$item = sprintf(
+				'* **%1$s** — %2$s',
+				number_format_i18n( (float) ( $finding['risk_score'] ?? 0 ), 1 ),
+				$title ?: __( '(no summary provided)', 'wporg-plugins' )
+			);
+
+			if ( ! empty( $finding['file_path'] ) ) {
+				$file_path = $this->excerpt( (string) $finding['file_path'], 200 );
+				$line      = (int) ( $finding['line'] ?? 0 );
+
+				$item .= "  \n  " . $file_path . ( $line ? ':' . $line : '' );
+				$item .= "  \n  " . $this->file_url( (string) $record['release_ref'], (string) $finding['file_path'], $line );
+			}
+
+			$items[] = $item;
+		}
+
+		if ( ! $items ) {
+			return '';
+		}
+
+		return __( 'Findings:', 'wporg-plugins' ) . "\n\n" . implode( "\n", $items );
+	}
+
+	/**
+	 * Return a link to the finding's file in the plugins Trac browser.
+	 *
+	 * @param string $release_ref The scanned release ref.
+	 * @param string $file_path   The file path, relative to the plugin root.
+	 * @param int    $line        The line number, or 0 for none.
+	 * @return string The Trac browser URL.
+	 */
+	private function file_url( string $release_ref, string $file_path, int $line ): string {
+		$url = sprintf(
+			'https://plugins.trac.wordpress.org/browser/%s/%s/%s',
+			$this->plugin->post_name,
+			'trunk' === $release_ref ? 'trunk' : 'tags/' . rawurlencode( $release_ref ),
+			implode( '/', array_map( 'rawurlencode', explode( '/', ltrim( $file_path, '/' ) ) ) )
+		);
+
+		if ( $line ) {
+			$url .= '#L' . $line;
+		}
+
+		return $url;
+	}
+
+	/**
+	 * Collapse untrusted text onto a single bounded line, without markup.
+	 *
+	 * @param string $text   The text to excerpt.
+	 * @param int    $length Maximum length in characters.
+	 * @return string The excerpted text.
+	 */
+	private function excerpt( string $text, int $length ): string {
+		$text = wp_strip_all_tags( $text );
+
+		// Neutralize Markdown link and image syntax; the HTML variant renders Markdown.
+		$text = str_replace( [ '[', ']' ], [ '(', ')' ], $text );
+
+		return mb_strimwidth( preg_replace( '/\s+/u', ' ', trim( $text ) ), 0, $length, '…' );
+	}
+}

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan-gandalf.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan-gandalf.php
@@ -7,6 +7,7 @@
 
 namespace WordPressdotorg\Plugin_Directory\Jobs;
 
+use WordPressdotorg\Plugin_Directory\Email\Security_Scan_Findings;
 use WordPressdotorg\Plugin_Directory\Plugin_Directory;
 use WordPressdotorg\Plugin_Directory\Template;
 use WordPressdotorg\Plugin_Directory\Tools;
@@ -36,8 +37,14 @@ class Plugin_Scan_Gandalf {
 	/** Consumed callbacks keyed by scan_id, to acknowledge retries without repeating effects. */
 	const CONSUMED_META_KEY = '_gandalf_scan_consumed';
 
+	/** Verdict hashes already emailed to the plugin committers, to avoid duplicate emails. */
+	const EMAILED_META_KEY = '_gandalf_scan_emailed';
+
 	/** Completed scans with a max risk score at or above this have their release blocked. */
 	const BLOCK_RISK_SCORE = PHP_FLOAT_MAX;
+
+	/** Completed scans with a max risk score at or above this have their committers emailed. */
+	const NOTIFY_RISK_SCORE = self::BLOCK_RISK_SCORE;
 
 	/** Gandalf scan endpoint. */
 	const ENDPOINT = 'https://gandalf.wordpress.org/scan';
@@ -278,6 +285,8 @@ class Plugin_Scan_Gandalf {
 			if ( $record['findings_count'] > 0 || 'advisory' !== $record['action'] ) {
 				self::notify_slack( $plugin, $record );
 			}
+
+			self::notify_committers( $plugin, $record );
 		} else {
 			self::record_last_error( $plugin, $data['error']['kind'], $data['error']['message'], $scan_id );
 		}
@@ -618,6 +627,65 @@ class Plugin_Scan_Gandalf {
 			PLUGIN_REVIEW_ALERT_SLACK_CHANNEL,
 			true
 		);
+	}
+
+	/**
+	 * Email the plugin committers about a completed scan's findings.
+	 *
+	 * @param \WP_Post $plugin The plugin post.
+	 * @param array    $record The completed scan record.
+	 */
+	protected static function notify_committers( $plugin, $record ) {
+		if ( empty( $record['verdict_hash'] ) ) {
+			return;
+		}
+
+		/**
+		 * Filters the risk score at which a completed security scan emails the plugin committers.
+		 *
+		 * @param float    $threshold The notification threshold, from 0 to 10. Above 10 disables the emails.
+		 * @param \WP_Post $plugin    The plugin post.
+		 */
+		$threshold = (float) apply_filters( 'wporg_plugins_security_scan_notify_risk_score', self::NOTIFY_RISK_SCORE, $plugin );
+
+		if ( $record['max_risk_score'] < $threshold ) {
+			return;
+		}
+
+		$already_emailed = get_post_meta( $plugin->ID, self::EMAILED_META_KEY, true ) ?: [];
+		foreach ( $already_emailed as $hash => $time ) {
+			if ( $time < time() - MONTH_IN_SECONDS ) {
+				unset( $already_emailed[ $hash ] );
+			}
+		}
+
+		// Release blocks always email; only advisory results deduplicate.
+		if ( 'advisory' === $record['action'] && isset( $already_emailed[ $record['verdict_hash'] ] ) ) {
+			update_post_meta( $plugin->ID, self::EMAILED_META_KEY, $already_emailed );
+			return;
+		}
+
+		$committers = array_diff(
+			Tools::get_plugin_committers( $plugin ),
+			$GLOBALS['bot_accounts'] ?? [],
+			$GLOBALS['nologin_accounts'] ?? []
+		);
+		if ( ! $committers ) {
+			return;
+		}
+
+		$already_emailed[ $record['verdict_hash'] ] = time();
+		update_post_meta( $plugin->ID, self::EMAILED_META_KEY, $already_emailed );
+
+		$email = new Security_Scan_Findings(
+			$plugin,
+			$committers,
+			[
+				'record' => $record,
+				'who'    => 'WordPress.org',
+			]
+		);
+		$email->send();
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan-gandalf.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan-gandalf.php
@@ -286,7 +286,7 @@ class Plugin_Scan_Gandalf {
 				self::notify_slack( $plugin, $record );
 			}
 
-			self::notify_committers( $plugin, $record );
+			self::notify_committers( $plugin, $record, $data['findings'] );
 		} else {
 			self::record_last_error( $plugin, $data['error']['kind'], $data['error']['message'], $scan_id );
 		}
@@ -632,10 +632,11 @@ class Plugin_Scan_Gandalf {
 	/**
 	 * Email the plugin committers about a completed scan's findings.
 	 *
-	 * @param \WP_Post $plugin The plugin post.
-	 * @param array    $record The completed scan record.
+	 * @param \WP_Post $plugin   The plugin post.
+	 * @param array    $record   The completed scan record.
+	 * @param array    $findings The reported findings, with code snippets and explanations intact.
 	 */
-	protected static function notify_committers( $plugin, $record ) {
+	protected static function notify_committers( $plugin, $record, $findings ) {
 		if ( empty( $record['verdict_hash'] ) ) {
 			return;
 		}
@@ -676,6 +677,9 @@ class Plugin_Scan_Gandalf {
 
 		$already_emailed[ $record['verdict_hash'] ] = time();
 		update_post_meta( $plugin->ID, self::EMAILED_META_KEY, $already_emailed );
+
+		// The stored record's findings are stripped for the meta row; the email gets them intact.
+		$record['findings'] = self::top_findings( $findings, 10 );
 
 		$email = new Security_Scan_Findings(
 			$plugin,

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan-gandalf.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan-gandalf.php
@@ -286,7 +286,7 @@ class Plugin_Scan_Gandalf {
 				self::notify_slack( $plugin, $record );
 			}
 
-			self::notify_committers( $plugin, $record, $data['findings'] );
+			self::notify_committers( $plugin, $record );
 		} else {
 			self::record_last_error( $plugin, $data['error']['kind'], $data['error']['message'], $scan_id );
 		}
@@ -632,11 +632,10 @@ class Plugin_Scan_Gandalf {
 	/**
 	 * Email the plugin committers about a completed scan's findings.
 	 *
-	 * @param \WP_Post $plugin   The plugin post.
-	 * @param array    $record   The completed scan record.
-	 * @param array    $findings The reported findings, with code snippets and explanations intact.
+	 * @param \WP_Post $plugin The plugin post.
+	 * @param array    $record The completed scan record.
 	 */
-	protected static function notify_committers( $plugin, $record, $findings ) {
+	protected static function notify_committers( $plugin, $record ) {
 		if ( empty( $record['verdict_hash'] ) ) {
 			return;
 		}
@@ -678,8 +677,7 @@ class Plugin_Scan_Gandalf {
 		$already_emailed[ $record['verdict_hash'] ] = time();
 		update_post_meta( $plugin->ID, self::EMAILED_META_KEY, $already_emailed );
 
-		// The stored record's findings are stripped for the meta row; the email gets them intact.
-		$record['findings'] = self::top_findings( $findings, 10 );
+		$record['findings'] = self::top_findings( $record['findings'], 10 );
 
 		$email = new Security_Scan_Findings(
 			$plugin,

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Security_Scan_Notification_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Security_Scan_Notification_Test.php
@@ -87,6 +87,13 @@ class Security_Scan_Notification_Test extends TestCase {
 	private $threshold_pin;
 
 	/**
+	 * The REMOTE_ADDR the test overwrote, restored on teardown.
+	 *
+	 * @var string|null
+	 */
+	private ?string $remote_addr = null;
+
+	/**
 	 * Create a published plugin with a pending security scan and one committer.
 	 */
 	protected function setUp(): void {
@@ -102,6 +109,7 @@ class Security_Scan_Notification_Test extends TestCase {
 		add_filter( 'wporg_plugins_security_scan_notify_risk_score', $this->threshold_pin );
 
 		// Tools::audit_log() reads it unguarded.
+		$this->remote_addr      = isset( $_SERVER['REMOTE_ADDR'] ) ? (string) $_SERVER['REMOTE_ADDR'] : null; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- Captured verbatim to restore in tearDown, not used as input.
 		$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
 
 		$plugin = Plugin_Directory::create_plugin_post(
@@ -176,7 +184,13 @@ class Security_Scan_Notification_Test extends TestCase {
 			$this->threshold_filter = null;
 		}
 
-		unset( $GLOBALS['bot_accounts'], $GLOBALS['phpmailer'] );
+		unset( $GLOBALS['bot_accounts'], $GLOBALS['nologin_accounts'], $GLOBALS['phpmailer'] );
+
+		if ( null === $this->remote_addr ) {
+			unset( $_SERVER['REMOTE_ADDR'] );
+		} else {
+			$_SERVER['REMOTE_ADDR'] = $this->remote_addr;
+		}
 
 		parent::tearDown();
 	}
@@ -435,7 +449,7 @@ class Security_Scan_Notification_Test extends TestCase {
 		$message = $this->emails[0]['message'];
 
 		$this->assertStringNotContainsString( '<script>alert(7)', $message );
-		$this->assertStringContainsString( '&lt;script&gt;', $message );
+		$this->assertStringContainsString( '9.9 &lt;script&gt;alert(7)', $message );
 	}
 
 	/**
@@ -520,6 +534,80 @@ class Security_Scan_Notification_Test extends TestCase {
 		// A carriage-return-smuggled marker is neutralized too.
 		$this->assertStringContainsString( '&#35;## smuggled', $message );
 		$this->assertStringNotContainsString( 'smuggled</h3>', $message );
+	}
+
+	/**
+	 * An explanation cannot forge lists, tables, definition lists, or fences.
+	 */
+	public function test_explanation_cannot_forge_structured_blocks(): void {
+		$callback = $this->completed_callback(
+			array(
+				'findings_count' => 1,
+				'findings'       => array(
+					$this->finding(
+						9.8,
+						array(
+							'code_snippet' => '',
+							'explanation'  => "+ bullet\n\n1. numbered\n\n| a | b |\n| - | - |\n| 1 | 2 |\n\nterm\n:   def\n\n~~~\nfenced\n~~~",
+						)
+					),
+				),
+			)
+		);
+
+		Plugin_Scan_Gandalf::handle_callback( $this->plugin, $callback );
+
+		$message = $this->emails[0]['message'];
+
+		// None of the block openers produce a real structured element.
+		$this->assertStringNotContainsString( '<ul', $message );
+		$this->assertStringNotContainsString( '<ol', $message );
+		$this->assertStringNotContainsString( '<table', $message );
+		$this->assertStringNotContainsString( '<dl', $message );
+		$this->assertStringNotContainsString( '<pre>', $message );
+
+		// The text still reaches the reader.
+		$this->assertStringContainsString( 'bullet', $message );
+		$this->assertStringContainsString( 'fenced', $message );
+	}
+
+	/**
+	 * The plain-text body decodes entities without reconstructing live markup.
+	 *
+	 * The pre_wp_mail harness captures only the HTML variant, so the plain-text
+	 * body() is exercised directly here.
+	 */
+	public function test_plain_text_body_is_inert(): void {
+		$record = array(
+			'scan_id'         => self::SCAN_ID,
+			'version'         => self::VERSION,
+			'release_ref'     => self::VERSION,
+			'completed_at'    => time(),
+			'verdict_hash'    => 'f71c3d944050095a4e2e20f9ee8a7c9a',
+			'findings_count'  => 1,
+			'severity_counts' => array( 'error' => 1 ),
+			'max_risk_score'  => 9.8,
+			'report_url'      => 'https://scanner.example/runs/' . self::SCAN_ID,
+			'action'          => 'advisory',
+			'findings'        => array( $this->finding( 9.8, array( 'explanation' => '# heading text' ) ) ),
+		);
+
+		$email = new \WordPressdotorg\Plugin_Directory\Email\Security_Scan_Findings(
+			$this->plugin,
+			array( $this->committer ),
+			array( 'record' => $record )
+		);
+
+		$body = $email->body();
+
+		// The HTML entities are decoded back to plain characters for the text/plain part.
+		$this->assertStringContainsString( '<script>alert(1)</script>', $body );
+		$this->assertStringContainsString( '# heading text', $body );
+
+		// The HTML variant keeps them escaped and neutralized.
+		$html = $email->html();
+		$this->assertStringContainsString( '&lt;script&gt;alert(1)&lt;/script&gt;', $html );
+		$this->assertStringContainsString( '&#35; heading text', $html );
 	}
 
 	/**
@@ -638,6 +726,25 @@ class Security_Scan_Notification_Test extends TestCase {
 	}
 
 	/**
+	 * No-login committers are not emailed.
+	 */
+	public function test_nologin_committers_are_not_emailed(): void {
+		$this->stage_release();
+
+		// A real account, so only the no-login filter keeps it from being emailed.
+		$nologin_login = 'gandalf-nologin-' . self::$plugin_count;
+		$this->assertIsInt( wp_create_user( $nologin_login, wp_generate_password(), $nologin_login . '@example.com' ) );
+
+		$this->prime_committers( array( $this->committer->user_login, $nologin_login ) );
+		$GLOBALS['nologin_accounts'] = array( $nologin_login );
+
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->completed_callback() ) );
+
+		$this->assertCount( 1, $this->emails );
+		$this->assertSame( $this->committer->user_email, $this->emails[0]['to'] );
+	}
+
+	/**
 	 * A finding carrying only the required risk_score still renders.
 	 */
 	public function test_minimal_finding_renders(): void {
@@ -653,6 +760,10 @@ class Security_Scan_Notification_Test extends TestCase {
 		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $callback ) );
 
 		$this->assertCount( 1, $this->emails );
-		$this->assertStringContainsString( '9.9', $this->emails[0]['message'] );
+		$message = $this->emails[0]['message'];
+
+		// The absent title falls back, and the finding renders without a crash.
+		$this->assertStringContainsString( '9.9', $message );
+		$this->assertStringContainsString( '(no summary provided)', $message );
 	}
 }

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Security_Scan_Notification_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Security_Scan_Notification_Test.php
@@ -451,6 +451,39 @@ class Security_Scan_Notification_Test extends TestCase {
 	}
 
 	/**
+	 * Line-leading markers in an explanation cannot forge headings or rules.
+	 *
+	 * A carriage return is a line break to the Markdown processor, so it can
+	 * smuggle a marker to the start of a line as well.
+	 */
+	public function test_explanation_cannot_forge_markdown_blocks(): void {
+		$callback = $this->completed_callback(
+			array(
+				'findings_count' => 1,
+				'findings'       => array(
+					$this->finding(
+						9.8,
+						array( 'explanation' => "# Forged heading\n\n---\n\ntext\r### smuggled" )
+					),
+				),
+			)
+		);
+
+		Plugin_Scan_Gandalf::handle_callback( $this->plugin, $callback );
+
+		$message = $this->emails[0]['message'];
+
+		// The forged markers render as text, not as heading or rule elements.
+		$this->assertStringContainsString( '&#35; Forged heading', $message );
+		$this->assertStringContainsString( '&#45;--', $message );
+		$this->assertStringNotContainsString( '<h1', $message );
+
+		// A carriage-return-smuggled marker is neutralized too.
+		$this->assertStringContainsString( '&#35;## smuggled', $message );
+		$this->assertStringNotContainsString( 'smuggled</h3>', $message );
+	}
+
+	/**
 	 * A high-risk verdict that could not block still emails, as advisory.
 	 */
 	public function test_advisory_high_risk_scan_emails_committers(): void {

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Security_Scan_Notification_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Security_Scan_Notification_Test.php
@@ -426,6 +426,31 @@ class Security_Scan_Notification_Test extends TestCase {
 	}
 
 	/**
+	 * A lone carriage return in a snippet cannot break a line out of the code block.
+	 *
+	 * The Markdown processor maps a bare \r to a newline; if the snippet is not
+	 * normalized first, the split-out line loses its indent and renders as live
+	 * HTML instead of escaped code.
+	 */
+	public function test_snippet_carriage_return_stays_in_code_block(): void {
+		$callback = $this->completed_callback(
+			array(
+				'findings_count' => 1,
+				'findings'       => array(
+					$this->finding( 9.8, array( 'code_snippet' => "safe_line\r<script>alert(4)</script>" ) ),
+				),
+			)
+		);
+
+		Plugin_Scan_Gandalf::handle_callback( $this->plugin, $callback );
+
+		$message = $this->emails[0]['message'];
+
+		$this->assertStringContainsString( '&lt;script&gt;alert(4)&lt;/script&gt;', $message );
+		$this->assertStringNotContainsString( '<script>alert(4)', $message );
+	}
+
+	/**
 	 * A high-risk verdict that could not block still emails, as advisory.
 	 */
 	public function test_advisory_high_risk_scan_emails_committers(): void {

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Security_Scan_Notification_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Security_Scan_Notification_Test.php
@@ -340,7 +340,7 @@ class Security_Scan_Notification_Test extends TestCase {
 		$this->assertStringContainsString( 'has been blocked due to security findings', $email['subject'] );
 		$this->assertStringContainsString( self::VERSION, $email['subject'] );
 
-		$this->assertStringContainsString( 'block it from being offered as an update', $email['message'] );
+		$this->assertStringContainsString( 'block this version from being offered as an update', $email['message'] );
 		$this->assertStringContainsString( '9.8', $email['message'] );
 		$this->assertStringContainsString( 'Remote response controls a PHP callable', $email['message'] );
 		// The relative path links to the file in the Trac browser.
@@ -397,6 +397,32 @@ class Security_Scan_Notification_Test extends TestCase {
 
 		// A hostile snippet renders escaped inside its code block.
 		$this->assertStringContainsString( '&lt;script&gt;alert(2)&lt;/script&gt;', $message );
+	}
+
+	/**
+	 * Indented snippets render outdented, keeping their relative indentation.
+	 */
+	public function test_snippet_outdents_common_indentation(): void {
+		$callback = $this->completed_callback(
+			array(
+				'findings_count' => 2,
+				'findings'       => array(
+					$this->finding( 9.8, array( 'code_snippet' => "        if ( \$x ) {\n\n            do_thing();\n        }" ) ),
+					$this->finding( 9.7, array( 'code_snippet' => "function f() {\n    return 1;\n}" ) ),
+				),
+			)
+		);
+
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $callback ) );
+
+		$this->assertCount( 1, $this->emails );
+		$message = $this->emails[0]['message'];
+
+		// The shared indent is gone, the nested line keeps its relative step, the blank line survives.
+		$this->assertStringContainsString( "if ( \$x ) {\n\n    do_thing();\n}", $message );
+
+		// A snippet already at the margin is untouched.
+		$this->assertStringContainsString( "function f() {\n    return 1;\n}", $message );
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Security_Scan_Notification_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Security_Scan_Notification_Test.php
@@ -337,10 +337,10 @@ class Security_Scan_Notification_Test extends TestCase {
 		$email = $this->emails[0];
 
 		$this->assertSame( $this->committer->user_email, $email['to'] );
-		$this->assertStringContainsString( 'has been blocked pending a security review', $email['subject'] );
+		$this->assertStringContainsString( 'has been blocked due to security findings', $email['subject'] );
 		$this->assertStringContainsString( self::VERSION, $email['subject'] );
 
-		$this->assertStringContainsString( 'blocked from being offered as an update', $email['message'] );
+		$this->assertStringContainsString( 'block it from being offered as an update', $email['message'] );
 		$this->assertStringContainsString( '9.8', $email['message'] );
 		$this->assertStringContainsString( 'Remote response controls a PHP callable', $email['message'] );
 		$this->assertStringContainsString(
@@ -475,7 +475,7 @@ class Security_Scan_Notification_Test extends TestCase {
 		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( get_post( $this->plugin->ID ), $retry ) );
 
 		$this->assertCount( 2, $this->emails );
-		$this->assertStringContainsString( 'has been blocked pending a security review', $this->emails[1]['subject'] );
+		$this->assertStringContainsString( 'has been blocked due to security findings', $this->emails[1]['subject'] );
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Security_Scan_Notification_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Security_Scan_Notification_Test.php
@@ -94,6 +94,13 @@ class Security_Scan_Notification_Test extends TestCase {
 	private ?string $remote_addr = null;
 
 	/**
+	 * The account-exclusion globals the tests set, restored on teardown.
+	 *
+	 * @var array
+	 */
+	private array $account_globals = array();
+
+	/**
 	 * Create a published plugin with a pending security scan and one committer.
 	 */
 	protected function setUp(): void {
@@ -111,6 +118,11 @@ class Security_Scan_Notification_Test extends TestCase {
 		// Tools::audit_log() reads it unguarded.
 		$this->remote_addr      = isset( $_SERVER['REMOTE_ADDR'] ) ? (string) $_SERVER['REMOTE_ADDR'] : null; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- Captured verbatim to restore in tearDown, not used as input.
 		$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+
+		// Capture the exclusion globals the tests overwrite, to restore them without clobbering a pre-existing value.
+		foreach ( array( 'bot_accounts', 'nologin_accounts' ) as $global ) {
+			$this->account_globals[ $global ] = array_key_exists( $global, $GLOBALS ) ? $GLOBALS[ $global ] : null;
+		}
 
 		$plugin = Plugin_Directory::create_plugin_post(
 			array(
@@ -184,7 +196,15 @@ class Security_Scan_Notification_Test extends TestCase {
 			$this->threshold_filter = null;
 		}
 
-		unset( $GLOBALS['bot_accounts'], $GLOBALS['nologin_accounts'], $GLOBALS['phpmailer'] );
+		unset( $GLOBALS['phpmailer'] );
+
+		foreach ( $this->account_globals as $global => $value ) {
+			if ( null === $value ) {
+				unset( $GLOBALS[ $global ] );
+			} else {
+				$GLOBALS[ $global ] = $value;
+			}
+		}
 
 		if ( null === $this->remote_addr ) {
 			unset( $_SERVER['REMOTE_ADDR'] );

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Security_Scan_Notification_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Security_Scan_Notification_Test.php
@@ -400,6 +400,45 @@ class Security_Scan_Notification_Test extends TestCase {
 	}
 
 	/**
+	 * An author-controlled version header does not reach the email as markup.
+	 *
+	 * The version is interpolated into the Markdown intro, so HTML and link
+	 * syntax in it must be neutralized like any other untrusted string.
+	 */
+	public function test_email_neutralizes_hostile_version(): void {
+		$version = '9.9 <script>alert(7)</script>';
+
+		update_post_meta( $this->plugin->ID, 'version', $version );
+		update_post_meta( $this->plugin->ID, 'stable_tag', $version );
+		update_post_meta(
+			$this->plugin->ID,
+			Plugin_Scan_Gandalf::PENDING_META_KEY,
+			array(
+				self::SCAN_ID => array(
+					'version'      => $version,
+					'release_ref'  => $version,
+					'requested_at' => time(),
+				),
+			)
+		);
+
+		$callback = $this->completed_callback(
+			array(
+				'version'     => $version,
+				'release_ref' => $version,
+			)
+		);
+
+		Plugin_Scan_Gandalf::handle_callback( $this->plugin, $callback );
+
+		$this->assertCount( 1, $this->emails );
+		$message = $this->emails[0]['message'];
+
+		$this->assertStringNotContainsString( '<script>alert(7)', $message );
+		$this->assertStringContainsString( '&lt;script&gt;', $message );
+	}
+
+	/**
 	 * Indented snippets render outdented, keeping their relative indentation.
 	 */
 	public function test_snippet_outdents_common_indentation(): void {

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Security_Scan_Notification_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Security_Scan_Notification_Test.php
@@ -343,10 +343,17 @@ class Security_Scan_Notification_Test extends TestCase {
 		$this->assertStringContainsString( 'block it from being offered as an update', $email['message'] );
 		$this->assertStringContainsString( '9.8', $email['message'] );
 		$this->assertStringContainsString( 'Remote response controls a PHP callable', $email['message'] );
+		// The relative path links to the file in the Trac browser.
 		$this->assertStringContainsString(
 			sprintf( 'https://plugins.trac.wordpress.org/browser/%s/tags/%s/includes/class-admin.php#L688', $this->plugin->post_name, self::VERSION ),
 			$email['message']
 		);
+		$this->assertStringContainsString( '>includes/class-admin.php:688</a>', $email['message'] );
+
+		// The code snippet renders escaped in a code block; the explanation as prose.
+		$this->assertStringContainsString( '$clean = $this-&gt;write;', $email['message'] );
+		$this->assertStringContainsString( '<code>', $email['message'] );
+		$this->assertStringContainsString( 'The response body reaches a callable.', $email['message'] );
 	}
 
 	/**
@@ -363,7 +370,13 @@ class Security_Scan_Notification_Test extends TestCase {
 				'findings_count' => 2,
 				'findings'       => array(
 					$this->finding( 9.8 ),
-					$this->finding( 9.7, array( 'title' => '[Appeal this decision](https://evil.example/appeal)' ) ),
+					$this->finding(
+						9.7,
+						array(
+							'title'        => '[Appeal this decision](https://evil.example/appeal)',
+							'code_snippet' => '<script>alert(2)</script>',
+						)
+					),
 				),
 			)
 		);
@@ -373,13 +386,17 @@ class Security_Scan_Notification_Test extends TestCase {
 		$this->assertCount( 1, $this->emails );
 		$message = $this->emails[0]['message'];
 
+		// Markup in a title renders as inert, escaped text.
 		$this->assertStringNotContainsString( '<script>', $message );
-		$this->assertStringNotContainsString( 'alert(1)', $message );
+		$this->assertStringContainsString( '&lt;script&gt;alert(1)&lt;/script&gt;', $message );
 
 		// The Markdown link must not survive as a masquerading anchor.
 		$this->assertStringContainsString( 'Appeal this decision', $message );
 		$this->assertStringNotContainsString( '[Appeal', $message );
 		$this->assertStringNotContainsString( '>Appeal this decision</a>', $message );
+
+		// A hostile snippet renders escaped inside its code block.
+		$this->assertStringContainsString( '&lt;script&gt;alert(2)&lt;/script&gt;', $message );
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Security_Scan_Notification_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Security_Scan_Notification_Test.php
@@ -392,7 +392,7 @@ class Security_Scan_Notification_Test extends TestCase {
 
 		$this->assertCount( 1, $this->emails );
 		$this->assertStringContainsString( 'Security scan findings in', $this->emails[0]['subject'] );
-		$this->assertStringContainsString( 'No action has been taken against this version', $this->emails[0]['message'] );
+		$this->assertStringContainsString( 'Please review the findings and address them in an upcoming release.', $this->emails[0]['message'] );
 		$this->assertStringNotContainsString( 'blocked', $this->emails[0]['message'] );
 	}
 

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Security_Scan_Notification_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Security_Scan_Notification_Test.php
@@ -1,0 +1,518 @@
+<?php
+/**
+ * Tests for the security scan committer email notifications.
+ *
+ * @package WordPressdotorg\Plugin_Directory\Tests
+ */
+
+declare( strict_types = 1 );
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use WordPressdotorg\Plugin_Directory\Jobs\API_Update_Updater;
+use WordPressdotorg\Plugin_Directory\Jobs\Plugin_Scan_Gandalf;
+use WordPressdotorg\Plugin_Directory\Plugin_Directory;
+
+/**
+ * Tests that completed security scan callbacks email the plugin committers.
+ *
+ * Extends the plain PHPUnit TestCase: WP_UnitTestCase is not compatible with
+ * the PHPUnit 11 runner used by this suite. Isolation comes from giving every
+ * test its own plugin post and committer instead of per-test transactions.
+ *
+ * The group is declared as an attribute as well as `@group`: PHPUnit 11 ignores
+ * a class-level `@group` docblock, while older runners ignore the attribute.
+ *
+ * @group jobs
+ */
+#[Group( 'jobs' )]
+class Security_Scan_Notification_Test extends TestCase {
+
+	/** The scan ID used for the pending scan fixture. */
+	private const SCAN_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+	/** A second scan ID, for retries of the same verdict. */
+	private const SECOND_SCAN_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+	/** The version and release ref used for the pending scan fixture. */
+	private const VERSION = '1.4.4';
+
+	/**
+	 * Counter to give every test plugin and committer a unique slug.
+	 *
+	 * @var int
+	 */
+	private static int $plugin_count = 0;
+
+	/**
+	 * The plugin post under test.
+	 *
+	 * @var \WP_Post
+	 */
+	private \WP_Post $plugin;
+
+	/**
+	 * The committer of the plugin under test.
+	 *
+	 * @var \WP_User
+	 */
+	private \WP_User $committer;
+
+	/**
+	 * The emails captured from wp_mail().
+	 *
+	 * @var array
+	 */
+	private array $emails = array();
+
+	/**
+	 * The pre_wp_mail callback capturing emails, removed on teardown.
+	 *
+	 * @var callable
+	 */
+	private $mail_filter;
+
+	/**
+	 * The notification threshold filter of the current test, removed on teardown.
+	 *
+	 * @var callable|null
+	 */
+	private $threshold_filter = null;
+
+	/**
+	 * The threshold filter pinning the suite to 8.0, removed on teardown.
+	 *
+	 * @var callable
+	 */
+	private $threshold_pin;
+
+	/**
+	 * Create a published plugin with a pending security scan and one committer.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		wp_cache_flush();
+
+		// Pin the thresholds the suite was written against; the shipped defaults disable both.
+		$this->threshold_pin = static function (): float {
+			return 8.0;
+		};
+		add_filter( 'wporg_plugins_security_scan_block_risk_score', $this->threshold_pin );
+		add_filter( 'wporg_plugins_security_scan_notify_risk_score', $this->threshold_pin );
+
+		// Tools::audit_log() reads it unguarded.
+		$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+
+		$plugin = Plugin_Directory::create_plugin_post(
+			array(
+				'post_name'   => 'notify-test-' . ( ++self::$plugin_count ),
+				'post_title'  => 'Scan Notification Test Plugin',
+				'post_status' => 'publish',
+			)
+		);
+
+		$this->assertInstanceOf( \WP_Post::class, $plugin );
+		$this->plugin = $plugin;
+
+		/*
+		 * The stub update_source table survives across runs — the WP test
+		 * installer only drops core tables — so clear leftovers that would
+		 * collide with this run's plugin ID or read as a served version.
+		 */
+		global $wpdb;
+		$wpdb->delete( $wpdb->prefix . 'update_source', array( 'plugin_id' => $this->plugin->ID ) );
+		$wpdb->delete( $wpdb->prefix . 'update_source', array( 'plugin_slug' => $this->plugin->post_name ) );
+
+		update_post_meta( $this->plugin->ID, 'version', self::VERSION );
+		update_post_meta( $this->plugin->ID, 'stable_tag', self::VERSION );
+		$this->add_pending_scan( self::SCAN_ID );
+
+		$login   = 'scan-committer-' . self::$plugin_count;
+		$user_id = wp_create_user( $login, wp_generate_password(), $login . '@example.com' );
+		$this->assertIsInt( $user_id );
+		$this->committer = new \WP_User( $user_id );
+
+		$this->prime_committers( array( $login ) );
+
+		$this->emails      = array();
+		$this->mail_filter = function ( $short_circuit, $atts ) {
+			$this->emails[] = $atts;
+			return true;
+		};
+		add_filter( 'pre_wp_mail', $this->mail_filter, 10, 2 );
+
+		/*
+		 * The HTML email resets the mailer after wp_mail(); with wp_mail()
+		 * short-circuited nothing initializes the global, so stub it.
+		 */
+		$GLOBALS['phpmailer'] = new class() {
+			/**
+			 * The plain-text alternative body.
+			 *
+			 * @var string
+			 */
+			public $AltBody = ''; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase
+
+			/**
+			 * Toggle HTML mode.
+			 *
+			 * @param bool $is_html Whether to send HTML.
+			 */
+			public function IsHTML( bool $is_html = true ): void {} // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+		};
+	}
+
+	/**
+	 * Remove the filters and globals the tests installed.
+	 */
+	protected function tearDown(): void {
+		remove_filter( 'pre_wp_mail', $this->mail_filter, 10 );
+		remove_filter( 'wporg_plugins_security_scan_block_risk_score', $this->threshold_pin );
+		remove_filter( 'wporg_plugins_security_scan_notify_risk_score', $this->threshold_pin );
+
+		if ( $this->threshold_filter ) {
+			remove_filter( 'wporg_plugins_security_scan_notify_risk_score', $this->threshold_filter, 10 );
+			$this->threshold_filter = null;
+		}
+
+		unset( $GLOBALS['bot_accounts'], $GLOBALS['phpmailer'] );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Register a pending scan on the plugin fixture.
+	 *
+	 * @param string $scan_id The scan ID to register.
+	 */
+	private function add_pending_scan( string $scan_id ): void {
+		$pending = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::PENDING_META_KEY, true );
+		$pending = is_array( $pending ) ? $pending : array();
+
+		$pending[ $scan_id ] = array(
+			'version'      => self::VERSION,
+			'release_ref'  => self::VERSION,
+			'requested_at' => time(),
+		);
+
+		update_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::PENDING_META_KEY, $pending );
+	}
+
+	/**
+	 * Prime the committer cache Tools::get_plugin_committers() reads.
+	 *
+	 * @param array $logins The committer logins.
+	 */
+	private function prime_committers( array $logins ): void {
+		wp_cache_set( $this->plugin->post_name, $logins, 'plugin-committers', HOUR_IN_SECONDS );
+	}
+
+	/**
+	 * Filter the notification threshold for the current test.
+	 *
+	 * @param float $threshold The notification threshold to use.
+	 */
+	private function set_notify_threshold( float $threshold ): void {
+		$this->threshold_filter = static function () use ( $threshold ): float {
+			return $threshold;
+		};
+		add_filter( 'wporg_plugins_security_scan_notify_risk_score', $this->threshold_filter );
+	}
+
+	/**
+	 * Register a release for the scanned version, still inside its cooldown window.
+	 */
+	private function stage_release(): void {
+		update_post_meta(
+			$this->plugin->ID,
+			'releases',
+			array(
+				array(
+					'date'                     => time(),
+					'tag'                      => self::VERSION,
+					'version'                  => self::VERSION,
+					'zips_built'               => true,
+					'zips_built_from_revision' => 0,
+					'confirmations'            => array(),
+					'confirmed'                => true,
+					'confirmations_required'   => 0,
+					'committer'                => array(),
+					'revision'                 => array(),
+					'release_delay'            => DAY_IN_SECONDS,
+				),
+			)
+		);
+	}
+
+	/**
+	 * Stage an update_source row serving the scanned version, so a verdict
+	 * that can't un-ship anything stays advisory.
+	 */
+	private function stage_served_release(): void {
+		global $wpdb;
+
+		$wpdb->insert(
+			$wpdb->prefix . 'update_source',
+			array(
+				'plugin_id'        => $this->plugin->ID,
+				'plugin_slug'      => $this->plugin->post_name,
+				'available'        => 1,
+				'version'          => self::VERSION,
+				'stable_tag'       => self::VERSION,
+				'plugin_name'      => $this->plugin->post_title,
+				'requires_plugins' => '',
+				'last_updated'     => $this->plugin->post_modified,
+			)
+		);
+
+		$this->stage_release();
+	}
+
+	/**
+	 * Build a finding entry matching the callback contract.
+	 *
+	 * @param float $risk_score The finding risk score.
+	 * @param array $overrides  Fields to override.
+	 * @return array The finding.
+	 */
+	private function finding( float $risk_score, array $overrides = array() ): array {
+		return array_merge(
+			array(
+				'id'            => 'finding-' . md5( (string) $risk_score ),
+				'ref'           => 'prompt-security.supply_chain.remote_controlled_code',
+				'title'         => 'Remote response controls a PHP callable <script>alert(1)</script>',
+				'severity'      => 'error',
+				'file_path'     => 'includes/class-admin.php',
+				'line'          => 688,
+				'code_snippet'  => '$clean = $this->write;',
+				'explanation'   => 'The response body reaches a callable.',
+				'risk_score'    => $risk_score,
+				'investigation' => array(
+					'status'  => 'completed',
+					'result'  => 'reproduced',
+					'summary' => 'The unauthenticated probe reached the sink.',
+				),
+			),
+			$overrides
+		);
+	}
+
+	/**
+	 * Build a completed callback matching the pending scan fixture.
+	 *
+	 * @param array $overrides Fields to override.
+	 * @return array The callback data.
+	 */
+	private function completed_callback( array $overrides = array() ): array {
+		$defaults = array(
+			'status'          => 'completed',
+			'scan_id'         => self::SCAN_ID,
+			'subject_type'    => 'plugin',
+			'slug'            => $this->plugin->post_name,
+			'version'         => self::VERSION,
+			'release_ref'     => self::VERSION,
+			'completed_at'    => time(),
+			'verdict_hash'    => 'f71c3d944050095a4e2e20f9ee8a7c9a',
+			'findings_count'  => 1,
+			'findings'        => array( $this->finding( 9.8 ) ),
+			'max_risk_score'  => 9.8,
+			'severity_counts' => array( 'error' => 1 ),
+			'scanner_version' => '0.3.0',
+			'report_url'      => 'https://scanner.example/runs/' . self::SCAN_ID,
+		);
+
+		return array_merge( $defaults, $overrides );
+	}
+
+	/**
+	 * A blocked release emails the committers, reflecting the block.
+	 */
+	public function test_blocked_scan_emails_committers(): void {
+		$this->stage_release();
+
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->completed_callback() ) );
+
+		$this->assertCount( 1, $this->emails );
+		$email = $this->emails[0];
+
+		$this->assertSame( $this->committer->user_email, $email['to'] );
+		$this->assertStringContainsString( 'has been blocked pending a security review', $email['subject'] );
+		$this->assertStringContainsString( self::VERSION, $email['subject'] );
+
+		$this->assertStringContainsString( 'blocked from being offered as an update', $email['message'] );
+		$this->assertStringContainsString( '9.8', $email['message'] );
+		$this->assertStringContainsString( 'Remote response controls a PHP callable', $email['message'] );
+		$this->assertStringContainsString(
+			sprintf( 'https://plugins.trac.wordpress.org/browser/%s/tags/%s/includes/class-admin.php#L688', $this->plugin->post_name, self::VERSION ),
+			$email['message']
+		);
+	}
+
+	/**
+	 * Hostile finding strings do not reach the email as markup.
+	 *
+	 * The HTML variant renders Markdown, so both HTML tags and Markdown link
+	 * syntax must be neutralized.
+	 */
+	public function test_email_neutralizes_hostile_findings(): void {
+		$this->stage_release();
+
+		$callback = $this->completed_callback(
+			array(
+				'findings_count' => 2,
+				'findings'       => array(
+					$this->finding( 9.8 ),
+					$this->finding( 9.7, array( 'title' => '[Appeal this decision](https://evil.example/appeal)' ) ),
+				),
+			)
+		);
+
+		Plugin_Scan_Gandalf::handle_callback( $this->plugin, $callback );
+
+		$this->assertCount( 1, $this->emails );
+		$message = $this->emails[0]['message'];
+
+		$this->assertStringNotContainsString( '<script>', $message );
+		$this->assertStringNotContainsString( 'alert(1)', $message );
+
+		// The Markdown link must not survive as a masquerading anchor.
+		$this->assertStringContainsString( 'Appeal this decision', $message );
+		$this->assertStringNotContainsString( '[Appeal', $message );
+		$this->assertStringNotContainsString( '>Appeal this decision</a>', $message );
+	}
+
+	/**
+	 * A high-risk verdict that could not block still emails, as advisory.
+	 */
+	public function test_advisory_high_risk_scan_emails_committers(): void {
+		$this->stage_served_release();
+
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->completed_callback() ) );
+
+		$this->assertCount( 1, $this->emails );
+		$this->assertStringContainsString( 'Security scan findings in', $this->emails[0]['subject'] );
+		$this->assertStringContainsString( 'No action has been taken against this version', $this->emails[0]['message'] );
+		$this->assertStringNotContainsString( 'blocked', $this->emails[0]['message'] );
+	}
+
+	/**
+	 * Scans below the notification threshold do not email the committers.
+	 */
+	public function test_below_threshold_sends_no_email(): void {
+		$this->stage_release();
+
+		$callback = $this->completed_callback(
+			array(
+				'findings'       => array( $this->finding( 7.9 ) ),
+				'max_risk_score' => 7.9,
+			)
+		);
+
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $callback ) );
+		$this->assertCount( 0, $this->emails );
+	}
+
+	/**
+	 * Lowering the threshold emails advisory results below the block threshold.
+	 */
+	public function test_threshold_filter_lowers_notification_bar(): void {
+		$this->set_notify_threshold( 5.0 );
+
+		$callback = $this->completed_callback(
+			array(
+				'findings'       => array( $this->finding( 5.2 ) ),
+				'max_risk_score' => 5.2,
+			)
+		);
+
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $callback ) );
+
+		$this->assertCount( 1, $this->emails );
+		$this->assertStringContainsString( 'Security scan findings in', $this->emails[0]['subject'] );
+	}
+
+	/**
+	 * A threshold above 10 disables the emails, even for a blocked release.
+	 */
+	public function test_threshold_filter_disables_notifications(): void {
+		$this->set_notify_threshold( 11.0 );
+		$this->stage_release();
+
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->completed_callback() ) );
+
+		$this->assertTrue( API_Update_Updater::is_release_blocked( Plugin_Directory::get_release( $this->plugin, self::VERSION ) ) );
+		$this->assertCount( 0, $this->emails );
+	}
+
+	/**
+	 * The same advisory verdict is emailed once, even across scans.
+	 */
+	public function test_same_advisory_verdict_is_emailed_once(): void {
+		$this->stage_served_release();
+
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->completed_callback() ) );
+
+		$this->add_pending_scan( self::SECOND_SCAN_ID );
+		$retry = $this->completed_callback( array( 'scan_id' => self::SECOND_SCAN_ID ) );
+
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( get_post( $this->plugin->ID ), $retry ) );
+
+		$this->assertCount( 1, $this->emails );
+	}
+
+	/**
+	 * A blocked release always emails, even for an already-emailed verdict.
+	 */
+	public function test_blocked_verdict_always_emails(): void {
+		$this->stage_release();
+
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->completed_callback() ) );
+
+		$this->add_pending_scan( self::SECOND_SCAN_ID );
+		$retry = $this->completed_callback( array( 'scan_id' => self::SECOND_SCAN_ID ) );
+
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( get_post( $this->plugin->ID ), $retry ) );
+
+		$this->assertCount( 2, $this->emails );
+		$this->assertStringContainsString( 'has been blocked pending a security review', $this->emails[1]['subject'] );
+	}
+
+	/**
+	 * Bot committers are not emailed.
+	 */
+	public function test_bot_committers_are_not_emailed(): void {
+		$this->stage_release();
+
+		// A real account, so only the bot filter keeps it from being emailed.
+		$bot_login = 'gandalf-bot-' . self::$plugin_count;
+		$this->assertIsInt( wp_create_user( $bot_login, wp_generate_password(), $bot_login . '@example.com' ) );
+
+		$this->prime_committers( array( $this->committer->user_login, $bot_login ) );
+		$GLOBALS['bot_accounts'] = array( $bot_login );
+
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->completed_callback() ) );
+
+		$this->assertCount( 1, $this->emails );
+		$this->assertSame( $this->committer->user_email, $this->emails[0]['to'] );
+	}
+
+	/**
+	 * A finding carrying only the required risk_score still renders.
+	 */
+	public function test_minimal_finding_renders(): void {
+		$this->stage_release();
+
+		$callback = $this->completed_callback(
+			array(
+				'findings'       => array( array( 'risk_score' => 9.9 ) ),
+				'max_risk_score' => 9.9,
+			)
+		);
+
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $callback ) );
+
+		$this->assertCount( 1, $this->emails );
+		$this->assertStringContainsString( '9.9', $this->emails[0]['message'] );
+	}
+}


### PR DESCRIPTION
## Summary

Adds the author-facing half of the security scan pipeline: a completed scan callback now emails the plugin's committers its findings, alongside the existing reviewer surfaces (Slack alert, internal note).

### What it does

- A new `Email\Security_Scan_Findings` (Markdown, multipart HTML + plain text) tells committers what was found: per finding the risk score, title, the file path linked to the plugins.trac.wordpress.org browser, the reported code snippet as a code block, and the finding's explanation. Findings render highest-risk first under a Findings subheader, bounded to ten; snippets and explanations reach the email unstripped since only the stored meta row needs bounding. The internal report URL is deliberately not shared.
- The email reflects what happened. Blocked: the security review found issues severe enough to withhold the version from the update API, sites keep receiving the previous version, and the fix is in the author's hands — address the findings and release a new version, which escapes the block (#785's per-release scoping). Advisory: please review the findings and address them in an upcoming release.
- Whether to notify is adjustable by risk score: `Plugin_Scan_Gandalf::NOTIFY_RISK_SCORE` (default 8.0, the block threshold) via the `wporg_plugins_security_scan_notify_risk_score` filter — lower it to start advising authors below the block bar, raise it above 10 to disable the emails entirely.
- Recipients are the plugin's committers minus bot and no-login accounts, matching the release-confirmation email in `cli/class-import.php`. Dedup mirrors the Slack alert: release blocks always email, advisory results deduplicate per verdict hash (month window), so a blocked outcome can never be silenced by an earlier advisory email of the same verdict.
- Finding strings are treated as untrusted scanner output: angle brackets are entity-encoded rather than stripped (so text like `<slug>` or `<?php` survives as text while markup can't go live; the plain-text variant decodes them back), length is bounded, Markdown link/image syntax is neutralized so a hostile title can't smuggle a masquerading anchor into an email from plugins@wordpress.org, backticks become apostrophes to keep line-leading pairs out of `Markdown::code_trick()`, and snippets use indented code blocks, which Markdown escapes and which have no fence to break out of. Trac URLs are built from per-segment `rawurlencode()`d paths.

### Testing

`tests/Security_Scan_Notification_Test.php` (10 tests) covers the blocked and advisory email content, the inclusive threshold and both filter directions (lowering and disabling), advisory dedup across scans vs. blocks always emailing, bot-account exclusion (against a real account, so only the filter excludes it), hostile-string neutralization (escaped markup in titles and snippets, Markdown links), and a finding carrying only the contractually required `risk_score`. Full plugin-directory suite passes (229 tests); both new files lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated security-scan email notifications for plugin committers.
  * Notifications distinguish blocked releases from advisory findings and include risk scores, summaries, affected files, code snippets, and guidance.
  * Added configurable risk thresholds and duplicate-notification prevention.
  * Excluded bot and no-login accounts from notifications.

* **Bug Fixes**
  * Sanitized scan findings, plugin versions, explanations, and code snippets to prevent unsafe Markdown or HTML content while preserving readable formatting.
  * Improved plain-text email rendering for safer, clearer content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->