### PR TITLE
Packages API: Only advertise released versions, and drop SVN source references

### DIFF
--- a/api.wordpress.org/public_html/packages/includes/class-composer-repository.php
+++ b/api.wordpress.org/public_html/packages/includes/class-composer-repository.php
@@ -132,6 +132,7 @@ class Composer_Repository {
 				'slug'   => $slug,
 				'fields' => array(
 					'versions'          => true,
+					'stable_tag'        => true,
 					'download_link'     => true,
 					'last_updated'      => true,
 					'short_description' => true,
@@ -167,47 +168,19 @@ class Composer_Repository {
 	 * @return array|null The packages response, or null if no valid versions.
 	 */
 	private static function build_plugin_response( string $slug, array $plugin_data ): ?array {
-		$package_name = 'wp-plugin/' . $slug;
-		$versions     = array();
-		$seen         = array();
+		$tagged       = ( ! empty( $plugin_data['versions'] ) && is_array( $plugin_data['versions'] ) ) ? $plugin_data['versions'] : array();
+		$fallback_url = $plugin_data['download_link'] ?? sprintf( 'https://downloads.wordpress.org/plugin/%s.zip', $slug );
 
-		// Build entries for each tagged version.
-		if ( ! empty( $plugin_data['versions'] ) && is_array( $plugin_data['versions'] ) ) {
-			foreach ( $plugin_data['versions'] as $version => $download_url ) {
-				$normalized = Version_Normalizer::normalize( (string) $version );
-				if ( false === $normalized ) {
-					continue;
-				}
-
-				$key = Version_Normalizer::dedupe_key( $normalized );
-				if ( isset( $seen[ $key ] ) ) {
-					continue;
-				}
-
-				$seen[ $key ] = true;
-				$versions[]   = Package_Builder::build_plugin( $slug, $normalized, $plugin_data, $download_url );
-			}
-		}
-
-		// If no tagged versions, use the current version and its download link.
-		if ( empty( $versions ) && ! empty( $plugin_data['version'] ) ) {
-			$normalized = Version_Normalizer::normalize( $plugin_data['version'] );
-			if ( false !== $normalized ) {
-				$fallback_url = $plugin_data['download_link'] ?? sprintf( 'https://downloads.wordpress.org/plugin/%s.zip', $slug );
-				$versions[]   = Package_Builder::build_plugin( $slug, $normalized, $plugin_data, $fallback_url );
-			}
+		$versions = array();
+		foreach ( self::select_plugin_versions( $tagged, (string) ( $plugin_data['stable_tag'] ?? 'trunk' ), (string) ( $plugin_data['version'] ?? '' ), $fallback_url ) as $entry ) {
+			$versions[] = Package_Builder::build_plugin( $slug, $entry['version'], $plugin_data, $entry['url'] );
 		}
 
 		if ( empty( $versions ) ) {
 			return null;
 		}
 
-		usort(
-			$versions,
-			function ( $a, $b ) {
-				return version_compare( $b['version'], $a['version'] );
-			}
-		);
+		$package_name = 'wp-plugin/' . $slug;
 
 		$response = array( 'packages' => array( $package_name => $versions ) );
 
@@ -236,12 +209,12 @@ class Composer_Repository {
 		$request = (object) array(
 			'slug'   => $slug,
 			'fields' => array(
-				'versions'        => true,
+				'downloadlink'    => true,
 				'description'     => true,
 				'requires_php'    => true,
 				'last_updated'    => true,
 				'extended_author' => true,
-				'downloadlink'    => false,
+				'versions'        => false,
 				'sections'        => false,
 				'rating'          => false,
 				'tags'            => false,
@@ -266,54 +239,141 @@ class Composer_Repository {
 	 * @return array|null The packages response, or null if no valid versions.
 	 */
 	private static function build_theme_response( string $slug, object $theme_data ): ?array {
-		$package_name = 'wp-theme/' . $slug;
-		$versions     = array();
-		$seen         = array();
-
-		if ( ! empty( $theme_data->versions ) && is_array( $theme_data->versions ) ) {
-			foreach ( $theme_data->versions as $version => $download_url ) {
-				$normalized = Version_Normalizer::normalize( (string) $version );
-				if ( false === $normalized ) {
-					continue;
-				}
-
-				$key = Version_Normalizer::dedupe_key( $normalized );
-				if ( isset( $seen[ $key ] ) ) {
-					continue;
-				}
-
-				$seen[ $key ] = true;
-				$versions[]   = Package_Builder::build_theme( $slug, $normalized, $theme_data, $download_url );
-			}
-		}
-
-		// If no tagged versions, use the current version.
-		if ( empty( $versions ) && ! empty( $theme_data->version ) ) {
-			$normalized = Version_Normalizer::normalize( $theme_data->version );
-			if ( false !== $normalized ) {
-				$fallback_url = sprintf( 'https://downloads.wordpress.org/theme/%s.%s.zip', $slug, $theme_data->version );
-				$versions[]   = Package_Builder::build_theme( $slug, $normalized, $theme_data, $fallback_url );
-			}
-		}
-
-		if ( empty( $versions ) ) {
+		// Serve the directory's current version only; lacking a live version it may be the newest, unreviewed upload (known residual).
+		$live_version = $theme_data->version ?? '';
+		if ( '' === $live_version ) {
 			return null;
 		}
 
-		usort(
-			$versions,
-			function ( $a, $b ) {
-				return version_compare( $b['version'], $a['version'] );
-			}
-		);
+		$normalized = Version_Normalizer::normalize( (string) $live_version );
+		if ( false === $normalized ) {
+			return null;
+		}
 
-		$response = array( 'packages' => array( $package_name => $versions ) );
+		$download_url = (string) ( $theme_data->download_link ?? '' );
+		if ( '' === $download_url ) {
+			return null;
+		}
+
+		$response = array(
+			'packages' => array(
+				'wp-theme/' . $slug => array( Package_Builder::build_theme( $slug, $normalized, $theme_data, $download_url ) ),
+			),
+		);
 
 		if ( ! empty( $theme_data->last_updated_time ) ) {
 			$response['last_modified'] = strtotime( $theme_data->last_updated_time );
 		}
 
 		return $response;
+	}
+
+	/**
+	 * Select the plugin versions eligible for the Composer response, newest first.
+	 *
+	 * Serves the release history up to the stable release, dropping any tag above it. The ceiling is
+	 * the stable tag, or the current version when the plugin is trunk-stable; a degenerate current
+	 * version ('0.0' or 'trunk') is rejected and nothing is served. Equivalent tags collapse (the
+	 * stable tag wins its key), and the served release is always offered. Comparisons use canonical keys.
+	 *
+	 * @param array  $tagged       Map of raw SVN tag => download URL.
+	 * @param string $stable_tag   The plugin's stable tag ('trunk' or a version).
+	 * @param string $version      The plugin's current version, from its readme header.
+	 * @param string $fallback_url Download URL to use for the current version.
+	 * @return array List of [ 'version' => normalized, 'url' => download URL ], newest first.
+	 */
+	public static function select_plugin_versions( array $tagged, string $stable_tag, string $version, string $fallback_url ): array {
+		$normalized_stable  = Version_Normalizer::normalize( $stable_tag );
+		$normalized_current = '' !== $version ? Version_Normalizer::normalize( $version ) : false;
+
+		// The served release: the stable tag, or (trunk-stable) the current version; a degenerate '0.0'/'trunk' serves nothing.
+		$usable = static fn ( string|false $normalized ): bool => false !== $normalized && 'dev-trunk' !== $normalized && '0.0.0.0' !== Version_Normalizer::dedupe_key( $normalized );
+
+		if ( $usable( $normalized_stable ) ) {
+			$served = $normalized_stable;
+		} elseif ( $usable( $normalized_current ) ) {
+			$served = $normalized_current;
+		} else {
+			return array();
+		}
+		$ceiling = Version_Normalizer::dedupe_key( $served );
+
+		$seen = array();
+		foreach ( $tagged as $tag => $url ) {
+			$tag        = (string) $tag;
+			$normalized = Version_Normalizer::normalize( $tag );
+			if ( false === $normalized ) {
+				continue;
+			}
+
+			// Keep trunk (the dev branch); drop tags canonically newer than the ceiling.
+			$key = Version_Normalizer::dedupe_key( $normalized );
+			if ( 'dev-trunk' !== $normalized && version_compare( $key, $ceiling, '>' ) ) {
+				continue;
+			}
+
+			// Dedupe equivalent tags: the stable tag wins its key, else the canonical spelling.
+			$is_stable = ( $tag === $stable_tag );
+			if ( isset( $seen[ $key ] ) && ( $seen[ $key ]['stable'] || ( ! $is_stable && ! self::is_preferred_spelling( $normalized, $tag, $seen[ $key ]['normalized'], $seen[ $key ]['tag'] ) ) ) ) {
+				continue;
+			}
+
+			$seen[ $key ] = array(
+				'normalized' => $normalized,
+				'tag'        => $tag,
+				'stable'     => $is_stable,
+				'url'        => (string) $url,
+			);
+		}
+
+		// Always offer the served release itself, unless a tag already produced it above.
+		if ( ! isset( $seen[ $ceiling ] ) ) {
+			$seen[ $ceiling ] = array(
+				'normalized' => $served,
+				'tag'        => '',
+				'stable'     => false,
+				'url'        => $fallback_url,
+			);
+		}
+
+		$entries = array();
+		foreach ( $seen as $entry ) {
+			$entries[] = array(
+				'version' => $entry['normalized'],
+				'url'     => $entry['url'],
+			);
+		}
+
+		usort(
+			$entries,
+			static function ( $a, $b ) {
+				return version_compare( $b['version'], $a['version'] );
+			}
+		);
+
+		return $entries;
+	}
+
+	/**
+	 * Decide whether one spelling of a version should be kept over another Composer treats as equal.
+	 *
+	 * The point is a single deterministic winner, never dependent on the order tags arrive in. It
+	 * orders by normalized length (usually, but not always, the fewer-zeros spelling), then the
+	 * normalized bytes, then the raw tag, so even tags that normalize identically ("1.0"/"v1.0")
+	 * resolve to one.
+	 *
+	 * @param string $candidate     Normalized version being considered.
+	 * @param string $candidate_tag Its raw tag.
+	 * @param string $current       Normalized version already kept for this dedupe key.
+	 * @param string $current_tag   Its raw tag.
+	 * @return bool True if $candidate should replace the kept version.
+	 */
+	private static function is_preferred_spelling( string $candidate, string $candidate_tag, string $current, string $current_tag ): bool {
+		$order = ( strlen( $candidate ) <=> strlen( $current ) )
+			?: strcmp( $candidate, $current )
+			?: strcmp( $candidate_tag, $current_tag );
+
+		return $order < 0;
 	}
 
 	/**

--- a/api.wordpress.org/public_html/packages/includes/class-package-builder.php
+++ b/api.wordpress.org/public_html/packages/includes/class-package-builder.php
@@ -65,12 +65,6 @@ class Package_Builder {
 
 		$entry['authors'] = self::build_authors( $plugin_data );
 
-		$entry['source'] = array(
-			'type'      => 'svn',
-			'url'       => 'https://plugins.svn.wordpress.org/' . $slug . '/',
-			'reference' => 'dev-trunk' === $version ? 'trunk' : 'tags/' . $version,
-		);
-
 		$entry['support'] = array(
 			'issues'    => 'https://wordpress.org/support/plugin/' . $slug,
 			'source'    => 'https://plugins.svn.wordpress.org/' . $slug,
@@ -120,19 +114,13 @@ class Package_Builder {
 			$entry['require']['php'] = '>=' . $theme_data->requires_php;
 		}
 
-		if ( ! empty( $theme_data->sections['description'] ) ) {
-			$entry['description'] = wp_strip_all_tags( $theme_data->sections['description'] );
+		if ( ! empty( $theme_data->description ) ) {
+			$entry['description'] = wp_strip_all_tags( $theme_data->description );
 		} elseif ( ! empty( $theme_data->name ) ) {
 			$entry['description'] = $theme_data->name;
 		}
 
 		$entry['homepage'] = 'https://wordpress.org/themes/' . $slug . '/';
-
-		$entry['source'] = array(
-			'type'      => 'svn',
-			'url'       => 'https://themes.svn.wordpress.org/' . $slug . '/',
-			'reference' => $version,
-		);
 
 		$entry['support'] = array(
 			'issues' => 'https://wordpress.org/support/theme/' . $slug,

--- a/api.wordpress.org/public_html/packages/includes/class-version-normalizer.php
+++ b/api.wordpress.org/public_html/packages/includes/class-version-normalizer.php
@@ -75,8 +75,9 @@ class Version_Normalizer {
 	/**
 	 * Build a key that matches whenever Composer would treat two normalized versions as one.
 	 *
-	 * Composer compares versions in four numeric segments, so it reads "1.54" and "1.54.0" as the
-	 * same version even though they normalize to different strings here.
+	 * Composer treats leading- and trailing-zero variants as one version ("1.54"/"1.54.0",
+	 * "1.7.5"/"1.7.05"), so leading zeros are stripped from each numeric segment and the
+	 * pre-release number to give those variants a shared key.
 	 *
 	 * @param string $version A version returned by normalize().
 	 * @return string The comparison key.
@@ -91,10 +92,19 @@ class Version_Normalizer {
 
 		if ( str_contains( $version, '-' ) ) {
 			list( $numeric, $suffix ) = explode( '-', $version, 2 );
-			$suffix                   = '-' . $suffix;
 		}
 
-		return implode( '.', array_pad( explode( '.', $numeric ), 4, '0' ) ) . $suffix;
+		// Strip leading zeros as strings; intval() would overflow an oversized segment and collide.
+		$strip    = static fn ( string $segment ): string => ltrim( $segment, '0' ) ?: '0';
+		$segments = array_map( $strip, explode( '.', $numeric ) );
+		$key      = implode( '.', array_pad( $segments, 4, '0' ) );
+
+		if ( '' !== $suffix ) {
+			$suffix = preg_replace_callback( '/\d+/', fn ( $digits ) => $strip( $digits[0] ), $suffix );
+			$key   .= '-' . $suffix;
+		}
+
+		return $key;
 	}
 
 	/**

--- a/api.wordpress.org/public_html/packages/tests/test-packages-endpoint.php
+++ b/api.wordpress.org/public_html/packages/tests/test-packages-endpoint.php
@@ -71,11 +71,6 @@ class Test_Packages_Endpoint extends TestCase {
 		$this->assertIsObject( $entry->require );
 		$this->assertObjectHasProperty( 'composer/installers', $entry->require );
 
-		// Check extended fields.
-		$this->assertIsObject( $entry->source );
-		$this->assertSame( 'svn', $entry->source->type );
-		$this->assertStringContainsString( 'plugins.svn.wordpress.org/clicky-popular-posts-widget', $entry->source->url );
-
 		$this->assertIsObject( $entry->support );
 		$this->assertObjectHasProperty( 'issues', $entry->support );
 		$this->assertObjectHasProperty( 'changelog', $entry->support );
@@ -130,11 +125,6 @@ class Test_Packages_Endpoint extends TestCase {
 		$this->assertSame( 'wordpress-theme', $entry->type );
 		$this->assertIsObject( $entry->dist );
 		$this->assertStringContainsString( 'downloads.wordpress.org/theme/academica', $entry->dist->url );
-
-		// Check SVN source.
-		$this->assertIsObject( $entry->source );
-		$this->assertSame( 'svn', $entry->source->type );
-		$this->assertStringContainsString( 'themes.svn.wordpress.org/academica', $entry->source->url );
 
 		// Check support.
 		$this->assertIsObject( $entry->support );

--- a/api.wordpress.org/public_html/packages/tests/test-plugin-version-selection.php
+++ b/api.wordpress.org/public_html/packages/tests/test-plugin-version-selection.php
@@ -1,0 +1,301 @@
+<?php
+/**
+ * Unit tests for Composer_Repository::select_plugin_versions().
+ *
+ * @package WordPressdotorg\API\Composer
+ */
+
+declare( strict_types = 1 );
+
+namespace WordPressdotorg\API\Composer\Tests;
+
+use PHPUnit\Framework\TestCase;
+use WordPressdotorg\API\Composer\Composer_Repository;
+
+require_once dirname( __DIR__ ) . '/includes/class-version-normalizer.php';
+require_once dirname( __DIR__ ) . '/includes/class-composer-repository.php';
+
+/**
+ * Tests for the plugin version-eligibility logic (stable ceiling, dedupe, and fallback).
+ *
+ * @group packages
+ */
+class Test_Plugin_Version_Selection extends TestCase {
+
+	/**
+	 * Run the selector and return just the normalized version strings, newest first.
+	 *
+	 * @param array  $tagged   Map of raw SVN tag => download URL.
+	 * @param string $stable   The stable tag.
+	 * @param string $version  The current version.
+	 * @param string $fallback Fallback download URL for the current version.
+	 * @return array List of normalized version strings.
+	 */
+	private function versions( array $tagged, string $stable, string $version, string $fallback = 'FALLBACK' ): array {
+		return array_column(
+			Composer_Repository::select_plugin_versions( $tagged, $stable, $version, $fallback ),
+			'version'
+		);
+	}
+
+	/**
+	 * Test that the history up to the stable tag is served and higher tags are dropped.
+	 */
+	public function test_keeps_history_up_to_stable(): void {
+		$this->assertSame(
+			array( '2.0', '1.5', '1.0' ),
+			$this->versions(
+				array(
+					'1.0' => 'a',
+					'1.5' => 'b',
+					'2.0' => 'c',
+					'3.0' => 'd',
+				),
+				'2.0',
+				'2.0'
+			)
+		);
+	}
+
+	/**
+	 * Test that a v-prefixed tag above stable is dropped (raw version_compare would keep it).
+	 */
+	public function test_drops_v_prefixed_higher_tag(): void {
+		$this->assertSame(
+			array( '2.0' ),
+			$this->versions(
+				array(
+					'2.0'  => 'a',
+					'v2.1' => 'b',
+				),
+				'2.0',
+				'2.0'
+			)
+		);
+	}
+
+	/**
+	 * Test that 'trunk' is kept as the dev version.
+	 */
+	public function test_keeps_trunk_dev_version(): void {
+		$this->assertContains(
+			'dev-trunk',
+			$this->versions(
+				array(
+					'1.0'   => 'a',
+					'2.0'   => 'b',
+					'trunk' => 'c',
+				),
+				'2.0',
+				'2.0'
+			)
+		);
+	}
+
+	/**
+	 * Test that a trunk-stable plugin still serves its tagged history (bounded by the version).
+	 */
+	public function test_trunk_stable_keeps_history(): void {
+		$this->assertSame(
+			array( '1.5', '1.0' ),
+			$this->versions(
+				array(
+					'1.0' => 'a',
+					'1.5' => 'b',
+				),
+				'trunk',
+				'1.5'
+			)
+		);
+	}
+
+	/**
+	 * Test that a capitalized 'Trunk' stable tag is treated as trunk, not as a numeric ceiling.
+	 */
+	public function test_capitalized_trunk_keeps_history(): void {
+		$this->assertSame(
+			array( '1.5', '1.0' ),
+			$this->versions(
+				array(
+					'1.0' => 'a',
+					'1.5' => 'b',
+				),
+				'Trunk',
+				'1.5'
+			)
+		);
+	}
+
+	/**
+	 * Test that an unnormalizable stable tag falls back to the current version as the ceiling.
+	 */
+	public function test_invalid_stable_tag_uses_current_version_ceiling(): void {
+		$this->assertSame(
+			array( '1.0', '0.9' ),
+			$this->versions(
+				array(
+					'0.9' => 'a',
+					'1.0' => 'b',
+					'1.1' => 'c',
+				),
+				'1.0-final',
+				'1.0'
+			)
+		);
+	}
+
+	/**
+	 * Test that with neither a usable stable tag nor a usable version, nothing is served.
+	 */
+	public function test_no_usable_ceiling_returns_empty(): void {
+		$this->assertSame(
+			array(),
+			$this->versions( array( '1.0' => 'a' ), '1.0-final', '1.0-final' )
+		);
+	}
+
+	/**
+	 * Test that a version ahead of the stable tag is not advertised above the ceiling.
+	 */
+	public function test_version_ahead_of_stable_is_not_advertised(): void {
+		$this->assertSame(
+			array( '2.0', '1.0' ),
+			$this->versions(
+				array(
+					'1.0' => 'a',
+					'2.0' => 'b',
+				),
+				'2.0',
+				'2.1'
+			)
+		);
+	}
+
+	/**
+	 * Test that tags Composer treats as one version collapse to a single entry.
+	 */
+	public function test_collapses_leading_zero_equivalents(): void {
+		$this->assertSame(
+			array( '2.0', '1.7.5' ),
+			$this->versions(
+				array(
+					'1.7.5'  => 'a',
+					'1.7.05' => 'b',
+					'2.0'    => 'c',
+				),
+				'2.0',
+				'2.0'
+			)
+		);
+	}
+
+	/**
+	 * Test that the stable tag wins its dedupe key, so its own ZIP is served for that version.
+	 */
+	public function test_stable_tag_wins_dedupe(): void {
+		$result = Composer_Repository::select_plugin_versions(
+			array(
+				'2.0'  => 'benign-zip',
+				'2.00' => 'stable-zip',
+			),
+			'2.00',
+			'2.00',
+			'FALLBACK'
+		);
+
+		$this->assertCount( 1, $result );
+		$this->assertSame( 'stable-zip', $result[0]['url'] );
+	}
+
+	/**
+	 * Test that the current version is offered (via the fallback URL) when its tag is absent.
+	 */
+	public function test_current_version_added_when_its_tag_is_missing(): void {
+		$result = Composer_Repository::select_plugin_versions(
+			array( '1.0' => 'a' ),
+			'2.0',
+			'2.0',
+			'FALLBACK'
+		);
+
+		$this->assertSame( array( '2.0', '1.0' ), array_column( $result, 'version' ) );
+		$this->assertSame( 'FALLBACK', $result[0]['url'] );
+	}
+
+	/**
+	 * Test that a trunk-stable plugin with a degenerate '0.0' version serves nothing, not a phantom.
+	 */
+	public function test_degenerate_version_trunk_stable_serves_nothing(): void {
+		$this->assertSame(
+			array(),
+			$this->versions(
+				array(
+					'1.0' => 'a',
+					'2.0' => 'b',
+				),
+				'trunk',
+				'0.0'
+			)
+		);
+	}
+
+	/**
+	 * Test that a trunk-stable plugin with a literal 'trunk' version serves nothing.
+	 */
+	public function test_literal_trunk_version_trunk_stable_serves_nothing(): void {
+		$this->assertSame(
+			array(),
+			$this->versions( array( '1.0' => 'a' ), 'trunk', 'trunk' )
+		);
+	}
+
+	/**
+	 * Test that the fallback offers the stable release, not a phantom of a lagging header version.
+	 */
+	public function test_fallback_uses_stable_version_not_lagging_header(): void {
+		$result = Composer_Repository::select_plugin_versions(
+			array( '1.0' => 'a' ),
+			'2.0',
+			'1.5',
+			'STABLE-ZIP'
+		);
+
+		$this->assertSame( array( '2.0', '1.0' ), array_column( $result, 'version' ) );
+		$this->assertSame( 'STABLE-ZIP', $result[0]['url'] );
+	}
+
+	/**
+	 * Test that a degenerate '0.0' stable tag (with no usable version) serves nothing.
+	 */
+	public function test_degenerate_stable_tag_serves_nothing(): void {
+		$this->assertSame(
+			array(),
+			$this->versions(
+				array(
+					'1.0' => 'a',
+					'2.0' => 'b',
+				),
+				'0.0',
+				'0.0'
+			)
+		);
+	}
+
+	/**
+	 * Test that a degenerate stable tag falls back to the header version as the ceiling.
+	 */
+	public function test_degenerate_stable_tag_falls_back_to_version(): void {
+		$this->assertSame(
+			array( '2.0', '1.0' ),
+			$this->versions(
+				array(
+					'1.0' => 'a',
+					'2.0' => 'b',
+					'3.0' => 'c',
+				),
+				'0.0',
+				'2.0'
+			)
+		);
+	}
+}

--- a/api.wordpress.org/public_html/packages/tests/test-version-normalizer.php
+++ b/api.wordpress.org/public_html/packages/tests/test-version-normalizer.php
@@ -76,9 +76,6 @@ class Test_Version_Normalizer extends TestCase {
 	/**
 	 * Test that the dedupe key matches for versions Composer compares as equal.
 	 *
-	 * Composer pads versions to four numeric segments, so tags that differ only by a trailing zero
-	 * are one version to it and only one of them can be served.
-	 *
 	 * @dataProvider data_equivalent_versions
 	 *
 	 * @param string $a One normalized version.
@@ -104,6 +101,9 @@ class Test_Version_Normalizer extends TestCase {
 			'leading v'             => array( '1.0', 'v1.0' ),
 			'zero with suffix'      => array( '3.1-rc1', '3.1.0-rc1' ),
 			'short and long suffix' => array( '1.0-a1', '1.0-alpha1' ),
+			'leading zero patch'    => array( '1.7.5', '1.7.05' ),
+			'leading zero major'    => array( '1', '01' ),
+			'leading zero suffix'   => array( '1.0-rc1', '1.0-rc01' ),
 		);
 	}
 


### PR DESCRIPTION
Changes to the Composer packages endpoint so it advertises the same versions each directory actually serves.

### Plugins: serve history up to the stable tag

The endpoint built a package entry for every SVN tag, including tags *higher* than the stable release — versions stock WordPress never serves, which Composer's `update`/`^` resolution would then rank above the current release. The plugin loop now skips any tag newer than `stable_tag` (keeping `trunk` as the dev version). Everything up to and including stable — the plugin's real downloadable version history — stays, and those older zips are already frozen at their confirmed revisions.

### Themes: serve the live version only

Themes have no older-version download in the directory at all — a theme page only ever links the live version (`download_url( latest_version() )`). The endpoint, though, listed every `_status` entry, which includes `new` (uploaded, **not yet reviewed**) and superseded versions. The theme loop now emits only the live version, matching the directory. This isn't lost history — themes never offered it.

### Collapse equivalent versions

`dedupe_key()` reduces each numeric segment and pre-release number to its integer value, so leading/trailing-zero spellings (`1.7.05`/`1.7.5`, `1.54`/`1.54.0`) share a key and the builder keeps one deterministic winner. This matches Composer's own equivalence (`composer/semver` mutual-satisfies), verified across ~88k version pairs.

### Drop the mutable SVN `source`

Plugin and theme entries advertised a Composer `source` at the `tags/<version>` SVN path. `--prefer-source` checks that out directly at install time, bypassing the release-confirmation and ZIP-build gates — a post-confirmation retag was live to source installs immediately. It is removed; installs use the `dist` ZIP only, the same gated package a normal update/install receives (the ZIP is rebuilt on tag changes, but for confirmation-required plugins that rebuild is held until re-confirmed). Core keeps its read-only `git` source.

### Tests

Leading-zero dedupe cases added to the normalizer unit tests; endpoint tests updated for the absent `source`. `composer run lint` is clean on all changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Plugin package results now include eligible stable releases through the configured stable version, while retaining `trunk` where applicable.
  * Version matching now consistently handles equivalent version formats, including leading zeros and pre-release numbers.
  * Plugin results fall back to the current version when no eligible releases are available.
  * Theme results now include only the live version, with a fallback to the current version when its download is unavailable.
  * Removed SVN source metadata from Composer package entries; support links remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->