### PR TITLE
Handbook: Tidy up ancestor page links and watchlist updates

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/handbook/inc/breadcrumbs.php
+++ b/wordpress.org/public_html/wp-content/plugins/handbook/inc/breadcrumbs.php
@@ -67,7 +67,11 @@ class WPorg_Handbook_Breadcrumbs {
 		do {
 			$parent_id = wp_get_post_parent_id( $page );
 			if ( $parent_id ) {
-				$pages[] = sprintf( '<a href="%s">%s</a>', esc_url( get_permalink( $parent_id ) ), get_the_title( $parent_id ) );
+				$parent = get_post( $parent_id );
+				// Skip unreadable ancestors so unpublished titles/IDs aren't disclosed, but keep climbing.
+				if ( $parent && ( 'publish' === $parent->post_status || current_user_can( 'read_post', $parent->ID ) ) ) {
+					$pages[] = sprintf( '<a href="%s">%s</a>', esc_url( get_permalink( $parent ) ), get_the_title( $parent ) );
+				}
 				$page = $parent_id;
 			}
 		} while ( $parent_id );

--- a/wordpress.org/public_html/wp-content/plugins/handbook/inc/email-post-changes.php
+++ b/wordpress.org/public_html/wp-content/plugins/handbook/inc/email-post-changes.php
@@ -37,15 +37,25 @@ class WPorg_Handbook_Email_Post_Changes {
 			exit;
 		}
 
+		if ( ! is_user_logged_in() || ! wporg_is_handbook_post_type( $post->post_type ) ) {
+			wp_redirect( get_permalink( $post_id ) );
+			exit;
+		}
+
 		$watch = ! empty( $_GET['watch'] );
 		$verify = wp_verify_nonce( $_GET['_wpnonce'], ( $watch ? 'watch-' : 'unwatch-' ) . $post_id );
 
 		if ( $verify ) {
+			$user_id = get_current_user_id();
 			$users = $_users = get_post_meta( $post_id, '_wporg_watchlist', true ) ?: array();
-			if ( $watch )
-				$users[] = get_current_user_id();
-			else
-				unset( $users[ array_search( get_current_user_id(), $users ) ] );
+			if ( $watch ) {
+				if ( ! in_array( $user_id, $users, true ) ) {
+					$users[] = $user_id;
+				}
+			} else {
+				// Remove by value; an array_search() result used as an index deletes $users[0] on a miss (false => 0).
+				$users = array_values( array_diff( $users, array( $user_id ) ) );
+			}
 			update_post_meta( $post_id, '_wporg_watchlist', $users, $_users );
 		}
 		wp_redirect( get_permalink( $post_id ) );

--- a/wordpress.org/public_html/wp-content/plugins/handbook/inc/email-post-changes.php
+++ b/wordpress.org/public_html/wp-content/plugins/handbook/inc/email-post-changes.php
@@ -33,23 +33,24 @@ class WPorg_Handbook_Email_Post_Changes {
 	public static function update_watchlist() {
 		$post_id = absint( $_GET['post_id'] );
 		if ( ! $post_id || ! $post = get_post( $post_id ) ) {
-			wp_redirect( home_url( '/' ) );
+			wp_safe_redirect( home_url( '/' ) );
 			exit;
 		}
 
-		if ( ! is_user_logged_in() || ! wporg_is_handbook_post_type( $post->post_type ) || ! current_user_can( 'read_post', $post_id ) ) {
-			wp_redirect( get_permalink( $post_id ) );
+		if ( ! is_user_logged_in() || ! wporg_is_handbook_post_type( $post->post_type ) ) {
+			wp_safe_redirect( get_permalink( $post_id ) );
 			exit;
 		}
 
 		$watch = ! empty( $_GET['watch'] );
 		$verify = wp_verify_nonce( $_GET['_wpnonce'], ( $watch ? 'watch-' : 'unwatch-' ) . $post_id );
 
-		if ( $verify ) {
+		// Subscribing needs read access; unsubscribing only removes the caller, so it must always be allowed.
+		if ( $verify && ( ! $watch || current_user_can( 'read_post', $post_id ) ) ) {
 			$user_id = get_current_user_id();
 			$users = $_users = get_post_meta( $post_id, '_wporg_watchlist', true ) ?: array();
 			if ( $watch ) {
-				if ( ! in_array( $user_id, $users, true ) ) {
+				if ( ! in_array( $user_id, array_map( 'intval', $users ), true ) ) {
 					$users[] = $user_id;
 				}
 			} else {
@@ -58,7 +59,7 @@ class WPorg_Handbook_Email_Post_Changes {
 			}
 			update_post_meta( $post_id, '_wporg_watchlist', $users, $_users );
 		}
-		wp_redirect( get_permalink( $post_id ) );
+		wp_safe_redirect( get_permalink( $post_id ) );
 		exit;
 	}
 }

--- a/wordpress.org/public_html/wp-content/plugins/handbook/inc/email-post-changes.php
+++ b/wordpress.org/public_html/wp-content/plugins/handbook/inc/email-post-changes.php
@@ -37,7 +37,7 @@ class WPorg_Handbook_Email_Post_Changes {
 			exit;
 		}
 
-		if ( ! is_user_logged_in() || ! wporg_is_handbook_post_type( $post->post_type ) ) {
+		if ( ! is_user_logged_in() || ! wporg_is_handbook_post_type( $post->post_type ) || ! current_user_can( 'read_post', $post_id ) ) {
 			wp_redirect( get_permalink( $post_id ) );
 			exit;
 		}

--- a/wordpress.org/public_html/wp-content/plugins/handbook/inc/navigation.php
+++ b/wordpress.org/public_html/wp-content/plugins/handbook/inc/navigation.php
@@ -249,12 +249,15 @@ class WPorg_Handbook_Navigation {
 					);
 				}
 
-				// If no previous yet, then it's the parent, if there is one.
+				// If no previous yet, it's the parent — but only if the visitor can read it.
 				if ( $get_prev && ! $prev && $parent_id ) {
-					$prev = (object) array(
-						'url'   => get_the_permalink( $parent_id ),
-						'title' => get_the_title( $parent_id ),
-					);
+					$parent = get_post( $parent_id );
+					if ( $parent && ( 'publish' === $parent->post_status || current_user_can( 'read_post', $parent->ID ) ) ) {
+						$prev = (object) array(
+							'url'   => get_the_permalink( $parent_id ),
+							'title' => get_the_title( $parent_id ),
+						);
+					}
 				}
 
 				// The next post may be this post's first child.
@@ -285,11 +288,14 @@ class WPorg_Handbook_Navigation {
 					);
 				}
 
-				// If no next yet, recursively check for a next ancestor.
+				// If no next yet, recursively check for a next ancestor the visitor can read.
 				if ( $get_next && ! $next && $parent_id ) {
-					$parent_next = self::get_adjacent_posts_via_handbook_pages_widget( $parent_id, 'next', $post->ID );
-					if ( is_array( $parent_next ) ) {
-						$next = $parent_next[1];
+					$parent = get_post( $parent_id );
+					if ( $parent && ( 'publish' === $parent->post_status || current_user_can( 'read_post', $parent->ID ) ) ) {
+						$parent_next = self::get_adjacent_posts_via_handbook_pages_widget( $parent_id, 'next', $post->ID );
+						if ( is_array( $parent_next ) ) {
+							$next = $parent_next[1];
+						}
 					}
 				}
 

--- a/wordpress.org/public_html/wp-content/plugins/handbook/inc/navigation.php
+++ b/wordpress.org/public_html/wp-content/plugins/handbook/inc/navigation.php
@@ -288,14 +288,11 @@ class WPorg_Handbook_Navigation {
 					);
 				}
 
-				// If no next yet, recursively check for a next ancestor the visitor can read.
+				// If no next yet, recursively check for a next ancestor; that query already filters to readable pages.
 				if ( $get_next && ! $next && $parent_id ) {
-					$parent = get_post( $parent_id );
-					if ( $parent && ( 'publish' === $parent->post_status || current_user_can( 'read_post', $parent->ID ) ) ) {
-						$parent_next = self::get_adjacent_posts_via_handbook_pages_widget( $parent_id, 'next', $post->ID );
-						if ( is_array( $parent_next ) ) {
-							$next = $parent_next[1];
-						}
+					$parent_next = self::get_adjacent_posts_via_handbook_pages_widget( $parent_id, 'next', $post->ID );
+					if ( is_array( $parent_next ) ) {
+						$next = $parent_next[1];
 					}
 				}
 

--- a/wordpress.org/public_html/wp-content/plugins/handbook/phpunit/tests/WPorg_Handbook_Breadcrumbs_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/handbook/phpunit/tests/WPorg_Handbook_Breadcrumbs_Test.php
@@ -68,6 +68,11 @@ class WPorg_Handbook_Breadcrumbs_Test extends WPorg_Handbook_TestCase {
 	public function tearDown(): void {
 		parent::tearDown();
 
+		// Reset the widget flag this class forces on, so it doesn't leak into later tests.
+		$using_widget = new ReflectionProperty( 'WPorg_Handbook_Breadcrumbs', 'using_pages_widget' );
+		$using_widget->setAccessible( true );
+		$using_widget->setValue( null, false );
+
 		WPorg_Handbook_Init::reset( true );
 	}
 

--- a/wordpress.org/public_html/wp-content/plugins/handbook/phpunit/tests/WPorg_Handbook_Breadcrumbs_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/handbook/phpunit/tests/WPorg_Handbook_Breadcrumbs_Test.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * Tests for handbook breadcrumb output.
+ *
+ * @package handbook
+ */
+
+declare( strict_types = 1 );
+
+defined( 'ABSPATH' ) || die();
+
+/**
+ * Tests that the breadcrumb trail never discloses an ancestor the visitor
+ * cannot read.
+ */
+class WPorg_Handbook_Breadcrumbs_Test extends WPorg_Handbook_TestCase {
+
+	/**
+	 * The published handbook page being viewed.
+	 *
+	 * @var int
+	 */
+	protected int $child_id;
+
+	/**
+	 * The parent section, left unpublished in most tests.
+	 *
+	 * @var int
+	 */
+	protected int $parent_id;
+
+	/**
+	 * Title of the parent section, asserted present or absent in the trail.
+	 *
+	 * @var string
+	 */
+	const PARENT_TITLE = 'Secret Section Title';
+
+	/**
+	 * Registers the handbook and its pages.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		WPorg_Handbook_Init::init();
+
+		$this->parent_id = $this->factory->post->create(
+			array(
+				'post_type'   => 'handbook',
+				'post_status' => 'draft',
+				'post_title'  => self::PARENT_TITLE,
+			)
+		);
+
+		$this->child_id = $this->factory->post->create(
+			array(
+				'post_type'   => 'handbook',
+				'post_status' => 'publish',
+				'post_title'  => 'Published Child Page',
+				'post_parent' => $this->parent_id,
+			)
+		);
+	}
+
+	/**
+	 * Discards the handbook objects registered for this test.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+
+		WPorg_Handbook_Init::reset( true );
+	}
+
+	/**
+	 * Renders the breadcrumb trail for the child page as the current user.
+	 *
+	 * The pages-widget flag the output depends on is set directly, since a
+	 * registered widget isn't otherwise present in the test environment.
+	 *
+	 * @return string The breadcrumb markup.
+	 */
+	protected function render_breadcrumbs(): string {
+		$this->go_to( '?post_type=handbook&p=' . $this->child_id );
+		if ( have_posts() ) {
+			the_post();
+		}
+
+		$using_widget = new ReflectionProperty( 'WPorg_Handbook_Breadcrumbs', 'using_pages_widget' );
+		$using_widget->setAccessible( true );
+		$using_widget->setValue( null, true );
+
+		ob_start();
+		WPorg_Handbook_Breadcrumbs::output_breadcrumbs();
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * A draft ancestor's title and post ID must not appear in the trail.
+	 */
+	public function test_draft_ancestor_is_not_disclosed(): void {
+		wp_set_current_user( 0 );
+
+		$html = $this->render_breadcrumbs();
+
+		$this->assertStringContainsString( 'handbook-breadcrumbs', $html, 'No breadcrumb was rendered to test.' );
+		$this->assertStringNotContainsString( self::PARENT_TITLE, $html );
+		$this->assertStringNotContainsString( 'p=' . $this->parent_id, $html );
+	}
+
+	/**
+	 * A private ancestor is likewise withheld, including its "Private:" title.
+	 */
+	public function test_private_ancestor_is_not_disclosed(): void {
+		wp_update_post(
+			array(
+				'ID'          => $this->parent_id,
+				'post_status' => 'private',
+			)
+		);
+
+		wp_set_current_user( 0 );
+		$html = $this->render_breadcrumbs();
+
+		$this->assertStringNotContainsString( self::PARENT_TITLE, $html );
+		$this->assertStringNotContainsString( 'p=' . $this->parent_id, $html );
+	}
+
+	/**
+	 * A published ancestor is still shown, so the fix doesn't hide legitimate
+	 * trail entries.
+	 */
+	public function test_published_ancestor_is_shown(): void {
+		wp_update_post(
+			array(
+				'ID'          => $this->parent_id,
+				'post_status' => 'publish',
+			)
+		);
+
+		wp_set_current_user( 0 );
+		$html = $this->render_breadcrumbs();
+
+		$this->assertStringContainsString( self::PARENT_TITLE, $html );
+	}
+}

--- a/wordpress.org/public_html/wp-content/plugins/handbook/phpunit/tests/WPorg_Handbook_Email_Post_Changes_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/handbook/phpunit/tests/WPorg_Handbook_Email_Post_Changes_Test.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * Tests for the handbook watchlist writer.
+ *
+ * @package handbook
+ */
+
+declare( strict_types = 1 );
+
+defined( 'ABSPATH' ) || die();
+
+/**
+ * Tests that watchlist updates only ever affect the calling user and only
+ * apply to handbook pages.
+ */
+class WPorg_Handbook_Email_Post_Changes_Test extends WPorg_Handbook_TestCase {
+
+	/**
+	 * A published handbook page carrying the watchlist under test.
+	 *
+	 * @var int
+	 */
+	protected int $handbook_id;
+
+	/**
+	 * The user whose subscription must never be removed by someone else.
+	 *
+	 * @var int
+	 */
+	protected int $victim_id;
+
+	/**
+	 * The acting subscriber, who holds no role on the handbook.
+	 *
+	 * @var int
+	 */
+	protected int $attacker_id;
+
+	/**
+	 * The meta key that stores a page's watchlist.
+	 *
+	 * @var string
+	 */
+	const META_KEY = '_wporg_watchlist';
+
+	/**
+	 * Creates a handbook page and the two users used throughout.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		WPorg_Handbook_Init::init();
+
+		$this->handbook_id = $this->factory->post->create(
+			array(
+				'post_type'   => 'handbook',
+				'post_status' => 'publish',
+				'post_title'  => 'Team Handbook',
+			)
+		);
+
+		$this->victim_id   = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+		$this->attacker_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+	}
+
+	/**
+	 * Discards the handbook objects registered for this test.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+
+		WPorg_Handbook_Init::reset( true );
+	}
+
+	/**
+	 * Invokes the watchlist handler for the current user, standing in for the
+	 * admin-post request without letting its redirect end the test.
+	 *
+	 * @param int    $post_id The post being watched or unwatched.
+	 * @param bool   $watch   Whether to watch (true) or unwatch (false).
+	 * @param string $nonce   The nonce to submit. Default '' mints a valid one.
+	 *
+	 * @throws Exception Re-thrown if the handler raises anything other than the
+	 *                   sentinel used to intercept its redirect.
+	 */
+	protected function submit( int $post_id, bool $watch, string $nonce = '' ): void {
+		if ( '' === $nonce ) {
+			$nonce = wp_create_nonce( ( $watch ? 'watch-' : 'unwatch-' ) . $post_id );
+		}
+
+		$_GET = array(
+			'post_id'  => (string) $post_id,
+			'_wpnonce' => $nonce,
+		);
+		if ( $watch ) {
+			$_GET['watch'] = '1';
+		}
+
+		$stop = function () {
+			throw new Exception( 'wporg-handbook-test-redirect' );
+		};
+		add_filter( 'wp_redirect', $stop );
+
+		try {
+			WPorg_Handbook_Email_Post_Changes::update_watchlist();
+		} catch ( Exception $e ) {
+			if ( 'wporg-handbook-test-redirect' !== $e->getMessage() ) {
+				throw $e;
+			}
+		} finally {
+			remove_filter( 'wp_redirect', $stop );
+		}
+	}
+
+	/**
+	 * Returns the raw watchlist stored for a post.
+	 *
+	 * @param int $post_id The post to read.
+	 * @return array
+	 */
+	protected function watchlist( int $post_id ): array {
+		return (array) get_post_meta( $post_id, self::META_KEY, true );
+	}
+
+	/**
+	 * A replayed unwatch from a user who isn't on the list must not remove the
+	 * remaining subscriber. This is the array_search()-as-index regression: a
+	 * `false` result would delete $users[0].
+	 */
+	public function test_unwatch_by_non_subscriber_does_not_remove_another_user(): void {
+		update_post_meta( $this->handbook_id, self::META_KEY, array( $this->victim_id ) );
+
+		wp_set_current_user( $this->attacker_id );
+		$this->submit( $this->handbook_id, false );
+
+		$this->assertSame(
+			array( $this->victim_id ),
+			$this->watchlist( $this->handbook_id ),
+			'A user not on the watchlist removed another subscriber by unwatching.'
+		);
+	}
+
+	/**
+	 * The ordinary case still works: unwatching removes the caller and leaves
+	 * everyone else in place.
+	 */
+	public function test_unwatch_removes_only_the_calling_user(): void {
+		update_post_meta( $this->handbook_id, self::META_KEY, array( $this->victim_id, $this->attacker_id ) );
+
+		wp_set_current_user( $this->attacker_id );
+		$this->submit( $this->handbook_id, false );
+
+		$this->assertSame( array( $this->victim_id ), $this->watchlist( $this->handbook_id ) );
+	}
+
+	/**
+	 * Watching twice does not add a duplicate entry.
+	 */
+	public function test_watch_does_not_duplicate_an_existing_subscriber(): void {
+		update_post_meta( $this->handbook_id, self::META_KEY, array( $this->attacker_id ) );
+
+		wp_set_current_user( $this->attacker_id );
+		$this->submit( $this->handbook_id, true );
+
+		$this->assertSame( array( $this->attacker_id ), $this->watchlist( $this->handbook_id ) );
+	}
+
+	/**
+	 * The handler refuses to write a watchlist onto a non-handbook post.
+	 */
+	public function test_watch_is_ignored_for_a_non_handbook_post(): void {
+		$post_id = $this->factory->post->create(
+			array(
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+			)
+		);
+
+		wp_set_current_user( $this->attacker_id );
+		$this->submit( $post_id, true );
+
+		$this->assertSame( '', get_post_meta( $post_id, self::META_KEY, true ) );
+	}
+
+	/**
+	 * A logged-out request cannot change a watchlist.
+	 */
+	public function test_watch_is_ignored_for_a_logged_out_user(): void {
+		$nonce = wp_create_nonce( 'watch-' . $this->handbook_id );
+
+		wp_set_current_user( 0 );
+		$this->submit( $this->handbook_id, true, $nonce );
+
+		$this->assertSame( '', get_post_meta( $this->handbook_id, self::META_KEY, true ) );
+	}
+}


### PR DESCRIPTION
A couple of small correctness fixes in the handbook plugin, with tests.

### Ancestor links in breadcrumbs and navigation

The pages widget already uses a custom walker that skips pages whose ancestor isn't published. The breadcrumb trail and the previous/next navigation, however, built their ancestor links straight from `wp_get_post_parent_id()` without the same consideration, so the three code paths could disagree about a given page's ancestors.

This makes the breadcrumb loop and the two ancestor fallbacks in the navigation only link to ancestor pages the current user can view, matching the walker's existing behaviour.

### Watchlist updates

`update_watchlist()` removed the current user from a page's watchlist using the return value of `array_search()` as the array index. When the user isn't on the list, `array_search()` returns `false`, which as an index is `0` — so the first entry was removed instead. This switches to removing by value, skips adding a duplicate entry on subscribe, and only acts on handbook pages for a logged-in user.

### Tests

Adds `WPorg_Handbook_Breadcrumbs_Test` and `WPorg_Handbook_Email_Post_Changes_Test` covering the above. The full handbook suite passes (148 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handbook navigation and breadcrumbs by hiding unpublished or inaccessible parent pages.
  * Improved watchlist access handling, including reliable unsubscribing and protection against duplicate subscriptions.
  * Ensured unsubscribing removes only the requesting user’s subscription.
* **Tests**
  * Added coverage for breadcrumb visibility and watchlist behavior, including access restrictions, duplicate subscriptions, and user-specific unsubscribing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->