### PR TITLE
Login: Update the WordCamp login message copy

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/functions.php
@@ -483,8 +483,7 @@ function wporg_login_wporg_is_starpress( $redirect_to = '' ) {
 			$message .= '<strong>' . sprintf( __( 'Register for %s', 'wporg' ), esc_html( $_REQUEST['wcname'] ) ) . '</strong>';
 			$message .=  __( 'Log in to your WordPress.org account. If you don\'t have one, you can <a href="/register">create an account</a>.', 'wporg' );
 		} else {
-			$message .= '<strong>' . __( 'WordCamp is part of WordPress.org', 'wporg' ) . '</strong>';
-			$message .= __( 'Log in to your WordPress.org account to contribute to WordCamps and meetups around the globe.', 'wporg' );
+			$message .= __( 'Log in to your WordPress.org account to participate in WordCamps and meetups around the world.', 'wporg' );
 		}
 	} elseif ( str_contains( $from, 'learn.wordpress.org' ) ) {
 		$message .= '<strong>' . __( 'Access all of Learn WordPress', 'wporg' ) . '</strong>';


### PR DESCRIPTION
Updates the login message shown when signing in from `wordcamp.org` / `events.wordpress.org` (the generic case, without a `wcname`), per feedback from @annezazu in https://github.com/WordPress/wordcamp.org/issues/1858#issuecomment-5273914858:

- Removes the bolded "WordCamp is part of WordPress.org" heading.
- Reworks the remaining sentence — "participate" reads better than "contribute" here:

Before:
> **WordCamp is part of WordPress.org**
> Log in to your WordPress.org account to contribute to WordCamps and meetups around the globe.

After:
> Log in to your WordPress.org account to participate in WordCamps and meetups around the world.

The `wcname` branch (event-specific "Register for %s" message) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)