### PR TITLE
PHPCS: Exclude the vendored adhocore/php-jwt library from linting

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -36,6 +36,9 @@
 	<rule ref="PHPCompatibilityWP"/>
 
 	<rule ref="WordPress">
+		<!-- Vendored library; carries local patches, so PHPCompatibilityWP stays active on it. -->
+		<exclude-pattern>*/dotorg/trac/pr/adhocore-php-jwt/*</exclude-pattern>
+
 		<exclude name="WordPress.DB.DirectDatabaseQuery" />
 		<exclude name="WordPress.DB.SlowDBQuery" />
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -36,7 +36,7 @@
 	<rule ref="PHPCompatibilityWP"/>
 
 	<rule ref="WordPress">
-		<!-- Vendored library; carries local patches, so PHPCompatibilityWP stays active on it. -->
+		<!-- Not in the global excludes: PHPCompatibilityWP must keep covering its local patches. -->
 		<exclude-pattern>*/dotorg/trac/pr/adhocore-php-jwt/*</exclude-pattern>
 
 		<exclude name="WordPress.DB.DirectDatabaseQuery" />


### PR DESCRIPTION
PHPCS reports 14 `WordPress.Security.EscapeOutput.ExceptionNotEscaped` violations (plus assorted style noise) against `api.wordpress.org/public_html/dotorg/trac/pr/adhocore-php-jwt/` — the MIT-licensed [adhocore/php-jwt](https://github.com/adhocore/php-jwt) library, which we shouldn't hold to WordPress coding standards, matching the existing excludes for `plugin-directory/libs/`, `theme-directory/lib/`, and `wpf-stripe/stripe-php/`.

The exclude is scoped to the `WordPress` ruleset rather than global: this copy is not pristine upstream — it carries local patches (991cf8525 for PHP 8.4 implicit-nullable deprecations, 6f3fdbc02 for a private-key check) — so `PHPCompatibilityWP` deliberately stays active on it, preserving the signal that caught the 8.4 breakage in these files. Verified with a canary that deprecated constructs in the directory are still flagged while the WordPress-ruleset violations are silenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated coding standards checks to accommodate the vendored JWT library while retaining PHP compatibility validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->