### PR TITLE
Photo Directory: Escape metabox and contributor output consistently

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/admin.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/admin.php
@@ -683,8 +683,8 @@ class Admin {
 
 		echo '<dl>';
 		foreach ( $exif as $key => $data ) {
-			echo "<dt>{$data['label']}</dt>\n";
-			echo "<dd>{$data['value']}</dd>\n";
+			echo '<dt>' . esc_html( $data['label'] ) . "</dt>\n";
+			echo '<dd>' . esc_html( $data['value'] ) . "</dd>\n";
 		}
 		echo "</dl>\n";
 
@@ -1197,9 +1197,9 @@ class Admin {
 			<div class="photo-contributor-info">
 				<strong>
 					<?php if ( $author->user_url ) { ?><a class="photo-contributor-url" rel="noopener noreferrer" href="<?php echo esc_url( $author->user_url ); ?>"><?php } ?>
-					<?php echo $author->display_name; ?>
+					<?php echo esc_html( $author->display_name ); ?>
 					<?php if ( $author->user_url ) { ?></a><?php } ?>
-					<div class="photo-contributor-profile"><a href="<?php echo esc_url( 'https://profiles.wordpress.org/' . $author->user_nicename . '/' ); ?>">@<?php echo $author->user_nicename; ?></a></div>
+					<div class="photo-contributor-profile"><a href="<?php echo esc_url( 'https://profiles.wordpress.org/' . $author->user_nicename . '/' ); ?>">@<?php echo esc_html( $author->user_nicename ); ?></a></div>
 				</strong>
 				<ul>
 					<li><?php

--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/photo.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/photo.php
@@ -939,7 +939,7 @@ $exif = self::exif_read_data_as_data_stream( $file );
 
 			switch ( $key ) {
 				case 'aperture':
-					$value = '&#402;/' . $value;
+					$value = 'ƒ/' . $value;
 					break;
 				case 'created_timestamp':
 					$label = 'Created';


### PR DESCRIPTION
Follows up [c33e88854] by escaping the remaining spots in the Photo Directory admin output that echo values without late-escaping.

- EXIF metabox rows (`Admin::meta_box_exif()`) now wrap the label and value in `esc_html()`, matching the raw-EXIF dump just below it and the moderation-flags block above it.
- The contributor card (`Admin::meta_box_recent_submissions_by_contributor()`) escapes the display name and nicename it prints.
- The aperture value switches from the `&#402;/` HTML entity to the literal `ƒ` character so it still renders correctly now that the value is escaped.

No behavior change beyond consistent output escaping; output for well-formed values is identical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security when displaying EXIF metadata and contributor information in the administration area.
  * Corrected the formatting of aperture values in photo details using the proper ƒ character.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->