### PR TITLE
Plugin Directory: Consume security scan callbacks exactly once

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan-gandalf.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan-gandalf.php
@@ -191,8 +191,7 @@ class Plugin_Scan_Gandalf {
 	protected static function consume_callback( $plugin, $data ) {
 		$scan_id  = $data['scan_id'];
 		$digest   = self::callback_digest( $data );
-		$consumed = get_post_meta( $plugin->ID, self::CONSUMED_META_KEY, true );
-		$consumed = is_array( $consumed ) ? $consumed : [];
+		$consumed = get_post_meta( $plugin->ID, self::CONSUMED_META_KEY, true ) ?: [];
 		foreach ( $consumed as $consumed_scan_id => $consumed_record ) {
 			if ( ! is_array( $consumed_record ) || ( $consumed_record['time'] ?? 0 ) < time() - WEEK_IN_SECONDS ) {
 				unset( $consumed[ $consumed_scan_id ] );
@@ -213,8 +212,7 @@ class Plugin_Scan_Gandalf {
 			}
 		}
 
-		$pending = get_post_meta( $plugin->ID, self::PENDING_META_KEY, true );
-		$pending = is_array( $pending ) ? $pending : [];
+		$pending = get_post_meta( $plugin->ID, self::PENDING_META_KEY, true ) ?: [];
 
 		if ( empty( $pending[ $scan_id ] ) ) {
 			$error = new WP_Error( 'unknown_gandalf_scan', 'Unknown security scan.', [ 'status' => WP_Http::BAD_REQUEST ] );

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan-gandalf.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan-gandalf.php
@@ -27,6 +27,9 @@ class Plugin_Scan_Gandalf {
 	/** Last dispatch or callback error for quick operator debugging. */
 	const LAST_ERROR_META_KEY = '_gandalf_scan_last_error';
 
+	/** Consumed callbacks keyed by scan_id, to acknowledge retries without repeating effects. */
+	const CONSUMED_META_KEY = '_gandalf_scan_consumed';
+
 	/** Gandalf scan endpoint. */
 	const ENDPOINT = 'https://gandalf.wordpress.org/scan';
 
@@ -156,15 +159,65 @@ class Plugin_Scan_Gandalf {
 	 * Handle a completed or failed scan callback.
 	 *
 	 * @param \WP_Post $plugin The plugin post.
-	 * @param array    $data   The Gandalf callback data.
-	 * @return true|WP_Error True on success, or an error when the scan is unknown.
+	 * @param array    $data   The security scan callback data, validated by the route.
+	 * @return true|WP_Error True on success, or an error when the callback is invalid.
 	 */
 	public static function handle_callback( $plugin, $data ) {
-		$scan_id = $data['scan_id'];
-		$pending = get_post_meta( $plugin->ID, self::PENDING_META_KEY, true ) ?: [];
+		/*
+		 * Serialize processing per plugin, not per scan: callbacks read-modify-write
+		 * shared per-plugin meta, and a scanner retry racing a slow first delivery
+		 * waits for the consumed record.
+		 */
+		if ( ! wp_cache_add( 'gandalf-scan-callback-' . $plugin->ID, 1, 'plugin-scans', 5 * MINUTE_IN_SECONDS ) ) {
+			return new WP_Error( 'security_scan_locked', 'A security scan callback for this plugin is already being processed.', [ 'status' => WP_Http::CONFLICT ] );
+		}
+
+		try {
+			return self::consume_callback( $plugin, $data );
+		} finally {
+			wp_cache_delete( 'gandalf-scan-callback-' . $plugin->ID, 'plugin-scans' );
+		}
+	}
+
+	/**
+	 * Consume a validated callback exactly once.
+	 *
+	 * Runs under the per-plugin lock taken by handle_callback().
+	 *
+	 * @param \WP_Post $plugin The plugin post.
+	 * @param array    $data   The validated security scan callback data.
+	 * @return true|WP_Error True on success, or an error when the callback is invalid.
+	 */
+	protected static function consume_callback( $plugin, $data ) {
+		$scan_id  = $data['scan_id'];
+		$digest   = self::callback_digest( $data );
+		$consumed = get_post_meta( $plugin->ID, self::CONSUMED_META_KEY, true );
+		$consumed = is_array( $consumed ) ? $consumed : [];
+		foreach ( $consumed as $consumed_scan_id => $consumed_record ) {
+			if ( ! is_array( $consumed_record ) || ( $consumed_record['time'] ?? 0 ) < time() - WEEK_IN_SECONDS ) {
+				unset( $consumed[ $consumed_scan_id ] );
+			}
+		}
+
+		if ( isset( $consumed[ $scan_id ] ) ) {
+			// Identical retry of a consumed callback: acknowledge without repeating effects.
+			if ( hash_equals( $consumed[ $scan_id ]['digest'], $digest ) ) {
+				return true;
+			}
+
+			// Only a completed verdict may supersede a consumed failure report for the same scan.
+			if ( 'completed' !== $data['status'] || 'failed' !== ( $consumed[ $scan_id ]['status'] ?? '' ) ) {
+				$error = new WP_Error( 'security_scan_conflict', 'A different security scan callback was already consumed for this scan.', [ 'status' => WP_Http::CONFLICT ] );
+				self::record_invalid_callback( $plugin, $error, $scan_id );
+				return $error;
+			}
+		}
+
+		$pending = get_post_meta( $plugin->ID, self::PENDING_META_KEY, true );
+		$pending = is_array( $pending ) ? $pending : [];
 
 		if ( empty( $pending[ $scan_id ] ) ) {
-			$error = new WP_Error( 'unknown_gandalf_scan', 'Unknown Gandalf scan_id.', [ 'status' => WP_Http::BAD_REQUEST ] );
+			$error = new WP_Error( 'unknown_gandalf_scan', 'Unknown security scan.', [ 'status' => WP_Http::BAD_REQUEST ] );
 			self::record_invalid_callback( $plugin, $error, $scan_id );
 			return $error;
 		}
@@ -172,7 +225,7 @@ class Plugin_Scan_Gandalf {
 		$pending_record = $pending[ $scan_id ];
 
 		if ( $data['version'] !== $pending_record['version'] || $data['release_ref'] !== $pending_record['release_ref'] ) {
-			$error = new WP_Error( 'invalid_gandalf_scan', 'Gandalf callback does not match the pending scan.', [ 'status' => WP_Http::BAD_REQUEST ] );
+			$error = new WP_Error( 'invalid_gandalf_scan', 'Security scan callback does not match the pending scan.', [ 'status' => WP_Http::BAD_REQUEST ] );
 			self::record_invalid_callback( $plugin, $error, $scan_id );
 			return $error;
 		}
@@ -197,10 +250,57 @@ class Plugin_Scan_Gandalf {
 			self::record_last_error( $plugin, $data['error']['kind'], $data['error']['message'], $scan_id );
 		}
 
-		unset( $pending[ $scan_id ] );
-		update_post_meta( $plugin->ID, self::PENDING_META_KEY, $pending );
+		/*
+		 * Deliberately recorded after the effects, failing closed: a crash
+		 * mid-processing makes the retry re-apply the (idempotent) effects
+		 * rather than acknowledge effects that never happened.
+		 */
+		$consumed[ $scan_id ] = [
+			'digest' => $digest,
+			'status' => $data['status'],
+			'time'   => time(),
+		];
+		update_post_meta( $plugin->ID, self::CONSUMED_META_KEY, $consumed );
+
+		/*
+		 * A failed report keeps the pending entry: the scanner may still deliver
+		 * a completed verdict for this scan, which supersedes the failure.
+		 */
+		if ( 'completed' === $data['status'] ) {
+			unset( $pending[ $scan_id ] );
+			update_post_meta( $plugin->ID, self::PENDING_META_KEY, $pending );
+		}
 
 		return true;
+	}
+
+	/**
+	 * Return a canonical digest of a callback body.
+	 *
+	 * Keys are sorted recursively so a scanner retry that re-marshals the same
+	 * data with a different key order still matches its consumed record.
+	 *
+	 * @param array $data The validated security scan callback data.
+	 * @return string A sha256 hex digest.
+	 */
+	protected static function callback_digest( $data ) {
+		self::ksort_deep( $data );
+		return hash( 'sha256', wp_json_encode( $data ) );
+	}
+
+	/**
+	 * Recursively sort an array by key. Sequential lists are unaffected.
+	 *
+	 * @param array $data The array to sort, by reference.
+	 */
+	protected static function ksort_deep( &$data ) {
+		ksort( $data );
+		foreach ( $data as &$value ) {
+			if ( is_array( $value ) ) {
+				self::ksort_deep( $value );
+			}
+		}
+		unset( $value );
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan-gandalf.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan-gandalf.php
@@ -163,11 +163,7 @@ class Plugin_Scan_Gandalf {
 	 * @return true|WP_Error True on success, or an error when the callback is invalid.
 	 */
 	public static function handle_callback( $plugin, $data ) {
-		/*
-		 * Serialize processing per plugin, not per scan: callbacks read-modify-write
-		 * shared per-plugin meta, and a scanner retry racing a slow first delivery
-		 * waits for the consumed record.
-		 */
+		// Serialize per plugin: callbacks read-modify-write shared per-plugin meta.
 		if ( ! wp_cache_add( 'gandalf-scan-callback-' . $plugin->ID, 1, 'plugin-scans', 5 * MINUTE_IN_SECONDS ) ) {
 			return new WP_Error( 'security_scan_locked', 'A security scan callback for this plugin is already being processed.', [ 'status' => WP_Http::CONFLICT ] );
 		}
@@ -248,11 +244,7 @@ class Plugin_Scan_Gandalf {
 			self::record_last_error( $plugin, $data['error']['kind'], $data['error']['message'], $scan_id );
 		}
 
-		/*
-		 * Deliberately recorded after the effects, failing closed: a crash
-		 * mid-processing makes the retry re-apply the (idempotent) effects
-		 * rather than acknowledge effects that never happened.
-		 */
+		// Recorded after the effects, so a crashed delivery is retried, not acknowledged.
 		$consumed[ $scan_id ] = [
 			'digest' => $digest,
 			'status' => $data['status'],
@@ -260,10 +252,7 @@ class Plugin_Scan_Gandalf {
 		];
 		update_post_meta( $plugin->ID, self::CONSUMED_META_KEY, $consumed );
 
-		/*
-		 * A failed report keeps the pending entry: the scanner may still deliver
-		 * a completed verdict for this scan, which supersedes the failure.
-		 */
+		// A failed report keeps the pending entry for a completed verdict that may still arrive.
 		if ( 'completed' === $data['status'] ) {
 			unset( $pending[ $scan_id ] );
 			update_post_meta( $plugin->ID, self::PENDING_META_KEY, $pending );

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Security_Scan_Consumption_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Security_Scan_Consumption_Test.php
@@ -75,8 +75,7 @@ class Security_Scan_Consumption_Test extends TestCase {
 	 * @param string $scan_id The scan ID to register.
 	 */
 	private function add_pending_scan( string $scan_id ): void {
-		$pending = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::PENDING_META_KEY, true );
-		$pending = is_array( $pending ) ? $pending : array();
+		$pending = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::PENDING_META_KEY, true ) ?: array();
 
 		$pending[ $scan_id ] = array(
 			'version'      => self::VERSION,

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Security_Scan_Consumption_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Security_Scan_Consumption_Test.php
@@ -179,10 +179,7 @@ class Security_Scan_Consumption_Test extends TestCase {
 		$consumed = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::CONSUMED_META_KEY, true );
 		$this->assertArrayHasKey( self::SCAN_ID, $consumed );
 
-		/*
-		 * The Slack dedup record is written even without a configured channel;
-		 * clearing it exposes whether the retry re-runs the notification effects.
-		 */
+		// Clearing the Slack dedup record exposes whether the retry re-runs notification effects.
 		delete_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::NOTIFIED_META_KEY );
 
 		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( get_post( $this->plugin->ID ), $callback ) );

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Security_Scan_Consumption_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Security_Scan_Consumption_Test.php
@@ -1,0 +1,292 @@
+<?php
+/**
+ * Tests for the exactly-once consumption of security scan callbacks.
+ *
+ * @package WordPressdotorg\Plugin_Directory\Tests
+ */
+
+declare( strict_types = 1 );
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use WordPressdotorg\Plugin_Directory\Jobs\Plugin_Scan_Gandalf;
+use WordPressdotorg\Plugin_Directory\Plugin_Directory;
+
+/**
+ * Tests that security scan callbacks are consumed exactly once.
+ *
+ * Extends the plain PHPUnit TestCase: WP_UnitTestCase is not compatible with
+ * the PHPUnit 11 runner used by this suite. Isolation comes from giving every
+ * test its own plugin post instead of per-test transactions.
+ *
+ * The group is declared as an attribute as well as `@group`: PHPUnit 11 ignores
+ * a class-level `@group` docblock, while older runners ignore the attribute.
+ *
+ * @group jobs
+ */
+#[Group( 'jobs' )]
+class Security_Scan_Consumption_Test extends TestCase {
+
+	/** The scan ID used for the pending scan fixture. */
+	private const SCAN_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+	/** The version and release ref used for the pending scan fixture. */
+	private const VERSION = '1.4.4';
+
+	/**
+	 * Counter to give every test plugin a unique slug.
+	 *
+	 * @var int
+	 */
+	private static int $plugin_count = 0;
+
+	/**
+	 * The plugin post under test.
+	 *
+	 * @var \WP_Post
+	 */
+	private \WP_Post $plugin;
+
+	/**
+	 * Create a published plugin with a pending security scan.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		wp_cache_flush();
+
+		$plugin = Plugin_Directory::create_plugin_post(
+			array(
+				'post_name'   => 'consumption-test-' . ( ++self::$plugin_count ),
+				'post_title'  => 'Scan Consumption Test Plugin',
+				'post_status' => 'publish',
+			)
+		);
+
+		$this->assertInstanceOf( \WP_Post::class, $plugin );
+		$this->plugin = $plugin;
+
+		$this->add_pending_scan( self::SCAN_ID );
+	}
+
+	/**
+	 * Register a pending scan on the plugin fixture.
+	 *
+	 * @param string $scan_id The scan ID to register.
+	 */
+	private function add_pending_scan( string $scan_id ): void {
+		$pending = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::PENDING_META_KEY, true );
+		$pending = is_array( $pending ) ? $pending : array();
+
+		$pending[ $scan_id ] = array(
+			'version'      => self::VERSION,
+			'release_ref'  => self::VERSION,
+			'requested_at' => time(),
+		);
+
+		update_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::PENDING_META_KEY, $pending );
+	}
+
+	/**
+	 * Build a finding entry matching the callback contract.
+	 *
+	 * @param float $risk_score The finding risk score.
+	 * @return array The finding.
+	 */
+	private function finding( float $risk_score ): array {
+		return array(
+			'id'            => 'finding-' . md5( (string) $risk_score ),
+			'ref'           => 'prompt-security.supply_chain.remote_controlled_code',
+			'title'         => 'Remote response controls a PHP callable',
+			'severity'      => 'error',
+			'file_path'     => 'includes/class-admin.php',
+			'line'          => 688,
+			'code_snippet'  => '$clean = $this->write;',
+			'explanation'   => 'The response body reaches a callable.',
+			'risk_score'    => $risk_score,
+			'investigation' => array(
+				'status'  => 'completed',
+				'result'  => 'reproduced',
+				'summary' => 'The unauthenticated probe reached the sink.',
+			),
+		);
+	}
+
+	/**
+	 * Build a completed callback matching the pending scan fixture.
+	 *
+	 * @param array $overrides Fields to override.
+	 * @return array The callback data.
+	 */
+	private function completed_callback( array $overrides = array() ): array {
+		$defaults = array(
+			'status'          => 'completed',
+			'scan_id'         => self::SCAN_ID,
+			'subject_type'    => 'plugin',
+			'slug'            => $this->plugin->post_name,
+			'version'         => self::VERSION,
+			'release_ref'     => self::VERSION,
+			'completed_at'    => time(),
+			'verdict_hash'    => 'f71c3d944050095a4e2e20f9ee8a7c9a',
+			'findings_count'  => 2,
+			'findings'        => array( $this->finding( 9.8 ), $this->finding( 5.2 ) ),
+			'max_risk_score'  => 9.8,
+			'severity_counts' => array( 'error' => 2 ),
+			'scanner_version' => '0.3.0',
+			'report_url'      => 'https://scanner.example/runs/' . self::SCAN_ID,
+		);
+
+		return array_merge( $defaults, $overrides );
+	}
+
+	/**
+	 * Build a failed callback matching the pending scan fixture.
+	 *
+	 * @param array $overrides Fields to override.
+	 * @return array The callback data.
+	 */
+	private function failed_callback( array $overrides = array() ): array {
+		$defaults = array(
+			'status'       => 'failed',
+			'scan_id'      => self::SCAN_ID,
+			'subject_type' => 'plugin',
+			'slug'         => $this->plugin->post_name,
+			'version'      => self::VERSION,
+			'release_ref'  => self::VERSION,
+			'completed_at' => time(),
+			'report_url'   => 'https://scanner.example/runs/' . self::SCAN_ID,
+			'error'        => array(
+				'kind'    => 'timeout',
+				'message' => 'Scan exceeded the runtime deadline.',
+			),
+		);
+
+		return array_merge( $defaults, $overrides );
+	}
+
+	/**
+	 * An identical retry of a consumed callback is acknowledged without
+	 * repeating effects.
+	 *
+	 * Before consumption records existed, a retry arriving after the pending
+	 * entry was cleared was rejected as an unknown scan.
+	 */
+	public function test_identical_replay_is_acknowledged_once(): void {
+		$callback = $this->completed_callback();
+
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $callback ) );
+		$this->assertEmpty( get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::PENDING_META_KEY, true ) );
+
+		$consumed = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::CONSUMED_META_KEY, true );
+		$this->assertArrayHasKey( self::SCAN_ID, $consumed );
+
+		/*
+		 * The Slack dedup record is written even without a configured channel;
+		 * clearing it exposes whether the retry re-runs the notification effects.
+		 */
+		delete_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::NOTIFIED_META_KEY );
+
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( get_post( $this->plugin->ID ), $callback ) );
+		$this->assertEmpty( get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::NOTIFIED_META_KEY, true ) );
+	}
+
+	/**
+	 * A different callback body for a consumed scan is rejected as a conflict.
+	 */
+	public function test_conflicting_replay_is_rejected(): void {
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->completed_callback() ) );
+
+		$conflicting = $this->completed_callback( array( 'report_url' => 'https://scanner.example/runs/other' ) );
+		$result      = Plugin_Scan_Gandalf::handle_callback( get_post( $this->plugin->ID ), $conflicting );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'security_scan_conflict', $result->get_error_code() );
+	}
+
+	/**
+	 * A retry that re-marshals the same callback with a different key order is
+	 * acknowledged as an identical retry.
+	 */
+	public function test_reordered_replay_is_acknowledged(): void {
+		$callback = $this->completed_callback();
+
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $callback ) );
+
+		$reordered             = array_reverse( $callback, true );
+		$reordered['findings'] = array_map(
+			static function ( array $finding ): array {
+				$finding['investigation'] = array_reverse( $finding['investigation'], true );
+				return array_reverse( $finding, true );
+			},
+			$reordered['findings']
+		);
+
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( get_post( $this->plugin->ID ), $reordered ) );
+	}
+
+	/**
+	 * A completed verdict supersedes an earlier failure report for the same scan.
+	 */
+	public function test_completed_verdict_supersedes_failed_report(): void {
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->failed_callback() ) );
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( get_post( $this->plugin->ID ), $this->completed_callback() ) );
+
+		// The completed verdict was processed, not swallowed by the consumed failure.
+		$notified = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::NOTIFIED_META_KEY, true );
+		$this->assertArrayHasKey( 'f71c3d944050095a4e2e20f9ee8a7c9a', $notified );
+
+		$consumed = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::CONSUMED_META_KEY, true );
+		$this->assertSame( 'completed', $consumed[ self::SCAN_ID ]['status'] );
+
+		$this->assertEmpty( get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::PENDING_META_KEY, true ) );
+	}
+
+	/**
+	 * A failure report records the error and keeps the pending entry for a
+	 * completed verdict that may still arrive.
+	 */
+	public function test_failed_scan_records_error(): void {
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->failed_callback() ) );
+		$this->assertSame( 'publish', get_post( $this->plugin->ID )->post_status );
+
+		$last_error = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::LAST_ERROR_META_KEY, true );
+		$this->assertSame( 'timeout', $last_error['kind'] );
+
+		$consumed = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::CONSUMED_META_KEY, true );
+		$this->assertArrayHasKey( self::SCAN_ID, $consumed );
+
+		$pending = get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::PENDING_META_KEY, true );
+		$this->assertArrayHasKey( self::SCAN_ID, $pending );
+	}
+
+	/**
+	 * A callback for a different version than the pending scan is rejected
+	 * and not recorded as consumed.
+	 */
+	public function test_mismatched_version_is_rejected(): void {
+		$result = Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->completed_callback( array( 'version' => '9.9.9' ) ) );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'invalid_gandalf_scan', $result->get_error_code() );
+
+		$this->assertEmpty( get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::CONSUMED_META_KEY, true ) );
+	}
+
+	/**
+	 * A callback arriving while another is being processed for the same plugin
+	 * is rejected without consuming anything.
+	 */
+	public function test_concurrent_callback_is_rejected_while_locked(): void {
+		wp_cache_add( 'gandalf-scan-callback-' . $this->plugin->ID, 1, 'plugin-scans', 5 * MINUTE_IN_SECONDS );
+
+		$result = Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->completed_callback() );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'security_scan_locked', $result->get_error_code() );
+		$this->assertEmpty( get_post_meta( $this->plugin->ID, Plugin_Scan_Gandalf::CONSUMED_META_KEY, true ) );
+
+		// Once the holder releases the lock, the retry consumes normally.
+		wp_cache_delete( 'gandalf-scan-callback-' . $this->plugin->ID, 'plugin-scans' );
+		$this->assertTrue( Plugin_Scan_Gandalf::handle_callback( $this->plugin, $this->completed_callback() ) );
+	}
+}


### PR DESCRIPTION
## Summary

Spun out of #777: the exactly-once consumption of security scan callbacks, independent of any release-blocking policy. Splitting it out lets #795 (and other consumers of scan results) be based on trunk without carrying #777's policy change.

### What it does

- Consumed callbacks are recorded per `scan_id` under a canonical (key-order-insensitive) digest: an identical scanner retry — including one that re-marshals the same body with a different key order — is acknowledged without repeating effects, where previously a retry arriving after the pending entry was cleared was rejected as an unknown scan.
- A different body for an already-consumed scan is rejected as a conflict (HTTP 409) and recorded for operators.
- A completed verdict supersedes an earlier failure report for the same scan: a failure report keeps the pending entry alive for exactly that reason, and only a completed callback clears it.
- A short per-plugin lock (released even if processing throws) serializes callback processing, so a scanner retry racing a slow first delivery can't double-process or clobber the consumed record. Consumption is recorded after the effects, failing closed: a crash mid-processing makes the retry re-apply the idempotent effects rather than acknowledge effects that never happened.
- Consumed records are pruned after a week; the existing advisory behavior (Slack alert on findings, error recording on failure) is unchanged.

### Testing

`tests/Security_Scan_Consumption_Test.php` (7 tests) covers the identical replay acknowledged without re-running effects, conflict rejection, a re-marshalled retry with different key order, a completed verdict superseding a failure report, the failure report keeping the pending entry, a mismatched version leaving no consumed record, and the per-plugin lock rejecting a concurrent callback without consuming anything. Full plugin-directory suite passes (206 tests); both files lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
