### PR TITLE
Auto-review comments are posted without checking the ticket matches the theme

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/rest-api.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/rest-api.php
@@ -46,14 +46,14 @@ add_filter( 'rest_pre_echo_response', function( $result ) {
 
 // Include the REST API Endpoints at the appropriate time.
 add_action( 'rest_api_init', function() {
-	include __DIR__ . '/rest-api/class-internal.php';
-	include __DIR__ . '/rest-api/class-info-endpoint.php';
-	include __DIR__ . '/rest-api/class-query-endpoint.php';
-	include __DIR__ . '/rest-api/class-commercial-shops-endpoint.php';
-	include __DIR__ . '/rest-api/class-features-endpoint.php';
-	include __DIR__ . '/rest-api/class-tags-endpoint.php';
-	include __DIR__ . '/rest-api/class-themes-auto-review.php';
-	include __DIR__ . '/rest-api/class-theme-categorization.php';
-	include __DIR__ . '/rest-api/class-theme-review-stats.php';
-	include __DIR__ . '/rest-api/class-theme-preview.php';
+	include_once __DIR__ . '/rest-api/class-internal.php';
+	include_once __DIR__ . '/rest-api/class-info-endpoint.php';
+	include_once __DIR__ . '/rest-api/class-query-endpoint.php';
+	include_once __DIR__ . '/rest-api/class-commercial-shops-endpoint.php';
+	include_once __DIR__ . '/rest-api/class-features-endpoint.php';
+	include_once __DIR__ . '/rest-api/class-tags-endpoint.php';
+	include_once __DIR__ . '/rest-api/class-themes-auto-review.php';
+	include_once __DIR__ . '/rest-api/class-theme-categorization.php';
+	include_once __DIR__ . '/rest-api/class-theme-review-stats.php';
+	include_once __DIR__ . '/rest-api/class-theme-preview.php';
 } );

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/rest-api/class-themes-auto-review.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/rest-api/class-themes-auto-review.php
@@ -86,7 +86,10 @@ class Auto_Review_Controller extends WP_REST_Controller {
 	 * rather than searching for the bare slug keeps a slug that is a substring
 	 * of another theme's slug from matching that theme's ticket.
 	 *
-	 * @param string $keywords   The ticket's keywords, space separated.
+	 * Keywords are written as a space separated list, but the Trac field is free
+	 * text and reviewers do separate them with commas, so both are accepted.
+	 *
+	 * @param string $keywords   The ticket's keywords.
 	 * @param string $theme_slug The theme slug.
 	 * @return bool
 	 */
@@ -95,7 +98,9 @@ class Auto_Review_Controller extends WP_REST_Controller {
 			return false;
 		}
 
-		return in_array( 'theme-' . $theme_slug, preg_split( '/\s+/', trim( $keywords ) ), true );
+		$keywords = preg_split( '/[\s,]+/', strtolower( $keywords ), -1, PREG_SPLIT_NO_EMPTY );
+
+		return in_array( 'theme-' . strtolower( $theme_slug ), $keywords, true );
 	}
 
 	/**
@@ -172,7 +177,12 @@ class Auto_Review_Controller extends WP_REST_Controller {
 		if ( ! $this->ticket_is_for_theme( $ticket['keywords'] ?? '', $theme_slug ) ) {
 			return new \WP_Error(
 				'rest_ticket_theme_mismatch',
-				__( 'That ticket is not for this theme.', 'wporg-themes' ),
+				sprintf(
+					/* translators: 1: Trac ticket ID, 2: theme slug. */
+					__( 'Ticket %1$d carries no keyword for the theme %2$s.', 'wporg-themes' ),
+					(int) $ticket_id,
+					$theme_slug
+				),
 				array( 'status' => \WP_Http::BAD_REQUEST )
 			);
 		}

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/rest-api/class-themes-auto-review.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/rest-api/class-themes-auto-review.php
@@ -81,12 +81,21 @@ class Auto_Review_Controller extends WP_REST_Controller {
 	/**
 	 * Returns whether the ticket number is for the correct theme.
 	 * 
-	 * @param string $keywords A string that should include the theme slug.
+	 * Tickets carry a `theme-{slug}` keyword, added by
+	 * WPORG_Themes_Upload::prepare_trac_ticket(). Matching that whole keyword
+	 * rather than searching for the bare slug keeps a slug that is a substring
+	 * of another theme's slug from matching that theme's ticket.
+	 *
+	 * @param string $keywords   The ticket's keywords, space separated.
 	 * @param string $theme_slug The theme slug.
 	 * @return bool
 	 */
 	public function ticket_is_for_theme( $keywords, $theme_slug ) {
-		return ! empty( $keywords ) && strpos( $keywords , $theme_slug );
+		if ( empty( $keywords ) || empty( $theme_slug ) ) {
+			return false;
+		}
+
+		return in_array( 'theme-' . $theme_slug, preg_split( '/\s+/', trim( $keywords ) ), true );
 	}
 
 	/**
@@ -157,6 +166,14 @@ class Auto_Review_Controller extends WP_REST_Controller {
 				'rest_invalid_ticket',
 				__( 'Unable to locate ticket.', 'wporg-themes' ),
 				array( 'status' => \WP_Http::NOT_FOUND )
+			);
+		}
+
+		if ( ! $this->ticket_is_for_theme( $ticket['keywords'] ?? '', $theme_slug ) ) {
+			return new \WP_Error(
+				'rest_ticket_theme_mismatch',
+				__( 'That ticket is not for this theme.', 'wporg-themes' ),
+				array( 'status' => \WP_Http::BAD_REQUEST )
 			);
 		}
 

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Auto_Review_Ticket_Match_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Auto_Review_Ticket_Match_Test.php
@@ -15,6 +15,8 @@ use PHPUnit\Framework\TestCase;
 use WordPressdotorg\Theme_Directory\Rest_API\Auto_Review_Controller;
 
 /**
+ * Covers the ticket-to-theme match used before an auto-review comment is posted.
+ *
  * @group themes-api
  */
 class Auto_Review_Ticket_Match_Test extends TestCase {
@@ -54,23 +56,25 @@ class Auto_Review_Ticket_Match_Test extends TestCase {
 	 */
 	public static function data_keywords() {
 		return array(
-			'keyword first in the list'   => array( 'theme-mente-clara', 'mente-clara', true ),
-			'keyword later in the list'   => array( 'child-theme theme-foo', 'foo', true ),
-			'comma separated'             => array( 'theme-foo, needs-screenshot', 'foo', true ),
-			'comma without a space'       => array( 'needs-screenshot,theme-foo', 'foo', true ),
-			'surrounding whitespace'      => array( '  theme-foo   child-theme  ', 'foo', true ),
-			'mixed case keyword'          => array( 'Theme-Twenty-Four', 'twenty-four', true ),
-			'mixed case slug'             => array( 'theme-twenty-four', 'Twenty-Four', true ),
-			'slug is a prefix of another' => array( 'theme-twentytwentyfour', 'twenty', false ),
-			'slug longer than the keyword' => array( 'theme-twenty', 'twentytwentyfour', false ),
-			'a different theme'           => array( 'theme-bar', 'foo', false ),
+			'keyword first in the list'     => array( 'theme-mente-clara', 'mente-clara', true ),
+			'keyword later in the list'     => array( 'child-theme theme-foo', 'foo', true ),
+			'comma separated'               => array( 'theme-foo, needs-screenshot', 'foo', true ),
+			'comma without a space'         => array( 'needs-screenshot,theme-foo', 'foo', true ),
+			'surrounding whitespace'        => array( '  theme-foo   child-theme  ', 'foo', true ),
+			'mixed case keyword'            => array( 'Theme-Twenty-Four', 'twenty-four', true ),
+			'mixed case slug'               => array( 'theme-twenty-four', 'Twenty-Four', true ),
+			'slug is a prefix of another'   => array( 'theme-twentytwentyfour', 'twenty', false ),
+			'slug longer than the keyword'  => array( 'theme-twenty', 'twentytwentyfour', false ),
+			'a different theme'             => array( 'theme-bar', 'foo', false ),
 			'parent keyword is not a match' => array( 'child-theme parent-foo', 'foo', false ),
-			'no keywords'                 => array( '', 'foo', false ),
-			'no slug'                     => array( 'theme-foo', '', false ),
+			'no keywords'                   => array( '', 'foo', false ),
+			'no slug'                       => array( 'theme-foo', '', false ),
 		);
 	}
 
 	/**
+	 * A ticket is the theme's only when it carries that theme's whole keyword.
+	 *
 	 * @dataProvider data_keywords
 	 *
 	 * @param string $keywords   The ticket's keywords.

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Auto_Review_Ticket_Match_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Auto_Review_Ticket_Match_Test.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Tests that auto-review results only reach the ticket for the theme they describe.
+ *
+ * The check this covers reads a `theme-{slug}` keyword off the ticket. Matching
+ * the whole keyword rather than searching for the slug inside the string is what
+ * keeps a slug that is a prefix of another theme's from matching that theme's
+ * ticket, and the earlier `strpos()` form also treated a match at offset 0 as a
+ * failure.
+ *
+ * @package theme-directory
+ */
+
+use PHPUnit\Framework\TestCase;
+use WordPressdotorg\Theme_Directory\Rest_API\Auto_Review_Controller;
+
+/**
+ * @group themes-api
+ */
+class Auto_Review_Ticket_Match_Test extends TestCase {
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var Auto_Review_Controller
+	 */
+	protected $controller;
+
+	/**
+	 * Loads the endpoint, which is only included on `rest_api_init`.
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
+		if ( ! class_exists( Auto_Review_Controller::class ) ) {
+			do_action( 'rest_api_init' );
+		}
+	}
+
+	/**
+	 * Builds the controller without its constructor, which registers REST routes.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->controller = ( new ReflectionClass( Auto_Review_Controller::class ) )
+			->newInstanceWithoutConstructor();
+	}
+
+	/**
+	 * Keyword strings paired with the slug each should or should not match.
+	 *
+	 * @return array
+	 */
+	public static function data_keywords() {
+		return array(
+			'keyword first in the list'   => array( 'theme-mente-clara', 'mente-clara', true ),
+			'keyword later in the list'   => array( 'child-theme theme-foo', 'foo', true ),
+			'comma separated'             => array( 'theme-foo, needs-screenshot', 'foo', true ),
+			'comma without a space'       => array( 'needs-screenshot,theme-foo', 'foo', true ),
+			'surrounding whitespace'      => array( '  theme-foo   child-theme  ', 'foo', true ),
+			'mixed case keyword'          => array( 'Theme-Twenty-Four', 'twenty-four', true ),
+			'mixed case slug'             => array( 'theme-twenty-four', 'Twenty-Four', true ),
+			'slug is a prefix of another' => array( 'theme-twentytwentyfour', 'twenty', false ),
+			'slug longer than the keyword' => array( 'theme-twenty', 'twentytwentyfour', false ),
+			'a different theme'           => array( 'theme-bar', 'foo', false ),
+			'parent keyword is not a match' => array( 'child-theme parent-foo', 'foo', false ),
+			'no keywords'                 => array( '', 'foo', false ),
+			'no slug'                     => array( 'theme-foo', '', false ),
+		);
+	}
+
+	/**
+	 * @dataProvider data_keywords
+	 *
+	 * @param string $keywords   The ticket's keywords.
+	 * @param string $theme_slug The theme slug.
+	 * @param bool   $expected   Whether the ticket should be treated as the theme's.
+	 */
+	public function test_ticket_is_for_theme( $keywords, $theme_slug, $expected ) {
+		$this->assertSame(
+			$expected,
+			$this->controller->ticket_is_for_theme( $keywords, $theme_slug )
+		);
+	}
+}


### PR DESCRIPTION
`Auto_Review_Controller` defines `ticket_is_for_theme()` to confirm that the ticket being commented on actually belongs to the theme named in the route — and then never calls it. `update_item()` fetches the ticket by ID, checks it exists, and posts, without ever comparing it against `theme_slug`. The helper is the only occurrence of its own name in the plugin.

This wires it up, and fixes the helper, which had two problems of its own:

```php
return ! empty( $keywords ) && strpos( $keywords , $theme_slug );
```

- `strpos()` returns `0` when the needle is at the start of the string, which is falsy. It happens to work today only because the keyword list begins with `theme-`, putting the slug at offset 6.
- Searching for the bare slug is a substring match, so a theme whose slug is a prefix of another's would match that theme's ticket — `twenty` matches a ticket keyworded `theme-twentytwentyfour`.

Both go away by matching the whole `theme-{slug}` keyword rather than searching for the slug inside the string. That keyword is added by `WPORG_Themes_Upload::prepare_trac_ticket()` and set on both the create and update paths, so every theme ticket carries it.

## Notes

- `Trac::ticket_get()` flattens the response attributes to the top level (`ATTRIBUTES = 3`), so `$ticket['keywords']` is the space-separated keyword string.
- The mismatch returns a distinct `rest_ticket_theme_mismatch` code with a 400 rather than reusing the existing 404. Reusing the 404 would avoid confirming whether a ticket ID exists, but the route is bearer-token gated, so that tells a caller nothing they didn't already have — and a clear error helps when a legitimate mismatch needs debugging. Happy to switch it if the uniform response is preferred.
- The rollout risk is any older ticket lacking the `theme-{slug}` keyword, which would start being rejected. I couldn't find a path that creates one without it, but it's the thing to watch.

## Checks

- `php -l` clean.
- PHPCS: no new violations. Compared the report against the file at `HEAD` — the file has pre-existing findings, and this change removes one docblock alignment warning without adding any.

Draft because this still needs a Meta Trac ticket to reference.