### PR TITLE
Plugin Directory: Re-confirm a released tag when its code changes on re-import

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-plugin-directory.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-plugin-directory.php
@@ -1733,23 +1733,27 @@ class Plugin_Directory {
 			}
 		}
 
-		$release = $release ?: [
-			'date'                     => time(),
-			'tag'                      => '',
-			'version'                  => '',
+		// The unconfirmed state of a release, shared by fresh releases and confirmation resets so the two can't drift apart.
+		$confirmation_defaults = [
 			// Assume zips built if no release confirmation.
 			'zips_built'               => ! $plugin->release_confirmation,
 			'zips_built_from_revision' => 0,
 			'confirmations'            => [],
-			// Confirmed by default if no release confiration.
+			// Confirmed by default if no release confirmation.
 			'confirmed'                => ! $plugin->release_confirmation,
 			'confirmations_required'   => (int) $plugin->release_confirmation,
-			'committer'                => [],
-			'revision'                 => [],
+		];
+
+		$release = $release ?: $confirmation_defaults + [
+			'date'          => time(),
+			'tag'           => '',
+			'version'       => '',
+			'committer'     => [],
+			'revision'      => [],
 			// Captures the release cooldown active at creation time so future filter/constant
 			// changes don't retroactively affect in-flight releases. Reviewers force-release
 			// by overriding this to 0 — see API_Update_Updater::force_release().
-			'release_delay'            => get_release_cooldown_delay( $plugin->post_name ),
+			'release_delay' => get_release_cooldown_delay( $plugin->post_name ),
 		];
 
 		// Fill the $release with the newish data. This could/should use wp_parse_args()?
@@ -1763,11 +1767,7 @@ class Plugin_Directory {
 
 		// Re-open a served release for fresh approval, clearing the old confirmation set the merge above can't. See Import::import_from_svn().
 		if ( ! empty( $data['reset_confirmation'] ) ) {
-			$release['confirmed']                = false;
-			$release['confirmations']            = [];
-			$release['confirmations_required']   = (int) $plugin->release_confirmation;
-			$release['zips_built']               = false;
-			$release['zips_built_from_revision'] = 0;
+			$release = array_merge( $release, $confirmation_defaults );
 		}
 		unset( $release['reset_confirmation'] );
 

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-plugin-directory.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-plugin-directory.php
@@ -1761,6 +1761,16 @@ class Plugin_Directory {
 			}
 		}
 
+		// Re-open a served release for fresh approval, clearing the old confirmation set the merge above can't. See Import::import_from_svn().
+		if ( ! empty( $data['reset_confirmation'] ) ) {
+			$release['confirmed']                = false;
+			$release['confirmations']            = [];
+			$release['confirmations_required']   = (int) $plugin->release_confirmation;
+			$release['zips_built']               = false;
+			$release['zips_built_from_revision'] = 0;
+		}
+		unset( $release['reset_confirmation'] );
+
 		/*
 		 * Allow a discarded release to be reset.
 		 * See API\Routes\Plugin_Release_Confirmation::undo_discard_release()

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-plugin-directory.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-plugin-directory.php
@@ -1772,6 +1772,9 @@ class Plugin_Directory {
 			// Re-opened code is new: re-arm the cooldown (dropping any force-release bypass) and resurface by date.
 			$release['release_delay'] = get_release_cooldown_delay( $plugin->post_name );
 			$release['date']          = time();
+
+			// A prior discard is stale once the code changes: fully re-open so it can be confirmed.
+			unset( $release['discarded'] );
 		}
 		unset( $release['reset_confirmation'] );
 

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-plugin-directory.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-plugin-directory.php
@@ -1690,10 +1690,11 @@ class Plugin_Directory {
 	public static function get_release( $plugin, $tag ) {
 		$releases = self::get_releases( $plugin );
 
-		// Look for the version released as a tag.
-		$filtered = wp_list_filter( $releases, compact( 'tag' ) );
-		if ( $filtered ) {
-			return array_shift( $filtered );
+		// Exact tag match first; wp_list_filter()'s loose == would confuse '1.4' with '1.40'.
+		foreach ( $releases as $release ) {
+			if ( isset( $release['tag'] ) && (string) $release['tag'] === (string) $tag ) {
+				return $release;
+			}
 		}
 
 		// Look for the tag as a trunk version.
@@ -1733,7 +1734,7 @@ class Plugin_Directory {
 			}
 		}
 
-		// The unconfirmed state of a release, shared by fresh releases and confirmation resets so the two can't drift apart.
+		// Unconfirmed-state defaults, shared by fresh releases and resets so the two can't drift apart.
 		$confirmation_defaults = [
 			// Assume zips built if no release confirmation.
 			'zips_built'               => ! $plugin->release_confirmation,

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-plugin-directory.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-plugin-directory.php
@@ -1690,7 +1690,7 @@ class Plugin_Directory {
 	public static function get_release( $plugin, $tag ) {
 		$releases = self::get_releases( $plugin );
 
-		// Exact tag match first; wp_list_filter()'s loose == would confuse '1.4' with '1.40'.
+		// Match the exact tag; '1.4' and '1.40' are distinct releases, not a numeric match.
 		foreach ( $releases as $release ) {
 			if ( isset( $release['tag'] ) && (string) $release['tag'] === (string) $tag ) {
 				return $release;

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-plugin-directory.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-plugin-directory.php
@@ -1768,8 +1768,17 @@ class Plugin_Directory {
 		// Re-open a served release for fresh approval, clearing the old confirmation set the merge above can't. See Import::import_from_svn().
 		if ( ! empty( $data['reset_confirmation'] ) ) {
 			$release = array_merge( $release, $confirmation_defaults );
+
+			// Re-opened code is new: re-arm the cooldown (dropping any force-release bypass) and resurface by date.
+			$release['release_delay'] = get_release_cooldown_delay( $plugin->post_name );
+			$release['date']          = time();
 		}
 		unset( $release['reset_confirmation'] );
+
+		// A discard voids approvals; clear them so undo_discard_release() can't restore stale confirmations.
+		if ( ! empty( $data['discarded'] ) ) {
+			$release['confirmations'] = [];
+		}
 
 		/*
 		 * Allow a discarded release to be reset.

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
@@ -72,10 +72,9 @@ class Import {
 	/**
 	 * Whether a tag's code changed since its release's confirmation state was established.
 	 *
-	 * Compares the tag's current "Last Changed Rev" against the recorded source_revision. A record
-	 * predating that field falls back to the served ZIP's export revision if it was built (failing
-	 * safe when that's unknown), or is left for the backfill if it isn't served yet; import_from_svn()
-	 * records source_revision so the fallback runs at most once per tag.
+	 * Each release remembers the revision it was approved at; a newer commit to the tag means it
+	 * changed. Older releases from before we tracked that lean on the best revision we have, and when
+	 * unsure are treated as changed rather than trusted — just once, until they record their own.
 	 *
 	 * @param array|false $release      Stored release record, per Plugin_Directory::get_release().
 	 * @param int         $tag_revision The tag path's current "Last Changed Rev".

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
@@ -265,6 +265,11 @@ class Import {
 
 				$release = Plugin_Directory::get_release( $plugin, $svn_changed_tag );
 
+				// get_release() matches loosely ('1.4' == '1.40', or a trunk@ fallback); only act on an exact-tag record.
+				if ( $release && (string) ( $release['tag'] ?? '' ) !== (string) $svn_changed_tag ) {
+					$release = false;
+				}
+
 				// $last_revision/$last_committer describe the stable path; other tags need their own.
 				if ( isset( $tag_last_changed[ $svn_changed_tag ] ) ) {
 					$tag_revision  = $tag_last_changed[ $svn_changed_tag ]['revision'];

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
@@ -70,6 +70,28 @@ class Import {
 	public $plugin;
 
 	/**
+	 * Determine whether a release's tag has been modified since the release was recorded.
+	 *
+	 * A tag last changed after every revision the release has recorded was modified behind its back.
+	 *
+	 * @param array|false $release      Stored release record, per Plugin_Directory::get_release().
+	 * @param int         $tag_revision The tag path's current "Last Changed Rev".
+	 * @return bool Whether the tag changed after the release's last recorded revision.
+	 */
+	public static function tag_modified_after_release( $release, $tag_revision ) {
+		// No release to protect, or a discarded release that isn't served.
+		if ( ! $release || ! empty( $release['discarded'] ) ) {
+			return false;
+		}
+
+		// Legacy records may predate the revision fields.
+		$known_revisions   = array_map( 'intval', (array) ( $release['revision'] ?? [] ) );
+		$known_revisions[] = (int) ( $release['zips_built_from_revision'] ?? 0 );
+
+		return $tag_revision > max( $known_revisions );
+	}
+
+	/**
 	 * Process an import for a Plugin into the Plugin Directory.
 	 *
 	 * @throws \Exception
@@ -231,31 +253,49 @@ class Import {
 
 				$release = Plugin_Directory::get_release( $plugin, $svn_changed_tag );
 
+				// The tag's own last change; $last_revision/$last_committer describe the stable tag's path, which may be a different tag.
+				if ( $svn_changed_tag === $stable_tag ) {
+					$tag_revision  = (int) $last_revision;
+					$tag_committer = $last_committer;
+				} else {
+					$tag_info      = SVN::info( self::PLUGIN_SVN_BASE . "/{$plugin_slug}/tags/{$svn_changed_tag}" );
+					$tag_revision  = (int) ( $tag_info['result']['Last Changed Rev'] ?? 0 );
+					$tag_committer = $tag_info['result']['Last Changed Author'] ?? $last_committer;
+				}
+
 				/*
-				 * A served tag re-committed with new code must re-confirm, not inherit its old approval
-				 * (including the zero-confirmation state grandfathered tags carry). The revision compare
-				 * keeps an identical re-import a no-op.
+				 * A served tag re-committed with new code must re-confirm, not inherit its old
+				 * approval — including the zero-confirmation state grandfathered tags carry, and
+				 * any confirmations already collected against the old code. An identical re-import
+				 * stays a no-op, as the tag's last change is then a revision the release has seen.
 				 */
-				$modified_after_release = $release
-					&& $release['confirmed']
-					&& $release['zips_built']
-					&& (int) $last_revision !== (int) $release['zips_built_from_revision'];
+				$modified_after_release = self::tag_modified_after_release( $release, $tag_revision );
 
 				if ( ! $release || $modified_after_release ) {
-					// Use the actual version for stable releases, otherwise fallback to the tag name, as we don't have the actual header data.
-					$release_version = ( $svn_changed_tag === $stable_tag ) ? $version : $svn_changed_tag;
+					if ( $svn_changed_tag === $stable_tag ) {
+						// Stable release, described by the parsed plugin headers.
+						$release_version = $version;
+					} elseif ( $release ) {
+						// Keep the stored version; there's no header data for non-stable tags.
+						$release_version = $release['version'] ?: $svn_changed_tag;
+					} else {
+						// New non-stable release; fallback to the tag name.
+						$release_version = $svn_changed_tag;
+					}
 
-					Plugin_Directory::add_release(
-						$plugin,
-						[
-							'tag'                => $svn_changed_tag,
-							'version'            => $release_version,
-							'committer'          => [ $last_committer ],
-							'revision'           => [ $last_revision ],
-							// Discard the prior approval when re-opening a modified release.
-							'reset_confirmation' => $modified_after_release,
-						]
-					);
+					$release_data = [
+						'tag'       => $svn_changed_tag,
+						'version'   => $release_version,
+						'committer' => [ $tag_committer ],
+						'revision'  => [ $tag_revision ],
+					];
+
+					// Discard the prior approval when re-opening a modified release.
+					if ( $modified_after_release ) {
+						$release_data['reset_confirmation'] = true;
+					}
+
+					Plugin_Directory::add_release( $plugin, $release_data );
 
 					/*
 					 * Trigger the release confirmation email.
@@ -273,7 +313,7 @@ class Import {
 						$plugin,
 						$who_to_email,
 						[
-							'who'     => $last_committer,
+							'who'     => $tag_committer,
 							'readme'  => $readme,
 							'headers' => $headers,
 							'version' => $release_version,

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
@@ -72,9 +72,10 @@ class Import {
 	/**
 	 * Whether a tag's code changed since its release's confirmation state was established.
 	 *
-	 * Compares the tag's current "Last Changed Rev" against the recorded source_revision. Records
-	 * predating that field fall back to the served ZIP's export revision, and fail safe (modified)
-	 * when even that is unknown; import_from_svn() backfills source_revision so the fallback runs once.
+	 * Compares the tag's current "Last Changed Rev" against the recorded source_revision. A record
+	 * predating that field falls back to the served ZIP's export revision if it was built (failing
+	 * safe when that's unknown), or is left for the backfill if it isn't served yet; import_from_svn()
+	 * records source_revision so the fallback runs at most once per tag.
 	 *
 	 * @param array|false $release      Stored release record, per Plugin_Directory::get_release().
 	 * @param int         $tag_revision The tag path's current "Last Changed Rev".
@@ -87,6 +88,11 @@ class Import {
 
 		if ( isset( $release['source_revision'] ) ) {
 			return (int) $tag_revision > (int) $release['source_revision'];
+		}
+
+		// An unbuilt legacy release isn't served, so nothing to protect: leave it for the backfill, don't wipe its confirmations.
+		if ( empty( $release['zips_built'] ) ) {
+			return false;
 		}
 
 		return (int) $tag_revision > (int) ( $release['zips_built_from_revision'] ?? 0 );
@@ -265,7 +271,7 @@ class Import {
 
 				$release = Plugin_Directory::get_release( $plugin, $svn_changed_tag );
 
-				// get_release() matches loosely ('1.4' == '1.40', or a trunk@ fallback); only act on an exact-tag record.
+				// get_release()'s trunk@ fallback can match a different release; only act on an exact-tag record.
 				if ( $release && (string) ( $release['tag'] ?? '' ) !== (string) $svn_changed_tag ) {
 					$release = false;
 				}
@@ -288,8 +294,8 @@ class Import {
 
 				if ( ! $release || $modified_after_release ) {
 					if ( $svn_changed_tag === $stable_tag ) {
-						// Stable release, described by the parsed plugin headers.
-						$release_version = $version;
+						// Stable release, described by the parsed plugin headers; don't clobber a stored version with an empty header.
+						$release_version = $version ?: ( ( $release['version'] ?? '' ) ?: $svn_changed_tag );
 					} elseif ( $release ) {
 						// Keep the stored version; there's no header data for non-stable tags.
 						$release_version = $release['version'] ?: $svn_changed_tag;
@@ -339,8 +345,10 @@ class Import {
 					$email->send();
 
 					if ( $modified_after_release ) {
+						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- CLI progress output.
 						echo "Plugin release {$svn_changed_tag} modified after release; confirmation reset.\n";
 					} else {
+						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- CLI progress output.
 						echo "Plugin release {$svn_changed_tag} not confirmed; email triggered.\n";
 					}
 				} elseif ( ! isset( $release['source_revision'] ) ) {
@@ -388,7 +396,7 @@ class Import {
 					 * This can be a confirmed release, but one which isn't set as stable.
 					 */
 					$this_release = Plugin_Directory::get_release( $plugin, $svn_changed_tag );
-					if ( $this_release['confirmed'] && ! $this_release['zips_built'] ) {
+					if ( $this_release && $this_release['confirmed'] && ! $this_release['zips_built'] ) {
 						$zips_to_build[] = $this_release['tag'];
 					}
 				}

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
@@ -70,25 +70,26 @@ class Import {
 	public $plugin;
 
 	/**
-	 * Determine whether a release's tag has been modified since the release was recorded.
+	 * Whether a tag's code changed since its release's confirmation state was established.
 	 *
-	 * A tag last changed after every revision the release has recorded was modified behind its back.
+	 * Compares the tag's current "Last Changed Rev" against the recorded source_revision. Records
+	 * predating that field fall back to the served ZIP's export revision, and fail safe (modified)
+	 * when even that is unknown; import_from_svn() backfills source_revision so the fallback runs once.
 	 *
 	 * @param array|false $release      Stored release record, per Plugin_Directory::get_release().
 	 * @param int         $tag_revision The tag path's current "Last Changed Rev".
-	 * @return bool Whether the tag changed after the release's last recorded revision.
+	 * @return bool Whether the tag changed after the recorded source revision.
 	 */
 	public static function tag_modified_after_release( $release, $tag_revision ) {
-		// No release to protect, or a discarded release that isn't served.
-		if ( ! $release || ! empty( $release['discarded'] ) ) {
+		if ( ! $release ) {
 			return false;
 		}
 
-		// Legacy records may predate the revision fields.
-		$known_revisions   = array_map( 'intval', (array) ( $release['revision'] ?? [] ) );
-		$known_revisions[] = (int) ( $release['zips_built_from_revision'] ?? 0 );
+		if ( isset( $release['source_revision'] ) ) {
+			return (int) $tag_revision > (int) $release['source_revision'];
+		}
 
-		return $tag_revision > max( $known_revisions );
+		return (int) $tag_revision > (int) ( $release['zips_built_from_revision'] ?? 0 );
 	}
 
 	/**
@@ -245,6 +246,17 @@ class Import {
 				throw new Exception( 'Plugin cannot be released from trunk due to release confirmation being enabled.' );
 			}
 
+			// Per-tag last-changed rev/author, from the listing export_and_parse_plugin() already fetched.
+			$tag_last_changed = [];
+			foreach ( $tagged_versions as $tag_meta ) {
+				if ( isset( $tag_meta['tag'] ) ) {
+					$tag_last_changed[ $tag_meta['tag'] ] = [
+						'revision' => (int) ( $tag_meta['revision'] ?? 0 ),
+						'author'   => (string) ( $tag_meta['author'] ?? '' ),
+					];
+				}
+			}
+
 			// Check to see if the commit has touched tags that don't have known confirmed releases.
 			foreach ( $svn_changed_tags as $svn_changed_tag ) {
 				if ( 'trunk' === $svn_changed_tag ) {
@@ -253,22 +265,20 @@ class Import {
 
 				$release = Plugin_Directory::get_release( $plugin, $svn_changed_tag );
 
-				// The tag's own last change; $last_revision/$last_committer describe the stable tag's path, which may be a different tag.
-				if ( $svn_changed_tag === $stable_tag ) {
+				// $last_revision/$last_committer describe the stable path; other tags need their own.
+				if ( isset( $tag_last_changed[ $svn_changed_tag ] ) ) {
+					$tag_revision  = $tag_last_changed[ $svn_changed_tag ]['revision'];
+					$tag_committer = $tag_last_changed[ $svn_changed_tag ]['author'] ?: $last_committer;
+				} elseif ( $svn_changed_tag === $stable_tag ) {
 					$tag_revision  = (int) $last_revision;
 					$tag_committer = $last_committer;
 				} else {
-					$tag_info      = SVN::info( self::PLUGIN_SVN_BASE . "/{$plugin_slug}/tags/{$svn_changed_tag}" );
-					$tag_revision  = (int) ( $tag_info['result']['Last Changed Rev'] ?? 0 );
-					$tag_committer = $tag_info['result']['Last Changed Author'] ?? $last_committer;
+					// Unknown revision (tag deleted mid-import, or listing failure): don't guess and risk a false reset.
+					$this->warnings['tag_revision_unresolved'][] = $svn_changed_tag;
+					continue;
 				}
 
-				/*
-				 * A served tag re-committed with new code must re-confirm, not inherit its old
-				 * approval — including the zero-confirmation state grandfathered tags carry, and
-				 * any confirmations already collected against the old code. An identical re-import
-				 * stays a no-op, as the tag's last change is then a revision the release has seen.
-				 */
+				// Re-committed code must re-confirm, not inherit the tag's old approval; an unchanged re-import is a no-op.
 				$modified_after_release = self::tag_modified_after_release( $release, $tag_revision );
 
 				if ( ! $release || $modified_after_release ) {
@@ -284,10 +294,12 @@ class Import {
 					}
 
 					$release_data = [
-						'tag'       => $svn_changed_tag,
-						'version'   => $release_version,
-						'committer' => [ $tag_committer ],
-						'revision'  => [ $tag_revision ],
+						'tag'             => $svn_changed_tag,
+						'version'         => $release_version,
+						'committer'       => [ $tag_committer ],
+						'revision'        => [ $tag_revision ],
+						// Baseline for later modification checks.
+						'source_revision' => $tag_revision,
 					];
 
 					// Discard the prior approval when re-opening a modified release.
@@ -326,6 +338,15 @@ class Import {
 					} else {
 						echo "Plugin release {$svn_changed_tag} not confirmed; email triggered.\n";
 					}
+				} elseif ( ! isset( $release['source_revision'] ) ) {
+					// Legacy record, unchanged: record its baseline so later checks are tag-specific.
+					Plugin_Directory::add_release(
+						$plugin,
+						[
+							'tag'             => $svn_changed_tag,
+							'source_revision' => $tag_revision,
+						]
+					);
 				}
 			}
 
@@ -788,9 +809,10 @@ class Import {
 			}
 
 			$tagged_versions[ $tag ] = [
-				'tag'    => $entry['filename'],
-				'author' => $entry['author'],
-				'date'   => $entry['date'],
+				'tag'      => $entry['filename'],
+				'author'   => $entry['author'],
+				'date'     => $entry['date'],
+				'revision' => (int) ( $entry['revision'] ?? 0 ),
 			];
 		}
 

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/cli/class-import.php
@@ -230,17 +230,30 @@ class Import {
 				}
 
 				$release = Plugin_Directory::get_release( $plugin, $svn_changed_tag );
-				if ( ! $release ) {
+
+				/*
+				 * A served tag re-committed with new code must re-confirm, not inherit its old approval
+				 * (including the zero-confirmation state grandfathered tags carry). The revision compare
+				 * keeps an identical re-import a no-op.
+				 */
+				$modified_after_release = $release
+					&& $release['confirmed']
+					&& $release['zips_built']
+					&& (int) $last_revision !== (int) $release['zips_built_from_revision'];
+
+				if ( ! $release || $modified_after_release ) {
 					// Use the actual version for stable releases, otherwise fallback to the tag name, as we don't have the actual header data.
 					$release_version = ( $svn_changed_tag === $stable_tag ) ? $version : $svn_changed_tag;
 
 					Plugin_Directory::add_release(
 						$plugin,
 						[
-							'tag'       => $svn_changed_tag,
-							'version'   => $release_version,
-							'committer' => [ $last_committer ],
-							'revision'  => [ $last_revision ]
+							'tag'                => $svn_changed_tag,
+							'version'            => $release_version,
+							'committer'          => [ $last_committer ],
+							'revision'           => [ $last_revision ],
+							// Discard the prior approval when re-opening a modified release.
+							'reset_confirmation' => $modified_after_release,
 						]
 					);
 
@@ -268,7 +281,11 @@ class Import {
 					);
 					$email->send();
 
-					echo "Plugin release {$svn_changed_tag} not confirmed; email triggered.\n";
+					if ( $modified_after_release ) {
+						echo "Plugin release {$svn_changed_tag} modified after release; confirmation reset.\n";
+					} else {
+						echo "Plugin release {$svn_changed_tag} not confirmed; email triggered.\n";
+					}
 				}
 			}
 

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Release_Confirmation_Immutable_Tag_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Release_Confirmation_Immutable_Tag_Test.php
@@ -287,6 +287,34 @@ class Release_Confirmation_Immutable_Tag_Test extends TestCase {
 	}
 
 	/**
+	 * Re-opening a modified release clears a prior discard, so it isn't left in a state the reset
+	 * email invites committers to confirm but confirm_release() and discard_release() both refuse.
+	 */
+	public function test_reset_clears_discarded(): void {
+		Plugin_Directory::add_release(
+			$this->plugin,
+			array(
+				'tag'       => '1.4.0',
+				'version'   => '1.4.0',
+				'discarded' => array(
+					'user' => 'reviewer',
+					'time' => 333,
+				),
+			)
+		);
+
+		Plugin_Directory::add_release(
+			$this->plugin,
+			array(
+				'tag'                => '1.4.0',
+				'reset_confirmation' => true,
+			)
+		);
+
+		$this->assertArrayNotHasKey( 'discarded', $this->release( '1.4.0' ) );
+	}
+
+	/**
 	 * Re-opening a release re-arms the current cooldown (dropping a force-release bypass) and
 	 * refreshes its date so it resurfaces in the confirmation queue instead of staying buried.
 	 */

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Release_Confirmation_Immutable_Tag_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Release_Confirmation_Immutable_Tag_Test.php
@@ -191,70 +191,133 @@ class Release_Confirmation_Immutable_Tag_Test extends TestCase {
 	}
 
 	/**
-	 * A tag last changed at (or before) a revision the release has already recorded is
-	 * unmodified — re-triggered imports of the same commit must stay a no-op.
+	 * A tag last changed at (or before) the release's recorded source revision is unmodified —
+	 * re-triggered imports of the same commit must stay a no-op.
 	 */
-	public function test_tag_at_a_recorded_revision_is_not_modified(): void {
-		$release = array(
-			'revision'                 => array( 100 ),
-			'zips_built_from_revision' => 0,
-		);
+	public function test_tag_at_source_revision_is_not_modified(): void {
+		$release = array( 'source_revision' => 100 );
 
 		$this->assertFalse( Import::tag_modified_after_release( $release, 100 ) );
 		$this->assertFalse( Import::tag_modified_after_release( $release, 90 ) );
 	}
 
 	/**
-	 * A tag last changed after every revision the release has recorded was modified
-	 * behind the release's back and must trigger a reset — regardless of whether the
-	 * release is confirmed or its zips are built, so the confirm-to-build window and
-	 * partially-confirmed releases are covered too.
+	 * A tag last changed after the recorded source revision was modified behind the release's
+	 * back and must trigger a reset — the check ignores confirmed/zips-built state, so the
+	 * confirm-to-build window and partially-confirmed releases are covered too.
 	 */
-	public function test_tag_changed_after_all_recorded_revisions_is_modified(): void {
-		$release = array(
-			'revision'                 => array( 100 ),
-			'zips_built_from_revision' => 0,
-		);
+	public function test_tag_changed_after_source_revision_is_modified(): void {
+		$release = array( 'source_revision' => 100 );
 
 		$this->assertTrue( Import::tag_modified_after_release( $release, 101 ) );
 	}
 
 	/**
-	 * The zip build's export revision extends the anchor: the build exported the repo at
-	 * that revision, so any tag change at or before it was part of the built code.
+	 * A discarded release is not exempt: its code can still be re-committed, so a change past
+	 * the source revision is detected. The reset (and discard itself) clears its confirmations.
 	 */
-	public function test_zip_build_revision_extends_the_anchor(): void {
+	public function test_discarded_release_is_not_exempt(): void {
 		$release = array(
-			'revision'                 => array( 100 ),
-			'zips_built_from_revision' => 150,
+			'source_revision' => 100,
+			'discarded'       => array( 'user' => 'someone' ),
 		);
+
+		$this->assertTrue( Import::tag_modified_after_release( $release, 200 ) );
+	}
+
+	/**
+	 * A legacy record predating source_revision falls back to the served ZIP's export revision: a
+	 * tag change after it is unshipped and re-opens the release, while a change already in the built
+	 * code does not.
+	 */
+	public function test_legacy_release_falls_back_to_zip_build_revision(): void {
+		$release = array( 'zips_built_from_revision' => 150 );
 
 		$this->assertFalse( Import::tag_modified_after_release( $release, 150 ) );
 		$this->assertTrue( Import::tag_modified_after_release( $release, 151 ) );
 	}
 
 	/**
-	 * Legacy release records that predate the revision fields must not raise undefined
-	 * array key warnings, and anchor at zero so any change re-opens them.
+	 * A legacy record with no revision information at all (e.g. a prefilled grandfathered tag) fails
+	 * safe: any real revision counts as modified rather than trusting the grandfathered approval.
 	 */
-	public function test_legacy_release_without_revision_fields(): void {
+	public function test_legacy_release_without_any_revision_fails_safe(): void {
 		$this->assertTrue( Import::tag_modified_after_release( array( 'tag' => '1.0' ), 100 ) );
 		$this->assertFalse( Import::tag_modified_after_release( array( 'tag' => '1.0' ), 0 ) );
 	}
 
 	/**
-	 * Missing and discarded releases carry no approval to protect, so they never count
-	 * as modified.
+	 * A missing release carries no approval to protect and never counts as modified.
 	 */
-	public function test_missing_and_discarded_releases_are_ignored(): void {
+	public function test_missing_release_is_not_modified(): void {
 		$this->assertFalse( Import::tag_modified_after_release( false, 100 ) );
+	}
 
-		$discarded = array(
-			'revision'                 => array( 100 ),
-			'zips_built_from_revision' => 0,
-			'discarded'                => true,
+	/**
+	 * Recording a discard clears the release's confirmations outright, so undo_discard_release()
+	 * can't restore approvals collected against code that has since changed.
+	 */
+	public function test_discard_clears_confirmations(): void {
+		Plugin_Directory::add_release(
+			$this->plugin,
+			array(
+				'tag'                    => '1.4.0',
+				'version'                => '1.4.0',
+				'confirmations_required' => 2,
+				'confirmations'          => array(
+					'alice' => 111,
+					'bob'   => 222,
+				),
+			)
 		);
 
-		$this->assertFalse( Import::tag_modified_after_release( $discarded, 200 ) );
+		Plugin_Directory::add_release(
+			$this->plugin,
+			array(
+				'tag'       => '1.4.0',
+				'confirmed' => false,
+				'discarded' => array(
+					'user' => 'reviewer',
+					'time' => 333,
+				),
+			)
+		);
+
+		$this->assertSame( array(), $this->release( '1.4.0' )['confirmations'] );
+	}
+
+	/**
+	 * Re-opening a release re-arms the current cooldown (dropping a force-release bypass) and
+	 * refreshes its date so it resurfaces in the confirmation queue instead of staying buried.
+	 */
+	public function test_reset_rearms_cooldown_and_refreshes_date(): void {
+		$before = time();
+
+		Plugin_Directory::add_release(
+			$this->plugin,
+			array(
+				'tag'           => '1.4.0',
+				'version'       => '1.4.0',
+				'confirmed'     => true,
+				'date'          => $before - WEEK_IN_SECONDS,
+				'release_delay' => 0,
+			)
+		);
+
+		Plugin_Directory::add_release(
+			$this->plugin,
+			array(
+				'tag'                => '1.4.0',
+				'reset_confirmation' => true,
+			)
+		);
+
+		$release = $this->release( '1.4.0' );
+
+		$this->assertSame(
+			\WordPressdotorg\Plugin_Directory\get_release_cooldown_delay( $this->plugin->post_name ),
+			$release['release_delay']
+		);
+		$this->assertGreaterThanOrEqual( $before, $release['date'] );
 	}
 }

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Release_Confirmation_Immutable_Tag_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Release_Confirmation_Immutable_Tag_Test.php
@@ -10,6 +10,7 @@ declare( strict_types = 1 );
 
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use WordPressdotorg\Plugin_Directory\CLI\Import;
 use WordPressdotorg\Plugin_Directory\Plugin_Directory;
 
 /**
@@ -20,7 +21,8 @@ use WordPressdotorg\Plugin_Directory\Plugin_Directory;
  * zero-confirmation state.
  *
  * These tests cover the `reset_confirmation` seam Import::import_from_svn() uses to
- * re-open a modified released tag, and confirm a plain merge never resets on its own.
+ * re-open a modified released tag, the Import::tag_modified_after_release() check that
+ * decides when to use it, and confirm a plain merge never resets on its own.
  *
  * Extends the plain PHPUnit TestCase for the same reasons as
  * Current_Release_Resolution_Test: WP_UnitTestCase is incompatible with the
@@ -186,5 +188,73 @@ class Release_Confirmation_Immutable_Tag_Test extends TestCase {
 
 		$this->assertTrue( $release['confirmed'] );
 		$this->assertSame( 0, $release['confirmations_required'] );
+	}
+
+	/**
+	 * A tag last changed at (or before) a revision the release has already recorded is
+	 * unmodified — re-triggered imports of the same commit must stay a no-op.
+	 */
+	public function test_tag_at_a_recorded_revision_is_not_modified(): void {
+		$release = array(
+			'revision'                 => array( 100 ),
+			'zips_built_from_revision' => 0,
+		);
+
+		$this->assertFalse( Import::tag_modified_after_release( $release, 100 ) );
+		$this->assertFalse( Import::tag_modified_after_release( $release, 90 ) );
+	}
+
+	/**
+	 * A tag last changed after every revision the release has recorded was modified
+	 * behind the release's back and must trigger a reset — regardless of whether the
+	 * release is confirmed or its zips are built, so the confirm-to-build window and
+	 * partially-confirmed releases are covered too.
+	 */
+	public function test_tag_changed_after_all_recorded_revisions_is_modified(): void {
+		$release = array(
+			'revision'                 => array( 100 ),
+			'zips_built_from_revision' => 0,
+		);
+
+		$this->assertTrue( Import::tag_modified_after_release( $release, 101 ) );
+	}
+
+	/**
+	 * The zip build's export revision extends the anchor: the build exported the repo at
+	 * that revision, so any tag change at or before it was part of the built code.
+	 */
+	public function test_zip_build_revision_extends_the_anchor(): void {
+		$release = array(
+			'revision'                 => array( 100 ),
+			'zips_built_from_revision' => 150,
+		);
+
+		$this->assertFalse( Import::tag_modified_after_release( $release, 150 ) );
+		$this->assertTrue( Import::tag_modified_after_release( $release, 151 ) );
+	}
+
+	/**
+	 * Legacy release records that predate the revision fields must not raise undefined
+	 * array key warnings, and anchor at zero so any change re-opens them.
+	 */
+	public function test_legacy_release_without_revision_fields(): void {
+		$this->assertTrue( Import::tag_modified_after_release( array( 'tag' => '1.0' ), 100 ) );
+		$this->assertFalse( Import::tag_modified_after_release( array( 'tag' => '1.0' ), 0 ) );
+	}
+
+	/**
+	 * Missing and discarded releases carry no approval to protect, so they never count
+	 * as modified.
+	 */
+	public function test_missing_and_discarded_releases_are_ignored(): void {
+		$this->assertFalse( Import::tag_modified_after_release( false, 100 ) );
+
+		$discarded = array(
+			'revision'                 => array( 100 ),
+			'zips_built_from_revision' => 0,
+			'discarded'                => true,
+		);
+
+		$this->assertFalse( Import::tag_modified_after_release( $discarded, 200 ) );
 	}
 }

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Release_Confirmation_Immutable_Tag_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Release_Confirmation_Immutable_Tag_Test.php
@@ -226,24 +226,29 @@ class Release_Confirmation_Immutable_Tag_Test extends TestCase {
 	}
 
 	/**
-	 * A legacy record predating source_revision falls back to the served ZIP's export revision: a
-	 * tag change after it is unshipped and re-opens the release, while a change already in the built
+	 * A built legacy record predating source_revision falls back to the served ZIP's export revision:
+	 * a tag change after it is unshipped and re-opens the release, while a change already in the built
 	 * code does not.
 	 */
 	public function test_legacy_release_falls_back_to_zip_build_revision(): void {
-		$release = array( 'zips_built_from_revision' => 150 );
+		$release = array(
+			'zips_built'               => true,
+			'zips_built_from_revision' => 150,
+		);
 
 		$this->assertFalse( Import::tag_modified_after_release( $release, 150 ) );
 		$this->assertTrue( Import::tag_modified_after_release( $release, 151 ) );
 	}
 
 	/**
-	 * A legacy record with no revision information at all (e.g. a prefilled grandfathered tag) fails
-	 * safe: any real revision counts as modified rather than trusting the grandfathered approval.
+	 * A built legacy record with no export revision (e.g. a prefilled grandfathered tag) fails safe:
+	 * any real revision counts as modified rather than trusting the grandfathered approval.
 	 */
-	public function test_legacy_release_without_any_revision_fails_safe(): void {
-		$this->assertTrue( Import::tag_modified_after_release( array( 'tag' => '1.0' ), 100 ) );
-		$this->assertFalse( Import::tag_modified_after_release( array( 'tag' => '1.0' ), 0 ) );
+	public function test_built_legacy_release_without_revision_fails_safe(): void {
+		$release = array( 'zips_built' => true );
+
+		$this->assertTrue( Import::tag_modified_after_release( $release, 100 ) );
+		$this->assertFalse( Import::tag_modified_after_release( $release, 0 ) );
 	}
 
 	/**
@@ -251,6 +256,28 @@ class Release_Confirmation_Immutable_Tag_Test extends TestCase {
 	 */
 	public function test_missing_release_is_not_modified(): void {
 		$this->assertFalse( Import::tag_modified_after_release( false, 100 ) );
+	}
+
+	/**
+	 * An unbuilt legacy release (no source_revision, never served) is never modified: the import
+	 * that confirm_release() queues must not wipe the confirmation it just collected.
+	 */
+	public function test_unbuilt_legacy_release_is_not_modified(): void {
+		$release = array( 'zips_built' => false );
+
+		$this->assertFalse( Import::tag_modified_after_release( $release, 999 ) );
+	}
+
+	/**
+	 * Exact-tag lookup: a numerically-equal distinct tag ('1.40' vs '1.4') must not shadow the other,
+	 * which would mislead the importer's modified check and the stable-tag gate.
+	 */
+	public function test_get_release_matches_exact_tag_not_numeric_equal(): void {
+		$this->add_grandfathered_release( '1.4', '1.4' );
+		$this->add_grandfathered_release( '1.40', '1.40' );
+
+		$this->assertSame( '1.4', Plugin_Directory::get_release( $this->plugin, '1.4' )['tag'] );
+		$this->assertSame( '1.40', Plugin_Directory::get_release( $this->plugin, '1.40' )['tag'] );
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Release_Confirmation_Immutable_Tag_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Release_Confirmation_Immutable_Tag_Test.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * Tests that a released tag cannot silently inherit its prior confirmation when
+ * its code is modified after Release Confirmation is enabled.
+ *
+ * @package WordPressdotorg\Plugin_Directory\Tests
+ */
+
+declare( strict_types = 1 );
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use WordPressdotorg\Plugin_Directory\Plugin_Directory;
+
+/**
+ * When Release Confirmation is enabled after a plugin already has tagged releases,
+ * those tags are grandfathered as `confirmed = true`, `confirmations_required = 0`,
+ * `zips_built = true`. If a committer then rewrites the code inside such a tag, the
+ * altered revision must be re-approved from scratch rather than riding the old
+ * zero-confirmation state.
+ *
+ * These tests cover the `reset_confirmation` seam Import::import_from_svn() uses to
+ * re-open a modified released tag, and confirm a plain merge never resets on its own.
+ *
+ * Extends the plain PHPUnit TestCase for the same reasons as
+ * Current_Release_Resolution_Test: WP_UnitTestCase is incompatible with the
+ * PHPUnit 11 runner, and per-test isolation comes from a unique plugin post.
+ *
+ * @group jobs
+ */
+#[Group( 'jobs' )]
+class Release_Confirmation_Immutable_Tag_Test extends TestCase {
+
+	/**
+	 * Counter to give every test plugin a unique slug.
+	 *
+	 * @var int
+	 */
+	private static int $plugin_count = 0;
+
+	/**
+	 * The plugin post under test.
+	 *
+	 * @var \WP_Post
+	 */
+	private \WP_Post $plugin;
+
+	/**
+	 * Create a published plugin with two-person Release Confirmation enabled.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		wp_cache_flush();
+
+		$plugin = Plugin_Directory::create_plugin_post(
+			array(
+				'post_name'   => 'immutable-tag-test-' . ( ++self::$plugin_count ),
+				'post_title'  => 'Immutable Tag Test Plugin',
+				'post_status' => 'publish',
+			)
+		);
+
+		$this->assertInstanceOf( \WP_Post::class, $plugin );
+		$this->plugin = $plugin;
+
+		update_post_meta( $this->plugin->ID, 'release_confirmation', 2 );
+	}
+
+	/**
+	 * Store a grandfathered release: served, confirmed, zero confirmations required.
+	 *
+	 * Mirrors the state Plugin_Directory::prefill_releases_meta() records for a tag
+	 * that existed before Release Confirmation was enabled.
+	 *
+	 * @param string $tag     The release tag.
+	 * @param string $version The release version.
+	 */
+	private function add_grandfathered_release( string $tag, string $version ): void {
+		Plugin_Directory::add_release(
+			$this->plugin,
+			array(
+				'tag'                      => $tag,
+				'version'                  => $version,
+				'zips_built'               => true,
+				'zips_built_from_revision' => 0,
+				'confirmed'                => true,
+				'confirmations_required'   => 0,
+			)
+		);
+	}
+
+	/**
+	 * The current stored release for a tag.
+	 *
+	 * @param string $tag The release tag.
+	 * @return array The release record.
+	 */
+	private function release( string $tag ): array {
+		return Plugin_Directory::get_release( get_post( $this->plugin->ID ), $tag );
+	}
+
+	/**
+	 * Re-opening a grandfathered release wipes its zero-confirmation approval and
+	 * restores the plugin's current required confirmation count.
+	 */
+	public function test_reset_confirmation_clears_grandfathered_approval(): void {
+		$this->add_grandfathered_release( '1.4.0', '1.4.0' );
+
+		Plugin_Directory::add_release(
+			$this->plugin,
+			array(
+				'tag'                => '1.4.0',
+				'version'            => '99.0.0',
+				'committer'          => array( 'attacker' ),
+				'revision'           => array( 5000 ),
+				'reset_confirmation' => true,
+			)
+		);
+
+		$release = $this->release( '1.4.0' );
+
+		$this->assertFalse( $release['confirmed'] );
+		$this->assertSame( array(), $release['confirmations'] );
+		$this->assertSame( 2, $release['confirmations_required'] );
+		$this->assertFalse( $release['zips_built'] );
+		$this->assertSame( 0, $release['zips_built_from_revision'] );
+		$this->assertSame( '99.0.0', $release['version'] );
+	}
+
+	/**
+	 * A reset drops any confirmations already recorded against the old revision, so
+	 * a stale approval can't pre-satisfy the count for the modified code.
+	 */
+	public function test_reset_confirmation_discards_prior_confirmations(): void {
+		Plugin_Directory::add_release(
+			$this->plugin,
+			array(
+				'tag'                      => '1.4.0',
+				'version'                  => '1.4.0',
+				'zips_built'               => true,
+				'zips_built_from_revision' => 4000,
+				'confirmed'                => true,
+				'confirmations_required'   => 2,
+				'confirmations'            => array(
+					'alice' => 111,
+					'bob'   => 222,
+				),
+			)
+		);
+
+		Plugin_Directory::add_release(
+			$this->plugin,
+			array(
+				'tag'                => '1.4.0',
+				'version'            => '99.0.0',
+				'reset_confirmation' => true,
+			)
+		);
+
+		$release = $this->release( '1.4.0' );
+
+		$this->assertFalse( $release['confirmed'] );
+		$this->assertSame( array(), $release['confirmations'] );
+	}
+
+	/**
+	 * Control: a normal merge (no reset flag) never disturbs the confirmation state.
+	 * This is exactly why a modified grandfathered tag needs the explicit reset — the
+	 * importer's ordinary version/revision update would otherwise keep it approved.
+	 */
+	public function test_plain_merge_preserves_confirmation(): void {
+		$this->add_grandfathered_release( '1.4.0', '1.4.0' );
+
+		Plugin_Directory::add_release(
+			$this->plugin,
+			array(
+				'tag'       => '1.4.0',
+				'version'   => '99.0.0',
+				'committer' => array( 'attacker' ),
+				'revision'  => array( 5000 ),
+			)
+		);
+
+		$release = $this->release( '1.4.0' );
+
+		$this->assertTrue( $release['confirmed'] );
+		$this->assertSame( 0, $release['confirmations_required'] );
+	}
+}


### PR DESCRIPTION
## What

With Release Confirmation enabled, tags that already existed are recorded as confirmed with zero required confirmations so their built packages keep being served. `import_from_svn()` reused that state on any later commit to the same tag, so a re-import that changed a released tag's code rebuilt and served it without a confirmation.

## Change

Re-open a released tag for confirmation when its code actually changes since it was last approved.

- Each release records a `source_revision` — the tag's own last-changed revision its confirmation state covers. `Import::tag_modified_after_release()` compares the tag's current revision against it; an unchanged re-import is a no-op. Records predating the field fall back to the served ZIP's export revision and fail closed when that's unknown, so a grandfathered tag's first modification is still caught, and the field is backfilled once.
- Each changed tag's own last-changed revision and committer come from the tag listing the importer already fetches, so the release and its notification are attributed to the right commit.
- `Plugin_Directory::add_release()` clears a release's confirmations when it's discarded (so an undo can't restore stale approvals onto changed code) and, when re-opening a release, re-arms the current cooldown and refreshes its date.

Because it keys on the tag's own revision rather than confirmation/zip-build flags, this also covers the failed-build window and partially-confirmed releases.

## Tests

`Release_Confirmation_Immutable_Tag_Test` covers `tag_modified_after_release()` (the `source_revision` baseline, the served-ZIP fallback, the no-baseline fail-safe) and `add_release()` (the confirmation reset, the discard clearing confirmations, the cooldown/date refresh). Existing `Current_Release_Resolution`, `Plugin_Import_Merge`, and `Update_Source_Hold` suites still pass (61/61 together).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Release confirmations are cleared when releases are reset or discarded, preventing outdated approvals from being restored.
  * Reset releases now receive refreshed dates and cooldown periods.
  * Tag changes are detected more reliably using revision information, including support for older release records.
  * Imports preserve tag-specific revision and author details and skip tags when revision data cannot be verified.
  * Similar tag versions are matched exactly, preventing incorrect release associations.

* **Tests**
  * Added coverage for confirmation resets, discarded releases, revision tracking, exact tag matching, and legacy release records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->