### PR TITLE
Trac oEmbed: only render HTML responses from Trac

### DIFF
--- a/api.wordpress.org/public_html/dotorg/trac/oembed/index.php
+++ b/api.wordpress.org/public_html/dotorg/trac/oembed/index.php
@@ -71,7 +71,7 @@ $type = $m['type'];
 // Reject Trac output-format selectors (e.g. ?format=csv), which return non-HTML bytes rather than an embeddable page.
 $query_args = [];
 wp_parse_str( (string) wp_parse_url( $url, PHP_URL_QUERY ), $query_args );
-if ( in_array( 'format', array_map( 'strtolower', array_keys( $query_args ) ), true ) ) {
+if ( isset( $query_args['format'] ) ) {
 	header( 'HTTP/1.1 404 Not Found', true, 404 );
 	die();
 }
@@ -164,7 +164,9 @@ $response = wp_safe_remote_get(
 );
 
 $html         = wp_remote_retrieve_body( $response );
-$content_type = strtolower( (string) wp_remote_retrieve_header( $response, 'content-type' ) );
+$content_type = wp_remote_retrieve_header( $response, 'content-type' );
+// A duplicated header comes back as an array; the last value is the effective one.
+$content_type = strtolower( (string) ( is_array( $content_type ) ? end( $content_type ) : $content_type ) );
 
 if (
 	! $html ||

--- a/api.wordpress.org/public_html/dotorg/trac/oembed/index.php
+++ b/api.wordpress.org/public_html/dotorg/trac/oembed/index.php
@@ -68,6 +68,14 @@ if ( ! $m ) {
 
 $type = $m['type'];
 
+// Reject Trac output-format selectors (e.g. ?format=csv), which return non-HTML bytes rather than an embeddable page.
+$query_args = [];
+wp_parse_str( (string) wp_parse_url( $url, PHP_URL_QUERY ), $query_args );
+if ( in_array( 'format', array_map( 'strtolower', array_keys( $query_args ) ), true ) ) {
+	header( 'HTTP/1.1 404 Not Found', true, 404 );
+	die();
+}
+
 // if not iframe embed, respond with oembed payload.
 if ( ! isset( $_GET['embed'] ) ) {
 	header( 'Content-Type: application/json; charset=UTF-8' );
@@ -146,19 +154,22 @@ if ( $data = wp_cache_get( $cache_key, 'trac-oembed' ) ) {
 	die( $data );
 }
 
-$html = wp_remote_retrieve_body(
-	wp_safe_remote_get(
-		$url,
-		[
-			'user_agent'          => 'WordPress.org Trac oEmbed; https://api.wordpress.org/dotorg/trac/oembed',
-			'timeout'             => 15,
-			'limit_response_size' => 500 * KB_IN_BYTES,
-		]
-	)
+$response = wp_safe_remote_get(
+	$url,
+	[
+		'user_agent'          => 'WordPress.org Trac oEmbed; https://api.wordpress.org/dotorg/trac/oembed',
+		'timeout'             => 15,
+		'limit_response_size' => 500 * KB_IN_BYTES,
+	]
 );
+
+$html         = wp_remote_retrieve_body( $response );
+$content_type = strtolower( (string) wp_remote_retrieve_header( $response, 'content-type' ) );
 
 if (
 	! $html ||
+	// Security guard: only reparse responses Trac serves as HTML. A non-HTML format (e.g. ?format=csv) returns unescaped ticket content that would become executable markup on this origin (XSS) once parsed as HTML below.
+	! str_contains( $content_type, 'text/html' ) ||
 	(
 		! str_starts_with( $html, '<' ) &&
 		str_contains( $html, 'TracError: ' )

--- a/api.wordpress.org/public_html/dotorg/trac/oembed/index.php
+++ b/api.wordpress.org/public_html/dotorg/trac/oembed/index.php
@@ -71,7 +71,7 @@ $type = $m['type'];
 // Reject Trac output-format selectors (e.g. ?format=csv), which return non-HTML bytes rather than an embeddable page.
 $query_args = [];
 wp_parse_str( (string) wp_parse_url( $url, PHP_URL_QUERY ), $query_args );
-if ( isset( $query_args['format'] ) ) {
+if ( ! empty( $query_args['format'] ) ) {
 	header( 'HTTP/1.1 404 Not Found', true, 404 );
 	die();
 }
@@ -173,6 +173,7 @@ foreach ( (array) wp_remote_retrieve_header( $response, 'content-type' ) as $con
 
 if (
 	! $html ||
+	200 !== wp_remote_retrieve_response_code( $response ) ||
 	// Security guard: only reparse responses Trac serves as HTML. A non-HTML format (e.g. ?format=csv) returns unescaped ticket content that would become executable markup on this origin (XSS) once parsed as HTML below.
 	[ 'text/html' ] !== array_unique( $content_types ) ||
 	(

--- a/api.wordpress.org/public_html/dotorg/trac/oembed/index.php
+++ b/api.wordpress.org/public_html/dotorg/trac/oembed/index.php
@@ -163,7 +163,7 @@ $response = wp_safe_remote_get(
 	]
 );
 
-$html         = wp_remote_retrieve_body( $response );
+$html = wp_remote_retrieve_body( $response );
 // A duplicated header comes back as an array; every value must declare HTML.
 $content_types = [];
 foreach ( (array) wp_remote_retrieve_header( $response, 'content-type' ) as $content_type ) {

--- a/api.wordpress.org/public_html/dotorg/trac/oembed/index.php
+++ b/api.wordpress.org/public_html/dotorg/trac/oembed/index.php
@@ -174,7 +174,7 @@ foreach ( (array) wp_remote_retrieve_header( $response, 'content-type' ) as $con
 if (
 	! $html ||
 	200 !== wp_remote_retrieve_response_code( $response ) ||
-	// Security guard: only reparse responses Trac serves as HTML. A non-HTML format (e.g. ?format=csv) returns unescaped ticket content that would become executable markup on this origin (XSS) once parsed as HTML below.
+	// Only reparse what Trac serves as HTML — anything else could become executable markup on this origin.
 	[ 'text/html' ] !== array_unique( $content_types ) ||
 	(
 		! str_starts_with( $html, '<' ) &&

--- a/api.wordpress.org/public_html/dotorg/trac/oembed/index.php
+++ b/api.wordpress.org/public_html/dotorg/trac/oembed/index.php
@@ -164,14 +164,17 @@ $response = wp_safe_remote_get(
 );
 
 $html         = wp_remote_retrieve_body( $response );
-$content_type = wp_remote_retrieve_header( $response, 'content-type' );
-// A duplicated header comes back as an array; the last value is the effective one.
-$content_type = strtolower( (string) ( is_array( $content_type ) ? end( $content_type ) : $content_type ) );
+// A duplicated header comes back as an array; every value must declare HTML.
+$content_types = [];
+foreach ( (array) wp_remote_retrieve_header( $response, 'content-type' ) as $content_type ) {
+	// Reduce to the bare media type, e.g. `text/html; charset=utf-8` => `text/html`.
+	$content_types[] = strtolower( trim( explode( ';', (string) $content_type )[0] ) );
+}
 
 if (
 	! $html ||
 	// Security guard: only reparse responses Trac serves as HTML. A non-HTML format (e.g. ?format=csv) returns unescaped ticket content that would become executable markup on this origin (XSS) once parsed as HTML below.
-	! str_contains( $content_type, 'text/html' ) ||
+	[ 'text/html' ] !== array_unique( $content_types ) ||
 	(
 		! str_starts_with( $html, '<' ) &&
 		str_contains( $html, 'TracError: ' )

--- a/api.wordpress.org/public_html/dotorg/trac/oembed/index.php
+++ b/api.wordpress.org/public_html/dotorg/trac/oembed/index.php
@@ -71,7 +71,7 @@ $type = $m['type'];
 // Reject Trac output-format selectors (e.g. ?format=csv), which return non-HTML bytes rather than an embeddable page.
 $query_args = [];
 wp_parse_str( (string) wp_parse_url( $url, PHP_URL_QUERY ), $query_args );
-if ( ! empty( $query_args['format'] ) ) {
+if ( array_key_exists( 'format', $query_args ) && '' !== $query_args['format'] ) {
 	header( 'HTTP/1.1 404 Not Found', true, 404 );
 	die();
 }


### PR DESCRIPTION
The Trac oEmbed handler fetches a Trac page, reparses it with `DOMDocument`, and re-serves the result as HTML inside the embed iframe. It currently keeps only the response body and assumes it's an HTML document.

This makes two small adjustments so the handler only ever renders Trac's own HTML pages:

- Confirm the upstream response `Content-Type` is `text/html` before parsing/rendering it. A non-HTML response now falls back to the existing "Temporarily Unavailable" path instead of being reparsed as markup.
- Ignore Trac output-format selectors (e.g. `?format=csv`, `?format=rss`) on the `query` endpoint, since those return data files rather than an embeddable page.

No change to the embeddable endpoints themselves (ticket, changeset, milestone, ticketgraph, query) — they all return `text/html` and continue to work as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Trac oEmbed requests now reject nonempty `format` query values.
  * Remote responses are checked for a successful HTTP 200 status before their HTML content is processed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->