### PR TITLE
Slack webhooks: Validate webhook signatures and payload fields at the edge

### DIFF
--- a/api.wordpress.org/public_html/dotorg/slack/announce.php
+++ b/api.wordpress.org/public_html/dotorg/slack/announce.php
@@ -9,6 +9,13 @@ namespace Dotorg\Slack\Announce {
 
 require dirname( dirname( __DIR__ ) ) . '/includes/slack/announce/lib.php';
 
+/* phpcs:disable Generic.WhiteSpace.ScopeIndent -- file-scope code here is historically unindented.
+ * phpcs:disable WordPress.Security.NonceVerification
+ * phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+ * Standalone Slack slash-command handler: WordPress is not loaded, so request data is
+ * never slashed; Slack authenticates with the shared WEBHOOK_TOKEN_* secrets below.
+ */
+
 function get_avatar( $username, $slack_id, $team_id ) {
 	global $wpdb;
 
@@ -29,7 +36,7 @@ function get_avatar( $username, $slack_id, $team_id ) {
 $i = 0;
 // WEBHOOK_TOKEN_1, WEBHOOK_TOKEN_2, etc.
 while ( defined( __NAMESPACE__ . '\\WEBHOOK_TOKEN_' . ++$i ) ) {
-	if ( hash_equals( constant( __NAMESPACE__ . '\\WEBHOOK_TOKEN_' . $i ), $_POST['token'] ) ) {
+	if ( hash_equals( constant( __NAMESPACE__ . '\\WEBHOOK_TOKEN_' . $i ), $_POST['token'] ?? '' ) ) {
 		run( $_POST );
 	}
 }

--- a/api.wordpress.org/public_html/dotorg/slack/announce.php
+++ b/api.wordpress.org/public_html/dotorg/slack/announce.php
@@ -1,9 +1,9 @@
 <?php
 namespace Dotorg\Slack\Announce;
 
-require dirname( dirname( __DIR__ ) ) . '/includes/hyperdb/bb-10-hyper-db.php';
-require dirname( dirname( __DIR__ ) ) . '/includes/slack-config.php';
-require dirname( dirname( __DIR__ ) ) . '/includes/slack/announce/lib.php';
+require dirname( __DIR__, 2 ) . '/includes/hyperdb/bb-10-hyper-db.php';
+require dirname( __DIR__, 2 ) . '/includes/slack-config.php';
+require dirname( __DIR__, 2 ) . '/includes/slack/announce/lib.php';
 
 /*
  * This is a standalone Slack slash-command handler: WordPress is not loaded, so request

--- a/api.wordpress.org/public_html/dotorg/slack/announce.php
+++ b/api.wordpress.org/public_html/dotorg/slack/announce.php
@@ -1,17 +1,21 @@
 <?php
-namespace Dotorg\Slack\Announce;
-
-require dirname( __DIR__, 2 ) . '/includes/hyperdb/bb-10-hyper-db.php';
-require dirname( __DIR__, 2 ) . '/includes/slack-config.php';
-require dirname( __DIR__, 2 ) . '/includes/slack/announce/lib.php';
-
-/*
+/**
+ * Slack slash-command handler for making announcements in channels.
+ *
  * This is a standalone Slack slash-command handler: WordPress is not loaded, so request
  * data is never slashed. Slack authenticates itself with one of the shared
  * `WEBHOOK_TOKEN_*` secrets below; nonces don't exist in server-to-server webhooks.
  *
  * phpcs:disable WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+ *
+ * @package WordPressdotorg\API\Slack
  */
+
+namespace Dotorg\Slack\Announce;
+
+require dirname( __DIR__, 2 ) . '/includes/hyperdb/bb-10-hyper-db.php';
+require dirname( __DIR__, 2 ) . '/includes/slack-config.php';
+require dirname( __DIR__, 2 ) . '/includes/slack/announce/lib.php';
 
 function get_avatar( $username, $slack_id, $team_id ) {
 	global $wpdb;

--- a/api.wordpress.org/public_html/dotorg/slack/announce.php
+++ b/api.wordpress.org/public_html/dotorg/slack/announce.php
@@ -1,19 +1,16 @@
 <?php
+namespace Dotorg\Slack\Announce;
 
-namespace {
-	require dirname( dirname( __DIR__ ) ) . '/includes/hyperdb/bb-10-hyper-db.php';
-	require dirname( dirname( __DIR__ ) ) . '/includes/slack-config.php';
-}
-
-namespace Dotorg\Slack\Announce {
-
+require dirname( dirname( __DIR__ ) ) . '/includes/hyperdb/bb-10-hyper-db.php';
+require dirname( dirname( __DIR__ ) ) . '/includes/slack-config.php';
 require dirname( dirname( __DIR__ ) ) . '/includes/slack/announce/lib.php';
 
-/* phpcs:disable Generic.WhiteSpace.ScopeIndent -- file-scope code here is historically unindented.
- * phpcs:disable WordPress.Security.NonceVerification
- * phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash
- * Standalone Slack slash-command handler: WordPress is not loaded, so request data is
- * never slashed; Slack authenticates with the shared WEBHOOK_TOKEN_* secrets below.
+/*
+ * This is a standalone Slack slash-command handler: WordPress is not loaded, so request
+ * data is never slashed. Slack authenticates itself with one of the shared
+ * `WEBHOOK_TOKEN_*` secrets below; nonces don't exist in server-to-server webhooks.
+ *
+ * phpcs:disable WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
  */
 
 function get_avatar( $username, $slack_id, $team_id ) {
@@ -33,13 +30,15 @@ function get_avatar( $username, $slack_id, $team_id ) {
 	return sprintf( 'https://secure.gravatar.com/avatar/%s?s=96d=mm&r=G&%s', $hash, time() );
 }
 
+// An array (`token[]`) would make hash_equals() throw; bail on anything but a string.
+if ( ! is_string( $_POST['token'] ?? null ) ) {
+	return;
+}
+
 $i = 0;
 // WEBHOOK_TOKEN_1, WEBHOOK_TOKEN_2, etc.
 while ( defined( __NAMESPACE__ . '\\WEBHOOK_TOKEN_' . ++$i ) ) {
-	if ( hash_equals( constant( __NAMESPACE__ . '\\WEBHOOK_TOKEN_' . $i ), $_POST['token'] ?? '' ) ) {
+	if ( hash_equals( constant( __NAMESPACE__ . '\\WEBHOOK_TOKEN_' . $i ), $_POST['token'] ) ) {
 		run( $_POST );
 	}
 }
-
-}
-

--- a/api.wordpress.org/public_html/dotorg/slack/announce.php
+++ b/api.wordpress.org/public_html/dotorg/slack/announce.php
@@ -30,7 +30,6 @@ function get_avatar( $username, $slack_id, $team_id ) {
 	return sprintf( 'https://secure.gravatar.com/avatar/%s?s=96d=mm&r=G&%s', $hash, time() );
 }
 
-// An array (`token[]`) would make hash_equals() throw; bail on anything but a string.
 if ( ! is_string( $_POST['token'] ?? null ) ) {
 	return;
 }

--- a/api.wordpress.org/public_html/dotorg/slack/committers.php
+++ b/api.wordpress.org/public_html/dotorg/slack/committers.php
@@ -14,7 +14,6 @@ require dirname( dirname( __DIR__ ) ) . '/includes/slack-config.php';
  * phpcs:disable WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
  */
 
-// An array (`token[]`) would make hash_equals() throw; treat it as an invalid token.
 if ( ! is_string( $_POST['token'] ?? null ) || ! hash_equals( WEBHOOK_TOKEN, $_POST['token'] ) ) {
 	return;
 }

--- a/api.wordpress.org/public_html/dotorg/slack/committers.php
+++ b/api.wordpress.org/public_html/dotorg/slack/committers.php
@@ -14,7 +14,8 @@ require dirname( dirname( __DIR__ ) ) . '/includes/slack-config.php';
  * phpcs:disable WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
  */
 
-if ( ! hash_equals( WEBHOOK_TOKEN, $_POST['token'] ?? '' ) ) {
+// An array (`token[]`) would make hash_equals() throw; treat it as an invalid token.
+if ( ! is_string( $_POST['token'] ?? null ) || ! hash_equals( WEBHOOK_TOKEN, $_POST['token'] ) ) {
 	return;
 }
 

--- a/api.wordpress.org/public_html/dotorg/slack/committers.php
+++ b/api.wordpress.org/public_html/dotorg/slack/committers.php
@@ -6,14 +6,25 @@ namespace Dotorg\Slack\Committers;
 
 require dirname( dirname( __DIR__ ) ) . '/includes/slack-config.php';
 
-if ( ! hash_equals( WEBHOOK_TOKEN, $_POST['token'] ) ) {
+/*
+ * This is a standalone Slack outgoing-webhook handler: WordPress is not loaded, so request data
+ * is never slashed. Slack authenticates itself with the shared `WEBHOOK_TOKEN` below; nonces
+ * don't exist in server-to-server webhooks.
+ *
+ * phpcs:disable WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+ */
+
+if ( ! hash_equals( WEBHOOK_TOKEN, $_POST['token'] ?? '' ) ) {
 	return;
 }
+
+// The Slack user name of whoever triggered the webhook, echoed back in the JSON response below.
+$user_name = filter_var( $_POST['user_name'] ?? '', FILTER_UNSAFE_RAW, FILTER_FLAG_STRIP_LOW );
 
 echo json_encode( array(
 	'username'   => 'wordpressdotorg',
 	'link_names' => 1,
-	'text'       => sprintf( '@%s: Use the `/committers` command.', $_POST['user_name'] ),
+	'text'       => sprintf( '@%s: Use the `/committers` command.', $user_name ),
 ) );
 
 exit;

--- a/api.wordpress.org/public_html/dotorg/slack/committers.php
+++ b/api.wordpress.org/public_html/dotorg/slack/committers.php
@@ -1,18 +1,21 @@
 <?php
+/**
+ * Slack outgoing-webhook handler for the committers channel.
+ *
+ * This is a standalone Slack outgoing-webhook handler: WordPress is not loaded, so request data
+ * is never slashed. Slack authenticates itself with the shared `WEBHOOK_TOKEN` below; nonces
+ * don't exist in server-to-server webhooks.
+ *
+ * phpcs:disable WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+ *
+ * @package WordPressdotorg\API\Slack
+ */
 
 // Allow committers to publicly mention other committers via @committers.
 
 namespace Dotorg\Slack\Committers;
 
 require dirname( dirname( __DIR__ ) ) . '/includes/slack-config.php';
-
-/*
- * This is a standalone Slack outgoing-webhook handler: WordPress is not loaded, so request data
- * is never slashed. Slack authenticates itself with the shared `WEBHOOK_TOKEN` below; nonces
- * don't exist in server-to-server webhooks.
- *
- * phpcs:disable WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
- */
 
 if ( ! is_string( $_POST['token'] ?? null ) || ! hash_equals( WEBHOOK_TOKEN, $_POST['token'] ) ) {
 	return;

--- a/api.wordpress.org/public_html/dotorg/slack/committers.php
+++ b/api.wordpress.org/public_html/dotorg/slack/committers.php
@@ -22,7 +22,7 @@ if ( ! is_string( $_POST['token'] ?? null ) || ! hash_equals( WEBHOOK_TOKEN, $_P
 }
 
 // The Slack user name of whoever triggered the webhook, echoed back in the JSON response below.
-$user_name = filter_var( $_POST['user_name'] ?? '', FILTER_UNSAFE_RAW, FILTER_FLAG_STRIP_LOW );
+$user_name = (string) filter_var( $_POST['user_name'] ?? '', FILTER_UNSAFE_RAW, FILTER_FLAG_STRIP_LOW );
 
 echo json_encode( array(
 	'username'   => 'wordpressdotorg',

--- a/api.wordpress.org/public_html/dotorg/slack/community-deputies-calendly-webhook.php
+++ b/api.wordpress.org/public_html/dotorg/slack/community-deputies-calendly-webhook.php
@@ -57,7 +57,7 @@ function api_request( $url ) {
 }
 
 // Check the request is valid.
-if ( empty( $_GET['secret'] ) || ! hash_equals( COMMUNITY_CALENDLY_SECRET, wp_unslash( $_GET['secret'] ) ) ) {
+if ( empty( $_GET['secret'] ) || ! is_string( $_GET['secret'] ) || ! hash_equals( COMMUNITY_CALENDLY_SECRET, wp_unslash( $_GET['secret'] ) ) ) {
 	header( 'HTTP/1.1 403 Forbidden' );
 	die( 'Invalid secret provided.' );
 }

--- a/api.wordpress.org/public_html/dotorg/slack/community-deputies-calendly-webhook.php
+++ b/api.wordpress.org/public_html/dotorg/slack/community-deputies-calendly-webhook.php
@@ -1,4 +1,15 @@
 <?php
+/**
+ * Calendly webhook handler for community deputy meetings.
+ *
+ * Calendly authenticates itself with the shared `COMMUNITY_CALENDLY_SECRET` passed in the webhook
+ * URL, verified below; nonces don't exist in server-to-server webhooks.
+ *
+ * phpcs:disable WordPress.Security.NonceVerification
+ *
+ * @package WordPressdotorg\API\Slack
+ */
+
 namespace WordPressdotorg\API\Slack\Community_Deputy_Webhook;
 use Dotorg\Slack\Send;
 use DateTime, DateTimeZone;
@@ -8,13 +19,6 @@ use DateTime, DateTimeZone;
  */
 require dirname( __DIR__, 2 ) . '/wp-init.php';
 require dirname( __DIR__, 2 ) . '/includes/slack-config.php';
-
-/*
- * Calendly authenticates itself with the shared `COMMUNITY_CALENDLY_SECRET` passed in the webhook
- * URL, verified below; nonces don't exist in server-to-server webhooks.
- *
- * phpcs:disable WordPress.Security.NonceVerification
- */
 
 /**
  * Quick API wrapper for the Calendly API.

--- a/api.wordpress.org/public_html/dotorg/slack/community-deputies-calendly-webhook.php
+++ b/api.wordpress.org/public_html/dotorg/slack/community-deputies-calendly-webhook.php
@@ -9,6 +9,13 @@ use DateTime, DateTimeZone;
 require dirname( __DIR__, 2 ) . '/wp-init.php';
 require dirname( __DIR__, 2 ) . '/includes/slack-config.php';
 
+/*
+ * Calendly authenticates itself with the shared `COMMUNITY_CALENDLY_SECRET` passed in the webhook
+ * URL, verified below; nonces don't exist in server-to-server webhooks.
+ *
+ * phpcs:disable WordPress.Security.NonceVerification
+ */
+
 /**
  * Quick API wrapper for the Calendly API.
  */
@@ -40,6 +47,7 @@ function api_request( $url ) {
 		trigger_error(
 			'The Calendly token has probably been revoked, the password was probably changed.' .
 			'Please update the COMMUNITY_CALENDLY_TOKEN secrets constant with a new PAT created on https://calendly.com/integrations/api_webhooks from the WordCamp Calendly account.' .
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Plain-text PHP error log entry, not HTTP output.
 			wp_remote_retrieve_body( $req ),
 			E_USER_WARNING
 		);
@@ -49,7 +57,7 @@ function api_request( $url ) {
 }
 
 // Check the request is valid.
-if ( empty( $_GET['secret'] ) || ! hash_equals( COMMUNITY_CALENDLY_SECRET, $_GET['secret'] ) ) {
+if ( empty( $_GET['secret'] ) || ! hash_equals( COMMUNITY_CALENDLY_SECRET, wp_unslash( $_GET['secret'] ) ) ) {
 	header( 'HTTP/1.1 403 Forbidden' );
 	die( 'Invalid secret provided.' );
 }

--- a/api.wordpress.org/public_html/dotorg/slack/props.php
+++ b/api.wordpress.org/public_html/dotorg/slack/props.php
@@ -40,6 +40,7 @@ namespace Dotorg\Slack\Props {
 
 			header( 'X-Slack-No-Retry', 1 ); // Don't retry this event again.
 			trigger_error(
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Plain-text PHP error log entry, not HTTP output.
 				sprintf( 'Received retry for %s because: %s', $message_id, $headers['X-Slack-Retry-Reason'] ),
 				E_USER_NOTICE
 			);
@@ -51,6 +52,7 @@ namespace Dotorg\Slack\Props {
 		}
 
 	} catch ( Exception $exception ) {
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Plain-text PHP error log entry, not HTTP output.
 		trigger_error( $exception->getMessage(), E_USER_WARNING );
 
 	} finally {
@@ -59,6 +61,7 @@ namespace Dotorg\Slack\Props {
 		 * request, so this should still be 200 even if something goes wrong on our end.
 		 */
 		http_response_code( 200 );
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- plain-text response body for Slack.
 		die( $result );
 	}
 }

--- a/api.wordpress.org/public_html/dotorg/slack/security-team.php
+++ b/api.wordpress.org/public_html/dotorg/slack/security-team.php
@@ -2,10 +2,10 @@
 namespace Dotorg\Slack\Security_Team;
 
 if ( ! isset( $GLOBALS['wpdb'] ) ) {
-	require dirname( dirname( __DIR__ ) ) . '/includes/hyperdb/bb-10-hyper-db.php';
+	require dirname( __DIR__, 2 ) . '/includes/hyperdb/bb-10-hyper-db.php';
 }
 
-require dirname( dirname( __DIR__ ) ) . '/includes/slack-config.php';
+require dirname( __DIR__, 2 ) . '/includes/slack-config.php';
 
 /*
  * Standalone when requested directly: it loads HyperDB but not WordPress, so nothing is

--- a/api.wordpress.org/public_html/dotorg/slack/security-team.php
+++ b/api.wordpress.org/public_html/dotorg/slack/security-team.php
@@ -50,7 +50,7 @@ function get_security_team( $user_field = 'user_login' ) {
 
 	$slack_user_ids = $group['group']['members'];
 	$slack_user_ids = array_filter( $slack_user_ids, function( $user_id ) {
-		return (bool) preg_match( '/^U[A-Z0-9]+$/', $user_id );
+		return (bool) preg_match( '/^U[A-Z0-9]+\z/', $user_id );
 	});
 	$slack_user_ids_for_sql = "'" . implode( "', '", $slack_user_ids ) . "'";
 	$user_ids = $wpdb->get_col( "SELECT user_id FROM slack_users WHERE slack_id IN ($slack_user_ids_for_sql)" );

--- a/api.wordpress.org/public_html/dotorg/slack/security-team.php
+++ b/api.wordpress.org/public_html/dotorg/slack/security-team.php
@@ -66,7 +66,7 @@ function get_security_team( $user_field = 'user_login' ) {
 function api_call() {
 	header( 'Content-type: text/plain' );
 
-	// Confirm it came from the Trac server. An array (`token[]`) would make hash_equals() throw.
+	// Confirm it came from the Trac server.
 	if ( ! is_string( $_GET['token'] ?? null ) || ! hash_equals( API_TOKEN, $_GET['token'] ) ) {
 		exit;
 	}

--- a/api.wordpress.org/public_html/dotorg/slack/security-team.php
+++ b/api.wordpress.org/public_html/dotorg/slack/security-team.php
@@ -1,21 +1,18 @@
 <?php
+namespace Dotorg\Slack\Security_Team;
 
-namespace {
-	if ( ! isset( $GLOBALS['wpdb'] ) ) {
-		require dirname( dirname( __DIR__ ) ) . '/includes/hyperdb/bb-10-hyper-db.php';
-	}
+if ( ! isset( $GLOBALS['wpdb'] ) ) {
+	require dirname( dirname( __DIR__ ) ) . '/includes/hyperdb/bb-10-hyper-db.php';
 }
-
-namespace Dotorg\Slack\Security_Team {
 
 require dirname( dirname( __DIR__ ) ) . '/includes/slack-config.php';
 
-/* phpcs:disable Generic.WhiteSpace.ScopeIndent -- file-scope code here is historically unindented.
- * phpcs:disable WordPress.Security.NonceVerification
- * phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+/*
  * Standalone when requested directly: it loads HyperDB but not WordPress, so nothing is
  * slashed. (Also included as a library by trac/mentions-handler.php, which skips the
  * request handling below.) The Trac server authenticates with the shared API_TOKEN secret.
+ *
+ * phpcs:disable WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
  */
 
 function slack_api( $method, $content = array() ) {
@@ -69,8 +66,8 @@ function get_security_team( $user_field = 'user_login' ) {
 function api_call() {
 	header( 'Content-type: text/plain' );
 
-	// Confirm it came from the Trac server.
-	if ( ! hash_equals( API_TOKEN, $_GET['token'] ?? '' ) ) {
+	// Confirm it came from the Trac server. An array (`token[]`) would make hash_equals() throw.
+	if ( ! is_string( $_GET['token'] ?? null ) || ! hash_equals( API_TOKEN, $_GET['token'] ) ) {
 		exit;
 	}
 
@@ -92,6 +89,4 @@ function api_call() {
 // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- substring comparison only.
 if ( isset( $_SERVER['REQUEST_URI'] ) && false !== strpos( $_SERVER['REQUEST_URI'], '/security-team.php?token=' ) ) {
 	api_call();
-}
-
 }

--- a/api.wordpress.org/public_html/dotorg/slack/security-team.php
+++ b/api.wordpress.org/public_html/dotorg/slack/security-team.php
@@ -10,6 +10,14 @@ namespace Dotorg\Slack\Security_Team {
 
 require dirname( dirname( __DIR__ ) ) . '/includes/slack-config.php';
 
+/* phpcs:disable Generic.WhiteSpace.ScopeIndent -- file-scope code here is historically unindented.
+ * phpcs:disable WordPress.Security.NonceVerification
+ * phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+ * Standalone when requested directly: it loads HyperDB but not WordPress, so nothing is
+ * slashed. (Also included as a library by trac/mentions-handler.php, which skips the
+ * request handling below.) The Trac server authenticates with the shared API_TOKEN secret.
+ */
+
 function slack_api( $method, $content = array() ) {
 	$content['token'] = SLACK_TOKEN;
 	$content = http_build_query( $content );
@@ -76,10 +84,12 @@ function api_call() {
 		exit;
 	}
 
-	echo implode( "\n", $team ) . "\n"; // Trailing newline critical.
+	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- plain-text list; trailing newline critical.
+	echo implode( "\n", $team ) . "\n";
 	exit;
 }
 
+// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- substring comparison only.
 if ( isset( $_SERVER['REQUEST_URI'] ) && false !== strpos( $_SERVER['REQUEST_URI'], '/security-team.php?token=' ) ) {
 	api_call();
 }

--- a/api.wordpress.org/public_html/dotorg/slack/security-team.php
+++ b/api.wordpress.org/public_html/dotorg/slack/security-team.php
@@ -1,4 +1,16 @@
 <?php
+/**
+ * Slack security team membership helpers and Trac-facing API.
+ *
+ * Standalone when requested directly: it loads HyperDB but not WordPress, so nothing is
+ * slashed. (Also included as a library by trac/mentions-handler.php, which skips the
+ * request handling below.) The Trac server authenticates with the shared API_TOKEN secret.
+ *
+ * phpcs:disable WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+ *
+ * @package WordPressdotorg\API\Slack
+ */
+
 namespace Dotorg\Slack\Security_Team;
 
 if ( ! isset( $GLOBALS['wpdb'] ) ) {
@@ -6,14 +18,6 @@ if ( ! isset( $GLOBALS['wpdb'] ) ) {
 }
 
 require dirname( __DIR__, 2 ) . '/includes/slack-config.php';
-
-/*
- * Standalone when requested directly: it loads HyperDB but not WordPress, so nothing is
- * slashed. (Also included as a library by trac/mentions-handler.php, which skips the
- * request handling below.) The Trac server authenticates with the shared API_TOKEN secret.
- *
- * phpcs:disable WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
- */
 
 function slack_api( $method, $content = array() ) {
 	$content['token'] = SLACK_TOKEN;

--- a/api.wordpress.org/public_html/dotorg/slack/subgroup.php
+++ b/api.wordpress.org/public_html/dotorg/slack/subgroup.php
@@ -151,11 +151,11 @@ function handle_slash_command() {
 		],
 	];
 
-	$channel_id = filter_var( $_POST['channel_id'] ?? '', FILTER_VALIDATE_REGEXP, $id_options );
-	$user_id    = filter_var( $_POST['user_id'] ?? '', FILTER_VALIDATE_REGEXP, $id_options );
+	$channel_id = (string) filter_var( $_POST['channel_id'] ?? '', FILTER_VALIDATE_REGEXP, $id_options );
+	$user_id    = (string) filter_var( $_POST['user_id'] ?? '', FILTER_VALIDATE_REGEXP, $id_options );
 
 	// A trigger ID, eg. `13345224609.738474920.8088930838d88f008e0`.
-	$trigger_id = filter_var(
+	$trigger_id = (string) filter_var(
 		$_POST['trigger_id'] ?? '',
 		FILTER_VALIDATE_REGEXP,
 		[

--- a/api.wordpress.org/public_html/dotorg/slack/subgroup.php
+++ b/api.wordpress.org/public_html/dotorg/slack/subgroup.php
@@ -1,17 +1,20 @@
 <?php
-
-namespace Dotorg\Slack\Subgroup;
-
-require dirname( dirname( __DIR__ ) ) . '/includes/slack-config.php';
-
-/*
+/**
+ * Slack /subgroup app: slash command and interactivity endpoint.
+ *
  * This is a standalone Slack app endpoint: only the object cache is loaded, not WordPress, so
  * request data is never slashed. Slack authenticates every request with an HMAC signature over the
  * raw request body, verified in `verify_slack_signature()` before anything is dispatched; nonces
  * don't exist in server-to-server webhooks.
  *
  * phpcs:disable WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+ *
+ * @package WordPressdotorg\API\Slack
  */
+
+namespace Dotorg\Slack\Subgroup;
+
+require dirname( dirname( __DIR__ ) ) . '/includes/slack-config.php';
 
 const CACHE_GROUP                 = 'api-slack-subgroup';
 const CACHE_TTL_ACTIVE_CHANNELS   = 120;     // Users can create channels outside this app.

--- a/api.wordpress.org/public_html/dotorg/slack/subgroup.php
+++ b/api.wordpress.org/public_html/dotorg/slack/subgroup.php
@@ -101,7 +101,7 @@ function verify_slack_signature( $body ) {
 		FILTER_VALIDATE_REGEXP,
 		[
 			'options' => [
-				'regexp'  => '/^\d+$/',
+				'regexp'  => '/^\d+\z/',
 				'default' => '',
 			],
 		]
@@ -111,7 +111,7 @@ function verify_slack_signature( $body ) {
 		FILTER_VALIDATE_REGEXP,
 		[
 			'options' => [
-				'regexp'  => '/^v0=[0-9a-f]{64}$/',
+				'regexp'  => '/^v0=[0-9a-f]{64}\z/',
 				'default' => '',
 			],
 		]
@@ -146,7 +146,7 @@ function handle_slash_command() {
 	// Slack channel and user IDs are uppercase alphanumeric, eg. `C0123ABCD` and `U0123ABCD`.
 	$id_options = [
 		'options' => [
-			'regexp'  => '/^[A-Z0-9]+$/',
+			'regexp'  => '/^[A-Z0-9]+\z/',
 			'default' => '',
 		],
 	];
@@ -160,7 +160,7 @@ function handle_slash_command() {
 		FILTER_VALIDATE_REGEXP,
 		[
 			'options' => [
-				'regexp'  => '/^[A-Za-z0-9.]+$/',
+				'regexp'  => '/^[A-Za-z0-9.]+\z/',
 				'default' => '',
 			],
 		]
@@ -743,7 +743,7 @@ function finalize_create( $new_id, $name, $creator, $parent_id, $parent_name, $u
 	// conversations.invite fails the entire batch on one malformed ID. Filter
 	// defensively so a stray character in a config value can't sink everyone.
 	$valid_invitees = array_values( array_filter( $invitees, function ( $id ) {
-		return preg_match( '/^[UWB][A-Z0-9]+$/', $id );
+		return preg_match( '/^[UWB][A-Z0-9]+\z/', $id );
 	} ) );
 	$invitees = $valid_invitees;
 

--- a/api.wordpress.org/public_html/dotorg/slack/subgroup.php
+++ b/api.wordpress.org/public_html/dotorg/slack/subgroup.php
@@ -132,11 +132,7 @@ if ( ! verify_slack_signature( $raw_body ) ) {
 
 // Dispatch: slash command vs. interactivity callback.
 if ( isset( $_POST['payload'] ) ) {
-	/*
-	 * A JSON document covered by the verified signature above; sanitizing it would
-	 * corrupt it. Individual fields are validated where they're read.
-	 * phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-	 */
+	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- JSON document covered by the verified signature above; fields are validated where read.
 	$payload = json_decode( $_POST['payload'], true );
 	handle_interaction( $payload );
 	exit;

--- a/api.wordpress.org/public_html/dotorg/slack/subgroup.php
+++ b/api.wordpress.org/public_html/dotorg/slack/subgroup.php
@@ -4,6 +4,15 @@ namespace Dotorg\Slack\Subgroup;
 
 require dirname( dirname( __DIR__ ) ) . '/includes/slack-config.php';
 
+/*
+ * This is a standalone Slack app endpoint: only the object cache is loaded, not WordPress, so
+ * request data is never slashed. Slack authenticates every request with an HMAC signature over the
+ * raw request body, verified in `verify_slack_signature()` before anything is dispatched; nonces
+ * don't exist in server-to-server webhooks.
+ *
+ * phpcs:disable WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+ */
+
 const CACHE_GROUP                 = 'api-slack-subgroup';
 const CACHE_TTL_ACTIVE_CHANNELS   = 120;     // Users can create channels outside this app.
 const CACHE_TTL_ARCHIVED_CHANNELS = 3600;    // Archives are slower-moving.
@@ -83,8 +92,27 @@ function ack_and_finish() {
 }
 
 function verify_slack_signature( $body ) {
-	$timestamp = $_SERVER['HTTP_X_SLACK_REQUEST_TIMESTAMP'] ?? '';
-	$signature = $_SERVER['HTTP_X_SLACK_SIGNATURE'] ?? '';
+	// A Unix timestamp, and a `v0=` prefixed HMAC-SHA256 hex digest. Anything else can't be from Slack.
+	$timestamp = filter_var(
+		$_SERVER['HTTP_X_SLACK_REQUEST_TIMESTAMP'] ?? '',
+		FILTER_VALIDATE_REGEXP,
+		[
+			'options' => [
+				'regexp'  => '/^\d+$/',
+				'default' => '',
+			],
+		]
+	);
+	$signature = filter_var(
+		$_SERVER['HTTP_X_SLACK_SIGNATURE'] ?? '',
+		FILTER_VALIDATE_REGEXP,
+		[
+			'options' => [
+				'regexp'  => '/^v0=[0-9a-f]{64}$/',
+				'default' => '',
+			],
+		]
+	);
 	if ( ! $timestamp || ! $signature ) {
 		return false;
 	}
@@ -104,6 +132,11 @@ if ( ! verify_slack_signature( $raw_body ) ) {
 
 // Dispatch: slash command vs. interactivity callback.
 if ( isset( $_POST['payload'] ) ) {
+	/*
+	 * A JSON document covered by the verified signature above; sanitizing it would
+	 * corrupt it. Individual fields are validated where they're read.
+	 * phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+	 */
 	$payload = json_decode( $_POST['payload'], true );
 	handle_interaction( $payload );
 	exit;
@@ -111,9 +144,28 @@ if ( isset( $_POST['payload'] ) ) {
 handle_slash_command();
 
 function handle_slash_command() {
-	$channel_id = $_POST['channel_id'] ?? '';
-	$user_id    = $_POST['user_id'] ?? '';
-	$trigger_id = $_POST['trigger_id'] ?? '';
+	// Slack channel and user IDs are uppercase alphanumeric, eg. `C0123ABCD` and `U0123ABCD`.
+	$id_options = [
+		'options' => [
+			'regexp'  => '/^[A-Z0-9]+$/',
+			'default' => '',
+		],
+	];
+
+	$channel_id = filter_var( $_POST['channel_id'] ?? '', FILTER_VALIDATE_REGEXP, $id_options );
+	$user_id    = filter_var( $_POST['user_id'] ?? '', FILTER_VALIDATE_REGEXP, $id_options );
+
+	// A trigger ID, eg. `13345224609.738474920.8088930838d88f008e0`.
+	$trigger_id = filter_var(
+		$_POST['trigger_id'] ?? '',
+		FILTER_VALIDATE_REGEXP,
+		[
+			'options' => [
+				'regexp'  => '/^[A-Za-z0-9.]+$/',
+				'default' => '',
+			],
+		]
+	);
 
 	// trigger_id is only valid for 3s, and listing every subgroup's membership will take
 	// longer than that. Open a loading view now, then views.update after we have the data.

--- a/api.wordpress.org/public_html/dotorg/slack/trac-bot.php
+++ b/api.wordpress.org/public_html/dotorg/slack/trac-bot.php
@@ -129,8 +129,7 @@ namespace Dotorg\Slack\Trac {
 
 		$trac_xmlrpc = new \Trac( 'slackbot', SLACKBOT_WPORG_PASSWORD, "https://$trac.trac.wordpress.org/login/xmlrpc" );
 
-		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- local to this webhook script.
-		$comment = sprintf( $comment_template, $channel_name, $user_name, str_replace( '.', '', $msg_timestamp ) );
+		$trac_comment = sprintf( $comment_template, $channel_name, $user_name, str_replace( '.', '', $msg_timestamp ) );
 		foreach ( $results['ticket'] as $ticket ) {
 			$ticket_id = is_array( $ticket ) ? $ticket['id'] : $ticket;
 
@@ -154,7 +153,7 @@ namespace Dotorg\Slack\Trac {
 
 			$parser->set_redundancy( 'trac', $trac, 'ticket', $ticket_id );
 
-			$trac_xmlrpc->ticket_update( $ticket_id, $comment );
+			$trac_xmlrpc->ticket_update( $ticket_id, $trac_comment );
 		}
 	}
 }

--- a/api.wordpress.org/public_html/dotorg/slack/trac-bot.php
+++ b/api.wordpress.org/public_html/dotorg/slack/trac-bot.php
@@ -16,8 +16,8 @@ namespace Dotorg\Slack\Trac {
 	 * phpcs:disable WordPress.Security.NonceVerification
 	 */
 
-	// Verify it came from Slack.
-	if ( ! hash_equals( URL_SECRET__TRAC_BOT, wp_unslash( $_GET['token'] ?? '' ) ) ) {
+	// Verify it came from Slack. An array (`token[]`) would make hash_equals() throw.
+	if ( ! is_string( $_GET['token'] ?? null ) || ! hash_equals( URL_SECRET__TRAC_BOT, wp_unslash( $_GET['token'] ) ) ) {
 		return;
 	}
 

--- a/api.wordpress.org/public_html/dotorg/slack/trac-bot.php
+++ b/api.wordpress.org/public_html/dotorg/slack/trac-bot.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * Slack outgoing-webhook Trac bot: expands ticket and changeset references.
+ *
+ * Slack authenticates itself with the shared `URL_SECRET__TRAC_BOT` secret passed in the
+ * outgoing webhook URL, verified below; nonces don't exist in server-to-server webhooks.
+ *
+ * phpcs:disable WordPress.Security.NonceVerification
+ *
+ * @package WordPressdotorg\API\Slack
+ */
 
 namespace {
 	require dirname( dirname( __DIR__ ) ) . '/wp-init.php';
@@ -9,12 +19,6 @@ namespace {
 }
 
 namespace Dotorg\Slack\Trac {
-	/*
-	 * Slack authenticates itself with the shared `URL_SECRET__TRAC_BOT` secret passed in the
-	 * outgoing webhook URL, verified below; nonces don't exist in server-to-server webhooks.
-	 *
-	 * phpcs:disable WordPress.Security.NonceVerification
-	 */
 
 	// Verify it came from Slack.
 	if ( ! is_string( $_GET['token'] ?? null ) || ! hash_equals( URL_SECRET__TRAC_BOT, wp_unslash( $_GET['token'] ) ) ) {

--- a/api.wordpress.org/public_html/dotorg/slack/trac-bot.php
+++ b/api.wordpress.org/public_html/dotorg/slack/trac-bot.php
@@ -9,14 +9,28 @@ namespace {
 }
 
 namespace Dotorg\Slack\Trac {
+	/*
+	 * Slack authenticates itself with the shared `URL_SECRET__TRAC_BOT` secret passed in the
+	 * outgoing webhook URL, verified below; nonces don't exist in server-to-server webhooks.
+	 *
+	 * phpcs:disable WordPress.Security.NonceVerification
+	 */
 
 	// Verify it came from Slack.
-	if ( ! hash_equals( URL_SECRET__TRAC_BOT, $_GET['token'] ?? '' ) ) {
+	if ( ! hash_equals( URL_SECRET__TRAC_BOT, wp_unslash( $_GET['token'] ?? '' ) ) ) {
 		return;
 	}
 
+	/*
+	 * The Slack channel name, user name, and message timestamp are interpolated into the Trac
+	 * comment and the message permalink below.
+	 */
+	$channel_name  = sanitize_text_field( wp_unslash( $_POST['channel_name'] ?? '' ) );
+	$user_name     = sanitize_text_field( wp_unslash( $_POST['user_name'] ?? '' ) );
+	$msg_timestamp = sanitize_text_field( wp_unslash( $_POST['timestamp'] ?? '' ) );
+
 	// Prevent recursion.
-	if ( $_POST['user_name'] === 'slackbot' ) {
+	if ( 'slackbot' === $user_name ) {
 		return;
 	}
 
@@ -99,7 +113,7 @@ namespace Dotorg\Slack\Trac {
 
 		$slack->send( $parser->get_channel(), $parser->get_thread() );
 
-		if ( $_POST['channel_name'] === 'test' ) {
+		if ( 'test' === $channel_name ) {
 			// Don't post to Trac if we're coming from #test.
 			continue;
 		}
@@ -111,7 +125,8 @@ namespace Dotorg\Slack\Trac {
 
 		$trac_xmlrpc = new \Trac( 'slackbot', SLACKBOT_WPORG_PASSWORD, "https://$trac.trac.wordpress.org/login/xmlrpc" );
 
-		$comment = sprintf( $comment_template, $_POST['channel_name'], $_POST['user_name'], str_replace( '.', '', $_POST['timestamp'] ) );
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- local to this webhook script.
+		$comment = sprintf( $comment_template, $channel_name, $user_name, str_replace( '.', '', $msg_timestamp ) );
 		foreach ( $results['ticket'] as $ticket ) {
 			$ticket_id = is_array( $ticket ) ? $ticket['id'] : $ticket;
 

--- a/api.wordpress.org/public_html/dotorg/slack/trac-bot.php
+++ b/api.wordpress.org/public_html/dotorg/slack/trac-bot.php
@@ -16,7 +16,7 @@ namespace Dotorg\Slack\Trac {
 	 * phpcs:disable WordPress.Security.NonceVerification
 	 */
 
-	// Verify it came from Slack. An array (`token[]`) would make hash_equals() throw.
+	// Verify it came from Slack.
 	if ( ! is_string( $_GET['token'] ?? null ) || ! hash_equals( URL_SECRET__TRAC_BOT, wp_unslash( $_GET['token'] ) ) ) {
 		return;
 	}


### PR DESCRIPTION
Part of a sweep resolving all `WordPress.Security` PHPCS findings on the api.wordpress.org webhook handlers.

- Slack signature headers and timestamps are format-validated before the constant-time comparison in subgroup's HMAC check.
- Channel, user, and trigger IDs are validated against Slack's ID formats.
- User names echoed back into responses are stripped of control characters; token comparisons no longer warn when the token parameter is absent.
- Each handler documents its actual authentication mechanism (shared token or HMAC signature) in a justified file-level nonce disable; unslash is disabled only where WordPress genuinely isn't loaded — where it is loaded (calendly, trac-bot), `wp_unslash()`/`sanitize_text_field()` are used instead.

All files report zero `WordPress.Security` violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)