### PR TITLE
Translate: Resolve events consistently across the event routes.

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/includes/event/event-repository.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/includes/event/event-repository.php
@@ -255,13 +255,16 @@ class Event_Repository implements Event_Repository_Interface {
 	}
 
 	public function get_events_for_user( int $user_id, int $page = -1, int $page_size = -1 ): Events_Query_Result {
+		// Only users who manage events may see unpublished ones, so that an attendee row cannot surface a draft.
+		$post_status = user_can( $user_id, 'manage_translation_events' ) ? array( 'publish', 'draft' ) : array( 'publish' );
+
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 		return $this->execute_events_query(
 			$page,
 			$page_size,
 			array(
-				'post_status' => array( 'publish', 'draft' ),
+				'post_status' => $post_status,
 				'meta_key'    => '_event_start',
 				'orderby'     => array(
 					'meta_value' => 'DESC',

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/includes/routes/event/image.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/includes/routes/event/image.php
@@ -36,10 +36,12 @@ class Image_Route extends Route {
 			$this->die_with_error( esc_html__( 'The image cannot be generated because GD extension is not installed.', 'gp-translation-events' ) );
 		}
 
-		$event = $this->event_repository->get_event( $event_id );
-		$text  = ! $event ? esc_html__( 'Translation events', 'gp-translation-events' ) : $event->title();
-		$text  = '' === $text ? esc_html__( 'Translation events', 'gp-translation-events' ) : $text;
-		$text  = substr( $text, 0, 44 ); // Limit the text to 44 characters.
+		// Fall back to the generic image rather than leak the title of an event the viewer cannot see.
+		$event    = $this->event_repository->get_event( $event_id );
+		$can_view = $event && current_user_can( 'view_translation_event', $event->id() );
+		$text     = $can_view ? $event->title() : esc_html__( 'Translation events', 'gp-translation-events' );
+		$text     = '' === $text ? esc_html__( 'Translation events', 'gp-translation-events' ) : $text;
+		$text     = substr( $text, 0, 44 ); // Limit the text to 44 characters.
 
 		$lines = $this->split_text( $text, 22 ); // Limit each line to 22 characters.
 		$text1 = $lines[0];

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/includes/routes/event/image.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/includes/routes/event/image.php
@@ -73,6 +73,11 @@ class Image_Route extends Route {
 
 		imagettftext( $image, $text_size, $text_angle, $text_x1, $text_y1, $text_color, $font, $text1 );
 
+		if ( $event && 'publish' !== $event->status() ) {
+			// For an unpublished event the image depends on who is asking, so it must not be shared between viewers.
+			header( 'Cache-Control: private, no-store' );
+		}
+
 		header( 'Content-type: image/png' );
 		imagepng( $image );
 		imagedestroy( $image );

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/includes/routes/event/translations.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/includes/routes/event/translations.php
@@ -33,6 +33,10 @@ class Translations_Route extends Route {
 			$this->die_with_404();
 		}
 
+		if ( ! current_user_can( 'view_translation_event', $event->id() ) ) {
+			$this->die_with_error( esc_html__( 'You are not authorized to view this page.', 'gp-translation-events' ), 403 );
+		}
+
 		global $wpdb, $gp_table_prefix;
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/includes/routes/user/attend-event.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/includes/routes/user/attend-event.php
@@ -37,8 +37,8 @@ class Attend_Event_Route extends Route {
 			return; // die_with_*() doesn't die under GP_Route::$fake_request.
 		}
 
-		$nonce_name = '_attendee_nonce';
-		if ( ! isset( $_POST[ $nonce_name ] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST[ $nonce_name ] ) ), $nonce_name ) ) {
+		$nonce_action = 'attend_translation_event_' . $event_id;
+		if ( ! isset( $_POST['_attendee_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_attendee_nonce'] ) ), $nonce_action ) ) {
 			$this->die_with_error( esc_html__( 'Your link has expired or is invalid. Please reload the page and try again.', 'gp-translation-events' ), 403 );
 			return; // die_with_*() doesn't die under GP_Route::$fake_request.
 		}
@@ -46,6 +46,11 @@ class Attend_Event_Route extends Route {
 		$event = $this->event_repository->get_event( $event_id );
 		if ( ! $event ) {
 			$this->die_with_404();
+			return; // die_with_*() doesn't die under GP_Route::$fake_request.
+		}
+
+		if ( ! current_user_can( 'view_translation_event', $event->id() ) ) {
+			$this->die_with_error( esc_html__( 'You are not authorized to attend this event.', 'gp-translation-events' ), 403 );
 			return; // die_with_*() doesn't die under GP_Route::$fake_request.
 		}
 

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/templates/event-details.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/templates/event-details.php
@@ -284,7 +284,7 @@ Templates::header(
 				<?php // Contributors can't un-attend so don't show anything. ?>
 			<?php else : ?>
 				<form class="event-details-attend" method="post" action="<?php echo esc_url( Urls::event_toggle_attendee( $event->id() ) ); ?>">
-					<?php wp_nonce_field( '_attendee_nonce', '_attendee_nonce' ); ?>
+					<?php wp_nonce_field( 'attend_translation_event_' . $event->id(), '_attendee_nonce' ); ?>
 					<?php if ( $user_is_attending ) : ?>
 						<input type="submit" class="button is-secondary attending-btn" value="<?php esc_attr_e( "You're attending", 'gp-translation-events' ); ?>" />
 					<?php else : ?>


### PR DESCRIPTION
Routes in `wporg-gp-translation-events` follow a common shape: look the event up, then defer to `Event_Capabilities` through `current_user_can()`. That class is where the published-only rule for non-managers lives, so going through it is what keeps the routes agreeing with each other.

Three routes skipped the step and used the event directly:

| Route | Check today |
|---|---|
| `event/details.php` | `view_translation_event` |
| `attendee/list.php` | `edit_translation_event_attendees` |
| `event/trash.php`, `event/delete.php`, `event/edit.php` | `trash_` / `delete_` / `edit_translation_event` |
| `event/translations.php` | — |
| `user/attend-event.php` | — |
| `event/image.php` | — |

So for an event that isn't published, those three behaved differently from every sibling. This sends all three through `view_translation_event`.

While in there, two related bits of drift:

- The attend form used the literal string `_attendee_nonce` as its nonce action, where every other event form uses a per-event action (`trash_translation_event_{id}`, `toggle_translation_event_host_{id}_{user}`). It now follows the same convention. `templates/event-details.php` is the only place that emits the field.
- `get_events_for_user()` hard-coded `post_status => array( 'publish', 'draft' )`, so *My Events* listed drafts to anyone holding an attendee row. Drafts are now limited to users who manage events — which is who the capability layer shows unpublished events to anyway, and who authors them, since `create_translation_event` maps to `manage_translation_events`.

`event/image.php` falls back to the generic "Translation events" card rather than erroring, so social unfurlers keep working. Published events are unaffected: `current_user_can()` builds a `WP_User( 0 )` for logged-out callers and still runs the `user_has_cap` filter, so anonymous visitors resolve `view_translation_event` exactly as before.

### Testing

- Published event: details, translations and image pages render for anonymous and logged-in users; attending and un-attending work.
- Unpublished event: the three routes now match `details.php`; the image endpoint returns the generic card.
- *My Events* still lists drafts for managers, and no longer lists them for other users.

One user-visible side effect: an event page left open across the deploy will hit "Your link has expired" on the next attend click, since the nonce action changed. A reload fixes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)