### PR TITLE
Add Waveform player to the external libs

### DIFF
--- a/api.wordpress.org/public_html/core/credits/wp-71.php
+++ b/api.wordpress.org/public_html/core/credits/wp-71.php
@@ -950,6 +950,7 @@ class WP_71_Credits extends WP_Credits {
 			[ 'Twemoji', 'https://github.com/twitter/twemoji' ],
 			[ 'Underscore.js', 'https://underscorejs.org/' ],
 			[ 'wasm-vips', 'https://github.com/kleisauke/wasm-vips' ],
+			[ 'Waveform Player', 'https://waveformplayer.com' ],
 			[ 'whatwg-fetch', 'https://github.com/JakeChampion/fetch' ],
 			[ 'zxcvbn', 'https://github.com/dropbox/zxcvbn' ],
 		];


### PR DESCRIPTION
I'm not sure if this is the best way to add this, or if there's a process that generates it.