### PR TITLE
Plugin Directory: Resolve release holds from the stable tag

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/metabox/class-controls.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/metabox/class-controls.php
@@ -60,7 +60,7 @@ class Controls {
 			return;
 		}
 
-		$release = Plugin_Directory::get_release( $post, $version );
+		$release = API_Update_Updater::get_current_release( $post );
 		if ( ! $release ) {
 			return;
 		}

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/metabox/class-controls.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/metabox/class-controls.php
@@ -55,17 +55,12 @@ class Controls {
 	protected static function display_release_cooldown() {
 		$post = get_post();
 
-		$version = get_post_meta( $post->ID, 'version', true );
-		if ( ! $version ) {
-			return;
-		}
-
+		// Resolved from the stable tag, so the hold shows even when the Version header is empty or disagrees.
 		$release = API_Update_Updater::get_current_release( $post );
 		if ( ! $release ) {
 			return;
 		}
 
-		// The held release is resolved from the stable tag, so name it — not the Version header, which may disagree.
 		$release_version = $release['version'];
 
 		$release_delay = (int) ( $release['release_delay'] ?? 0 );
@@ -103,7 +98,7 @@ class Controls {
 					></textarea>
 				</p>
 				<p>
-					<button type="submit" name="force_release_version" value="<?php echo esc_attr( $version ); ?>" class="button">
+					<button type="submit" name="force_release_tag" value="<?php echo esc_attr( $release['tag'] ); ?>" class="button">
 						<?php
 						printf(
 							/* translators: %s: version */
@@ -124,7 +119,7 @@ class Controls {
 	 * @param int $post_id The post being saved.
 	 */
 	public static function save_post( $post_id ) {
-		if ( empty( $_POST['force_release_version'] ) ) {
+		if ( empty( $_POST['force_release_tag'] ) ) {
 			return;
 		}
 
@@ -141,10 +136,11 @@ class Controls {
 		// and to make the security boundary explicit.
 		check_admin_referer( 'update-post_' . $post_id );
 
-		$version           = get_post_meta( $post->ID, 'version', true );
-		$submitted_version = sanitize_text_field( wp_unslash( $_POST['force_release_version'] ) );
-		if ( $submitted_version !== $version ) {
-			// Submitted version doesn't match current — a newer commit landed since the form was rendered.
+		// Staleness guard on the release identity, not the header version: a newer commit
+		// that moved the stable tag since the form rendered lands a different release here.
+		$release       = API_Update_Updater::get_current_release( $post );
+		$submitted_tag = sanitize_text_field( wp_unslash( $_POST['force_release_tag'] ) );
+		if ( ! $release || $submitted_tag !== (string) $release['tag'] ) {
 			return;
 		}
 

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/metabox/class-controls.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/metabox/class-controls.php
@@ -136,8 +136,7 @@ class Controls {
 		// and to make the security boundary explicit.
 		check_admin_referer( 'update-post_' . $post_id );
 
-		// Staleness guard on the release identity, not the header version: a newer commit
-		// that moved the stable tag since the form rendered lands a different release here.
+		// Staleness guard on the release identity: a commit that moved the stable tag since the form rendered lands a different release here.
 		$release       = API_Update_Updater::get_current_release( $post );
 		$submitted_tag = sanitize_text_field( wp_unslash( $_POST['force_release_tag'] ) );
 		if ( ! $release || $submitted_tag !== (string) $release['tag'] ) {

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/metabox/class-controls.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/metabox/class-controls.php
@@ -65,6 +65,9 @@ class Controls {
 			return;
 		}
 
+		// The held release is resolved from the stable tag, so name it — not the Version header, which may disagree.
+		$release_version = $release['version'];
+
 		$release_delay = (int) ( $release['release_delay'] ?? 0 );
 		if ( ! $release_delay ) {
 			return;
@@ -82,7 +85,7 @@ class Controls {
 			printf(
 				/* translators: 1: version, 2: relative time until cooldown expires, 3: absolute UTC timestamp */
 				esc_html__( 'Version %1$s is in the release cooldown — it will be served to sites in %2$s (at %3$s UTC).', 'wporg-plugins' ),
-				esc_html( $version ),
+				esc_html( $release_version ),
 				esc_html( human_time_diff( time(), $cooldown_until ) ),
 				esc_html( gmdate( 'Y-m-d H:i', $cooldown_until ) )
 			);
@@ -105,7 +108,7 @@ class Controls {
 						printf(
 							/* translators: %s: version */
 							esc_html__( 'Force-release %s now', 'wporg-plugins' ),
-							esc_html( $version )
+							esc_html( $release_version )
 						);
 						?>
 					</button>

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-plugin-directory.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-plugin-directory.php
@@ -1722,12 +1722,14 @@ class Plugin_Directory {
 
 		$plugin = self::get_plugin_post( $plugin );
 
-		// Strict match only: get_release()'s loose lookup ('1.4' == '1.40') could merge onto the wrong release.
+		$releases = self::get_releases( $plugin );
+
+		// Strict match only: get_release()'s loose lookup ('1.4' == '1.40') could merge onto the wrong release. Only one release can exist in any given tag.
 		$release = false;
-		foreach ( self::get_releases( $plugin ) as $r ) {
+		foreach ( $releases as $i => $r ) {
 			if ( isset( $r['tag'] ) && (string) $r['tag'] === $data['tag'] ) {
-				$release = $r;
-				break;
+				$release = $release ?: $r;
+				unset( $releases[ $i ] );
 			}
 		}
 
@@ -1775,16 +1777,6 @@ class Plugin_Directory {
 			unset( $release['release_block'] );
 		}
 		unset( $release['unblock'] );
-
-		$releases = self::get_releases( $plugin );
-
-		// Find any other releases using this slug (as in the case of updates) and remove it.
-		// Only one release can exist in any given tag.
-		foreach ( $releases as $i => $r ) {
-			if ( (string) $r['tag'] === $release['tag'] ) {
-				unset( $releases[ $i ] );
-			}
-		}
 
 		// Add this release in
 		$releases[] = $release;

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-plugin-directory.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-plugin-directory.php
@@ -1722,7 +1722,16 @@ class Plugin_Directory {
 
 		$plugin = self::get_plugin_post( $plugin );
 
-		$release = self::get_release( $plugin, $data['tag'] ) ?: [
+		// Strict match only: get_release()'s loose lookup ('1.4' == '1.40') could merge onto the wrong release.
+		$release = false;
+		foreach ( self::get_releases( $plugin ) as $r ) {
+			if ( isset( $r['tag'] ) && (string) $r['tag'] === $data['tag'] ) {
+				$release = $r;
+				break;
+			}
+		}
+
+		$release = $release ?: [
 			'date'                     => time(),
 			'tag'                      => '',
 			'version'                  => '',
@@ -1772,7 +1781,7 @@ class Plugin_Directory {
 		// Find any other releases using this slug (as in the case of updates) and remove it.
 		// Only one release can exist in any given tag.
 		foreach ( $releases as $i => $r ) {
-			if ( $r['tag'] === $release['tag'] ) {
+			if ( (string) $r['tag'] === $release['tag'] ) {
 				unset( $releases[ $i ] );
 			}
 		}

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-api-update-updater.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-api-update-updater.php
@@ -234,17 +234,24 @@ class API_Update_Updater {
 	/**
 	 * The release being served or held for a plugin's current version.
 	 *
-	 * Resolved from the stable tag first — the served package is built from it,
-	 * and a Version header that doesn't match its tag must not orphan the
-	 * release's block or cooldown — falling back to the version for trunk
-	 * releases, which are keyed `trunk@{version}`.
+	 * Tagged plugins resolve strictly by the stable tag — the source the served
+	 * package is built from — so a Version header that disagrees with its tag
+	 * cannot redirect the release's block or cooldown onto a different release.
+	 * Trunk-stable plugins have no tag-named release row (theirs are keyed
+	 * `trunk@{version}`), so they resolve by version; their identity is the
+	 * header itself, so a header rename there is out of this method's reach.
 	 *
 	 * @param \WP_Post $post The plugin post.
 	 * @return array|false The release row from Plugin_Directory::get_release(), or false when none exists.
 	 */
 	public static function get_current_release( $post ) {
-		return Plugin_Directory::get_release( $post, get_post_meta( $post->ID, 'stable_tag', true ) )
-			?: Plugin_Directory::get_release( $post, get_post_meta( $post->ID, 'version', true ) );
+		$stable_tag = get_post_meta( $post->ID, 'stable_tag', true );
+
+		if ( ! $stable_tag || 'trunk' === $stable_tag ) {
+			return Plugin_Directory::get_release( $post, get_post_meta( $post->ID, 'version', true ) );
+		}
+
+		return Plugin_Directory::get_release( $post, $stable_tag );
 	}
 
 	/**
@@ -282,14 +289,13 @@ class API_Update_Updater {
 			return false;
 		}
 
-		$version = get_post_meta( $post->ID, 'version', true );
 		$release = self::get_current_release( $post );
 		if ( ! $release ) {
 			return false;
 		}
 
-		// Already live: a block can't un-ship a served version (compared with the column's varchar(128) truncation).
-		if ( self::get_served_version( $plugin_slug ) === substr( (string) $version, 0, 128 ) ) {
+		// Already live: a block can't un-ship the resolved release once it's the served version (compared with the column's varchar(128) truncation).
+		if ( self::get_served_version( $plugin_slug ) === substr( (string) ( $release['version'] ?? '' ), 0, 128 ) ) {
 			return false;
 		}
 
@@ -473,12 +479,13 @@ class API_Update_Updater {
 			return false;
 		}
 
-		$version = get_post_meta( $post->ID, 'version', true );
 		$release = self::get_current_release( $post );
 
 		if ( ! $release ) {
 			return false;
 		}
+
+		$version = $release['version'];
 
 		// Log only what is actually lifted: a deleted block's only trace, and the cooldown only while it still runs.
 		$lifted = array();

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-api-update-updater.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-api-update-updater.php
@@ -441,16 +441,24 @@ class API_Update_Updater {
 	/**
 	 * Determine the release timestamp for a plugin version.
 	 *
-	 * Falls back through the commit timestamp on the plugin post, and is replaced by the
-	 * latest committer-confirmation time when release confirmations are required (the
-	 * version isn't really "released" until the last confirmation lands).
+	 * Anchored on the version's commit time (`version_date`), falling back to the
+	 * release row's own date — unlike post_modified, neither slides on unrelated
+	 * post edits — and replaced by the latest committer-confirmation time when
+	 * release confirmations are required (the version isn't really "released"
+	 * until the last confirmation lands).
 	 *
 	 * @param \WP_Post   $post    The plugin post.
 	 * @param array|bool $release The release row from Plugin_Directory::get_release(), or false.
 	 * @return int Unix timestamp.
 	 */
 	public static function compute_release_time( $post, $release ) {
-		$release_time = strtotime( $post->version_date ? $post->version_date : $post->post_modified );
+		if ( $post->version_date ) {
+			$release_time = strtotime( $post->version_date );
+		} elseif ( ! empty( $release['date'] ) ) {
+			$release_time = (int) $release['date'];
+		} else {
+			$release_time = strtotime( $post->post_modified );
+		}
 
 		if (
 			$release &&

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-api-update-updater.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-api-update-updater.php
@@ -243,19 +243,41 @@ class API_Update_Updater {
 	 * Strict matching, unlike Plugin_Directory::get_release()'s loose lookup
 	 * (`'1.4' == '1.40'`), which could land on the wrong release.
 	 *
+	 * When the ref has no release row (a stable tag flipped to trunk at an
+	 * unchanged version creates none), the version-named — then version-
+	 * carrying — release is a fallback: a miss would fail the block and
+	 * cooldown gates open, and the fallback never overrides a ref-resolved
+	 * hold.
+	 *
 	 * @param \WP_Post $post The plugin post.
 	 * @return array|false The matching release row, or false when none exists.
 	 */
 	public static function get_current_release( $post ) {
-		$target = self::get_current_release_tag( $post );
+		$target   = self::get_current_release_tag( $post );
+		$releases = (array) Plugin_Directory::get_releases( $post );
 
-		foreach ( (array) Plugin_Directory::get_releases( $post ) as $release ) {
+		foreach ( $releases as $release ) {
 			if ( isset( $release['tag'] ) && (string) $release['tag'] === (string) $target ) {
 				return $release;
 			}
 		}
 
-		return false;
+		$version = (string) get_post_meta( $post->ID, 'version', true );
+		if ( '' === $version ) {
+			return false;
+		}
+
+		$carrying = false;
+		foreach ( $releases as $release ) {
+			if ( (string) ( $release['tag'] ?? '' ) === $version ) {
+				return $release;
+			}
+			if ( ! $carrying && (string) ( $release['version'] ?? '' ) === $version ) {
+				$carrying = $release;
+			}
+		}
+
+		return $carrying;
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-api-update-updater.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-api-update-updater.php
@@ -220,20 +220,30 @@ class API_Update_Updater {
 	}
 
 	/**
+	 * The `update_source` row identifying what is currently served.
+	 *
+	 * @param string $plugin_slug The plugin slug.
+	 * @return object|null The row's version and stable_tag, or null when the plugin isn't in `update_source`.
+	 */
+	public static function get_served_row( $plugin_slug ) {
+		global $wpdb;
+
+		return $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT version, stable_tag FROM {$wpdb->prefix}update_source WHERE plugin_slug = %s",
+				$plugin_slug
+			)
+		);
+	}
+
+	/**
 	 * The version currently served from `update_source`.
 	 *
 	 * @param string $plugin_slug The plugin slug.
 	 * @return string The served version, or '' when the plugin isn't in `update_source`.
 	 */
 	public static function get_served_version( $plugin_slug ) {
-		global $wpdb;
-
-		return (string) $wpdb->get_var(
-			$wpdb->prepare(
-				"SELECT version FROM {$wpdb->prefix}update_source WHERE plugin_slug = %s",
-				$plugin_slug
-			)
-		);
+		return (string) ( self::get_served_row( $plugin_slug )->version ?? '' );
 	}
 
 	/**
@@ -291,7 +301,7 @@ class API_Update_Updater {
 	 * version itself stays blocked until a reviewer force-releases it.
 	 *
 	 * The counterpart to force_release(). It refuses when the version cannot be
-	 * held: no plugin, no release, or the version already being served. Blocking
+	 * held: no plugin, no release, or the release already being served. Blocking
 	 * an already-held release is a no-op success that preserves the existing
 	 * block. Capability checks and audit logging are the caller's.
 	 *
@@ -310,10 +320,19 @@ class API_Update_Updater {
 			return false;
 		}
 
-		// Already live: a block can't un-ship the resolved release once it's the served version (compared with the column's varchar(128) truncation).
-		$served_version = self::get_served_version( $plugin_slug );
-		if ( '' !== $served_version && substr( (string) ( $release['version'] ?? '' ), 0, 128 ) === $served_version ) {
-			return false;
+		// Already live: a block can't un-ship a served release — compared by identity (the ref for tagged rows, the version for ref-less trunk-stable rows), with the columns' varchar(128) truncation.
+		$served = self::get_served_row( $plugin_slug );
+		if ( $served ) {
+			if ( $served->stable_tag && 'trunk' !== $served->stable_tag ) {
+				$is_served = substr( (string) $release['tag'], 0, 128 ) === (string) $served->stable_tag;
+			} else {
+				$is_served = '' !== (string) $served->version
+					&& substr( (string) ( $release['version'] ?? '' ), 0, 128 ) === (string) $served->version;
+			}
+
+			if ( $is_served ) {
+				return false;
+			}
 		}
 
 		// Already held; recording a second block would merge it into the first.

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-api-update-updater.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-api-update-updater.php
@@ -85,7 +85,7 @@ class API_Update_Updater {
 
 		$version          = get_post_meta( $post->ID, 'version', true );
 		$requires_plugins = get_post_meta( $post->ID, 'requires_plugins', true );
-		$release          = Plugin_Directory::get_release( $post, $version );
+		$release          = self::get_current_release( $post );
 		$release_time     = self::compute_release_time( $post, $release );
 		$existing_row     = $wpdb->get_row(
 			$wpdb->prepare(
@@ -232,6 +232,22 @@ class API_Update_Updater {
 	}
 
 	/**
+	 * The release being served or held for a plugin's current version.
+	 *
+	 * Resolved from the stable tag first — the served package is built from it,
+	 * and a Version header that doesn't match its tag must not orphan the
+	 * release's block or cooldown — falling back to the version for trunk
+	 * releases, which are keyed `trunk@{version}`.
+	 *
+	 * @param \WP_Post $post The plugin post.
+	 * @return array|false The release row from Plugin_Directory::get_release(), or false when none exists.
+	 */
+	public static function get_current_release( $post ) {
+		return Plugin_Directory::get_release( $post, get_post_meta( $post->ID, 'stable_tag', true ) )
+			?: Plugin_Directory::get_release( $post, get_post_meta( $post->ID, 'version', true ) );
+	}
+
+	/**
 	 * Whether a release is being held out of `update_source` by a block.
 	 *
 	 * Blocks are recorded on the release meta as `release_block`, and cleared by
@@ -267,7 +283,7 @@ class API_Update_Updater {
 		}
 
 		$version = get_post_meta( $post->ID, 'version', true );
-		$release = Plugin_Directory::get_release( $post, $version );
+		$release = self::get_current_release( $post );
 		if ( ! $release ) {
 			return false;
 		}
@@ -458,7 +474,7 @@ class API_Update_Updater {
 		}
 
 		$version = get_post_meta( $post->ID, 'version', true );
-		$release = Plugin_Directory::get_release( $post, $version );
+		$release = self::get_current_release( $post );
 
 		if ( ! $release ) {
 			return false;

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-api-update-updater.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-api-update-updater.php
@@ -234,16 +234,6 @@ class API_Update_Updater {
 	}
 
 	/**
-	 * The version currently served from `update_source`.
-	 *
-	 * @param string $plugin_slug The plugin slug.
-	 * @return string The served version, or '' when the plugin isn't in `update_source`.
-	 */
-	public static function get_served_version( $plugin_slug ) {
-		return (string) ( self::get_served_row( $plugin_slug )->version ?? '' );
-	}
-
-	/**
 	 * The release being served or held for a plugin's current version.
 	 *
 	 * Resolved strictly by the stable tag — the source of the served package —

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-api-update-updater.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-api-update-updater.php
@@ -253,7 +253,12 @@ class API_Update_Updater {
 	 * @return array|false The matching release row, or false when none exists.
 	 */
 	public static function get_current_release( $post ) {
-		$target   = self::get_current_release_tag( $post );
+		$stable_tag = get_post_meta( $post->ID, 'stable_tag', true );
+
+		$target = ( ! $stable_tag || 'trunk' === $stable_tag )
+			? 'trunk@' . get_post_meta( $post->ID, 'version', true )
+			: $stable_tag;
+
 		$releases = (array) Plugin_Directory::get_releases( $post );
 
 		foreach ( $releases as $release ) {
@@ -278,20 +283,6 @@ class API_Update_Updater {
 		}
 
 		return $carrying;
-	}
-
-	/**
-	 * The release tag a plugin's current version is served or held under.
-	 *
-	 * @param \WP_Post $post The plugin post.
-	 * @return string The stable tag, or `trunk@{version}` for trunk-stable plugins.
-	 */
-	public static function get_current_release_tag( $post ) {
-		$stable_tag = get_post_meta( $post->ID, 'stable_tag', true );
-
-		return ( ! $stable_tag || 'trunk' === $stable_tag )
-			? 'trunk@' . get_post_meta( $post->ID, 'version', true )
-			: $stable_tag;
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-api-update-updater.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-api-update-updater.php
@@ -101,11 +101,16 @@ class API_Update_Updater {
 		$is_new_version = substr( (string) $version, 0, 128 ) !== $existing_version;
 
 		/*
-		 * Hold a blocked version out of the row: the previously served version keeps
+		 * Hold a blocked release out of the row: the previously served version keeps
 		 * being served, and the deferred serve is cancelled rather than postponed.
 		 * Status changes still reach the row right away.
+		 *
+		 * Gated on the block alone, not $is_new_version: a header renamed to match
+		 * the served version would make that proxy false, writing the blocked
+		 * release's stable tag live. block_release() already refuses to block a
+		 * served release, so a held release is never the one already in the row.
 		 */
-		if ( self::is_release_blocked( $release ) && $is_new_version ) {
+		if ( self::is_release_blocked( $release ) ) {
 			wp_clear_scheduled_hook( "release_to_update_api:{$post->post_name}" );
 
 			if ( $existing_row ) {
@@ -238,20 +243,31 @@ class API_Update_Updater {
 	 * package is built from — so a Version header that disagrees with its tag
 	 * cannot redirect the release's block or cooldown onto a different release.
 	 * Trunk-stable plugins have no tag-named release row (theirs are keyed
-	 * `trunk@{version}`), so they resolve by version; their identity is the
-	 * header itself, so a header rename there is out of this method's reach.
+	 * `trunk@{version}`), so they resolve by that key; their identity is the
+	 * header version, so a header rename there is out of this method's reach.
+	 *
+	 * Matched strictly by tag, unlike Plugin_Directory::get_release(): its
+	 * wp_list_filter() match is loose (`'1.4' == '1.40'`) and prefers a bare
+	 * tag over a `trunk@{version}` row, either of which could resolve a hold
+	 * off the wrong release.
 	 *
 	 * @param \WP_Post $post The plugin post.
-	 * @return array|false The release row from Plugin_Directory::get_release(), or false when none exists.
+	 * @return array|false The matching release row, or false when none exists.
 	 */
 	public static function get_current_release( $post ) {
 		$stable_tag = get_post_meta( $post->ID, 'stable_tag', true );
 
-		if ( ! $stable_tag || 'trunk' === $stable_tag ) {
-			return Plugin_Directory::get_release( $post, get_post_meta( $post->ID, 'version', true ) );
+		$target = ( ! $stable_tag || 'trunk' === $stable_tag )
+			? 'trunk@' . get_post_meta( $post->ID, 'version', true )
+			: $stable_tag;
+
+		foreach ( (array) Plugin_Directory::get_releases( $post ) as $release ) {
+			if ( isset( $release['tag'] ) && (string) $release['tag'] === (string) $target ) {
+				return $release;
+			}
 		}
 
-		return Plugin_Directory::get_release( $post, $stable_tag );
+		return false;
 	}
 
 	/**
@@ -295,7 +311,8 @@ class API_Update_Updater {
 		}
 
 		// Already live: a block can't un-ship the resolved release once it's the served version (compared with the column's varchar(128) truncation).
-		if ( self::get_served_version( $plugin_slug ) === substr( (string) ( $release['version'] ?? '' ), 0, 128 ) ) {
+		$served_version = self::get_served_version( $plugin_slug );
+		if ( '' !== $served_version && substr( (string) ( $release['version'] ?? '' ), 0, 128 ) === $served_version ) {
 			return false;
 		}
 

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-api-update-updater.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-api-update-updater.php
@@ -101,14 +101,11 @@ class API_Update_Updater {
 		$is_new_version = substr( (string) $version, 0, 128 ) !== $existing_version;
 
 		/*
-		 * Hold a blocked release out of the row: the previously served version keeps
-		 * being served, and the deferred serve is cancelled rather than postponed.
-		 * Status changes still reach the row right away.
-		 *
-		 * Gated on the block alone, not $is_new_version: a header renamed to match
-		 * the served version would make that proxy false, writing the blocked
-		 * release's stable tag live. block_release() already refuses to block a
-		 * served release, so a held release is never the one already in the row.
+		 * Hold a blocked release out of the row: the previous version keeps being
+		 * served, the deferred serve is cancelled, and status changes still reach
+		 * the row. Gated on the block alone — a header renamed to the served
+		 * version turns the $is_new_version proxy false, and block_release()
+		 * refuses served releases, so a held release is never already in the row.
 		 */
 		if ( self::is_release_blocked( $release ) ) {
 			wp_clear_scheduled_hook( "release_to_update_api:{$post->post_name}" );
@@ -249,17 +246,12 @@ class API_Update_Updater {
 	/**
 	 * The release being served or held for a plugin's current version.
 	 *
-	 * Tagged plugins resolve strictly by the stable tag — the source the served
-	 * package is built from — so a Version header that disagrees with its tag
-	 * cannot redirect the release's block or cooldown onto a different release.
-	 * Trunk-stable plugins have no tag-named release row (theirs are keyed
-	 * `trunk@{version}`), so they resolve by that key; their identity is the
-	 * header version, so a header rename there is out of this method's reach.
-	 *
-	 * Matched strictly by tag, unlike Plugin_Directory::get_release(): its
-	 * wp_list_filter() match is loose (`'1.4' == '1.40'`) and prefers a bare
-	 * tag over a `trunk@{version}` row, either of which could resolve a hold
-	 * off the wrong release.
+	 * Resolved strictly by the stable tag — the source of the served package —
+	 * so a Version header that disagrees with its tag cannot redirect a hold
+	 * onto a different release. Trunk-stable plugins resolve by their
+	 * `trunk@{version}` key instead; their identity is the header version.
+	 * Strict matching, unlike Plugin_Directory::get_release()'s loose lookup
+	 * (`'1.4' == '1.40'`), which could land on the wrong release.
 	 *
 	 * @param \WP_Post $post The plugin post.
 	 * @return array|false The matching release row, or false when none exists.

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-api-update-updater.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-api-update-updater.php
@@ -247,11 +247,7 @@ class API_Update_Updater {
 	 * @return array|false The matching release row, or false when none exists.
 	 */
 	public static function get_current_release( $post ) {
-		$stable_tag = get_post_meta( $post->ID, 'stable_tag', true );
-
-		$target = ( ! $stable_tag || 'trunk' === $stable_tag )
-			? 'trunk@' . get_post_meta( $post->ID, 'version', true )
-			: $stable_tag;
+		$target = self::get_current_release_tag( $post );
 
 		foreach ( (array) Plugin_Directory::get_releases( $post ) as $release ) {
 			if ( isset( $release['tag'] ) && (string) $release['tag'] === (string) $target ) {
@@ -260,6 +256,20 @@ class API_Update_Updater {
 		}
 
 		return false;
+	}
+
+	/**
+	 * The release tag a plugin's current version is served or held under.
+	 *
+	 * @param \WP_Post $post The plugin post.
+	 * @return string The stable tag, or `trunk@{version}` for trunk-stable plugins.
+	 */
+	public static function get_current_release_tag( $post ) {
+		$stable_tag = get_post_meta( $post->ID, 'stable_tag', true );
+
+		return ( ! $stable_tag || 'trunk' === $stable_tag )
+			? 'trunk@' . get_post_meta( $post->ID, 'version', true )
+			: $stable_tag;
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-release-confirmation.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-release-confirmation.php
@@ -287,7 +287,8 @@ class Release_Confirmation {
 	 * Render a single line describing the cooldown state of a release: pending serve time.
 	 * Skipped for releases without a cooldown delay (feature off at release creation, or
 	 * force-released), discarded releases, releases that haven't moved past
-	 * confirmation/processing, or where the cooldown window has elapsed.
+	 * confirmation/processing, rows other than the current release (superseded rows are
+	 * never served), or where the cooldown window has elapsed.
 	 *
 	 * @param \WP_Post $plugin The plugin post object.
 	 * @param array    $data   The release row from Plugin_Directory::get_releases().
@@ -304,6 +305,12 @@ class Release_Confirmation {
 
 		// Skip when the release hasn't moved past the confirmation/processing stage yet.
 		if ( $data['confirmations_required'] && ( ! $data['confirmed'] || ! $data['zips_built'] ) ) {
+			return;
+		}
+
+		// Only the current release can be pending; superseded rows are never served.
+		$current = API_Update_Updater::get_current_release( $plugin );
+		if ( ! $current || (string) $current['tag'] !== (string) ( $data['tag'] ?? '' ) ) {
 			return;
 		}
 

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-release-confirmation.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-release-confirmation.php
@@ -483,11 +483,7 @@ class Release_Confirmation {
 			return;
 		}
 
-		$version = get_post_meta( $post->ID, 'version', true );
-		if ( ! $version ) {
-			return;
-		}
-
+		// Resolved from the stable tag, so the notice shows even when the Version header is empty or disagrees.
 		$release = API_Update_Updater::get_current_release( $post );
 		if ( ! $release ) {
 			return;

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-release-confirmation.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-release-confirmation.php
@@ -498,8 +498,8 @@ class Release_Confirmation {
 			return;
 		}
 
-		$release_time   = $release['confirmations'] ? max( $release['confirmations'] ) : (int) $release['date'];
-		$cooldown_until = $release_time + $release_delay;
+		// Match the enforced window: compute_release_time() is what update_single_plugin() gates on.
+		$cooldown_until = API_Update_Updater::compute_release_time( $post, $release ) + $release_delay;
 
 		if ( $cooldown_until <= time() ) {
 			return;
@@ -511,7 +511,7 @@ class Release_Confirmation {
 				sprintf(
 					/* translators: 1: plugin version, 2: relative time until cooldown expires, 3: delay duration in hours, 4: plugins@wordpress.org link */
 					__( 'Version %1$s will be released to sites in about %2$s. WordPress.org currently delays plugin updates by %3$d hours so moderators and security scanners can review changes before they reach users. If this update fixes a security issue that needs to ship sooner, contact %4$s.', 'wporg-plugins' ),
-					'<code>' . esc_html( $version ) . '</code>',
+					'<code>' . esc_html( $release['version'] ) . '</code>',
 					esc_html( human_time_diff( time(), $cooldown_until ) ),
 					(int) ( $release_delay / HOUR_IN_SECONDS ),
 					'<a href="mailto:plugins@wordpress.org">plugins@wordpress.org</a>'

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-release-confirmation.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-release-confirmation.php
@@ -309,8 +309,7 @@ class Release_Confirmation {
 		}
 
 		// Only the current release can be pending; superseded rows are never served.
-		$current = API_Update_Updater::get_current_release( $plugin );
-		if ( ! $current || (string) $current['tag'] !== (string) ( $data['tag'] ?? '' ) ) {
+		if ( (string) ( $data['tag'] ?? '' ) !== (string) API_Update_Updater::get_current_release_tag( $plugin ) ) {
 			return;
 		}
 

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-release-confirmation.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-release-confirmation.php
@@ -187,7 +187,7 @@ class Release_Confirmation {
 					implode( ', ', $data['committer'] ),
 				),
 				self::get_actions( $plugin, $data ),
-				self::get_approval_text( $plugin, $data, $current_release ) .
+				self::get_approval_text( $plugin, $data, $current_release ) . // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped when built.
 					self::get_rollout_strategy( $plugin, $data )
 			);
 		}
@@ -201,7 +201,15 @@ class Release_Confirmation {
 		</style>';
 	}
 
-	static function get_approval_text( $plugin, $data, $current_release = null ) {
+	/**
+	 * The confirmation/cooldown status text for a release row.
+	 *
+	 * @param \WP_Post   $plugin          The plugin post object.
+	 * @param array      $data            The release row from Plugin_Directory::get_releases().
+	 * @param array|null $current_release Optional. The already-resolved current release, to save re-resolving per row.
+	 * @return string The release approval text, filtered via `wporg_plugins_release_approval_text`.
+	 */
+	public static function get_approval_text( $plugin, $data, $current_release = null ) {
 		ob_start();
 
 		if ( ! $data['confirmations_required'] ) {

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-release-confirmation.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-release-confirmation.php
@@ -124,6 +124,9 @@ class Release_Confirmation {
 	static function single_plugin( $plugin ) {
 		$releases = Plugin_Directory::get_releases( $plugin );
 
+		// Resolved once for the whole listing; each row's cooldown line compares against it.
+		$current_release = API_Update_Updater::get_current_release( $plugin );
+
 		echo '<div class="wp-block-table is-style-stripes">
 		<table class="plugin-releases-listing">
 		<colgroup>
@@ -184,7 +187,7 @@ class Release_Confirmation {
 					implode( ', ', $data['committer'] ),
 				),
 				self::get_actions( $plugin, $data ),
-				self::get_approval_text( $plugin, $data ) .
+				self::get_approval_text( $plugin, $data, $current_release ) .
 					self::get_rollout_strategy( $plugin, $data )
 			);
 		}
@@ -198,7 +201,7 @@ class Release_Confirmation {
 		</style>';
 	}
 
-	static function get_approval_text( $plugin, $data ) {
+	static function get_approval_text( $plugin, $data, $current_release = null ) {
 		ob_start();
 
 		if ( ! $data['confirmations_required'] ) {
@@ -266,7 +269,7 @@ class Release_Confirmation {
 			);
 		}
 
-		self::render_cooldown_status( $plugin, $data );
+		self::render_cooldown_status( $plugin, $data, $current_release );
 
 		echo '</div>';
 
@@ -290,10 +293,11 @@ class Release_Confirmation {
 	 * confirmation/processing, rows other than the current release (superseded rows are
 	 * never served), or where the cooldown window has elapsed.
 	 *
-	 * @param \WP_Post $plugin The plugin post object.
-	 * @param array    $data   The release row from Plugin_Directory::get_releases().
+	 * @param \WP_Post   $plugin          The plugin post object.
+	 * @param array      $data            The release row from Plugin_Directory::get_releases().
+	 * @param array|null $current_release The already-resolved current release, or null to resolve here.
 	 */
-	protected static function render_cooldown_status( $plugin, $data ) {
+	protected static function render_cooldown_status( $plugin, $data, $current_release = null ) {
 		$release_delay = (int) ( $data['release_delay'] ?? 0 );
 		if ( ! $release_delay ) {
 			return;
@@ -309,7 +313,8 @@ class Release_Confirmation {
 		}
 
 		// Only the current release can be pending; superseded rows are never served.
-		if ( (string) ( $data['tag'] ?? '' ) !== (string) API_Update_Updater::get_current_release_tag( $plugin ) ) {
+		$current_release = $current_release ?? API_Update_Updater::get_current_release( $plugin );
+		if ( ! $current_release || (string) ( $data['tag'] ?? '' ) !== (string) $current_release['tag'] ) {
 			return;
 		}
 

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-release-confirmation.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-release-confirmation.php
@@ -266,7 +266,7 @@ class Release_Confirmation {
 			);
 		}
 
-		self::render_cooldown_status( $data );
+		self::render_cooldown_status( $plugin, $data );
 
 		echo '</div>';
 
@@ -289,9 +289,10 @@ class Release_Confirmation {
 	 * force-released), discarded releases, releases that haven't moved past
 	 * confirmation/processing, or where the cooldown window has elapsed.
 	 *
-	 * @param array $data The release row from Plugin_Directory::get_releases().
+	 * @param \WP_Post $plugin The plugin post object.
+	 * @param array    $data   The release row from Plugin_Directory::get_releases().
 	 */
-	protected static function render_cooldown_status( $data ) {
+	protected static function render_cooldown_status( $plugin, $data ) {
 		$release_delay = (int) ( $data['release_delay'] ?? 0 );
 		if ( ! $release_delay ) {
 			return;
@@ -306,8 +307,8 @@ class Release_Confirmation {
 			return;
 		}
 
-		$release_time   = $data['confirmations'] ? max( $data['confirmations'] ) : (int) $data['date'];
-		$cooldown_until = $release_time + $release_delay;
+		// Match the enforced window: compute_release_time() is what update_single_plugin() gates on.
+		$cooldown_until = API_Update_Updater::compute_release_time( $plugin, $data ) + $release_delay;
 
 		if ( $cooldown_until <= time() ) {
 			return;

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-release-confirmation.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-release-confirmation.php
@@ -1,6 +1,7 @@
 <?php
 namespace WordPressdotorg\Plugin_Directory\Shortcodes;
 
+use WordPressdotorg\Plugin_Directory\Jobs\API_Update_Updater;
 use WordPressdotorg\Plugin_Directory\Plugin_Directory;
 use WordPressdotorg\Plugin_Directory\Template;
 use WordPressdotorg\Plugin_Directory\Tools;
@@ -487,7 +488,7 @@ class Release_Confirmation {
 			return;
 		}
 
-		$release = Plugin_Directory::get_release( $post, $version );
+		$release = API_Update_Updater::get_current_release( $post );
 		if ( ! $release ) {
 			return;
 		}

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Current_Release_Resolution_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Current_Release_Resolution_Test.php
@@ -132,7 +132,7 @@ class Current_Release_Resolution_Test extends TestCase {
 	 * @return string The served version.
 	 */
 	private function served_version(): string {
-		return API_Update_Updater::get_served_version( $this->plugin->post_name );
+		return (string) ( API_Update_Updater::get_served_row( $this->plugin->post_name )->version ?? '' );
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Current_Release_Resolution_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Current_Release_Resolution_Test.php
@@ -457,6 +457,21 @@ class Current_Release_Resolution_Test extends TestCase {
 	}
 
 	/**
+	 * The listing's cooldown line follows the same resolution as the rest of the
+	 * UI: with the stable tag flipped to trunk at an unchanged version, the
+	 * fallback-resolved release is the current one and keeps its line.
+	 */
+	public function test_cooldown_line_follows_fallback_resolution(): void {
+		update_post_meta( $this->plugin->ID, 'version', self::RENAMED_VERSION );
+		update_post_meta( $this->plugin->ID, 'stable_tag', 'trunk' );
+		$this->add_release( self::RENAMED_VERSION, self::RENAMED_VERSION );
+
+		$releases = array_column( Plugin_Directory::get_releases( $this->plugin ), null, 'tag' );
+
+		$this->assertStringContainsString( 'Will be served', Release_Confirmation::get_approval_text( get_post( $this->plugin->ID ), $releases[ self::RENAMED_VERSION ] ) );
+	}
+
+	/**
 	 * The force-release audit note names the release actually unblocked — the
 	 * stable-tag-resolved one — not the plugin's Version header.
 	 */

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Current_Release_Resolution_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Current_Release_Resolution_Test.php
@@ -1,0 +1,235 @@
+<?php
+/**
+ * Tests for resolving the release a hold applies to.
+ *
+ * @package WordPressdotorg\Plugin_Directory\Tests
+ */
+
+declare( strict_types = 1 );
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use WordPressdotorg\Plugin_Directory\Jobs\API_Update_Updater;
+use WordPressdotorg\Plugin_Directory\Plugin_Directory;
+
+/**
+ * Tests that a Version header that doesn't match its tag cannot orphan the
+ * release's block or cooldown: the hold is resolved from the stable tag, the
+ * source of the served package, not from the header's version label.
+ *
+ * Extends the plain PHPUnit TestCase: WP_UnitTestCase is not compatible with
+ * the PHPUnit 11 runner used by this suite. Isolation comes from giving every
+ * test its own plugin post instead of per-test transactions.
+ *
+ * The group is declared as an attribute as well as `@group`: PHPUnit 11 ignores
+ * a class-level `@group` docblock, while older runners ignore the attribute.
+ *
+ * @group jobs
+ */
+#[Group( 'jobs' )]
+class Current_Release_Resolution_Test extends TestCase {
+
+	/** The version served by the update_source row fixture. */
+	private const SERVED_VERSION = '1.0.0';
+
+	/** The tag of the held release. */
+	private const HELD_TAG = '1.4.4';
+
+	/** The mismatched Version header committed into the held tag. */
+	private const RENAMED_VERSION = '1.4.5';
+
+	/**
+	 * Counter to give every test plugin a unique slug.
+	 *
+	 * @var int
+	 */
+	private static int $plugin_count = 0;
+
+	/**
+	 * The plugin post under test.
+	 *
+	 * @var \WP_Post
+	 */
+	private \WP_Post $plugin;
+
+	/**
+	 * Create a published plugin whose held tag carries a mismatched Version header.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		wp_cache_flush();
+
+		// Tools::audit_log() reads it unguarded.
+		$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+
+		$plugin = Plugin_Directory::create_plugin_post(
+			array(
+				'post_name'   => 'resolution-test-' . ( ++self::$plugin_count ),
+				'post_title'  => 'Release Resolution Test Plugin',
+				'post_status' => 'publish',
+			)
+		);
+
+		$this->assertInstanceOf( \WP_Post::class, $plugin );
+		$this->plugin = $plugin;
+
+		/*
+		 * The stub update_source table survives across runs — the WP test
+		 * installer only drops core tables — so clear leftovers that would
+		 * collide with this run's plugin ID or read as a served version.
+		 */
+		global $wpdb;
+		$wpdb->delete( $wpdb->prefix . 'update_source', array( 'plugin_id' => $this->plugin->ID ) );
+		$wpdb->delete( $wpdb->prefix . 'update_source', array( 'plugin_slug' => $this->plugin->post_name ) );
+
+		$wpdb->insert(
+			$wpdb->prefix . 'update_source',
+			array(
+				'plugin_id'        => $this->plugin->ID,
+				'plugin_slug'      => $this->plugin->post_name,
+				'available'        => 1,
+				'version'          => self::SERVED_VERSION,
+				'stable_tag'       => self::SERVED_VERSION,
+				'plugin_name'      => $this->plugin->post_title,
+				'requires_plugins' => '',
+				'last_updated'     => $this->plugin->post_modified,
+			)
+		);
+
+		update_post_meta( $this->plugin->ID, 'version', self::RENAMED_VERSION );
+		update_post_meta( $this->plugin->ID, 'stable_tag', self::HELD_TAG );
+	}
+
+	/**
+	 * Register a release for a tag.
+	 *
+	 * @param string $tag       The release tag.
+	 * @param string $version   The release version.
+	 * @param array  $overrides Fields to override.
+	 */
+	private function add_release( string $tag, string $version, array $overrides = array() ): void {
+		Plugin_Directory::add_release(
+			$this->plugin,
+			array_merge(
+				array(
+					'tag'                      => $tag,
+					'version'                  => $version,
+					'zips_built'               => true,
+					'zips_built_from_revision' => 0,
+					'confirmed'                => true,
+					'confirmations_required'   => 0,
+					'release_delay'            => DAY_IN_SECONDS,
+				),
+				$overrides
+			)
+		);
+	}
+
+	/**
+	 * The version currently in the plugin's update_source row.
+	 *
+	 * @return string The served version.
+	 */
+	private function served_version(): string {
+		return API_Update_Updater::get_served_version( $this->plugin->post_name );
+	}
+
+	/**
+	 * A renamed Version header inside a tag under cooldown keeps the hold.
+	 */
+	public function test_renamed_header_keeps_cooldown_hold(): void {
+		$this->add_release( self::HELD_TAG, self::RENAMED_VERSION );
+
+		$this->assertTrue( API_Update_Updater::update_single_plugin( $this->plugin->post_name ) );
+
+		$this->assertSame( self::SERVED_VERSION, $this->served_version() );
+		$this->assertNotFalse( wp_next_scheduled( "release_to_update_api:{$this->plugin->post_name}" ) );
+	}
+
+	/**
+	 * A renamed Version header inside a blocked tag keeps the block's hold.
+	 */
+	public function test_renamed_header_keeps_block_hold(): void {
+		$this->add_release(
+			self::HELD_TAG,
+			self::RENAMED_VERSION,
+			array(
+				'release_block' => array(
+					'scan_id'    => 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+					'risk_score' => 9.8,
+					'blocked_at' => time(),
+				),
+			)
+		);
+
+		$this->assertTrue( API_Update_Updater::update_single_plugin( $this->plugin->post_name ) );
+
+		$this->assertSame( self::SERVED_VERSION, $this->served_version() );
+		$this->assertFalse( wp_next_scheduled( "release_to_update_api:{$this->plugin->post_name}" ) );
+	}
+
+	/**
+	 * A header renamed to another, clean release's version still resolves the
+	 * hold from the stable tag serving the package.
+	 */
+	public function test_header_renamed_to_other_release_version_keeps_hold(): void {
+		$this->add_release( '2.0', '2.0', array( 'release_delay' => 0 ) );
+		$this->add_release(
+			self::HELD_TAG,
+			self::RENAMED_VERSION,
+			array(
+				'release_block' => array( 'blocked_at' => time() ),
+			)
+		);
+		update_post_meta( $this->plugin->ID, 'version', '2.0' );
+
+		$this->assertTrue( API_Update_Updater::update_single_plugin( $this->plugin->post_name ) );
+
+		$this->assertSame( self::SERVED_VERSION, $this->served_version() );
+	}
+
+	/**
+	 * A scan-driven block lands on the stable tag's release despite the rename.
+	 */
+	public function test_block_release_records_block_on_stable_tag_release(): void {
+		$this->add_release( self::HELD_TAG, self::RENAMED_VERSION );
+
+		$this->assertTrue( API_Update_Updater::block_release( $this->plugin->post_name, array( 'risk_score' => 9.8 ) ) );
+
+		$release = Plugin_Directory::get_release( get_post( $this->plugin->ID ), self::HELD_TAG );
+		$this->assertTrue( API_Update_Updater::is_release_blocked( $release ) );
+	}
+
+	/**
+	 * A reviewer force-release lifts the hold on the stable tag's release and
+	 * serves the version despite the rename.
+	 */
+	public function test_force_release_serves_renamed_version(): void {
+		$this->add_release(
+			self::HELD_TAG,
+			self::RENAMED_VERSION,
+			array(
+				'release_block' => array( 'blocked_at' => time() ),
+			)
+		);
+
+		$this->assertTrue( API_Update_Updater::force_release( $this->plugin->post_name, 'Reviewed; findings are a false positive.' ) );
+
+		$this->assertSame( self::RENAMED_VERSION, $this->served_version() );
+	}
+
+	/**
+	 * Trunk releases keep resolving by version: their rows are keyed
+	 * `trunk@{version}` and there is no stable tag release to prefer.
+	 */
+	public function test_trunk_release_still_resolves_by_version(): void {
+		update_post_meta( $this->plugin->ID, 'stable_tag', 'trunk' );
+		$this->add_release( 'trunk@' . self::RENAMED_VERSION, self::RENAMED_VERSION );
+
+		$this->assertTrue( API_Update_Updater::update_single_plugin( $this->plugin->post_name ) );
+
+		$this->assertSame( self::SERVED_VERSION, $this->served_version() );
+		$this->assertNotFalse( wp_next_scheduled( "release_to_update_api:{$this->plugin->post_name}" ) );
+	}
+}

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Current_Release_Resolution_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Current_Release_Resolution_Test.php
@@ -259,6 +259,64 @@ class Current_Release_Resolution_Test extends TestCase {
 	}
 
 	/**
+	 * A header renamed down to the already-served version cannot write the
+	 * blocked tag into update_source: the block gate no longer keys on the
+	 * header-derived is_new_version proxy.
+	 */
+	public function test_block_held_when_header_matches_served_version(): void {
+		global $wpdb;
+
+		update_post_meta( $this->plugin->ID, 'version', self::SERVED_VERSION );
+		$this->add_release( self::HELD_TAG, self::SERVED_VERSION, array( 'release_block' => array( 'blocked_at' => time() ) ) );
+
+		$this->assertTrue( API_Update_Updater::update_single_plugin( $this->plugin->post_name ) );
+
+		$row = $wpdb->get_row( $wpdb->prepare( "SELECT version, stable_tag FROM {$wpdb->prefix}update_source WHERE plugin_slug = %s", $this->plugin->post_name ) );
+		$this->assertSame( self::SERVED_VERSION, $row->version );
+		$this->assertSame( self::SERVED_VERSION, $row->stable_tag );
+	}
+
+	/**
+	 * The already-served guard doesn't read an empty served version and an empty
+	 * resolved version as a match, which would wrongly refuse the block.
+	 */
+	public function test_block_not_refused_for_empty_versions(): void {
+		global $wpdb;
+
+		$wpdb->delete( $wpdb->prefix . 'update_source', array( 'plugin_slug' => $this->plugin->post_name ) );
+		$this->add_release( self::HELD_TAG, '' );
+
+		$this->assertTrue( API_Update_Updater::block_release( $this->plugin->post_name, array( 'risk_score' => 9.8 ) ) );
+		$this->assertTrue( API_Update_Updater::is_release_blocked( Plugin_Directory::get_release( get_post( $this->plugin->ID ), self::HELD_TAG ) ) );
+	}
+
+	/**
+	 * A tag that is numerically equal but textually different to the stable tag
+	 * does not resolve: the match is strict, not wp_list_filter's loose ==.
+	 */
+	public function test_numeric_collision_tag_not_matched(): void {
+		update_post_meta( $this->plugin->ID, 'stable_tag', '1.4' );
+		$this->add_release( '1.40', '1.40', array( 'release_block' => array( 'blocked_at' => time() ) ) );
+
+		$this->assertFalse( API_Update_Updater::get_current_release( get_post( $this->plugin->ID ) ) );
+	}
+
+	/**
+	 * A dormant SVN tag named like the trunk version does not shadow the
+	 * `trunk@{version}` release the trunk plugin actually serves.
+	 */
+	public function test_trunk_version_not_shadowed_by_like_named_tag(): void {
+		update_post_meta( $this->plugin->ID, 'stable_tag', 'trunk' );
+		update_post_meta( $this->plugin->ID, 'version', '1.2.3' );
+		$this->add_release( '1.2.3', '1.2.3', array( 'release_block' => array( 'blocked_at' => time() ) ) );
+		$this->add_release( 'trunk@1.2.3', '1.2.3' );
+
+		$release = API_Update_Updater::get_current_release( get_post( $this->plugin->ID ) );
+		$this->assertSame( 'trunk@1.2.3', $release['tag'] );
+		$this->assertFalse( API_Update_Updater::is_release_blocked( $release ) );
+	}
+
+	/**
 	 * The force-release audit note names the release actually unblocked — the
 	 * stable-tag-resolved one — not the plugin's Version header.
 	 */

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Current_Release_Resolution_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Current_Release_Resolution_Test.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use WordPressdotorg\Plugin_Directory\Jobs\API_Update_Updater;
 use WordPressdotorg\Plugin_Directory\Plugin_Directory;
+use WordPressdotorg\Plugin_Directory\Shortcodes\Release_Confirmation;
 
 /**
  * Tests that a Version header that doesn't match its tag cannot orphan the
@@ -398,6 +399,23 @@ class Current_Release_Resolution_Test extends TestCase {
 		);
 
 		$this->assertSame( $version_time, API_Update_Updater::compute_release_time( get_post( $this->plugin->ID ), $release ) );
+	}
+
+	/**
+	 * The releases listing shows the cooldown line only for the current release:
+	 * a superseded row is never served, so the plugin-wide version_date anchor
+	 * must not re-display a pending serve time on old rows after a new commit.
+	 */
+	public function test_cooldown_line_only_for_current_release(): void {
+		update_post_meta( $this->plugin->ID, 'version_date', gmdate( 'Y-m-d H:i:s' ) );
+		$this->add_release( self::HELD_TAG, self::RENAMED_VERSION );
+		$this->add_release( '1.0', '1.0', array( 'date' => time() - WEEK_IN_SECONDS ) );
+
+		$releases = array_column( Plugin_Directory::get_releases( $this->plugin ), null, 'tag' );
+		$plugin   = get_post( $this->plugin->ID );
+
+		$this->assertStringContainsString( 'Will be served', Release_Confirmation::get_approval_text( $plugin, $releases[ self::HELD_TAG ] ) );
+		$this->assertStringNotContainsString( 'Will be served', Release_Confirmation::get_approval_text( $plugin, $releases['1.0'] ) );
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Current_Release_Resolution_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Current_Release_Resolution_Test.php
@@ -370,6 +370,37 @@ class Current_Release_Resolution_Test extends TestCase {
 	}
 
 	/**
+	 * Without a version_date, the release clock anchors on the release row's own
+	 * date: post_modified would slide on unrelated post edits and re-arm cooldown
+	 * displays for an already-served release.
+	 */
+	public function test_release_time_anchors_on_release_date_without_version_date(): void {
+		$release = array(
+			'date'                   => time() - WEEK_IN_SECONDS,
+			'confirmations_required' => 0,
+			'confirmations'          => array(),
+		);
+
+		$this->assertSame( $release['date'], API_Update_Updater::compute_release_time( get_post( $this->plugin->ID ), $release ) );
+	}
+
+	/**
+	 * A version_date on the plugin outranks the release row's date as the clock anchor.
+	 */
+	public function test_release_time_prefers_version_date(): void {
+		$version_time = time() - DAY_IN_SECONDS;
+		update_post_meta( $this->plugin->ID, 'version_date', gmdate( 'Y-m-d H:i:s', $version_time ) );
+
+		$release = array(
+			'date'                   => time() - WEEK_IN_SECONDS,
+			'confirmations_required' => 0,
+			'confirmations'          => array(),
+		);
+
+		$this->assertSame( $version_time, API_Update_Updater::compute_release_time( get_post( $this->plugin->ID ), $release ) );
+	}
+
+	/**
 	 * The force-release audit note names the release actually unblocked — the
 	 * stable-tag-resolved one — not the plugin's Version header.
 	 */

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Current_Release_Resolution_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Current_Release_Resolution_Test.php
@@ -244,7 +244,7 @@ class Current_Release_Resolution_Test extends TestCase {
 	}
 
 	/**
-	 * The block's already-served guard compares the resolved release's version,
+	 * The block's already-served guard keys on the resolved release's identity,
 	 * not the header: a header renamed to equal the served version cannot make
 	 * a different, unserved release look already-live and refuse the block.
 	 */
@@ -314,6 +314,59 @@ class Current_Release_Resolution_Test extends TestCase {
 		$release = API_Update_Updater::get_current_release( get_post( $this->plugin->ID ) );
 		$this->assertSame( 'trunk@1.2.3', $release['tag'] );
 		$this->assertFalse( API_Update_Updater::is_release_blocked( $release ) );
+	}
+
+	/**
+	 * A re-commit into the already-served tag cannot be blocked, even when it
+	 * bumps the header: the guard compares the ref the row serves, not the
+	 * version label, so it can't claim to hold a package that already shipped.
+	 */
+	public function test_block_refused_for_recommit_into_served_tag(): void {
+		update_post_meta( $this->plugin->ID, 'stable_tag', self::SERVED_VERSION );
+		update_post_meta( $this->plugin->ID, 'version', '1.0.1' );
+		$this->add_release( self::SERVED_VERSION, '1.0.1' );
+
+		$this->assertFalse( API_Update_Updater::block_release( $this->plugin->post_name, array( 'risk_score' => 9.8 ) ) );
+		$this->assertFalse( API_Update_Updater::is_release_blocked( Plugin_Directory::get_release( get_post( $this->plugin->ID ), self::SERVED_VERSION ) ) );
+	}
+
+	/**
+	 * Trunk-stable rows carry no per-release ref, so the already-served guard
+	 * falls back to their identity — the version — and still refuses the block.
+	 */
+	public function test_block_refused_for_served_trunk_release(): void {
+		global $wpdb;
+
+		$wpdb->update(
+			$wpdb->prefix . 'update_source',
+			array( 'stable_tag' => 'trunk' ),
+			array( 'plugin_slug' => $this->plugin->post_name )
+		);
+		update_post_meta( $this->plugin->ID, 'stable_tag', 'trunk' );
+		update_post_meta( $this->plugin->ID, 'version', self::SERVED_VERSION );
+		$this->add_release( 'trunk@' . self::SERVED_VERSION, self::SERVED_VERSION );
+
+		$this->assertFalse( API_Update_Updater::block_release( $this->plugin->post_name, array( 'risk_score' => 9.8 ) ) );
+		$this->assertFalse( API_Update_Updater::is_release_blocked( Plugin_Directory::get_release( get_post( $this->plugin->ID ), 'trunk@' . self::SERVED_VERSION ) ) );
+	}
+
+	/**
+	 * The block's write lands on the exact tag: add_release() must not merge it
+	 * onto a numerically-equal different release ('1.4' == '1.40') and delete
+	 * the genuine row in the process.
+	 */
+	public function test_block_write_lands_on_exact_tag_not_numeric_equal(): void {
+		update_post_meta( $this->plugin->ID, 'stable_tag', '1.4' );
+		$this->add_release( '1.40', '1.40', array( 'date' => time() ) );
+		$this->add_release( '1.4', '1.4', array( 'date' => time() - DAY_IN_SECONDS ) );
+
+		$this->assertTrue( API_Update_Updater::block_release( $this->plugin->post_name, array( 'risk_score' => 9.8 ) ) );
+
+		$releases = array_column( Plugin_Directory::get_releases( $this->plugin ), null, 'tag' );
+		$this->assertSame( '1.4', $releases['1.4']['version'] );
+		$this->assertTrue( API_Update_Updater::is_release_blocked( $releases['1.4'] ) );
+		$this->assertSame( '1.40', $releases['1.40']['version'] );
+		$this->assertFalse( API_Update_Updater::is_release_blocked( $releases['1.40'] ) );
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Current_Release_Resolution_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Current_Release_Resolution_Test.php
@@ -232,4 +232,50 @@ class Current_Release_Resolution_Test extends TestCase {
 		$this->assertSame( self::SERVED_VERSION, $this->served_version() );
 		$this->assertNotFalse( wp_next_scheduled( "release_to_update_api:{$this->plugin->post_name}" ) );
 	}
+
+	/**
+	 * A tagged plugin resolves strictly by its stable tag: a release row that
+	 * exists only for the header version is not a fallback.
+	 */
+	public function test_tagged_plugin_ignores_version_release_row(): void {
+		$this->add_release( self::RENAMED_VERSION, self::RENAMED_VERSION, array( 'release_block' => array( 'blocked_at' => time() ) ) );
+
+		$this->assertFalse( API_Update_Updater::get_current_release( get_post( $this->plugin->ID ) ) );
+	}
+
+	/**
+	 * The block's already-served guard compares the resolved release's version,
+	 * not the header: a header renamed to equal the served version cannot make
+	 * a different, unserved release look already-live and refuse the block.
+	 */
+	public function test_block_release_guard_uses_resolved_release_version(): void {
+		update_post_meta( $this->plugin->ID, 'version', self::SERVED_VERSION );
+		$this->add_release( self::HELD_TAG, '2.0' );
+
+		$this->assertTrue( API_Update_Updater::block_release( $this->plugin->post_name, array( 'risk_score' => 9.8 ) ) );
+
+		$release = Plugin_Directory::get_release( get_post( $this->plugin->ID ), self::HELD_TAG );
+		$this->assertTrue( API_Update_Updater::is_release_blocked( $release ) );
+	}
+
+	/**
+	 * The force-release audit note names the release actually unblocked — the
+	 * stable-tag-resolved one — not the plugin's Version header.
+	 */
+	public function test_force_release_audit_log_names_resolved_release(): void {
+		update_post_meta( $this->plugin->ID, 'version', '9.9.9' );
+		$this->add_release( self::HELD_TAG, '7.7.7', array( 'release_block' => array( 'blocked_at' => time() ) ) );
+
+		$this->assertTrue( API_Update_Updater::force_release( $this->plugin->post_name, 'Reviewed.' ) );
+
+		$notes = get_comments(
+			array(
+				'post_id' => $this->plugin->ID,
+				'type'    => 'internal-note',
+			)
+		);
+		$this->assertNotEmpty( $notes );
+		$this->assertStringContainsString( 'version 7.7.7', $notes[0]->comment_content );
+		$this->assertStringNotContainsString( '9.9.9', $notes[0]->comment_content );
+	}
 }

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Current_Release_Resolution_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Current_Release_Resolution_Test.php
@@ -235,13 +235,51 @@ class Current_Release_Resolution_Test extends TestCase {
 	}
 
 	/**
-	 * A tagged plugin resolves strictly by its stable tag: a release row that
-	 * exists only for the header version is not a fallback.
+	 * A release row for the header version is a fallback only: it resolves when
+	 * the stable tag has no row (the gates would otherwise fail open), and never
+	 * overrides the stable tag's own release.
 	 */
-	public function test_tagged_plugin_ignores_version_release_row(): void {
+	public function test_version_release_row_is_fallback_only(): void {
 		$this->add_release( self::RENAMED_VERSION, self::RENAMED_VERSION, array( 'release_block' => array( 'blocked_at' => time() ) ) );
 
-		$this->assertFalse( API_Update_Updater::get_current_release( get_post( $this->plugin->ID ) ) );
+		$release = API_Update_Updater::get_current_release( get_post( $this->plugin->ID ) );
+		$this->assertSame( self::RENAMED_VERSION, $release['tag'] );
+
+		$this->add_release( self::HELD_TAG, self::RENAMED_VERSION );
+
+		$release = API_Update_Updater::get_current_release( get_post( $this->plugin->ID ) );
+		$this->assertSame( self::HELD_TAG, $release['tag'] );
+	}
+
+	/**
+	 * Flipping the stable tag to trunk at an unchanged version creates no
+	 * trunk@{version} release row; the hold on the version-named release must
+	 * keep the gates closed rather than orphan into a fail-open miss.
+	 */
+	public function test_trunk_flip_at_same_version_keeps_hold(): void {
+		update_post_meta( $this->plugin->ID, 'version', self::RENAMED_VERSION );
+		update_post_meta( $this->plugin->ID, 'stable_tag', 'trunk' );
+		$this->add_release( self::RENAMED_VERSION, self::RENAMED_VERSION, array( 'release_block' => array( 'blocked_at' => time() ) ) );
+
+		$release = API_Update_Updater::get_current_release( get_post( $this->plugin->ID ) );
+		$this->assertSame( self::RENAMED_VERSION, $release['tag'] );
+		$this->assertTrue( API_Update_Updater::is_release_blocked( $release ) );
+
+		$this->assertTrue( API_Update_Updater::update_single_plugin( $this->plugin->post_name ) );
+		$this->assertSame( self::SERVED_VERSION, $this->served_version() );
+	}
+
+	/**
+	 * The fallback also survives the combination of both evasions: a renamed
+	 * header inside the held tag, then a stable-tag flip to trunk.
+	 */
+	public function test_trunk_flip_with_renamed_header_keeps_hold(): void {
+		update_post_meta( $this->plugin->ID, 'stable_tag', 'trunk' );
+		$this->add_release( self::HELD_TAG, self::RENAMED_VERSION, array( 'release_block' => array( 'blocked_at' => time() ) ) );
+
+		$release = API_Update_Updater::get_current_release( get_post( $this->plugin->ID ) );
+		$this->assertSame( self::HELD_TAG, $release['tag'] );
+		$this->assertTrue( API_Update_Updater::is_release_blocked( $release ) );
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Update_Source_Hold_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Update_Source_Hold_Test.php
@@ -290,7 +290,7 @@ class Update_Source_Hold_Test extends TestCase {
 		$this->assertSame( 'High-risk release.', $block['reason'] );
 		$this->assertNotEmpty( $block['blocked_at'] );
 
-		$this->assertSame( self::SERVED_VERSION, API_Update_Updater::get_served_version( $this->plugin->post_name ) );
+		$this->assertSame( self::SERVED_VERSION, (string) ( $this->get_row()->version ?? '' ) );
 		$this->assertFalse( wp_next_scheduled( "release_to_update_api:{$this->plugin->post_name}" ) );
 	}
 
@@ -313,7 +313,7 @@ class Update_Source_Hold_Test extends TestCase {
 
 		API_Update_Updater::update_single_plugin( $this->plugin->post_name );
 
-		$this->assertSame( self::SERVED_VERSION, API_Update_Updater::get_served_version( $this->plugin->post_name ) );
+		$this->assertSame( self::SERVED_VERSION, (string) ( $this->get_row()->version ?? '' ) );
 	}
 
 	/**
@@ -334,7 +334,7 @@ class Update_Source_Hold_Test extends TestCase {
 
 		API_Update_Updater::update_single_plugin( $this->plugin->post_name );
 
-		$this->assertSame( '', API_Update_Updater::get_served_version( $this->plugin->post_name ) );
+		$this->assertSame( '', (string) ( $this->get_row()->version ?? '' ) );
 	}
 
 	/**
@@ -453,7 +453,7 @@ class Update_Source_Hold_Test extends TestCase {
 		$this->assertTrue( API_Update_Updater::force_release( $this->plugin->post_name, 'Reviewed; false positive.' ) );
 
 		$this->assertFalse( API_Update_Updater::is_release_blocked( $this->get_release() ) );
-		$this->assertSame( self::STAGED_VERSION, API_Update_Updater::get_served_version( $this->plugin->post_name ) );
+		$this->assertSame( self::STAGED_VERSION, (string) ( $this->get_row()->version ?? '' ) );
 
 		$audit_log = $this->get_audit_log();
 		$this->assertStringContainsString( 'lifting the release block', $audit_log );
@@ -471,7 +471,7 @@ class Update_Source_Hold_Test extends TestCase {
 		$this->assertTrue( API_Update_Updater::force_release( $this->plugin->post_name, 'Reviewed; false positive.' ) );
 
 		$this->assertFalse( API_Update_Updater::is_release_blocked( $this->get_release() ) );
-		$this->assertSame( self::STAGED_VERSION, API_Update_Updater::get_served_version( $this->plugin->post_name ) );
+		$this->assertSame( self::STAGED_VERSION, (string) ( $this->get_row()->version ?? '' ) );
 
 		$this->assertStringContainsString(
 			'lifting the release block and bypassing the 24-hour release cooldown',


### PR DESCRIPTION
The release cooldown and #785's release block are resolved by looking up the release *named after the plugin's Version header*: `update_single_plugin()`, `block_release()`, and `force_release()` all call `get_release( $post, $version )`, which matches by tag. An author can commit one line into a held tag — changing `Version: 1.4.4` to `Version: 1.4.5` — and the lookup finds no release for "1.4.5": no block, no cooldown, and the tag's rebuilt package is written to `update_source` immediately under the new version label. The importer's `version_tag_mismatch` check is a warning, not a gate. The same rename can point at another, clean release's version to inherit its (absent) hold. With the release cooldown live in production, this is an active bypass of it today: the rename ships a held tag's rebuilt package immediately instead of waiting out the cooldown. It would equally bypass #777's scan-driven blocks once those land.

Builds on #785; complements #777 and #806.

### What it does

- `API_Update_Updater::get_current_release()` resolves the release being served or held from the **stable tag** — the source of the served package, so the hold follows the content, not the header's label — falling back to the version for trunk releases, which are keyed `trunk@{version}`. A rename inside a held tag now resolves to that tag's release, block and cooldown intact.
- `update_single_plugin()`, `block_release()`, and `force_release()` use it, so enforcement, scan-driven blocking, and the reviewer's release all target the same release row. Force-release keeps working on a renamed release rather than failing to find it.
- The two cooldown displays (wp-admin publish metabox, Release Management notice) use it too, so the UI shows the hold that is actually enforced.
- For the normal case — header matching its tag, or a trunk release — both lookups land on the same row and nothing changes. Plugins whose stable tag legitimately differs from their version (e.g. tag `1.4` carrying version `1.4.0`) were previously invisible to the cooldown entirely; they now resolve correctly.

### Testing

`tests/Current_Release_Resolution_Test.php` (6 tests): a renamed header keeps the cooldown hold and keeps a block's hold, a rename pointing at another clean release's version still holds, `block_release()` lands the block on the stable tag's release, force-release serves the renamed version, and trunk releases still resolve by version. Verified the first three fail against the previous resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

