### PR TITLE
Slack: Stop unauthenticated requests from fataling the webhook endpoints

### DIFF
--- a/api.wordpress.org/public_html/dotorg/slack/announce.php
+++ b/api.wordpress.org/public_html/dotorg/slack/announce.php
@@ -1,26 +1,49 @@
 <?php
+/**
+ * Slack slash-command handler for @here and @channel announcements.
+ *
+ * Standalone handler: WordPress is not loaded, so request data is never slashed. Slack
+ * authenticates itself with one of the shared `WEBHOOK_TOKEN_*` secrets below; nonces do
+ * not exist in server-to-server webhooks.
+ *
+ * phpcs:disable WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+ *
+ * @package WordPressdotorg\API\Slack
+ */
 
-namespace {
-	require dirname( dirname( __DIR__ ) ) . '/includes/hyperdb/bb-10-hyper-db.php';
-	require dirname( dirname( __DIR__ ) ) . '/includes/slack-config.php';
-}
+namespace Dotorg\Slack\Announce;
 
-namespace Dotorg\Slack\Announce {
+require dirname( __DIR__, 2 ) . '/includes/hyperdb/bb-10-hyper-db.php';
+require dirname( __DIR__, 2 ) . '/includes/slack-config.php';
+require dirname( __DIR__, 2 ) . '/includes/slack/announce/lib.php';
 
-require dirname( dirname( __DIR__ ) ) . '/includes/slack/announce/lib.php';
-
-function get_avatar( $username, $slack_id, $team_id ) {
+/**
+ * Returns the Gravatar URL for the WordPress.org account linked to a Slack user.
+ *
+ * Defined in this namespace so that `run()` in lib.php picks it up as an optional hook;
+ * it falls back to the Slack profile image when this function is not available.
+ *
+ * @param string $username The Slack user name. Unused, part of the hook signature.
+ * @param string $slack_id The Slack user ID to look up.
+ * @param string $team_id  The Slack team ID. Unused, part of the hook signature.
+ * @return string The Gravatar URL for the linked account.
+ */
+function get_avatar( $username, $slack_id, $team_id ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter -- Signature is fixed by the call in lib.php.
 	global $wpdb;
 
-	$wp_user_id = $wpdb->get_var( $wpdb->prepare(
-		"SELECT user_id FROM slack_users WHERE slack_id = %s",
-		$slack_id
-	) );
+	$wp_user_id = $wpdb->get_var(
+		$wpdb->prepare(
+			'SELECT user_id FROM slack_users WHERE slack_id = %s',
+			$slack_id
+		)
+	);
 
-	$email = $wpdb->get_var( $wpdb->prepare(
-		"SELECT user_email FROM $wpdb->users WHERE ID = %d",
-		$wp_user_id
-	) );
+	$email = $wpdb->get_var(
+		$wpdb->prepare(
+			"SELECT user_email FROM $wpdb->users WHERE ID = %d",
+			$wp_user_id
+		)
+	);
 
 	$hash = hash( 'sha256', strtolower( trim( $email ) ) );
 	return sprintf( 'https://secure.gravatar.com/avatar/%s?s=96d=mm&r=G&%s', $hash, time() );
@@ -33,12 +56,9 @@ if ( ! isset( $_POST['token'] ) || ! is_string( $_POST['token'] ) || '' === $_PO
 
 $i = 0;
 // WEBHOOK_TOKEN_1, WEBHOOK_TOKEN_2, etc.
-while ( defined( __NAMESPACE__ . '\\WEBHOOK_TOKEN_' . ++$i ) ) {
+while ( defined( __NAMESPACE__ . '\\WEBHOOK_TOKEN_' . ( ++$i ) ) ) {
 	if ( hash_equals( constant( __NAMESPACE__ . '\\WEBHOOK_TOKEN_' . $i ), $_POST['token'] ) ) {
 		run( $_POST );
 		break;
 	}
 }
-
-}
-

--- a/api.wordpress.org/public_html/dotorg/slack/announce.php
+++ b/api.wordpress.org/public_html/dotorg/slack/announce.php
@@ -26,11 +26,17 @@ function get_avatar( $username, $slack_id, $team_id ) {
 	return sprintf( 'https://secure.gravatar.com/avatar/%s?s=96d=mm&r=G&%s', $hash, time() );
 }
 
+// Slack sends the token as POST data; anything else is not a webhook request.
+if ( ! isset( $_POST['token'] ) || ! is_string( $_POST['token'] ) || '' === $_POST['token'] ) {
+	return;
+}
+
 $i = 0;
 // WEBHOOK_TOKEN_1, WEBHOOK_TOKEN_2, etc.
 while ( defined( __NAMESPACE__ . '\\WEBHOOK_TOKEN_' . ++$i ) ) {
 	if ( hash_equals( constant( __NAMESPACE__ . '\\WEBHOOK_TOKEN_' . $i ), $_POST['token'] ) ) {
 		run( $_POST );
+		break;
 	}
 }
 

--- a/api.wordpress.org/public_html/dotorg/slack/announce.php
+++ b/api.wordpress.org/public_html/dotorg/slack/announce.php
@@ -26,7 +26,7 @@ require dirname( __DIR__, 2 ) . '/includes/slack/announce/lib.php';
  * @param string $username The Slack user name. Unused, part of the hook signature.
  * @param string $slack_id The Slack user ID to look up.
  * @param string $team_id  The Slack team ID. Unused, part of the hook signature.
- * @return string The Gravatar URL for the linked account.
+ * @return string The Gravatar URL, or an empty string when the Slack account is not linked.
  */
 function get_avatar( $username, $slack_id, $team_id ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter -- Signature is fixed by the call in lib.php.
 	global $wpdb;
@@ -38,6 +38,10 @@ function get_avatar( $username, $slack_id, $team_id ) { // phpcs:ignore Generic.
 		)
 	);
 
+	if ( ! $wp_user_id ) {
+		return '';
+	}
+
 	$email = $wpdb->get_var(
 		$wpdb->prepare(
 			"SELECT user_email FROM $wpdb->users WHERE ID = %d",
@@ -45,8 +49,12 @@ function get_avatar( $username, $slack_id, $team_id ) { // phpcs:ignore Generic.
 		)
 	);
 
+	if ( ! $email ) {
+		return '';
+	}
+
 	$hash = hash( 'sha256', strtolower( trim( $email ) ) );
-	return sprintf( 'https://secure.gravatar.com/avatar/%s?s=96d=mm&r=G&%s', $hash, time() );
+	return sprintf( 'https://secure.gravatar.com/avatar/%s?s=96&d=mm&r=G&%s', $hash, time() );
 }
 
 // Slack sends the token as POST data; anything else is not a webhook request.

--- a/api.wordpress.org/public_html/dotorg/slack/committers.php
+++ b/api.wordpress.org/public_html/dotorg/slack/committers.php
@@ -6,6 +6,11 @@ namespace Dotorg\Slack\Committers;
 
 require dirname( dirname( __DIR__ ) ) . '/includes/slack-config.php';
 
+// Slack sends the token as POST data; anything else is not a webhook request.
+if ( ! isset( $_POST['token'] ) || ! is_string( $_POST['token'] ) || '' === $_POST['token'] ) {
+	return;
+}
+
 if ( ! hash_equals( WEBHOOK_TOKEN, $_POST['token'] ) ) {
 	return;
 }

--- a/api.wordpress.org/public_html/dotorg/slack/committers.php
+++ b/api.wordpress.org/public_html/dotorg/slack/committers.php
@@ -1,10 +1,19 @@
 <?php
-
-// Allow committers to publicly mention other committers via @committers.
+/**
+ * Slack outgoing-webhook handler that redirects @committers mentions to the slash command.
+ *
+ * Standalone handler: WordPress is not loaded, so request data is never slashed. Slack
+ * authenticates itself with the shared `WEBHOOK_TOKEN` secret below; nonces do not exist
+ * in server-to-server webhooks.
+ *
+ * phpcs:disable WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+ *
+ * @package WordPressdotorg\API\Slack
+ */
 
 namespace Dotorg\Slack\Committers;
 
-require dirname( dirname( __DIR__ ) ) . '/includes/slack-config.php';
+require dirname( __DIR__, 2 ) . '/includes/slack-config.php';
 
 // Slack sends the token as POST data; anything else is not a webhook request.
 if ( ! isset( $_POST['token'] ) || ! is_string( $_POST['token'] ) || '' === $_POST['token'] ) {
@@ -15,10 +24,16 @@ if ( ! hash_equals( WEBHOOK_TOKEN, $_POST['token'] ) ) {
 	return;
 }
 
-echo json_encode( array(
-	'username'   => 'wordpressdotorg',
-	'link_names' => 1,
-	'text'       => sprintf( '@%s: Use the `/committers` command.', $_POST['user_name'] ),
-) );
+// The Slack user name of whoever triggered the webhook, echoed back in the JSON response below.
+$user_name = (string) filter_var( $_POST['user_name'] ?? '', FILTER_UNSAFE_RAW, FILTER_FLAG_STRIP_LOW );
+
+// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode -- No WP loaded.
+echo json_encode(
+	array(
+		'username'   => 'wordpressdotorg',
+		'link_names' => 1,
+		'text'       => sprintf( '@%s: Use the `/committers` command.', $user_name ),
+	)
+);
 
 exit;


### PR DESCRIPTION
`announce.php` and `committers.php` pass `$_POST['token']` straight into `hash_equals()`. Both are Slack outgoing-webhook endpoints, so they assume a POST body carrying a token. A bare `GET` — which scanners send regularly — leaves `$_POST` empty, and PHP 8 raises an uncaught `TypeError` where PHP 7 only warned about the non-string argument:

```
E_ERROR: Uncaught TypeError: hash_equals(): Argument #2 ($user_string) must be
of type string, null given in dotorg/slack/announce.php:32
Source: GET https://api.wordpress.org/dotorg/slack/announce.php
```

Nothing leaks — the token comparison can never succeed — but every probe of these URLs writes a fatal to the error log.

## Changes

Guard both endpoints with an `isset()` / `is_string()` / non-empty check before the comparison:

* `is_string()` matters because an array token (`token[]=x`) would otherwise trigger the same `TypeError` that a `?? ''` fallback alone would not catch.
* The non-empty check avoids matching a misconfigured empty constant.
* The superglobal stays inside `hash_equals()` rather than being copied to a local, so the comparison remains timing-safe and PHPCS continues to credit `hash_equals()` as the sanitizer.

Also `break` out of the token loop in `announce.php` after a match. `run()` returns rather than exits, so the loop kept testing the remaining `WEBHOOK_TOKEN_N` constants; harmless while the tokens are distinct, but it would post the announcement twice if two were ever configured with the same value.

Unauthenticated requests now get the same empty `200` that a wrong token already produced.

## Notes

* The `WordPress.Security.ValidatedSanitizedInput.InputNotValidated` error PHPCS already reported on both files — *"possibly undefined superglobal array index"*, literally this bug — is gone, and no new sniffs are introduced. The remaining `MissingUnslash` errors are pre-existing and not fixable here: these endpoints don't bootstrap WordPress, so there is no `wp_unslash()`. The rest of `dotorg/slack/` carries them too.
* I swept the other endpoints in the directory for the same pattern. `trac-bot.php`, `security-team.php`, and `community-deputies-calendly-webhook.php` already guard with `?? ''` / `empty()`, and `subgroup.php` guards its signature headers. These two files were the only remaining instances.
* There is no test coverage under `api.wordpress.org/public_html/dotorg/` — these files bootstrap outside WordPress and have no PHPUnit setup. Verification was `php -l`, a before/after PHPCS comparison, and an isolated check that `return` at the top level of a braced `namespace {}` block exits cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Coding standards

The repository's branch linter checks changed lines only, and the fix above tripped it, so a second commit takes both files to **zero PHPCS errors and warnings against the full ruleset** — not just on the changed lines.

* **`announce.php` namespace flattened.** The braced `namespace {}` / `namespace Dotorg\Slack\Announce {}` pair left the entire file body at zero indentation inside a scope PHPCS expects indented, so every line in the file tripped `Generic.WhiteSpace.ScopeIndent`. The global block was never necessary: an included file's namespace comes from its own declaration, not the include site, and variable scope is namespace-independent, so `$wpdb` stays global either way. Collapsing to one unbraced declaration clears that plus `DisallowCurlyBraceSyntax`, `DisallowDeclarationWithoutName`, and `OneDeclarationPerFile` — without reindenting a single body line.
* **File-level docblocks** on both handlers documenting the actual authentication mechanism, with `phpcs:disable` for the two sniffs that cannot apply: these endpoints never load WordPress, so there is no `wp_unslash()` to call and no nonce to verify.
* **Ordinary fixes:** function docblock on `get_avatar()`, multi-line call formatting on the two `$wpdb->prepare()` calls, single quotes on the SQL that needs no interpolation, brackets around `++$i` in string concatenation, and `dirname( __DIR__, 2 )` for the nested `dirname()` calls — matching `props.php` and the Calendly webhook in this directory.
* **`committers.php` echoes `$_POST['user_name']`** back in its JSON response, so control characters are stripped and the value defaults when absent.

## Gravatar lookup

A third commit fixes two defects in `get_avatar()`, both surfaced while reviewing the reformatting above.

**Unlinked accounts raised a deprecation and collided.** When a Slack ID has no linked WordPress.org account, both queries return `null`, so `trim( null )` raised a PHP 8.1+ deprecation — into the same error log this branch is cleaning up — and `hash( 'sha256', '' )` returned the constant `e3b0c442…` for every unlinked user, giving them all the same avatar. It now bails as soon as the `slack_users` lookup comes up empty, so that case no longer passes `null` into the second `prepare()` for a `WHERE ID = 0` round-trip that can never match, with a second check for a linked account that has no email on file. `run()` only consults this hook when Slack has no profile image and gates on the result, so an empty return leaves the icon unset.

**The query string was missing a separator.** `?s=96d=mm&r=G` parses as:

```php
array( 's' => '96d=mm', 'r' => 'G' )   // no 'd' at all
```

So the size was a garbage value and the `mm` default-avatar fallback never reached Gravatar. Corrected to `?s=96&d=mm&r=G`, which parses as `s=96`, `d=mm`, `r=G`.

## Verification

No test coverage exists under `api.wordpress.org/public_html/dotorg/` — these files bootstrap outside WordPress and have no PHPUnit setup. Verification was:

* `php -l` on both files, and full-file `phpcs` reporting zero errors and zero warnings.
* A harness with stand-ins for hyperdb, `slack-config.php`, and `lib.php`, exercising the flattened namespace: no token, empty token, array token, valid token matching the first constant, valid token matching the second, and a wrong token. Confirmed the guard rejects every malformed case without a fatal; that `run()` fires on a match with the `get_avatar()` hook resolving in the right namespace and `global $wpdb` seeing the value set by the un-namespaced include; that `break` stops the loop at the matching iteration; and that `( ++$i )` preserves the pre-increment.
* `get_avatar()` re-run against `null`, `''`, and a real address under `error_reporting( E_ALL )`: no deprecation, empty return on the first two, and the corrected URL parsing back to the intended four parameters.

## Relationship to #802

#802 overlaps this PR on both files — it independently flattens the same namespace, converts the same `dirname()` calls, and adds an equivalent token guard. Whichever lands first, the other needs a rebase. Unique here are the `break` after `run( $_POST )`, the rejection of an empty-string token, and the `get_avatar()` fixes above; #802 additionally hardens the five other handlers in this directory.
