### PR TITLE
Packages API: Correct version normalization and unresolved package responses

### DIFF
--- a/api.wordpress.org/public_html/packages/downloads/index.php
+++ b/api.wordpress.org/public_html/packages/downloads/index.php
@@ -32,7 +32,10 @@ if ( 'POST' !== ( $_SERVER['REQUEST_METHOD'] ?? '' ) ) {
 	exit;
 }
 
-// TODO: Parse the body and bump stats.
+/*
+ * TODO: Parse the body and bump stats. Needs an origin check or rate limiting when implementing —
+ * this endpoint is unauthenticated and sends `Access-Control-Allow-Origin: *`.
+ */
 
 // Accept the notification. Return 200 OK regardless.
 http_response_code( 200 );

--- a/api.wordpress.org/public_html/packages/includes/class-composer-repository.php
+++ b/api.wordpress.org/public_html/packages/includes/class-composer-repository.php
@@ -82,10 +82,8 @@ class Composer_Repository {
 
 		if ( 'not_found' === $response || null === $response ) {
 			/*
-			 * A 404 leaves the name unresolved, so Composer keeps looking through every repository
-			 * configured after this one, ending at Packagist, where these vendors are unclaimed.
-			 * Naming the package marks it found, which stops that search for all of them and reports
-			 * the name as unresolvable.
+			 * A 404 leaves the name unresolved, so Composer keeps searching every repository after
+			 * this one, ending at Packagist where these vendors are unclaimed. Naming it stops that.
 			 */
 			$package_name = 'wp-' . $type . '/' . $slug;
 

--- a/api.wordpress.org/public_html/packages/includes/class-composer-repository.php
+++ b/api.wordpress.org/public_html/packages/includes/class-composer-repository.php
@@ -82,9 +82,10 @@ class Composer_Repository {
 
 		if ( 'not_found' === $response || null === $response ) {
 			/*
-			 * A 404 leaves the name unresolved, so Composer falls through to the next repository —
-			 * Packagist by default, where these vendors are unclaimed. Naming the package marks it
-			 * found, so Composer stops looking and reports it as unresolvable.
+			 * A 404 leaves the name unresolved, so Composer keeps looking through every repository
+			 * configured after this one, ending at Packagist, where these vendors are unclaimed.
+			 * Naming the package marks it found, which stops that search for all of them and reports
+			 * the name as unresolvable.
 			 */
 			$package_name = 'wp-' . $type . '/' . $slug;
 
@@ -176,12 +177,17 @@ class Composer_Repository {
 		if ( ! empty( $plugin_data['versions'] ) && is_array( $plugin_data['versions'] ) ) {
 			foreach ( $plugin_data['versions'] as $version => $download_url ) {
 				$normalized = Version_Normalizer::normalize( (string) $version );
-				if ( false === $normalized || isset( $seen[ $normalized ] ) ) {
+				if ( false === $normalized ) {
 					continue;
 				}
 
-				$seen[ $normalized ] = true;
-				$versions[]          = Package_Builder::build_plugin( $slug, $normalized, $plugin_data, $download_url );
+				$key = Version_Normalizer::dedupe_key( $normalized );
+				if ( isset( $seen[ $key ] ) ) {
+					continue;
+				}
+
+				$seen[ $key ] = true;
+				$versions[]   = Package_Builder::build_plugin( $slug, $normalized, $plugin_data, $download_url );
 			}
 		}
 
@@ -269,12 +275,17 @@ class Composer_Repository {
 		if ( ! empty( $theme_data->versions ) && is_array( $theme_data->versions ) ) {
 			foreach ( $theme_data->versions as $version => $download_url ) {
 				$normalized = Version_Normalizer::normalize( (string) $version );
-				if ( false === $normalized || isset( $seen[ $normalized ] ) ) {
+				if ( false === $normalized ) {
 					continue;
 				}
 
-				$seen[ $normalized ] = true;
-				$versions[]          = Package_Builder::build_theme( $slug, $normalized, $theme_data, $download_url );
+				$key = Version_Normalizer::dedupe_key( $normalized );
+				if ( isset( $seen[ $key ] ) ) {
+					continue;
+				}
+
+				$seen[ $key ] = true;
+				$versions[]   = Package_Builder::build_theme( $slug, $normalized, $theme_data, $download_url );
 			}
 		}
 

--- a/api.wordpress.org/public_html/packages/includes/class-composer-repository.php
+++ b/api.wordpress.org/public_html/packages/includes/class-composer-repository.php
@@ -81,11 +81,15 @@ class Composer_Repository {
 		}
 
 		if ( 'not_found' === $response || null === $response ) {
-			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput
-			header( ( $_SERVER['SERVER_PROTOCOL'] ?? 'HTTP/1.0' ) . ' 404 Not Found', true, 404 );
+			/*
+			 * A 404 leaves the name unresolved, so Composer falls through to the next repository —
+			 * Packagist by default, where these vendors are unclaimed. Naming the package marks it
+			 * found, so Composer stops looking and reports it as unresolvable.
+			 */
+			$package_name = 'wp-' . $type . '/' . $slug;
 
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
-			echo json_encode( array( 'packages' => (object) array() ), JSON_UNESCAPED_SLASHES );
+			echo json_encode( array( 'packages' => array( $package_name => array() ) ), JSON_UNESCAPED_SLASHES );
 			exit;
 		}
 
@@ -166,16 +170,18 @@ class Composer_Repository {
 	private static function build_plugin_response( string $slug, array $plugin_data ): ?array {
 		$package_name = 'wp-plugin/' . $slug;
 		$versions     = array();
+		$seen         = array();
 
 		// Build entries for each tagged version.
 		if ( ! empty( $plugin_data['versions'] ) && is_array( $plugin_data['versions'] ) ) {
 			foreach ( $plugin_data['versions'] as $version => $download_url ) {
 				$normalized = Version_Normalizer::normalize( (string) $version );
-				if ( false === $normalized ) {
+				if ( false === $normalized || isset( $seen[ $normalized ] ) ) {
 					continue;
 				}
 
-				$versions[] = Package_Builder::build_plugin( $slug, $normalized, $plugin_data, $download_url );
+				$seen[ $normalized ] = true;
+				$versions[]          = Package_Builder::build_plugin( $slug, $normalized, $plugin_data, $download_url );
 			}
 		}
 
@@ -258,15 +264,17 @@ class Composer_Repository {
 	private static function build_theme_response( string $slug, object $theme_data ): ?array {
 		$package_name = 'wp-theme/' . $slug;
 		$versions     = array();
+		$seen         = array();
 
 		if ( ! empty( $theme_data->versions ) && is_array( $theme_data->versions ) ) {
 			foreach ( $theme_data->versions as $version => $download_url ) {
 				$normalized = Version_Normalizer::normalize( (string) $version );
-				if ( false === $normalized ) {
+				if ( false === $normalized || isset( $seen[ $normalized ] ) ) {
 					continue;
 				}
 
-				$versions[] = Package_Builder::build_theme( $slug, $normalized, $theme_data, $download_url );
+				$seen[ $normalized ] = true;
+				$versions[]          = Package_Builder::build_theme( $slug, $normalized, $theme_data, $download_url );
 			}
 		}
 

--- a/api.wordpress.org/public_html/packages/includes/class-version-normalizer.php
+++ b/api.wordpress.org/public_html/packages/includes/class-version-normalizer.php
@@ -49,9 +49,10 @@ class Version_Normalizer {
 
 		// Build the numeric part.
 		$major = $matches[1];
-		$minor = $matches[2] ?? '0';
-		$patch = ! empty( $matches[3] ) ? $matches[3] : null;
-		$extra = ! empty( $matches[4] ) ? $matches[4] : null;
+		// Test for an unmatched group rather than a falsy one, or a "0" segment would be dropped.
+		$minor = ( isset( $matches[2] ) && '' !== $matches[2] ) ? $matches[2] : '0';
+		$patch = ( isset( $matches[3] ) && '' !== $matches[3] ) ? $matches[3] : null;
+		$extra = ( isset( $matches[4] ) && '' !== $matches[4] ) ? $matches[4] : null;
 
 		$normalized = $major . '.' . $minor;
 		if ( null !== $patch ) {

--- a/api.wordpress.org/public_html/packages/includes/class-version-normalizer.php
+++ b/api.wordpress.org/public_html/packages/includes/class-version-normalizer.php
@@ -73,6 +73,31 @@ class Version_Normalizer {
 	}
 
 	/**
+	 * Build a key that matches whenever Composer would treat two normalized versions as one.
+	 *
+	 * Composer compares versions in four numeric segments, so it reads "1.54" and "1.54.0" as the
+	 * same version even though they normalize to different strings here.
+	 *
+	 * @param string $version A version returned by normalize().
+	 * @return string The comparison key.
+	 */
+	public static function dedupe_key( string $version ): string {
+		if ( str_starts_with( $version, 'dev-' ) ) {
+			return $version;
+		}
+
+		$numeric = $version;
+		$suffix  = '';
+
+		if ( str_contains( $version, '-' ) ) {
+			list( $numeric, $suffix ) = explode( '-', $version, 2 );
+			$suffix                   = '-' . $suffix;
+		}
+
+		return implode( '.', array_pad( explode( '.', $numeric ), 4, '0' ) ) . $suffix;
+	}
+
+	/**
 	 * Map various pre-release suffix names to canonical Composer names.
 	 *
 	 * @param string $suffix The raw suffix.

--- a/api.wordpress.org/public_html/packages/tests/test-packages-endpoint.php
+++ b/api.wordpress.org/public_html/packages/tests/test-packages-endpoint.php
@@ -239,8 +239,9 @@ class Test_Packages_Endpoint extends TestCase {
 		$data = json_decode( $response->body );
 		$this->assertIsObject( $data );
 		$this->assertObjectHasProperty( 'packages', $data );
+		$this->assertObjectHasProperty( 'wp-plugin/woocommerce-gateway-stripe', $data->packages );
 
-		$versions = $data->packages->{'wp-plugin/woocommerce-gateway-stripe'} ?? array();
+		$versions = $data->packages->{'wp-plugin/woocommerce-gateway-stripe'};
 
 		$dependencies = array();
 		foreach ( $versions as $entry ) {

--- a/api.wordpress.org/public_html/packages/tests/test-packages-endpoint.php
+++ b/api.wordpress.org/public_html/packages/tests/test-packages-endpoint.php
@@ -207,34 +207,88 @@ class Test_Packages_Endpoint extends TestCase {
 	}
 
 	/**
-	 * Test that an unknown plugin returns 404 with empty packages.
+	 * Test that an unknown plugin claims the name with no versions.
+	 *
+	 * Composer only stops consulting lower-priority repositories once a repository names the
+	 * package, so a name we can't serve must still be answered with an empty version list.
 	 */
-	public function test_unknown_plugin_returns_404(): void {
+	public function test_unknown_plugin_claims_name(): void {
 		$response = send_request( '/packages/p2/wp-plugin/this-plugin-definitely-does-not-exist-xyz.json' );
 
-		$this->assertSame( 404, $response->status_code );
+		$this->assertSame( 200, $response->status_code );
 
 		$data = json_decode( $response->body );
 		$this->assertIsObject( $data );
 		$this->assertObjectHasProperty( 'packages', $data );
+		$this->assertObjectHasProperty( 'wp-plugin/this-plugin-definitely-does-not-exist-xyz', $data->packages );
+		$this->assertSame( array(), $data->packages->{'wp-plugin/this-plugin-definitely-does-not-exist-xyz'} );
 	}
 
 	/**
-	 * Test that an unknown theme returns 404 with empty packages.
+	 * Test that every plugin dependency this repository emits is also answered by it.
+	 *
+	 * A `require` we publish but don't answer for is a name Composer will go looking for in the next
+	 * repository, so it has to resolve here whether the dependency is published, closed, or gone.
 	 */
-	public function test_unknown_theme_returns_404(): void {
+	public function test_plugin_dependencies_are_claimed(): void {
+		$response = send_request( '/packages/p2/wp-plugin/woocommerce-gateway-stripe.json' );
+
+		// Assert the fixture resolved, so a broken endpoint fails here instead of skipping below.
+		$this->assertSame( 200, $response->status_code );
+
+		$data = json_decode( $response->body );
+		$this->assertIsObject( $data );
+		$this->assertObjectHasProperty( 'packages', $data );
+
+		$versions = $data->packages->{'wp-plugin/woocommerce-gateway-stripe'} ?? array();
+
+		$dependencies = array();
+		foreach ( $versions as $entry ) {
+			foreach ( array_keys( (array) ( $entry->require ?? array() ) ) as $name ) {
+				if ( str_starts_with( $name, 'wp-plugin/' ) ) {
+					$dependencies[ $name ] = true;
+				}
+			}
+		}
+
+		if ( ! $dependencies ) {
+			$this->markTestSkipped( 'woocommerce-gateway-stripe no longer declares a plugin dependency.' );
+		}
+
+		foreach ( array_keys( $dependencies ) as $name ) {
+			$dependency = send_request( '/packages/p2/' . $name . '.json' );
+
+			$this->assertSame( 200, $dependency->status_code, "{$name} is not served by this repository." );
+			$this->assertObjectHasProperty( $name, json_decode( $dependency->body )->packages, "{$name} is not claimed by this repository." );
+		}
+	}
+
+	/**
+	 * Test that an unknown theme claims the name with no versions.
+	 */
+	public function test_unknown_theme_claims_name(): void {
 		$response = send_request( '/packages/p2/wp-theme/this-theme-definitely-does-not-exist-xyz.json' );
 
-		$this->assertSame( 404, $response->status_code );
+		$this->assertSame( 200, $response->status_code );
+
+		$data = json_decode( $response->body );
+		$this->assertIsObject( $data );
+		$this->assertObjectHasProperty( 'wp-theme/this-theme-definitely-does-not-exist-xyz', $data->packages );
+		$this->assertSame( array(), $data->packages->{'wp-theme/this-theme-definitely-does-not-exist-xyz'} );
 	}
 
 	/**
-	 * Test that an invalid core slug returns 404.
+	 * Test that an invalid core slug claims the name with no versions.
 	 */
-	public function test_invalid_core_slug_returns_404(): void {
+	public function test_invalid_core_slug_claims_name(): void {
 		$response = send_request( '/packages/p2/wp-core/not-wordpress.json' );
 
-		$this->assertSame( 404, $response->status_code );
+		$this->assertSame( 200, $response->status_code );
+
+		$data = json_decode( $response->body );
+		$this->assertIsObject( $data );
+		$this->assertObjectHasProperty( 'wp-core/not-wordpress', $data->packages );
+		$this->assertSame( array(), $data->packages->{'wp-core/not-wordpress'} );
 	}
 
 	/**

--- a/api.wordpress.org/public_html/packages/tests/test-version-normalizer.php
+++ b/api.wordpress.org/public_html/packages/tests/test-version-normalizer.php
@@ -74,6 +74,50 @@ class Test_Version_Normalizer extends TestCase {
 	}
 
 	/**
+	 * Test that the dedupe key matches for versions Composer compares as equal.
+	 *
+	 * Composer pads versions to four numeric segments, so tags that differ only by a trailing zero
+	 * are one version to it and only one of them can be served.
+	 *
+	 * @dataProvider data_equivalent_versions
+	 *
+	 * @param string $a One normalized version.
+	 * @param string $b A version Composer treats as equal to $a.
+	 */
+	public function test_dedupe_key_matches_equivalent_versions( string $a, string $b ): void {
+		$this->assertSame(
+			Version_Normalizer::dedupe_key( Version_Normalizer::normalize( $a ) ),
+			Version_Normalizer::dedupe_key( Version_Normalizer::normalize( $b ) )
+		);
+	}
+
+	/**
+	 * Data provider for versions Composer compares as equal.
+	 *
+	 * @return array Test cases.
+	 */
+	public function data_equivalent_versions(): array {
+		return array(
+			'trailing zero'         => array( '1.54', '1.54.0' ),
+			'two trailing zeros'    => array( '1.6', '1.6.0.0' ),
+			'four segment zero'     => array( '9.1.4', '9.1.4.0' ),
+			'leading v'             => array( '1.0', 'v1.0' ),
+			'zero with suffix'      => array( '3.1-rc1', '3.1.0-rc1' ),
+			'short and long suffix' => array( '1.0-a1', '1.0-alpha1' ),
+		);
+	}
+
+	/**
+	 * Test that the dedupe key differs for versions Composer compares as distinct.
+	 */
+	public function test_dedupe_key_separates_hotfix_versions(): void {
+		$this->assertNotSame(
+			Version_Normalizer::dedupe_key( Version_Normalizer::normalize( '8.7.1' ) ),
+			Version_Normalizer::dedupe_key( Version_Normalizer::normalize( '8.7.0.1' ) )
+		);
+	}
+
+	/**
 	 * Test that hotfix releases don't collapse onto the release they patch.
 	 *
 	 * WordPress hotfixes use an x.y.0.z tag, which has to stay distinct from x.y.z — otherwise both

--- a/api.wordpress.org/public_html/packages/tests/test-version-normalizer.php
+++ b/api.wordpress.org/public_html/packages/tests/test-version-normalizer.php
@@ -63,6 +63,26 @@ class Test_Version_Normalizer extends TestCase {
 			'two segment with beta'     => array( '6.9-beta3', '6.9-beta3' ),
 			'three segment with RC'     => array( '6.9.1-RC1', '6.9.1-rc1' ),
 			'version with v and suffix' => array( 'v2.0-beta1', '2.0-beta1' ),
+			'zero patch kept'           => array( '1.2.0', '1.2.0' ),
+			'zero patch and minor kept' => array( '1.0.0', '1.0.0' ),
+			'zero third segment kept'   => array( '8.7.0.1', '8.7.0.1' ),
+			'zero fourth segment kept'  => array( '2.1.3.0', '2.1.3.0' ),
+			'all zeros kept'            => array( '0.0.0', '0.0.0' ),
+			'zero minor kept'           => array( '4.0', '4.0' ),
+			'zero patch with suffix'    => array( '3.1.0-rc1', '3.1.0-rc1' ),
+		);
+	}
+
+	/**
+	 * Test that hotfix releases don't collapse onto the release they patch.
+	 *
+	 * WordPress hotfixes use an x.y.0.z tag, which has to stay distinct from x.y.z — otherwise both
+	 * are served under one Composer version and a pinned requirement resolves to the wrong zip.
+	 */
+	public function test_normalize_keeps_hotfix_versions_distinct(): void {
+		$this->assertNotSame(
+			Version_Normalizer::normalize( '8.7.1' ),
+			Version_Normalizer::normalize( '8.7.0.1' )
 		);
 	}
 


### PR DESCRIPTION
Two corrections to the Composer repository under `api.wordpress.org/packages`.

### Version normalization drops zero segments

`Version_Normalizer` tested capture groups with `! empty()`, and `empty( "0" )` is `true`, so a zero segment in the middle of a version was discarded:

```
8.7.0.1  ->  8.7.1        1.2.0  ->  1.2
6.4.0.1  ->  6.4.1        1.0.0  ->  1.0
```

Hotfix tags use exactly that shape, so they collapsed onto the release they patch. Nothing deduplicated afterwards, so the package advertised two entries for one version pointing at different archives. Composer takes the first, which is the `x.y.0.z` one in the current output — a requirement pinned to `x.y.z` therefore resolved to a different release.

Scanning 28 popular plugins found 5 affected today: jetpack (8.7.1, 8.2.1, 7.5.1), wpforms-lite (1.10.2, 1.10.1, 1.6.1), advanced-custom-fields (6.4.1), litespeed-cache (7.8.1, 7.0.1) and contact-form-7 (1.10.1, 1.8.1). The same mismatch reached `source.reference`, so `--prefer-source` checked out the wrong tag as well.

Fixed by testing for an unmatched group rather than a falsy one, plus a guard that skips duplicates where normalization still maps two tags onto one version (`v1.0` and `1.0`, for instance). The guard keeps the first entry, which is the one Composer was already choosing, so it removes the misleading duplicate without changing which archive wins.

### Unresolved names fall through to the next repository

`packages.json` advertises `wp-plugin/*`, `wp-theme/*` and `wp-core/*`, but `available-package-patterns` only tells Composer which names to ask us about — it does not claim the namespace. A 404 leaves the name unresolved, and `PoolBuilder` drops a name from its batch only once a repository reports having found it, so the lookup continues to whatever repository is configured next.

That matters for any name we reference but cannot serve. A plugin's `requires_plugins` metadata is validated when the plugin is imported and never revisited, so a dependency that is later closed stays in the parent's published `require` while its own endpoint 404s.

Serving the package name with an empty version list marks it as found, so resolution stops here and reports the name as unresolvable.

### Notes for review

- The p2 tests in the `e2e` group assert against production and will not pass until this is deployed.
- Packages whose versions previously collided will resolve to a different archive afterwards, so an existing `composer.lock` pinning one of the versions listed above will pick up a different zip. That is the intended outcome, but it is a visible change.
- The `downloads` endpoint still discards its body; its TODO now records that the origin check belongs with the implementation, since it is unauthenticated and sends `Access-Control-Allow-Origin: *`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)