### PR TITLE
Slack: Trac Bot: Ignore references to tickets that don't exist.

### DIFF
--- a/api.wordpress.org/public_html/dotorg/slack/trac-bot.php
+++ b/api.wordpress.org/public_html/dotorg/slack/trac-bot.php
@@ -75,6 +75,14 @@ namespace Dotorg\Slack\Trac {
 					$parser->set_redundancy( 'slack', $trac, $type, $id );
 					$slack->add_attachment( $attachment );
 				} else {
+					/*
+					 * A number matching no ticket is more likely a misparse than a reference.
+					 * Setting redundancy would let the repost-a-link path above surface the dead URL.
+					 */
+					if ( $obj->is_not_found() ) {
+						continue;
+					}
+
 					// We don't have an attachment when the Trac is private or if we experienced an error.
 					// Don't set redundancy times on errors.
 					if ( ! $trac_obj->is_public() ) {
@@ -118,10 +126,15 @@ namespace Dotorg\Slack\Trac {
 			// If the ticket is closed and hasn't been modified in over 2 years, don't post a reference to it.
 			if ( ! empty( $parsed_objects[ 'ticket' ][ $ticket_id ] ) ) {
 				$ticket_object = $parsed_objects[ 'ticket' ][ $ticket_id ];
-				$ticket_object->fetch();
 
+				if ( $ticket_object->is_not_found() ) {
+					continue;
+				}
+
+				// Trac labels the column 'modified' and names it 'changetime'.
+				$modified          = $ticket_object->modified ?: $ticket_object->changetime;
 				$is_closed         = ( 'closed' === $ticket_object->status );
-				$last_modified     = strtotime( $ticket_object->modified );
+				$last_modified     = $modified ? strtotime( $modified ) : false;
 				$has_recent_change = ( ! $last_modified || $last_modified > ( time() - 2 * YEAR_IN_SECONDS ) );
 
 				if ( $is_closed && ! $has_recent_change ) {

--- a/common/includes/slack/trac/comment-handler.php
+++ b/common/includes/slack/trac/comment-handler.php
@@ -241,12 +241,19 @@ class Comment_Handler {
 	function format_comment_for_slack() {
 		// Link 'Replying to [comment:1 user]:'
 		$ticket_url = $this->ticket_url;
-		$comment = preg_replace_callback( '/Replying to \[comment:(\d+) (.*)\]/m',
+
+		// Escape before the link below is built, so that one survives.
+		$comment = Trac::escape_for_slack( $this->comment );
+
+		$comment = preg_replace_callback(
+			'/Replying to \[comment:(\d+) (.*)\]/m',
 			function ( $matches ) use ( $ticket_url ) {
 				$comment_url = $ticket_url . '#comment:' . $matches[1];
 				$text = 'Replying to ' . $matches[2];
 				return "<$comment_url|$text>";
-			}, $this->comment );
+			},
+			$comment
+		);
 
 		$comment = Trac::format_for_slack( $comment );
 		return $comment;
@@ -257,9 +264,11 @@ class Comment_Handler {
 		$this->send->set_username( $this->trac->get_ticket_username() );
 
 		$comment         = $this->format_comment_for_slack();
-		$main_attachment = $this->changes ? implode( "\n", $this->changes ) : $comment;
+		$main_attachment = $this->changes ? Trac::escape_for_slack( implode( "\n", $this->changes ) ) : $comment;
 		$author          = $this->author ? $this->author : 'Someone';
-		$pretext         = sprintf( '*%s updated <%s|#%s %s>*', $author, $this->comment_url, $this->ticket_id, htmlspecialchars( $this->title, ENT_NOQUOTES ) );
+		// A > would close the link early, so the label needs it escaped too.
+		$title           = htmlspecialchars( $this->title, ENT_NOQUOTES | ENT_SUBSTITUTE );
+		$pretext         = sprintf( '*%s updated <%s|#%s %s>*', Trac::escape_for_slack( $author ), $this->comment_url, $this->ticket_id, $title );
 		$fallback        = trim( $pretext, '*' ) . "\n" . $main_attachment;
 
 		$attachment = array(

--- a/common/includes/slack/trac/new-ticket.php
+++ b/common/includes/slack/trac/new-ticket.php
@@ -13,7 +13,7 @@ class New_Ticket extends Ticket {
 			return sprintf( 'New ticket: *%s*', $text );
 		}
 
-		return sprintf( 'New %s opened by %s: *%s*', self::get_type( $this->type ), $this->reporter, $text );
+		return sprintf( 'New %s opened by %s: *%s*', self::get_type( $this->type ), Trac::escape_for_slack( $this->reporter ), $text );
 	}
 
 	function get_attachment() {
@@ -22,9 +22,9 @@ class New_Ticket extends Ticket {
 			return $attachment;
 		}
 
-		$attachment['pretext'] = sprintf( 'New %s opened by %s', self::get_type( $this->type ), $this->reporter );
+		$attachment['pretext'] = sprintf( 'New %s opened by %s', self::get_type( $this->type ), Trac::escape_for_slack( $this->reporter ) );
 
-		$attachment['text']  = Trac::format_for_slack( $this->description );
+		$attachment['text']  = Trac::format_for_slack( Trac::escape_for_slack( $this->description ) );
 		$attachment['color'] = $this->trac->get_color();
 
 		return $attachment;

--- a/common/includes/slack/trac/resource.php
+++ b/common/includes/slack/trac/resource.php
@@ -46,6 +46,16 @@ class Resource implements User {
 		return $this->trac->get_icon();
 	}
 
+	/**
+	 * Whether the resource is known not to exist, rather than merely unreadable.
+	 * Subclasses that can tell the difference override this.
+	 *
+	 * @return bool
+	 */
+	public function is_not_found() {
+		return false;
+	}
+
 	function __get( $prop ) {
 		return isset( $this->data->$prop ) ? $this->data->$prop : false;
 	}

--- a/common/includes/slack/trac/ticket.php
+++ b/common/includes/slack/trac/ticket.php
@@ -4,6 +4,12 @@ namespace Dotorg\Slack\Trac;
 
 class Ticket extends Resource {
 	protected $data;
+	/**
+	 * Whether the Trac query matched no ticket.
+	 *
+	 * @var bool
+	 */
+	protected $not_found = false;
 
 	function get_text() {
 		$this->fetch();
@@ -12,7 +18,7 @@ class Ticket extends Resource {
 			return $this->get_url();
 		}
 
-		return sprintf( "<%s|#%s: %s>", $this->get_url(), $this->id, htmlspecialchars( $this->summary, ENT_NOQUOTES ) );
+		return sprintf( '<%s|#%s: %s>', $this->get_url(), $this->id, htmlspecialchars( $this->summary, ENT_NOQUOTES | ENT_SUBSTITUTE ) );
 	}
 
 	function get_short_attachment() {
@@ -40,11 +46,16 @@ class Ticket extends Resource {
 
 		unset( $attachment['text'] ); // Moved to title and title_link.
 
-		$attachment['title']      = sprintf( '#%s: %s', $this->id, htmlspecialchars( $this->summary, ENT_NOQUOTES ) );
+		$attachment['title']      = sprintf( '#%s: %s', $this->id, htmlspecialchars( $this->summary, ENT_NOQUOTES | ENT_SUBSTITUTE ) );
 		$attachment['title_link'] = $this->get_url();
 
 		$attachment['fields'] = self::get_ticket_fields( $this->data );
-		$attachment['ts']     = strtotime( $this->data->created );
+
+		// Trac labels the column 'created' and names it 'time'.
+		$ts = strtotime( $this->created ?: $this->time );
+		if ( $ts ) {
+			$attachment['ts'] = $ts;
+		}
 
 		$attachment['footer']      = sprintf( '<%s|%s>', $this->trac->get_url(), $this->trac->get_name() );
 		$attachment['footer_icon'] = sprintf( '%s/chrome/common/trac.ico', $this->trac->get_url() );
@@ -62,6 +73,10 @@ class Ticket extends Resource {
 			return;
 		}
 
+		/*
+		 * Don't reorder the columns: slack-trac-hook.php array_shift()s the parsed row
+		 * to drop the id, so whichever comes first is the one discarded.
+		 */
 		$url = sprintf(
 			'%s/query?id=%s&col=id&col=summary&col=owner&col=type&col=cc&col=status&col=priority&col=milestone&col=component&col=version&col=severity&col=resolution&col=time&col=changetime&col=focuses&col=reporter&col=keywords&col=description&format=csv',
 			$this->trac->get_url(),
@@ -83,13 +98,53 @@ class Ticket extends Resource {
 		// The first line are headers. All additional lines are part of
 		// of a single CSV row (there can be \n in content).
 		$contents = explode( "\n", $contents, 2 );
-		$ticket_info = array_combine(
-			str_getcsv( strtolower( $contents[0] ), ',', '"', '"' ),
-			str_getcsv( $contents[1], ',', '"', '"' )
-		);
+
+		// Trac sends a UTF-8 BOM and CRLF line endings, neither belongs in the keys.
+		$header_line = str_replace( "\xEF\xBB\xBF", '', $contents[0] );
+		$header_line = strtolower( rtrim( $header_line, "\r\n" ) );
+
+		$headers = str_getcsv( $header_line, ',', '"', '"' );
+
+		// A single field is an error page or a bot check, not a row of column names.
+		if ( count( $headers ) < 2 ) {
+			$this->data = false;
+			return;
+		}
+
+		/*
+		 * A header-only response matched no row we can see: no such ticket, or one hidden
+		 * from anonymous requests. Only say so for a response that really is the CSV, or a
+		 * bot check that happens to parse would pass for a missing ticket. Stock columns
+		 * only, as custom fields like focuses are defined per Trac.
+		 */
+		if ( ! isset( $contents[1] ) || '' === trim( $contents[1] ) ) {
+			$this->not_found = in_array( 'summary', $headers, true ) && in_array( 'status', $headers, true );
+			$this->data      = false;
+			return;
+		}
+
+		$values = str_getcsv( rtrim( $contents[1], "\r\n" ), ',', '"', '"' );
+
+		if ( count( $headers ) !== count( $values ) ) {
+			$this->data = false;
+			return;
+		}
+
+		$ticket_info = array_combine( $headers, $values );
 
 		$this->data = (object) $ticket_info;
 		return $this->data;
+	}
+
+	/**
+	 * Whether the Trac query came back empty. Fetches the ticket.
+	 *
+	 * @return bool
+	 */
+	public function is_not_found() {
+		$this->fetch();
+
+		return $this->not_found;
 	}
 
 	static function get_ticket_fields( $ticket ) {
@@ -151,7 +206,7 @@ class Ticket extends Resource {
 			);
 		}
 
-		if ( $ticket->keywords ) {
+		if ( ! empty( $ticket->keywords ) ) {
 			$ticket_fields[] = array(
 				'title' => 'Keywords',
 				'value' => $ticket->keywords,

--- a/common/includes/slack/trac/trac.php
+++ b/common/includes/slack/trac/trac.php
@@ -296,6 +296,23 @@ class Trac implements User {
 		return 'description';
 	}
 
+	/**
+	 * Stop message text people typed from being read as Slack markup.
+	 *
+	 * Escapes only & and <, the two characters mrkdwn needs to build a link or a
+	 * broadcast. > is left alone so quoted replies still render as blockquotes, and
+	 * unlike htmlspecialchars() this can't turn a mis-encoded body into an empty string.
+	 *
+	 * Text placed inside a <url|label> link needs > escaped as well, or it closes the
+	 * link early; those few call sites use htmlspecialchars() with ENT_SUBSTITUTE.
+	 *
+	 * @param string $text Text to escape.
+	 * @return string
+	 */
+	public static function escape_for_slack( $text ) {
+		return str_replace( array( '&', '<' ), array( '&amp;', '&lt;' ), $text );
+	}
+
 	static function format_for_slack( $text ) {
 		$text = str_replace( "\r\n", "\n", $text );
 		$text = preg_replace( "~^{{{\n?#!([\w+-/]+)$~m", '{{{' , $text ); // {{{#!php


### PR DESCRIPTION
`api.wordpress.org` was fataling with:

```
E_ERROR: Uncaught ValueError: array_combine(): Argument #1 ($keys) and argument #2 ($values)
must have the same number of elements in .../includes/slack/trac/ticket.php:86
```

Trac's CSV query returns only a header line for a ticket that doesn't exist, so `str_getcsv()` on the empty remainder gave one `null` against 18 keys. That was a warning on PHP 7 and is fatal on PHP 8, and it killed the entire trac-bot request — dropping every other ticket and commit referenced in the same Slack message. Any bare `#NNNN` in a non-GitHub channel resolves against the channel's default Trac, so a GitHub issue number was enough to trigger it.

## Parsing

**`Ticket::fetch()` tells "no such ticket" apart from "couldn't read the ticket".** A header-only response sets a `not_found` flag; a header/value count mismatch degrades to `false` instead of throwing. A response that isn't the CSV we asked for — an error page, a bot check — is treated as a failed read, not a missing ticket, so a Trac outage doesn't silently swallow every reference. Deciding which is which never gates the happy path: a response is rejected outright only if its first line isn't a row of column names at all, and the stock `summary`/`status` test only decides whether an *empty* response counts as "not found". Headers this code doesn't recognise still parse normally. The test avoids a column count because custom fields are per-Trac — `focuses` only exists on instances that inherit [`focuses.ini`](https://github.com/WordPress/wordpress.org/blob/trunk/trac.wordpress.org/conf/focuses.ini), so counting would break every ticket on the other Tracs.

Header-only is reported as "no row we can see" rather than strictly "no such ticket" — a permission-filtered or spam-quarantined ticket is indistinguishable from a nonexistent one in this response.

**The UTF-8 BOM and CRLF that Trac sends are stripped.** They were mangling the first and last column names into `"\xEF\xBB\xBFid"` and `"description\r"`.

**`trac-bot.php` stays silent for a nonexistent ticket** — no Slack attachment, no XML-RPC comment. Such a number is far more likely to be a misparse than a reference, and the existing URL fallback would post a link to a 404. Private Tracs and transient failures keep that fallback. Redundancy is deliberately left unset on the not-found path, or the repost-a-link branch would surface the dead URL later.

**Timestamps read whichever column Trac actually returned.** The code asks for `col=time`/`col=changetime` but reads `created`/`modified`, so both now fall back (`$this->created ?: $this->time`) and `ts` is omitted entirely rather than sent as `false`. This also revives the "closed and untouched for two years" suppression from 1f0cd885e, which `$ticket_object->modified` had been quietly disabling.

**The requested column order is left exactly as it was, deliberately.** `svn.wordpress.org/bin/slack-trac-hook.php` ships the parsed row to the mentions handler after an `array_shift( $payload )` to drop the id — positional, so whichever column comes first is the one discarded. That file runs from a separate checkout that this change can't deploy to, so the order is load-bearing and the query string is untouched, with a comment above it saying why. Replacing the `array_shift()` with an `unset()` by name is the real fix and wants a follow-up from someone who can deploy that host.

## Escaping

Fixing the CRLF restores `$this->description`, which `Resource::__get()` had been silently resolving to `false`. That text goes into an attachment marked `'mrkdwn_in' => array( 'text', 'fallback' )`, and `format_for_slack()` doesn't touch `&`, `<` or `>` — so a reporter could put `<!channel>` or `<https://evil.example|Trac>` into a new-ticket announcement.

The same gap already existed on the comment path, which posts every ticket comment through the identical unescaped route, so both go through a new `Trac::escape_for_slack()`:

- the new-ticket description, and the reporter in both the pretext and `get_text()`, which becomes the attachment's `fallback`,
- the comment body, escaped *before* the `Replying to [comment:N]` link is built so that link survives,
- the changed-field values, which land in the same attachment text and would otherwise be a trivial bypass,
- the comment author in the pretext, which is in `mrkdwn_in` alongside the already-escaped title.

All of it happens where the payload is built, not where the mail is parsed, so `Comment_Handler`'s properties stay raw — `slack-trac-hook.php` forwards `comment` and `changes` to the mentions API, which has no use for Slack escaping.

The one exception is the ticket title in that pretext, which sits inside a `<url|label>` link and so keeps `htmlspecialchars()` — with `ENT_SUBSTITUTE` added — because an unescaped `>` in a summary would close the link early.

That helper escapes `&` and `<` rather than calling `htmlspecialchars()`, for two reasons. `>` is left alone so quoted replies still render as blockquotes — escaping it turns every `Replying to…` comment into literal `&gt;` text. And `htmlspecialchars()` returns an empty string for input that isn't valid UTF-8 unless `ENT_SUBSTITUTE` is passed; Trac notification mail is only base64-decoded, never transcoded, so a Latin-1 body would silently post an attachment with no text at all. Neither `&` nor `<` can be dropped: `<` is what opens a link or a broadcast, and leaving `&` raw would let `&lt;!channel&gt;` be typed literally and unescaped back into one by Slack.

## Known gap, same file as the `array_shift()`

`slack-trac-hook.php:57` passes `$new_ticket->get_attachment()` straight into `add_attachment()`, and that can now return `false` where it previously fataled — so a new ticket whose CSV row isn't visible would post `"attachments":[false]` and be rejected by Slack. It needs the same `if ( $attachment )` check `trac-bot.php` already does, in the same file as the `array_shift()` fix above, so both want the follow-up together.

## Deploy note

`mentions-handler.php` scans `$payload->summary . ' ' . $payload->description` for new tickets, and `description` has been undefined for as long as the key was mangled. Once this deploys, new-ticket mention scanning starts reading full descriptions and notifying everyone @-mentioned in them. That's the intended behaviour returning, but it is a step up in notification volume with nothing throttling it.

## Verification

`php -l` clean on all six files; `.github/bin/phpcs-branch.php` reports nothing on the changed lines.

Behaviour was verified against a stubbed Trac serving fixture CSV (48 assertions, all passing), covering: a header-only response (`is_not_found()` true, no attachment, no Trac comment); a normal ticket (full attachment, description and timestamp intact, no stray `\r`); a Trac without the `focuses` custom field (17 columns — still parses, remaining columns stay aligned); CSV headers as field names as well as labels, including the timestamp falling back to `time`, and headers in neither form still parsing; the mentions payload's `array_shift()` still discarding the id column and nothing else, under both header conventions; a description containing `<!channel>`, a link, a bare `&`, a quoted line and an invalid UTF-8 byte (markup neutralised, blockquote preserved, text not emptied); a multi-line error page and a single-line bot-check page (both degrade to the URL fallback, neither reported as "not found"); an unparseable `created` value omitting the `ts` key rather than sending `false`; a summary containing `>` staying inside its link label; a reporter containing `<!channel>` neutralised in both the pretext and the fallback; and `Commit` inheriting the base `is_not_found()` so commits keep their URL fallback.

Live Trac could not be reached from the machine this was written on — `core.trac.wordpress.org` answers 403 with a bot-check interstitial — so the fixtures model its documented CSV output rather than a captured live response. That's also why the header row is treated as carrying either field names or labels throughout, rather than assuming one.
