### PR TITLE
Add message for WordCamp participation in login prompt

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/functions.php
@@ -483,6 +483,7 @@ function wporg_login_wporg_is_starpress( $redirect_to = '' ) {
 			$message .= '<strong>' . sprintf( __( 'Register for %s', 'wporg' ), esc_html( $_REQUEST['wcname'] ) ) . '</strong>';
 			$message .=  __( 'Log in to your WordPress.org account. If you don\'t have one, you can <a href="/register">create an account</a>.', 'wporg' );
 		} else {
+			$message .= '<strong>' . __( 'WordCamp is part of WordPress.org', 'wporg' ) . '</strong>';
 			$message .= __( 'Log in to your WordPress.org account to participate in WordCamps and meetups around the world.', 'wporg' );
 		}
 	} elseif ( str_contains( $from, 'learn.wordpress.org' ) ) {


### PR DESCRIPTION
Bring back the wrongly removed string, we only needed to change `contribute` to `participate`

Relates to #822