### PR TITLE
Plugin Directory: Add stats for block and cooldown overrides

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-api-update-updater.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-api-update-updater.php
@@ -537,14 +537,15 @@ class API_Update_Updater {
 		$version = $release['version'];
 
 		// Log only what is actually lifted: a deleted block's only trace, and the cooldown only while it still runs.
-		$lifted = array();
+		$was_blocked   = self::is_release_blocked( $release );
+		$release_delay = (int) ( $release['release_delay'] ?? 0 );
+		$in_cooldown   = $release_delay && self::compute_release_time( $post, $release ) + $release_delay > time();
 
-		if ( self::is_release_blocked( $release ) ) {
+		$lifted = array();
+		if ( $was_blocked ) {
 			$lifted[] = 'lifting the release block';
 		}
-
-		$release_delay = (int) ( $release['release_delay'] ?? 0 );
-		if ( $release_delay && self::compute_release_time( $post, $release ) + $release_delay > time() ) {
+		if ( $in_cooldown ) {
 			$lifted[] = sprintf( 'bypassing the %d-hour release cooldown', $release_delay / HOUR_IN_SECONDS );
 		}
 
@@ -566,6 +567,18 @@ class API_Update_Updater {
 				'unblock'       => true,
 			)
 		);
+
+		// Track what the force-release skipped: a readable reason total, and a per-plugin breakdown (groups display values, not a sum).
+		if ( function_exists( 'bump_stats_extra' ) && 'production' === wp_get_environment_type() ) {
+			if ( $was_blocked ) {
+				bump_stats_extra( 'plugin-force-release', 'block' );
+				bump_stats_extra( 'plugin-force-release-block', $post->post_name );
+			}
+			if ( $in_cooldown ) {
+				bump_stats_extra( 'plugin-force-release', 'cooldown' );
+				bump_stats_extra( 'plugin-force-release-cooldown', $post->post_name );
+			}
+		}
 
 		return self::update_single_plugin( $plugin_slug );
 	}


### PR DESCRIPTION
Force-releasing a version can override two release gates: an automated security block (from the Gandalf scan) and the release cooldown. This records a stat when either is overridden, so their rate sits alongside the other plugin-directory stats.

## What it does

`API_Update_Updater::force_release()` already detects which gates were in effect (it logs them in the audit entry). This bumps a stat for each gate the action actually overrode, guarded by the standard `function_exists( 'bump_stats_extra' ) && 'production' === wp_get_environment_type()` check the other stat sites use.

Each override is recorded twice, because the stats UI displays per-value counts but not a group total:

- `plugin-force-release` → `block` / `cooldown` — the readable per-reason totals.
- `plugin-force-release-block` / `plugin-force-release-cooldown` → plugin slug — the per-plugin breakdown.

The double-bump-per-event shape matches the existing `plugin-check-{type}` / `existing-plugins-{type}` pattern in `jobs/class-plugin-scan.php`. A force-release that overrode nothing bumps nothing, so the counts reflect gates actually overridden, not button clicks.

The detection lives inside `force_release()`, whose only production caller is the metabox control (`admin/metabox/class-controls.php`), so no author flow is counted. The existing `$lifted` conditions were hoisted into `$was_blocked` / `$in_cooldown` booleans shared by the audit log and the stats; the audit-log output is unchanged.

## Testing

No unit test: the four existing `bump_stats_extra` sites are all untested because of the production + `function_exists` guard, so this follows convention. The refactored gate detection stays covered by the existing force-release tests (`Security_Scan_Block_Test`, `Update_Source_Hold_Test`, `Current_Release_Resolution_Test`, 66 tests, all passing). `phpcs` introduces no new violations on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)