### PR TITLE
Themes: escape title output in bbPress loop and codex sidebar templates

### DIFF
--- a/buddypress.org/public_html/wp-content/themes/bb-base/bbpress/form-topic-split.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/bbpress/form-topic-split.php
@@ -39,7 +39,7 @@
 							<div>
 								<input name="bbp_topic_split_option" id="bbp_topic_split_option_reply" type="radio" checked="checked" value="reply" />
 								<label for="bbp_topic_split_option_reply"><?php printf( __( 'New topic in <strong>%s</strong> titled:', 'bbpress' ), bbp_get_forum_title( bbp_get_topic_forum_id( bbp_get_topic_id() ) ) ); ?></label>
-								<input type="text" id="bbp_topic_split_destination_title" value="<?php printf( __( 'Split: %s', 'bbpress' ), bbp_get_topic_title() ); ?>" size="35" name="bbp_topic_split_destination_title" />
+								<input type="text" id="bbp_topic_split_destination_title" value="<?php echo esc_attr( sprintf( __( 'Split: %s', 'bbpress' ), bbp_get_topic_title() ) ); ?>" size="35" name="bbp_topic_split_destination_title" />
 							</div>
 
 							<?php if ( bbp_has_topics( array( 'show_stickies' => false, 'post_parent' => bbp_get_topic_forum_id( bbp_get_topic_id() ), 'post__not_in' => array( bbp_get_topic_id() ) ) ) ) : ?>

--- a/buddypress.org/public_html/wp-content/themes/bb-base/bbpress/loop-single-forum.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/bbpress/loop-single-forum.php
@@ -1,6 +1,6 @@
 <ul id="bbp-forum-<?php bbp_forum_id(); ?>" <?php bbp_forum_class(); ?>>
 	<li class="bbp-forum-info">
-		<a class="bbp-forum-title" href="<?php bbp_forum_permalink(); ?>" title="<?php bbp_forum_title(); ?>"><?php bbp_forum_title(); ?></a>
+		<a class="bbp-forum-title" href="<?php echo esc_url( bbp_get_forum_permalink() ); ?>" title="<?php echo esc_attr( bbp_get_forum_title() ); ?>"><?php echo esc_html( bbp_get_forum_title() ); ?></a>
 	</li>
 	<li class="bbp-forum-topic-count"><?php bbp_forum_post_count(); ?></li>
 </ul><!-- #bbp-forum-<?php bbp_forum_id(); ?> -->

--- a/buddypress.org/public_html/wp-content/themes/codex-bbpress-org/sidebar.php
+++ b/buddypress.org/public_html/wp-content/themes/codex-bbpress-org/sidebar.php
@@ -39,7 +39,7 @@
 			if ( $relateds ) {
 				foreach ( $relateds as $related ) {
 					$title = apply_filters( 'the_title', $related->post_title );
-					$rel .= '<li><a href="' . get_permalink( $related->ID ) . '" title="' . $title . '">' . $title . '</a></li>';
+					$rel  .= '<li><a href="' . esc_url( get_permalink( $related->ID ) ) . '" title="' . esc_attr( wp_strip_all_tags( $title ) ) . '">' . $title . '</a></li>';
 				}
 				$rel = '<ul>' . $rel . '</ul>';
 				echo '<div class="related-content-widget widget listified"><h2 class="widgettitle">Related</h2>' . $rel . '</div>';

--- a/buddypress.org/public_html/wp-content/themes/codex-buddypress-org/sidebar.php
+++ b/buddypress.org/public_html/wp-content/themes/codex-buddypress-org/sidebar.php
@@ -40,7 +40,7 @@
 				if ( $relateds ) {
 					foreach ( $relateds as $related ) {
 						$title = apply_filters('the_title', $related->post_title);
-						$rel .= '<li><a href="' . get_permalink($related->ID) . '" title="' . $title . '">' . $title . '</a></li>';
+						$rel  .= '<li><a href="' . esc_url( get_permalink( $related->ID ) ) . '" title="' . esc_attr( wp_strip_all_tags( $title ) ) . '">' . $title . '</a></li>';
 					}
 					$rel = '<ul>' . $rel . '</ul>';
 					echo '<div class="related-content-widget widget listified"><h2 class="widgettitle">Related</h2>' . $rel . '</div>';

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/loop-single-forum.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/loop-single-forum.php
@@ -1,6 +1,6 @@
 <ul id="bbp-forum-<?php bbp_forum_id(); ?>" <?php bbp_forum_class(); ?>>
 	<li class="bbp-forum-info">
-		<a class="bbp-forum-title" href="<?php bbp_forum_permalink(); ?>" title="<?php bbp_forum_title(); ?>"><?php bbp_forum_title(); ?></a>
+		<a class="bbp-forum-title" href="<?php echo esc_url( bbp_get_forum_permalink() ); ?>" title="<?php echo esc_attr( bbp_get_forum_title() ); ?>"><?php echo esc_html( bbp_get_forum_title() ); ?></a>
 		<br><?php bbp_forum_content(); ?>
 	</li>
 	<li class="bbp-forum-topic-count"><?php bbp_forum_topic_count(); ?></li>


### PR DESCRIPTION
Routes forum and page titles through the appropriate escaping when they are interpolated into these theme templates, matching the escaping the sibling templates in the same themes already use.

- `wporg-support-2024` and `bb-base` `bbpress/loop-single-forum.php`: switch the procedural echoes to the `bbp_get_forum_*()` accessors wrapped in `esc_url()` / `esc_attr()` / `esc_html()`, mirroring the neighbouring `loop-single-forum-homepage.php`.
- `codex-bbpress-org` and `codex-buddypress-org` `sidebar.php`: `esc_url()` the permalink and `esc_attr()` the `title` attribute in the related-content list.

No behavioural change for normal titles; output escaping only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security and reliability for forum and related-page links.
  * Added proper escaping for URLs, link attributes, displayed titles, and form values.
  * Removed HTML tags from link title attributes where needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->