### PR TITLE
Plugin Directory: Attribute SVN changes to the plugin each path belongs to

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-svn-watcher.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-svn-watcher.php
@@ -106,10 +106,22 @@ class SVN_Watcher {
 			return array();
 		}
 
-		// Summarize the plugin changes down into something more useful
+		return $this->summarize_plugin_changes( $logs['log'] );
+	}
+
+	/**
+	 * Summarizes a set of SVN log entries into per-plugin change data.
+	 *
+	 * A single commit may span multiple plugins, so the plugin each change belongs to is
+	 * determined from the individual path rather than from the commit as a whole.
+	 *
+	 * @param array $logs A list of log entries, as returned by SVN::log()'s 'log' key.
+	 * @return array A list of plugin changes to process, keyed by plugin slug.
+	 */
+	protected function summarize_plugin_changes( $logs ) {
 		$plugins = array();
 
-		foreach ( $logs['log'] as $log ) {
+		foreach ( $logs as $log ) {
 			// Discard some commits from the plugin management user.
 			if (
 				defined( 'PLUGIN_SVN_MANAGEMENT_USER' ) &&
@@ -133,22 +145,6 @@ class SVN_Watcher {
 				}
 			}
 
-			$plugin_slug = explode( '/', $log['paths'][0] )[1];
-
-			if ( ! isset( $plugins[ $plugin_slug ] ) ) {
-				$plugins[ $plugin_slug ] = array(
-					'tags_touched'   => array(), // trunk is a tag too!
-					'tags_deleted'   => array(),
-					'readme_touched' => false, // minor optimization, only parse readme i18n on readme-related commits
-					'code_touched'   => false,
-					'assets_touched' => false,
-					'revisions'      => array(),
-				);
-			}
-			$plugin =& $plugins[ $plugin_slug ];
-
-			// Keep track of the lowest revision number we've seen for this plugin
-			$plugin['revisions'][] = $log['revision'];
 			foreach ( $log['paths'] as $path ) {
 				$path_parts  = explode( '/', trim( $path, '/' ) );
 				$is_deletion = ( isset( $log['actions'][ $path ] ) && 'D' === $log['actions'][ $path ] );
@@ -156,10 +152,30 @@ class SVN_Watcher {
 				if ( ! isset( $path_parts[1] ) ) {
 					continue;
 				}
-		
+
+				// A commit can span multiple plugins, so each path names the plugin it affects.
+				$plugin_slug = $path_parts[0];
+
+				if ( ! isset( $plugins[ $plugin_slug ] ) ) {
+					$plugins[ $plugin_slug ] = array(
+						'tags_touched'   => array(), // trunk is a tag too!
+						'tags_deleted'   => array(),
+						'readme_touched' => false, // minor optimization, only parse readme i18n on readme-related commits
+						'code_touched'   => false,
+						'assets_touched' => false,
+						'revisions'      => array(),
+					);
+				}
+				$plugin =& $plugins[ $plugin_slug ];
+
+				// Keep track of the revisions we've seen for this plugin.
+				if ( ! in_array( $log['revision'], $plugin['revisions'], true ) ) {
+					$plugin['revisions'][] = $log['revision'];
+				}
+
 				if ( 'trunk' == $path_parts[1] ) {
 					$plugin['tags_touched'][] = 'trunk';
-		
+
 				} elseif ( 'tags' == $path_parts[1] && isset( $path_parts[2] ) ) {
 					if ( $is_deletion && ! isset( $path_parts[3] ) /* not a file deletion */ ) {
 						$plugin['tags_deleted'][] = $path_parts[2];
@@ -169,7 +185,7 @@ class SVN_Watcher {
 
 				} elseif ( 'assets' == $path_parts[1] ) {
 					$plugin['assets_touched'] = true;
-		
+
 				}
 
 				// Only count the readme at the root of /trunk or a tag — a readme.txt in a subdirectory is just bundled documentation.
@@ -179,9 +195,15 @@ class SVN_Watcher {
 				if ( ! $plugin['code_touched'] && ( '/' === substr( $path, -1 ) || '.php' === substr( $path, -4 ) || '.js' === substr( $path, -3 ) ) ) {
 					$plugin['code_touched'] = true;
 				}
-			}
 
-			$plugin['tags_touched'] = array_values( array_unique( $plugin['tags_touched'] ) );
+				// Break the reference, so the next iteration doesn't write through it.
+				unset( $plugin );
+			}
+		}
+
+		foreach ( $plugins as $plugin_slug => $plugin ) {
+			$plugins[ $plugin_slug ]['tags_touched'] = array_values( array_unique( $plugin['tags_touched'] ) );
+			$plugins[ $plugin_slug ]['tags_deleted'] = array_values( array_unique( $plugin['tags_deleted'] ) );
 		}
 
 		// Sort plugins by minimum revision, it should already be in this order, but double check.

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-svn-watcher.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-svn-watcher.php
@@ -160,7 +160,7 @@ class SVN_Watcher {
 					$plugins[ $plugin_slug ] = array(
 						'tags_touched'   => array(), // trunk is a tag too!
 						'tags_deleted'   => array(),
-						'readme_touched' => false, // minor optimization, only parse readme i18n on readme-related commits
+						'readme_touched' => false, // minor optimization, only parse readme i18n on readme-related commits.
 						'code_touched'   => false,
 						'assets_touched' => false,
 						'revisions'      => array(),

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/SVN_Watcher_Log_Summary_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/SVN_Watcher_Log_Summary_Test.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Tests for SVN_Watcher::summarize_plugin_changes().
+ *
+ * @package WordPressdotorg\Plugin_Directory\Tests
+ */
+
+use PHPUnit\Framework\TestCase;
+use WordPressdotorg\Plugin_Directory\CLI\SVN_Watcher;
+
+/**
+ * @group cli
+ */
+class SVN_Watcher_Log_Summary_Test extends TestCase {
+
+	/**
+	 * Invoke the protected SVN_Watcher::summarize_plugin_changes() helper.
+	 */
+	private function summarize( array $logs ): array {
+		$method = new ReflectionMethod( SVN_Watcher::class, 'summarize_plugin_changes' );
+		$method->setAccessible( true );
+
+		return $method->invoke( new SVN_Watcher(), $logs );
+	}
+
+	/**
+	 * Build a log entry in the shape SVN::log() returns.
+	 *
+	 * @param int    $revision The revision number.
+	 * @param array  $paths    Map of path => action, or a list of paths (assumed modified).
+	 * @param string $author   The commit author.
+	 * @param string $message  The commit message.
+	 */
+	private function log_entry( int $revision, array $paths, string $author = 'committer', string $message = '' ): array {
+		$actions = array();
+
+		foreach ( $paths as $key => $value ) {
+			if ( is_int( $key ) ) {
+				$actions[ $value ] = 'M';
+			} else {
+				$actions[ $key ] = $value;
+			}
+		}
+
+		return array(
+			'revision' => $revision,
+			'author'   => $author,
+			'date'     => 0,
+			'paths'    => array_keys( $actions ),
+			'actions'  => $actions,
+			'message'  => $message,
+		);
+	}
+
+	/**
+	 * A single commit can span several plugins — a "bump Tested up to" sweep across a
+	 * committer's whole portfolio, for example. Each path has to be attributed to the
+	 * plugin it actually belongs to, rather than every path being credited to whichever
+	 * plugin happened to sort first in the commit.
+	 */
+	public function test_commit_spanning_multiple_plugins_is_split_per_plugin() {
+		$plugins = $this->summarize( array(
+			$this->log_entry( 3644696, array(
+				'/autoclose/tags/3.1.2/readme.txt',
+				'/autoclose/trunk/readme.txt',
+				'/better-search/tags/4.4.0/readme.txt',
+				'/better-search/trunk/readme.txt',
+				'/top-10/tags/4.4.2/readme.txt',
+			), 'Ajay', 'Update Tested up to: 7.1' ),
+		) );
+
+		$this->assertEqualsCanonicalizing(
+			array( 'autoclose', 'better-search', 'top-10' ),
+			array_keys( $plugins ),
+			'Every plugin in the commit should be queued for import.'
+		);
+
+		$this->assertEqualsCanonicalizing( array( 'trunk', '3.1.2' ), $plugins['autoclose']['tags_touched'] );
+		$this->assertEqualsCanonicalizing( array( 'trunk', '4.4.0' ), $plugins['better-search']['tags_touched'] );
+		$this->assertEqualsCanonicalizing( array( '4.4.2' ), $plugins['top-10']['tags_touched'] );
+
+		// The regression: another plugin's tags must never leak into the first plugin of the commit.
+		$this->assertNotContains( '4.4.0', $plugins['autoclose']['tags_touched'] );
+		$this->assertNotContains( '4.4.2', $plugins['autoclose']['tags_touched'] );
+	}
+
+	/**
+	 * The per-plugin flags describe that plugin's paths only, and shouldn't be set by
+	 * what a different plugin in the same commit happened to change.
+	 */
+	public function test_flags_are_not_shared_between_plugins_in_one_commit() {
+		$plugins = $this->summarize( array(
+			$this->log_entry( 100, array(
+				'/plugin-a/trunk/readme.txt',
+				'/plugin-b/trunk/plugin-b.php',
+				'/plugin-c/assets/banner-772x250.png',
+			) ),
+		) );
+
+		$this->assertTrue( $plugins['plugin-a']['readme_touched'] );
+		$this->assertFalse( $plugins['plugin-a']['code_touched'] );
+		$this->assertFalse( $plugins['plugin-a']['assets_touched'] );
+
+		$this->assertFalse( $plugins['plugin-b']['readme_touched'] );
+		$this->assertTrue( $plugins['plugin-b']['code_touched'] );
+		$this->assertFalse( $plugins['plugin-b']['assets_touched'] );
+
+		$this->assertFalse( $plugins['plugin-c']['readme_touched'] );
+		$this->assertTrue( $plugins['plugin-c']['assets_touched'] );
+		$this->assertSame( array(), $plugins['plugin-c']['tags_touched'] );
+	}
+
+	/**
+	 * Each plugin should record the revision once, however many of its paths the commit touched.
+	 */
+	public function test_revisions_are_recorded_once_per_commit() {
+		$plugins = $this->summarize( array(
+			$this->log_entry( 200, array(
+				'/plugin-a/trunk/plugin-a.php',
+				'/plugin-a/trunk/readme.txt',
+				'/plugin-a/tags/1.0/plugin-a.php',
+			) ),
+		) );
+
+		$this->assertSame( array( 200 ), $plugins['plugin-a']['revisions'] );
+		$this->assertEqualsCanonicalizing( array( 'trunk', '1.0' ), $plugins['plugin-a']['tags_touched'] );
+	}
+
+	/**
+	 * Revisions accumulate across commits, and plugins come back ordered by their earliest revision.
+	 */
+	public function test_multiple_commits_accumulate_and_sort_by_earliest_revision() {
+		$plugins = $this->summarize( array(
+			$this->log_entry( 300, array( '/plugin-b/trunk/readme.txt' ) ),
+			$this->log_entry( 301, array( '/plugin-a/trunk/readme.txt' ) ),
+			$this->log_entry( 302, array( '/plugin-b/tags/2.0/readme.txt' ) ),
+		) );
+
+		$this->assertSame( array( 'plugin-b', 'plugin-a' ), array_keys( $plugins ) );
+		$this->assertSame( array( 300, 302 ), $plugins['plugin-b']['revisions'] );
+		$this->assertEqualsCanonicalizing( array( 'trunk', '2.0' ), $plugins['plugin-b']['tags_touched'] );
+	}
+
+	/**
+	 * Deleting a tag directory is a deletion; deleting a file inside a tag is just a change to it.
+	 */
+	public function test_tag_deletion_is_distinguished_from_a_file_deletion_within_a_tag() {
+		$plugins = $this->summarize( array(
+			$this->log_entry( 400, array(
+				'/plugin-a/tags/1.0'          => 'D',
+				'/plugin-a/tags/2.0/stale.php' => 'D',
+			) ),
+		) );
+
+		$this->assertSame( array( '1.0' ), $plugins['plugin-a']['tags_deleted'] );
+		$this->assertSame( array( '2.0' ), $plugins['plugin-a']['tags_touched'] );
+	}
+
+	/**
+	 * Paths that don't name anything below the plugin root carry no importable change.
+	 */
+	public function test_bare_plugin_root_paths_are_ignored() {
+		$plugins = $this->summarize( array(
+			$this->log_entry( 500, array(
+				'/plugin-a'                 => 'A',
+				'/plugin-b/trunk/readme.txt' => 'M',
+			) ),
+		) );
+
+		$this->assertSame( array( 'plugin-b' ), array_keys( $plugins ) );
+	}
+}

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/SVN_Watcher_Log_Summary_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/SVN_Watcher_Log_Summary_Test.php
@@ -9,12 +9,17 @@ use PHPUnit\Framework\TestCase;
 use WordPressdotorg\Plugin_Directory\CLI\SVN_Watcher;
 
 /**
+ * Tests that SVN log entries are attributed to the right plugin.
+ *
  * @group cli
  */
 class SVN_Watcher_Log_Summary_Test extends TestCase {
 
 	/**
 	 * Invoke the protected SVN_Watcher::summarize_plugin_changes() helper.
+	 *
+	 * @param array $logs A list of log entries, as returned by SVN::log()'s 'log' key.
+	 * @return array The per-plugin change data.
 	 */
 	private function summarize( array $logs ): array {
 		$method = new ReflectionMethod( SVN_Watcher::class, 'summarize_plugin_changes' );
@@ -59,15 +64,22 @@ class SVN_Watcher_Log_Summary_Test extends TestCase {
 	 * plugin happened to sort first in the commit.
 	 */
 	public function test_commit_spanning_multiple_plugins_is_split_per_plugin() {
-		$plugins = $this->summarize( array(
-			$this->log_entry( 3644696, array(
-				'/autoclose/tags/3.1.2/readme.txt',
-				'/autoclose/trunk/readme.txt',
-				'/better-search/tags/4.4.0/readme.txt',
-				'/better-search/trunk/readme.txt',
-				'/top-10/tags/4.4.2/readme.txt',
-			), 'Ajay', 'Update Tested up to: 7.1' ),
-		) );
+		$plugins = $this->summarize(
+			array(
+				$this->log_entry(
+					3644696,
+					array(
+						'/autoclose/tags/3.1.2/readme.txt',
+						'/autoclose/trunk/readme.txt',
+						'/better-search/tags/4.4.0/readme.txt',
+						'/better-search/trunk/readme.txt',
+						'/top-10/tags/4.4.2/readme.txt',
+					),
+					'Ajay',
+					'Update Tested up to: 7.1'
+				),
+			)
+		);
 
 		$this->assertEqualsCanonicalizing(
 			array( 'autoclose', 'better-search', 'top-10' ),
@@ -89,13 +101,18 @@ class SVN_Watcher_Log_Summary_Test extends TestCase {
 	 * what a different plugin in the same commit happened to change.
 	 */
 	public function test_flags_are_not_shared_between_plugins_in_one_commit() {
-		$plugins = $this->summarize( array(
-			$this->log_entry( 100, array(
-				'/plugin-a/trunk/readme.txt',
-				'/plugin-b/trunk/plugin-b.php',
-				'/plugin-c/assets/banner-772x250.png',
-			) ),
-		) );
+		$plugins = $this->summarize(
+			array(
+				$this->log_entry(
+					100,
+					array(
+						'/plugin-a/trunk/readme.txt',
+						'/plugin-b/trunk/plugin-b.php',
+						'/plugin-c/assets/banner-772x250.png',
+					)
+				),
+			)
+		);
 
 		$this->assertTrue( $plugins['plugin-a']['readme_touched'] );
 		$this->assertFalse( $plugins['plugin-a']['code_touched'] );
@@ -114,13 +131,18 @@ class SVN_Watcher_Log_Summary_Test extends TestCase {
 	 * Each plugin should record the revision once, however many of its paths the commit touched.
 	 */
 	public function test_revisions_are_recorded_once_per_commit() {
-		$plugins = $this->summarize( array(
-			$this->log_entry( 200, array(
-				'/plugin-a/trunk/plugin-a.php',
-				'/plugin-a/trunk/readme.txt',
-				'/plugin-a/tags/1.0/plugin-a.php',
-			) ),
-		) );
+		$plugins = $this->summarize(
+			array(
+				$this->log_entry(
+					200,
+					array(
+						'/plugin-a/trunk/plugin-a.php',
+						'/plugin-a/trunk/readme.txt',
+						'/plugin-a/tags/1.0/plugin-a.php',
+					)
+				),
+			)
+		);
 
 		$this->assertSame( array( 200 ), $plugins['plugin-a']['revisions'] );
 		$this->assertEqualsCanonicalizing( array( 'trunk', '1.0' ), $plugins['plugin-a']['tags_touched'] );
@@ -130,11 +152,13 @@ class SVN_Watcher_Log_Summary_Test extends TestCase {
 	 * Revisions accumulate across commits, and plugins come back ordered by their earliest revision.
 	 */
 	public function test_multiple_commits_accumulate_and_sort_by_earliest_revision() {
-		$plugins = $this->summarize( array(
-			$this->log_entry( 300, array( '/plugin-b/trunk/readme.txt' ) ),
-			$this->log_entry( 301, array( '/plugin-a/trunk/readme.txt' ) ),
-			$this->log_entry( 302, array( '/plugin-b/tags/2.0/readme.txt' ) ),
-		) );
+		$plugins = $this->summarize(
+			array(
+				$this->log_entry( 300, array( '/plugin-b/trunk/readme.txt' ) ),
+				$this->log_entry( 301, array( '/plugin-a/trunk/readme.txt' ) ),
+				$this->log_entry( 302, array( '/plugin-b/tags/2.0/readme.txt' ) ),
+			)
+		);
 
 		$this->assertSame( array( 'plugin-b', 'plugin-a' ), array_keys( $plugins ) );
 		$this->assertSame( array( 300, 302 ), $plugins['plugin-b']['revisions'] );
@@ -145,12 +169,17 @@ class SVN_Watcher_Log_Summary_Test extends TestCase {
 	 * Deleting a tag directory is a deletion; deleting a file inside a tag is just a change to it.
 	 */
 	public function test_tag_deletion_is_distinguished_from_a_file_deletion_within_a_tag() {
-		$plugins = $this->summarize( array(
-			$this->log_entry( 400, array(
-				'/plugin-a/tags/1.0'          => 'D',
-				'/plugin-a/tags/2.0/stale.php' => 'D',
-			) ),
-		) );
+		$plugins = $this->summarize(
+			array(
+				$this->log_entry(
+					400,
+					array(
+						'/plugin-a/tags/1.0'           => 'D',
+						'/plugin-a/tags/2.0/stale.php' => 'D',
+					)
+				),
+			)
+		);
 
 		$this->assertSame( array( '1.0' ), $plugins['plugin-a']['tags_deleted'] );
 		$this->assertSame( array( '2.0' ), $plugins['plugin-a']['tags_touched'] );
@@ -160,12 +189,17 @@ class SVN_Watcher_Log_Summary_Test extends TestCase {
 	 * Paths that don't name anything below the plugin root carry no importable change.
 	 */
 	public function test_bare_plugin_root_paths_are_ignored() {
-		$plugins = $this->summarize( array(
-			$this->log_entry( 500, array(
-				'/plugin-a'                 => 'A',
-				'/plugin-b/trunk/readme.txt' => 'M',
-			) ),
-		) );
+		$plugins = $this->summarize(
+			array(
+				$this->log_entry(
+					500,
+					array(
+						'/plugin-a'                  => 'A',
+						'/plugin-b/trunk/readme.txt' => 'M',
+					)
+				),
+			)
+		);
 
 		$this->assertSame( array( 'plugin-b' ), array_keys( $plugins ) );
 	}


### PR DESCRIPTION
## Problem

`SVN_Watcher::get_plugin_changes_between()` assumed one commit touches one plugin. It derived the slug from **only the first path** of the commit:

```php
$plugin_slug = explode( '/', $log['paths'][0] )[1];
```

…and then walked *every* path in that commit, appending each tag to that single plugin's `tags_touched`.

A commit spanning multiple plugins — e.g. a committer bumping "Tested up to" across their whole portfolio — is therefore misread completely.

## Observed impact

r3644696 on plugins.svn touched nine plugins in one commit. `autoclose` sorted first, so it absorbed everything:

```
E_USER_WARNING: ZIP build failed for autoclose 4.4.0: … URL 'https://plugins.svn.wordpress.org/autoclose/tags/4.4.0' doesn't exist
E_USER_WARNING: ZIP build failed for autoclose 4.3.0: … doesn't exist
E_USER_WARNING: ZIP build failed for autoclose 4.4.2: … doesn't exist
```

`4.4.0` is better-search's tag, `4.3.0` contextual-related-posts', `4.4.2` top-10's. `autoclose` has never had a 4.x release.

Two consequences beyond the log noise:

1. **A colliding tag gets rebuilt silently.** knowledgebase's `3.1.1` also exists as an `autoclose` tag, so that ZIP was re-exported and re-committed for no reason — no warning, invisible in the logs.
2. **The other plugins are never imported.** Only one slug is extracted, so nothing queues the rest. Their `post_modified` still predated the commit: better-search, contextual-related-posts, knowledgebase, popular-authors, webberzone-code-block-highlighting, webberzone-link-warnings and where-did-they-go-from-here all missed the readme change entirely. (top-10 only recovered because a separate top-10-only commit landed three minutes later.)

## Fix

Determine the slug from each path rather than from the commit, and record each revision once per plugin. The per-plugin flags (`readme_touched`, `code_touched`, `assets_touched`) now describe that plugin's own paths instead of the whole commit's.

The summarising is extracted into `SVN_Watcher::summarize_plugin_changes()`, which is pure — it takes the log array and returns the grouped result — so it can be tested without shelling out to SVN.

## Tests

Adds `tests/SVN_Watcher_Log_Summary_Test.php` (6 tests, 23 assertions), covering the multi-plugin commit, per-plugin flag isolation, revision de-duplication, ordering by earliest revision, tag-deletion vs. file-deletion-inside-a-tag, and bare plugin-root paths.

Verified they fail against the previous logic and pass with the fix:

```
# before
FF...F  6 / 6
1) test_commit_spanning_multiple_plugins_is_split_per_plugin
   -  1 => 'better-search'
   -  2 => 'top-10'
Tests: 6, Assertions: 11, Failures: 3.

# after
......  6 / 6
OK (6 tests, 23 assertions)
```

## Note

One intentional behaviour change: a commit whose only path for a plugin is the bare plugin root (`/plugin-name`, with no `/trunk`, `/tags` or `/assets` below it) no longer produces an entry. Previously it created one with an empty tag list and nothing to import. New-repo commits are unaffected — they're filtered by the `PLUGIN_SVN_MANAGEMENT_USER` check, and carry `/trunk` anyway.

No Meta Trac ticket yet — happy to open one and reference it if that's preferred.
