### PR TITLE
Trac: Stop loading the retired global-header navigation script on core and meta

### DIFF
--- a/trac.wordpress.org/templates/README
+++ b/trac.wordpress.org/templates/README
@@ -70,11 +70,35 @@ the shared site_head.html/site_footer.html `# include ... ignore missing`:
  *  core/site-specific-head.html      — make-core.css
  *  core/site-specific-footer.html    — #report-popup + contributor-label JS
  *  meta/site-specific-footer.html    — autocomplete-users JS
+ *  bbpress/site-specific-footer.html, buddypress/site-specific-footer.html
+                                      — legacy navigation.min.js (mobile menu)
  *  core/wporg-menu.html, meta/wporg-menu.html — per-Trac headline/menu
 
 bbpress/ and buddypress/ ship their own wporg-head/header/footer.html (bbPress.org
 / BuddyPress.org branding) and a no-op wporg-menu.html. Their old Genshi banner
 reorganization (py:match on div#banner) is now client-side in wp-trac.js / CSS.
+
+They are also the only environments still on the pre-block WordPress.org header
+markup (#wporg-header / #mobile-menu-button / #wporg-header-menu), so they are the
+only ones that still load s.w.org/style/js/navigation.min.js. On core.trac and
+meta.trac the global header is the block-based one, and its menu is driven by the
+Gutenberg Navigation block's Interactivity API view module
+(@wordpress/block-library/navigation/view), already included via wporg-footer.html.
+
+DON'T "modernize" those two by copying bbPress.org's/BuddyPress.org's current
+header markup (#header > #header-inner > #nav > #bb-menu-icon + #bb-nav). Its menu
+is CSS-only and needs no JS, which looks like a clean way to retire
+navigation.min.js, but the IDs collide with Trac's own:
+
+ *  Trac renders its own `<div id="header">` inside #banner (wp-trac.css hides it
+    with `#banner #header { display: none }`), so you end up with a duplicate ID.
+ *  trac.css styles `#header :link` (0-1-1-0), which outranks bb-base's `#nav li a`
+    (0-1-0-2). Every menu link loses its padding and turns #555, so the desktop nav
+    renders as one run-together string.
+
+#wporg-header / #wporg-header-menu exist precisely to stay out of the way of
+Trac's generic #header and #nav. Keep them, and keep the script that drives them.
+Verified against live bbpress.trac in Aug 2026.
 
 
 update-headers.php

--- a/trac.wordpress.org/templates/bbpress/site-specific-footer.html
+++ b/trac.wordpress.org/templates/bbpress/site-specific-footer.html
@@ -1,0 +1,8 @@
+{# bbpress.trac — end-of-<body> additions, included by the shared site_footer.html.
+
+  bbPress.org still ships the pre-block WordPress.org header markup (#wporg-header,
+  #mobile-menu-button, #wporg-header-menu), so it still needs the legacy navigation
+  script to toggle the mobile menu. core.trac and meta.trac use the block-based
+  global header, whose menu is driven by the Gutenberg Navigation block instead.
+#}
+<script src="https://s.w.org/style/js/navigation.min.js?20190128"></script>

--- a/trac.wordpress.org/templates/buddypress/site-specific-footer.html
+++ b/trac.wordpress.org/templates/buddypress/site-specific-footer.html
@@ -1,0 +1,8 @@
+{# buddypress.trac — end-of-<body> additions, included by the shared site_footer.html.
+
+  BuddyPress.org still ships the pre-block WordPress.org header markup (#wporg-header,
+  #mobile-menu-button, #wporg-header-menu), so it still needs the legacy navigation
+  script to toggle the mobile menu. core.trac and meta.trac use the block-based
+  global header, whose menu is driven by the Gutenberg Navigation block instead.
+#}
+<script src="https://s.w.org/style/js/navigation.min.js?20190128"></script>

--- a/trac.wordpress.org/templates/site_footer.html
+++ b/trac.wordpress.org/templates/site_footer.html
@@ -24,7 +24,6 @@ var wpTracCurrentUser = "${req.authname}";
 # endif
 
 ## JavaScript
-<script src="https://s.w.org/style/js/navigation.min.js?20190128"></script>
 <script src="https://s.w.org/style/trac/jquery.caret.min.js?ver=2015-02-01"></script>
 <script src="https://s.w.org/style/trac/jquery.atwho.min.js?ver=1.0.1"></script>
 <script src="https://s.w.org/style/trac/wp-trac.js?${scripts_version}"></script>


### PR DESCRIPTION
`trac.wordpress.org/templates/site_footer.html` loads a legacy script on every Trac page:

```html
<script src="https://s.w.org/style/js/navigation.min.js?20190128"></script>
```

That file drives the **pre-block WordPress.org global header**. Its entire body is guarded on three IDs:

```js
(s = document.getElementById("wporg-header")) &&
(a = document.getElementById("mobile-menu-button")) &&
(t = document.getElementById("wporg-header-menu")) && …
```

It toggles a `toggled` class on the menu from the hamburger button, plus `focus`-class handling for `.menu-item-has-children` on touch.

## core.trac / meta.trac — replaced by the Gutenberg Navigation block

These render the block-based global header, so none of those elements exist and the script exits at its first guard — a render-blocking request that does nothing.

`wporg-header.html` already carries the Interactivity API directives:

```html
<nav class="is-responsive global-header__navigation wp-block-navigation …"
     data-wp-interactive="core/navigation"
     data-wp-context="{&quot;overlayOpenedBy&quot;:{…},&quot;type&quot;:&quot;overlay&quot;,…}">
  <button class="wp-block-navigation__responsive-container-open"
          data-wp-on--click="actions.openMenuOnClick"
          data-wp-on--keydown="actions.handleMenuKeydown">…</button>
  <div class="wp-block-navigation__responsive-container"
       data-wp-class--is-menu-open="state.isMenuOpen"
       data-wp-watch="callbacks.initMenu">…</div>
```

and `wporg-footer.html` already loads the store implementing those actions:

```html
<script type="module"
        id="@wordpress/block-library/navigation/view-js-module"
        src="https://s.w.org/wp-content/plugins/gutenberg/build/modules/block-library/navigation/view.min.js"></script>
```

resolved via the `@wordpress/interactivity` import map in `wporg-head.html`. Gutenberg still ships this module — `navigation/index.php` enqueues it from `handle_view_script_module_loading()` whenever the block is interactive — so overlay, submenus, focus trapping and focusout are covered. Search toggle and the overflow "More" menu come from `wporg-global-header-script-js` (`global-header-footer/js/view.js`), also already in the footer.

## bbpress.trac / buddypress.trac — still need it

Those two haven't moved to the block header, and can't: bbPress.org and BuddyPress.org are classic-theme sites (`bb-base`) with no endpoint to sync from —

```
https://bbpress.org/wp-json/global-header-footer/v1/header     → 404
https://buddypress.org/wp-json/global-header-footer/v1/header  → 404
```

Their templates still emit the old markup:

```html
<div id="wporg-header">
  <div id="header-inner">
    <button id="mobile-menu-button" aria-expanded="false">…</button>
    <ul id="wporg-header-menu">…</ul>
```

So the script moves out of the shared `site_footer.html` into a per-environment `site-specific-footer.html` for each — the documented supplement hook `site_footer.html` already pulls in with `# include 'site-specific-footer.html' ignore missing`.

### Why they don't just adopt bbPress.org's current markup

bbPress.org and BuddyPress.org have since moved to `#header > #header-inner > #nav > #bb-menu-icon + #bb-nav`, whose menu opens with **CSS only** (`#header #nav:hover #bb-nav`) and needs no JS at all. Copying that would have let the script be deleted outright, so I tried it against live bbpress.trac. It doesn't work — the IDs collide with Trac's own:

- Trac renders its own `<div id="header">` inside `#banner`. `wp-trac.css` hides it (`#banner #header { display: none }`), but adopting `#header` still means a duplicate ID on every page.
- `trac.css` styles `#header :link` (specificity 0-1-1-0), which **outranks** bb-base's `#nav li a` (0-1-0-2). Measured on the live page: menu links drop to `padding: 0` and `color: #555`, and the desktop nav collapses into one run-together string.


`#wporg-header` / `#wporg-header-menu` exist precisely to stay clear of Trac's generic `#header` and `#nav`. So they keep the legacy markup, and keep the script that drives it. The README now records this so the next person doesn't retry it.

## Changes

- `templates/site_footer.html` — drop the `navigation.min.js` tag.
- `templates/bbpress/site-specific-footer.html` — new; loads `navigation.min.js`.
- `templates/buddypress/site-specific-footer.html` — new; loads `navigation.min.js`.
- `templates/README` — record which environment gets its menu from where, and why the `#header`/`#nav` route is closed.

## Testing

Templates only, no PHP touched. Verified against live assets and live bbpress.trac (DOM/CSS inspection, no local Trac available): `wp-trac.js` has zero references to `#wporg-header`, `#mobile-menu-button`, `#wporg-header-menu`, `#bb-nav` or `#bb-menu-icon`, and `bb-base/style-trac.css` doesn't style the header at all — so this is confined to the script tag itself. Still wants a pass on a local Trac 1.6 per the README:

- core.trac / meta.trac — global header menu, submenus and mobile overlay still open, close and trap focus; no request for `navigation.min.js`.
- bbpress.trac / buddypress.trac — hamburger still toggles `#wporg-header-menu`; `navigation.min.js` still loads, now later in the document, which is fine: it's a self-contained IIFE with no dependencies that only reads already-parsed header markup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
