### PR TITLE
Plugin Directory: supply the language suggestion endpoint through a filter

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/functions.php
@@ -407,6 +407,23 @@ function update_archive_description( $description ) {
 add_filter( 'get_the_archive_description', __NAMESPACE__ . '\update_archive_description' );
 
 /**
+ * Point the Language Suggest block at the directory's own suggestion API.
+ *
+ * @param string $endpoint Default endpoint URL.
+ * @return string Endpoint URL for the current request.
+ */
+function language_suggest_endpoint( $endpoint ) {
+	$endpoint = rest_url( '/plugins/v2/locale-banner' );
+
+	if ( is_singular( 'plugin' ) ) {
+		$endpoint = add_query_arg( 'plugin_slug', get_queried_object()->post_name, $endpoint );
+	}
+
+	return $endpoint;
+}
+add_filter( 'wporg_language_suggest_endpoint', __NAMESPACE__ . '\language_suggest_endpoint' );
+
+/**
  * Custom template tags for this theme.
  */
 require get_stylesheet_directory() . '/inc/template-tags.php';

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/patterns/front-page-header.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/patterns/front-page-header.php
@@ -39,6 +39,6 @@ $description = sprintf(
 </div>
 <!-- /wp:group -->
 
-<!-- wp:wporg/language-suggest {"align":"full","endpoint":"<?php echo esc_attr( rest_url( '/plugins/v2/locale-banner' ) ); ?>"} -->
-<div class="wp-block-wporg-language-suggest alignfull" data-endpoint="<?php echo esc_attr( rest_url( '/plugins/v2/locale-banner' ) ); ?>"></div>
+<!-- wp:wporg/language-suggest {"align":"full"} -->
+<div class="wp-block-wporg-language-suggest alignfull"></div>
 <!-- /wp:wporg/language-suggest -->

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/patterns/nav.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/patterns/nav.php
@@ -27,12 +27,6 @@
 	<!-- wp:navigation {"menuSlug":"plugins","overlayBackgroundColor":"charcoal-2","overlayTextColor":"white","icon":"menu","layout":{"type":"flex","orientation":"horizontal"},"style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} /-->
 <!-- /wp:wporg/local-navigation-bar -->
 
-<?php
-	$lang_suggest_endpoint = rest_url( '/plugins/v2/locale-banner' );
-	if ( is_singular( 'plugin' ) ) {
-		$lang_suggest_endpoint = add_query_arg( 'plugin_slug', get_queried_object()->post_name, $lang_suggest_endpoint );
-	}
-?>
-<!-- wp:wporg/language-suggest {"align":"full","endpoint":"<?php echo esc_attr( $lang_suggest_endpoint ); ?>"} -->
-<div class="wp-block-wporg-language-suggest alignfull" data-endpoint="<?php echo esc_attr( $lang_suggest_endpoint ); ?>"></div>
+<!-- wp:wporg/language-suggest {"align":"full"} -->
+<div class="wp-block-wporg-language-suggest alignfull"></div>
 <!-- /wp:wporg/language-suggest -->


### PR DESCRIPTION
Companion to WordPress/wporg-mu-plugins#764, which moves the Language Suggest block's endpoint resolution from a `data-endpoint` attribute to a `wporg_language_suggest_endpoint` filter.

### Changes

- `functions.php` — hooks the filter, returning `/plugins/v2/locale-banner` with `plugin_slug` appended on singular plugin views. Same logic that lived in `patterns/nav.php`.
- `patterns/nav.php`, `patterns/front-page-header.php` — drop the `data-endpoint` attribute and the PHP that built it.

The block delimiters also carried an `endpoint` attribute. The block declares no attributes, so it has never been read by anything; it goes with the markup that fed it.

### Result

Plugin pages currently fall back to the network-wide suggestion:

| | Now | With this change |
|---|---|---|
| `/plugins/activitypub/` | WordPress ist auch auf Deutsch verfügbar. | Dieses Plugin ist auch auf Deutsch verfügbar. Hilf mit, die Übersetzung zu verbessern! |
| `/plugins/` | WordPress ist auch auf Deutsch verfügbar. | Das Plugin-Verzeichnis ist auch auf Deutsch verfügbar. |

### Ordering

Needs WordPress/wporg-mu-plugins#764 deployed for the filter to exist. Landing in either order is safe — until both are out, the pages show the network-wide notice, which is where they already are.

`WordPress/wporg-theme-directory` has the equivalent change for the theme directory.

### Testing

`php -l` clean. phpcs unchanged on `functions.php` (44 pre-existing errors before and after) and improved on `nav.php` (4 → 1, remainder pre-existing). Verified the filter returns the same URLs the pattern previously emitted, for both the singular and archive cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved language suggestions across the plugin directory.
  * Language suggestions now automatically use the relevant plugin context on individual plugin pages.

* **Bug Fixes**
  * Simplified language-suggestion blocks to prevent incorrect or outdated endpoint information from being displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->