### PR TITLE
Escape output across several wporg components

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/official-wordpress-events/official-wordpress-events.php
+++ b/wordpress.org/public_html/wp-content/plugins/official-wordpress-events/official-wordpress-events.php
@@ -387,7 +387,7 @@ class Official_WordPress_Events {
 							if ( empty( $value ) ) {
 								continue 3;
 							} else {
-								$event['url'] = $value;
+								$event['url'] = esc_url_raw( $value );
 							}
 							break;
 

--- a/wordpress.org/public_html/wp-content/plugins/official-wordpress-events/official-wordpress-events.php
+++ b/wordpress.org/public_html/wp-content/plugins/official-wordpress-events/official-wordpress-events.php
@@ -384,10 +384,11 @@ class Official_WordPress_Events {
 							break;
 
 						case 'URL':
-							if ( empty( $value ) ) {
+							$url = esc_url_raw( $value );
+							if ( empty( $url ) ) {
 								continue 3;
 							} else {
-								$event['url'] = esc_url_raw( $value );
+								$event['url'] = $url;
 							}
 							break;
 
@@ -695,7 +696,7 @@ class Official_WordPress_Events {
 				'source_id'       => $meetup['id'],
 				'status'          => 'upcoming' === $meetup['status'] ? 'scheduled' : 'cancelled',
 				'title'           => $meetup['name'],
-				'url'             => $meetup['link'],
+				'url'             => esc_url_raw( $meetup['link'] ),
 				'meetup_name'     => $meetup['group']['name'],
 				'meetup_url'      => sprintf( 'https://www.meetup.com/%s/', $meetup['group']['urlname'] ),
 				'description'     => $meetup['description'] ?? '',

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/helper-functions.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/helper-functions.php
@@ -509,14 +509,14 @@ function wporg_references( $project, $entry ) {
 			list( $file, $line ) = array_pad( explode( ':', $reference ), 2, 0 );
 			if ( $source_url = $project->source_url( $file, $line ) ) :
 				?>
-				<li><a target="_blank" href="<?php echo $source_url; ?>"><?php echo $file.':'.$line ?></a></li>
+				<li><a target="_blank" href="<?php echo esc_url( $source_url ); ?>"><?php echo esc_html( $file . ':' . $line ); ?></a></li>
 			<?php
 			elseif ( wp_http_validate_url( $reference ) ) :
 				?>
 				<li><a target="_blank" href="<?php echo esc_url( $reference ); ?>"><?php echo esc_html( $reference ); ?></a></li>
 			<?php
 			else :
-				echo "<li>$file:$line</li>";
+				echo '<li>' . esc_html( "$file:$line" ) . '</li>';
 			endif;
 		endforeach;
 		?>

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-routes/inc/routes/class-locale.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-routes/inc/routes/class-locale.php
@@ -292,7 +292,7 @@ class Locale extends GP_Route {
 			case 'wp-themes':
 				$screenshot = gp_get_meta( 'wp-themes', $sub_project->id, 'screenshot' );
 				if ( $screenshot ) {
-					return '<div class="theme icon"><img src="https://i0.wp.com/' . $screenshot . '?w=' . ( $size * 2 ) . '&amp;strip=all" width="' . $size . '" height="' . $size . '"></div>';
+					return '<div class="theme icon"><img src="' . esc_url( 'https://i0.wp.com/' . $screenshot . '?w=' . ( $size * 2 ) . '&strip=all' ) . '" width="' . $size . '" height="' . $size . '"></div>';
 				} else {
 					return '<div class="default-icon"><span class="dashicons dashicons-admin-appearance"></span></div>';
 				}

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-theme-directory/inc/cli/class-set-theme-project.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-theme-directory/inc/cli/class-set-theme-project.php
@@ -108,25 +108,15 @@ class Set_Theme_Project extends WP_CLI_Command {
 	private function get_theme_data( $theme_slug, $theme_dir ) {
 		$style_css = "{$theme_dir}style.css";
 
-		$theme_data = array(
-			'name'        => 'Theme Name',
-			'version'     => 'Version',
-			'description' => 'Description',
+		$theme_data = get_file_data(
+			$style_css,
+			array(
+				'name'        => 'Theme Name',
+				'version'     => 'Version',
+				'description' => 'Description',
+			)
 		);
-
-		//  Pull only the first 8kiB of the file in.
-		$file_data = file_get_contents( $style_css, false, null, 0, 8192 );
-
-		// Make sure we catch CR-only line endings.
-		$file_data = str_replace( "\r", "\n", $file_data );
-
-		foreach ( $theme_data as $field => $regex ) {
-			if ( preg_match( '/^[ \t\/*#@]*' . preg_quote( $regex, '/' ) . ':(.*)$/mi', $file_data, $match ) && $match[1] ) {
-				$theme_data[ $field ] = strip_tags( _cleanup_header_comment( $match[1] ) );
-			} else {
-				$theme_data[ $field ] = '';
-			}
-		}
+		$theme_data = array_map( 'strip_tags', $theme_data );
 
 		// Screenshot
 		$theme_data['screenshot'] = '';

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-theme-directory/inc/cli/class-set-theme-project.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-theme-directory/inc/cli/class-set-theme-project.php
@@ -103,7 +103,7 @@ class Set_Theme_Project extends WP_CLI_Command {
 	}
 
 	/**
-	 * A cutdown version of core's get_file_data() to return specific headers from a Theme, plus it's screenshot.
+	 * Returns specific headers from a theme's style.css, plus its screenshot.
 	 */
 	private function get_theme_data( $theme_slug, $theme_dir ) {
 		$style_css = "{$theme_dir}style.css";

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-main/page-about-testimonials.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-main/page-about-testimonials.php
@@ -33,17 +33,16 @@ restore_current_blog();
 
 if ( $testimonials_post instanceof \WP_Post ) {
 	// We only need the URLs in the post_content.
-	preg_match_all( '|https://\S+|', $testimonials_post->post_content, $testimonials );
+	preg_match_all( '|https://\S+|', $testimonials_post->post_content, $matches );
 
 	// Keep only well-formed https URLs; the loose \S+ match otherwise admits quotes and angle brackets.
-	$testimonials = array_values( array_filter( array_map(
-		function( $url ) {
-			$url = esc_url_raw( $url );
-
-			return ( $url && 'https' === wp_parse_url( $url, PHP_URL_SCHEME ) ) ? $url : '';
-		},
-		$testimonials[0]
-	) ) );
+	$testimonials = array();
+	foreach ( $matches[0] as $url ) {
+		$url = esc_url_raw( $url );
+		if ( $url && 'https' === wp_parse_url( $url, PHP_URL_SCHEME ) ) {
+			$testimonials[] = $url;
+		}
+	}
 } else {
 	$testimonials = [];
 }

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-main/page-about-testimonials.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-main/page-about-testimonials.php
@@ -34,7 +34,16 @@ restore_current_blog();
 if ( $testimonials_post instanceof \WP_Post ) {
 	// We only need the URLs in the post_content.
 	preg_match_all( '|https://\S+|', $testimonials_post->post_content, $testimonials );
-	$testimonials = $testimonials[0];
+
+	// Keep only well-formed https URLs; the loose \S+ match otherwise admits quotes and angle brackets.
+	$testimonials = array_values( array_filter( array_map(
+		function( $url ) {
+			$url = esc_url_raw( $url );
+
+			return ( $url && 'https' === wp_parse_url( $url, PHP_URL_SCHEME ) ) ? $url : '';
+		},
+		$testimonials[0]
+	) ) );
 } else {
 	$testimonials = [];
 }


### PR DESCRIPTION
Escapes output and tightens input handling in a few wporg components, mostly bringing templates in line with coding standards and, in one case, with upstream GlotPress.

- **GlotPress** – Escape the source URL and `file:line` text in the references template (matching upstream), and read theme headers via core `get_file_data()` while escaping the locale theme icon URL.
- **Official WordPress Events** – Run imported event URLs through `esc_url_raw()`.
- **Main Theme** – Validate scraped testimonial URLs (`esc_url_raw()` + https scheme check) before output.

Each change is scoped to output escaping / input normalization, with no behavior change for well-formed data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
