### PR TITLE
Translate: Scope contributor moderation by the site's own host.

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-contributor-moderation/wporg-gp-contributor-moderation.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-contributor-moderation/wporg-gp-contributor-moderation.php
@@ -88,8 +88,8 @@ class WPORG_GP_Contributor_Moderation {
 	 * @return bool True if on target domain, false otherwise.
 	 */
 	private function is_target_domain() {
-		$current_host = isset( $_SERVER['HTTP_HOST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : '';
-		return self::TARGET_DOMAIN === $current_host;
+		$site_host = wp_parse_url( home_url(), PHP_URL_HOST );
+		return self::TARGET_DOMAIN === strtolower( (string) $site_host );
 	}
 
 	/**


### PR DESCRIPTION
`WPORG_GP_Contributor_Moderation::is_target_domain()` decides whether the plugin does anything, and both entry points — `show_message()` and `block_translation_contributions()` — go through it. It read the host from `$_SERVER['HTTP_HOST']`:

```php
$current_host = isset( $_SERVER['HTTP_HOST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : '';
return self::TARGET_DOMAIN === $current_host;
```

That's the host name the client asked for, not the one the site is configured with, and `===` compares it case-sensitively even though host names aren't. nginx will route `Translate.WordPress.org` to the same `server_name`; PHP's `===` won't agree.

Reading it from `home_url()` and lower-casing keeps the intent — only act on the translate site — while making the answer depend on the site's own configuration:

```php
$site_host = wp_parse_url( home_url(), PHP_URL_HOST );
return self::TARGET_DOMAIN === strtolower( (string) $site_host );
```

`parse_url( home_url(), … )` is already the pattern used elsewhere in meta, e.g. `wporg-bbp-also-viewing`.

### Why keep the check at all

Worth noting for reviewers, since it's a fair question: this is the only plugin in the `wporg-gp-*` family that scopes itself by host — the other thirteen are simply deployed to translate.wordpress.org and check nothing. Both of its hooks (`gp_pre_can_user`, `gp_before_translation_table`) are GlotPress hooks, so they only fire where GlotPress is loaded anyway.

I've left the check in rather than removing it, because whether it's genuinely redundant depends on production activation state that isn't visible from this repo. Happy to drop it in a follow-up if someone can confirm the plugin is activated only on the translate site.

### Testing

- translate.wordpress.org: `home_url()` is `https://translate.wordpress.org`, so the check passes and both callers behave exactly as before.
- `environments/translate`: runs on a wp-env localhost port, so the check returns false — same as today, since `localhost` never matched either.
- Mixed-case host names now resolve the same way the web server resolves them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)