### PR TITLE
GP Plugin Directory: Honor the destination project's permissions when syncing translations.

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-plugin-directory/inc/sync/class-translation-sync.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-plugin-directory/inc/sync/class-translation-sync.php
@@ -135,7 +135,8 @@ class Translation_Sync {
 	public function queue_translation_for_sync( $translation ) {
 		global $wpdb;
 
-		$allowed_statuses = array( 'current', 'rejected', 'changesrequested', 'fuzzy' );
+		// Only statuses GlotPress gates on `approve`; one a user can set without it must not cross projects.
+		$allowed_statuses = array( 'current', 'rejected', 'changesrequested' );
 		
 		// Do not propagate waiting translations and other translations with warnings.
 		if ( ! in_array( $translation->status, $allowed_statuses ) || ! empty( $translation->warnings ) ) {
@@ -221,6 +222,12 @@ class Translation_Sync {
 	 * @return bool False on failure, true on success.
 	 */
 	private function copy_translation_into_set( $translation, $new_translation_set, $new_original ) {
+		// Only propagate what the acting user could do in the destination; cron and CLI aren't acting for anyone.
+		$is_system_run = ( defined( 'WP_CLI' ) && WP_CLI ) || wp_doing_cron();
+		if ( ! $is_system_run && ! GP::$permission->current_user_can( 'approve', 'translation-set', $new_translation_set->id ) ) {
+			return true;
+		}
+
 		$locale = GP_Locales::by_slug( $new_translation_set->locale );
 		$new_translation = [];
 


### PR DESCRIPTION
Every hosted plugin has two GlotPress projects, `wp-plugins/<slug>/dev` and `.../stable`, and `Translation_Sync` keeps them in step. The propagation runs on `shutdown` and writes into the project the requester never addressed, so the statuses that cross that boundary ought to be ones the acting user could have set over there themselves.

`queue_translation_for_sync()` allowed four:

```php
$allowed_statuses = array( 'current', 'rejected', 'changesrequested', 'fuzzy' );
```

GlotPress's `can_set_status()` requires the `approve` permission for `current`, `rejected` and `changesrequested`, then falls through to `true` for everything else. `fuzzy` was therefore the one entry in that list that could be set without approval — and once queued it was carried into the counterpart project, where `copy_translation_into_set()` applied it to whatever translation text matched, along with discarding that translation's warnings.

Two changes:

- Narrow the list to the three statuses approval already gates, so nothing reaches the counterpart project that wasn't approved somewhere first.
- Measure the propagating write against the destination set before it happens. It sits at the top of `copy_translation_into_set()`, ahead of the warnings discard as well as the status change, so both are covered. Cron and CLI runs aren't acting on anyone's behalf, so there's nothing to measure them against and they're exempt — without that, `wporg-gp-rosetta-roles` denying logged-out users would stop cron-driven propagation altogether.

### On dropping `fuzzy`

Since r12498 `fuzzy` cannot create a translation — only re-status one whose text already matches. And the case translators actually report doesn't go through this path at all: in #6320 timse201 tested it on the live site in October 2025 and again in March 2026 and found that when dev is updated first, the fuzzy string is never transferred to stable, because the originals no longer match and `by_project_id_and_entry()` finds no counterpart.

So what this removes is the narrow remainder — same original text in both branches, and something marks it fuzzy. If that turns out to be worth keeping, the destination check added here makes restoring it safe, which seems the better order to do it in.

`current`, `rejected` and `changesrequested` propagation is untouched, as is the commit-triggered CLI sync in `Sync_Plugin_Translations`, which never goes through `copy_translation_into_set()` and only ever handled `current`.

### Testing

Not covered by an automated test — `wporg-gp-plugin-directory` has no suite and isn't in `.github/unit-tests-suites.yml`, and exercising this needs GlotPress plus two linked projects. Reviewed by tracing instead:

- Approve resolves at parent-project level (`get_parent_project_ids()`), so a PTE for `wp-plugins/<slug>` holds it on both `/dev` and `/stable` and sees no change.
- The permission lookup is cached at every layer it touches — per-request statics in `is_approver_for_locale()` and `get_locale_and_project_id()`, object cache in `get_project_id_access_list()` — and a queue batch shares one destination set, so this is one lookup per batch rather than one per translation.
- `wporg_translate_translation_synced` has no listeners in this repo, so a skipped propagation doesn't strand a consumer.

One behavior change worth knowing: a validator holding `approve` in the source set but not the destination now has their change quietly not propagate. Rare, given the parent-level grants above, but it fails silently rather than loudly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)