### PR TITLE
Plugin Directory: Don't queue a deleted /trunk for import

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-svn-watcher.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-svn-watcher.php
@@ -174,8 +174,13 @@ class SVN_Watcher {
 				}
 
 				if ( 'trunk' == $path_parts[1] ) {
-					$plugin['tags_touched'][] = 'trunk';
-
+					/*
+					 * A deleted /trunk has nothing left to export. It isn't recorded in tags_deleted
+					 * either, as that removes the matching release, and trunk has no release of its own.
+					 */
+					if ( ! $is_deletion || isset( $path_parts[2] ) /* a file within trunk */ ) {
+						$plugin['tags_touched'][] = 'trunk';
+					}
 				} elseif ( 'tags' == $path_parts[1] && isset( $path_parts[2] ) ) {
 					if ( $is_deletion && ! isset( $path_parts[3] ) /* not a file deletion */ ) {
 						$plugin['tags_deleted'][] = $path_parts[2];

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/SVN_Watcher_Log_Summary_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/SVN_Watcher_Log_Summary_Test.php
@@ -186,6 +186,69 @@ class SVN_Watcher_Log_Summary_Test extends TestCase {
 	}
 
 	/**
+	 * Deleting /trunk leaves nothing to export, so it mustn't be queued as a touched version.
+	 *
+	 * This is a real release pattern: the tag is added and trunk deleted in one commit, then
+	 * trunk is re-created from that tag a few seconds later. An import queued from the first
+	 * commit runs while trunk is missing, and the ZIP build fails against a URL that's gone.
+	 */
+	public function test_trunk_deletion_is_not_queued_as_a_touched_version() {
+		$plugins = $this->summarize(
+			array(
+				$this->log_entry(
+					3653586,
+					array(
+						'/wp-better-permalinks/tags/4.3.1'            => 'A',
+						'/wp-better-permalinks/tags/4.3.1/readme.txt' => 'A',
+						'/wp-better-permalinks/trunk'                 => 'D',
+					)
+				),
+			)
+		);
+
+		$this->assertSame( array( '4.3.1' ), $plugins['wp-better-permalinks']['tags_touched'] );
+		$this->assertNotContains( 'trunk', $plugins['wp-better-permalinks']['tags_touched'] );
+
+		// trunk has no release of its own, so there's nothing for the importer to remove either.
+		$this->assertSame( array(), $plugins['wp-better-permalinks']['tags_deleted'] );
+	}
+
+	/**
+	 * Deleting a file inside /trunk is a change to trunk, not the removal of it.
+	 */
+	public function test_file_deletion_within_trunk_still_touches_trunk() {
+		$plugins = $this->summarize(
+			array(
+				$this->log_entry( 600, array( '/plugin-a/trunk/deprecated.php' => 'D' ) ),
+			)
+		);
+
+		$this->assertSame( array( 'trunk' ), $plugins['plugin-a']['tags_touched'] );
+	}
+
+	/**
+	 * Once trunk is back, it's a change like any other — including when both commits land in
+	 * the same batch of revisions, where the deletion and the re-creation are seen together.
+	 */
+	public function test_recreated_trunk_is_queued_again() {
+		$plugins = $this->summarize(
+			array(
+				$this->log_entry(
+					3653586,
+					array(
+						'/plugin-a/tags/1.0' => 'A',
+						'/plugin-a/trunk'    => 'D',
+					)
+				),
+				$this->log_entry( 3653587, array( '/plugin-a/trunk' => 'A' ) ),
+			)
+		);
+
+		$this->assertEqualsCanonicalizing( array( '1.0', 'trunk' ), $plugins['plugin-a']['tags_touched'] );
+		$this->assertSame( array( 3653586, 3653587 ), $plugins['plugin-a']['revisions'] );
+	}
+
+	/**
 	 * Paths that don't name anything below the plugin root carry no importable change.
 	 */
 	public function test_bare_plugin_root_paths_are_ignored() {


### PR DESCRIPTION
## Problem

`SVN_Watcher::summarize_plugin_changes()` records a deleted `/trunk` as a *touched* version:

```php
if ( 'trunk' == $path_parts[1] ) {
    $plugin['tags_touched'][] = 'trunk';          // ← D /slug/trunk lands here too
} elseif ( 'tags' == $path_parts[1] && isset( $path_parts[2] ) ) {
    if ( $is_deletion && ! isset( $path_parts[3] ) ) {
        $plugin['tags_deleted'][] = $path_parts[2];   // ← the tags branch does check
```

The tags branch distinguishes a deletion; the trunk branch doesn't. So `Builder::export_plugin()` is asked to export a URL that has just been removed.

## Observed impact

Some release workflows delete trunk in the same commit that adds the tag, then re-create it from that tag moments later. If svn-watch polls in the gap, the import fails:

```
E_USER_WARNING: ZIP build failed for wp-better-permalinks trunk:
  Builder::export_plugin: URL 'https://plugins.svn.wordpress.org/wp-better-permalinks/trunk' doesn't exist
```

```
r3653587  22:08:26  A /wp-better-permalinks/trunk (from tags/4.3.1:3653586)
          22:08:18  ← import runs, trunk missing
r3653586  22:08:01  A /wp-better-permalinks/tags/4.3.1/…  +  D /wp-better-permalinks/trunk
```

Same thing thirteen minutes later on `webp-converter-for-media` (31-second window, r3653600 → r3653604). That committer has used this release pattern for months — 17 `D /trunk` commits in `webp-converter-for-media`'s last 40 revisions, back to 2025-12-08 — so the warning fires whenever the timing lines up.

It resolves itself: the commit that re-creates trunk queues another import, which builds the ZIP correctly. The cost is a failed import cycle and a warning that looks like a broken plugin rather than an in-progress release.

## Fix

Treat the removal of the bare `/slug/trunk` path as a deletion, and skip it. A file deletion *inside* trunk (`/slug/trunk/old.php`) is still a change to trunk and still queues it.

Trunk is deliberately **not** added to `tags_deleted`: the importer runs `remove_release()` over that list, and trunk has no release of its own to remove.

An import is still queued for the plugin — the commit that removed trunk also added the tag, and the stable-tag fallback may have changed — it just no longer names a version that can't be exported. A commit that deletes nothing but trunk yields an entry with an empty `tags_touched`, which the importer already handles.

## Tests

Adds 3 cases to `tests/SVN_Watcher_Log_Summary_Test.php`, built from the r3653586 log entry:

- `test_trunk_deletion_is_not_queued_as_a_touched_version` — the regression.
- `test_file_deletion_within_trunk_still_touches_trunk` — guards against over-correcting.
- `test_recreated_trunk_is_queued_again` — including when both commits land in one batch of revisions.

Verified against the pre-fix code:

```
# before
.....F...  9 / 9
1) test_trunk_deletion_is_not_queued_as_a_touched_version
   Failed asserting that two arrays are identical.
    Array &0 (
        0 => '4.3.1'
   +    1 => 'trunk'
    )
Tests: 9, Assertions: 27, Failures: 1.

# after
.........  9 / 9
OK (9 tests, 29 assertions)
```

The two guard tests pass either way, by design.

## Note

Follow-up to #804, which touched the same function but not this branch of it. No Meta Trac ticket — happy to open one and reference it if that's preferred.
