### PR TITLE
Trac Watcher: Use escapeshellarg() for svn command arguments

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/svn.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-trac-watcher/svn.php
@@ -96,7 +96,7 @@ function import_revisions( $svn ) {
 
 	$command = sprintf(
 		'svn log %s -r %d:HEAD --limit %d --xml -v 2>/dev/null',
-		esc_url( $svn_url ),
+		escapeshellarg( $svn_url ),
 		(int) $last_revision,
 		(int) MAX_REVISIONS
 	);
@@ -233,7 +233,7 @@ function get_wp_version( $svn_url, $branch, $revision = 'HEAD' ) {
 		$url = "{$svn_url}/{$branch}/{$f}";
 		$output = shell_exec( sprintf(
 			'svn cat %s@%d 2>/dev/null',
-			esc_url( $url ),
+			escapeshellarg( $url ),
 			(int) $revision
 		) );
 


### PR DESCRIPTION
The Trac Watcher SVN importer builds its `svn log` and `svn cat` command strings with `esc_url()`. That's a URL/HTML-context escaper; these values are arguments to a shell command, so `escapeshellarg()` is the appropriate function to quote them.

Besides being the right tool for the job, this stops `esc_url()` from rewriting the URL (percent-encoding, entity encoding) before `svn` receives it, so the importer passes the literal repository URL through unchanged.

No behavior change for existing branches and tags, whose names are already shell- and URL-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security when retrieving revision logs and WordPress version information by safely handling SVN command URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->