### PR TITLE
Photo Directory: Simplify explanation to contributors for rejections due to potential copyright

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/rejection.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/rejection.php
@@ -46,7 +46,7 @@ class Rejection {
 			],
 			'copyright'     => [
 				'label' => __( 'Copyright: Potential copyright/ownership infringement', 'wporg-photos' ),
-				'email' => __( "The photo has been previously posted elsewhere, but due to our limited resources we are unable to verify its ownership. We require that you 'have the copyright or other legal ownership for any photo you submit'. This does not include posting photos created by others, even if their licensing is permissive in its use, since copyright is not conferred to you.\n\nIf you do have the copyright, we apologize, but hope you understand our abundance of caution. Reply to let us know and provide some verification of that fact and we can remove the block that would prevent you from resubmitting the photo.", 'wporg-photos' ),
+				'email' => __( 'The photo has been previously posted elsewhere so we are unable to accept it due to potential copyright and/or licensing conflicts.', 'wporg-photos' ),
 			],
 			'faces'         => [
 				'label' => __( 'Faces: Contains human face(s)', 'wporg-photos' ),


### PR DESCRIPTION
The current notice to a photo contributor whose photo is rejected due to copyright is a bit over-explanatory.

Additionally, it directly invites the contributor to submit verification of ownership, which ultimately does not change the fate of the photo but does introduce extra work for moderators and the contributors who do so (who also occasionally submit too much verification).

The notice should be concise and conclusive.

Fixes https://meta.trac.wordpress.org/ticket/8404.