### PR TITLE
Directories: sanitize user-submitted plain-text fields stored as post content

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/uploads.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/uploads.php
@@ -103,7 +103,7 @@ class Uploads {
 		/* After submission, but before post is created. */
 
 		add_filter( 'fu_before_create_post', [ __CLASS__, 'sanitize_submitted_description' ], 5 );
-		add_filter( 'fu_before_create_post',            [ __CLASS__, 'make_post_pending_instead_of_private' ] );
+		add_filter( 'fu_before_create_post', [ __CLASS__, 'make_post_pending_instead_of_private' ] );
 
 		/* After submission, after an upload completes. */
 

--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/uploads.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/uploads.php
@@ -102,6 +102,7 @@ class Uploads {
 
 		/* After submission, but before post is created. */
 
+		add_filter( 'fu_before_create_post',            [ __CLASS__, 'sanitize_submitted_description' ], 5 );
 		add_filter( 'fu_before_create_post',            [ __CLASS__, 'make_post_pending_instead_of_private' ] );
 
 		/* After submission, after an upload completes. */
@@ -476,6 +477,24 @@ class Uploads {
 		$notices['fu-spam']['text'] = $rejection;
 
 		return $notices;
+	}
+
+	/**
+	 * Sanitizes the submitted "Alternative Text" as the plain text it is.
+	 *
+	 * @param array $post_array Array of post settings.
+	 * @return array
+	 */
+	public static function sanitize_submitted_description( $post_array ) {
+		if ( Registrations::get_post_type() !== ( $post_array['post_type'] ?? '' ) ) {
+			return $post_array;
+		}
+
+		if ( isset( $post_array['post_content'] ) ) {
+			$post_array['post_content'] = wp_slash( sanitize_textarea_field( wp_unslash( $post_array['post_content'] ) ) );
+		}
+
+		return $post_array;
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/uploads.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/uploads.php
@@ -486,6 +486,11 @@ class Uploads {
 	 * @return array
 	 */
 	public static function sanitize_submitted_description( $post_array ) {
+		// The photo form is the only Frontend Uploader form here; scope to it should another ever be added.
+		if ( Registrations::get_post_type() !== ( $post_array['post_type'] ?? '' ) ) {
+			return $post_array;
+		}
+
 		if ( isset( $post_array['post_content'] ) ) {
 			$post_array['post_content'] = wp_slash( sanitize_textarea_field( wp_unslash( $post_array['post_content'] ) ) );
 		}

--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/uploads.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/uploads.php
@@ -486,10 +486,6 @@ class Uploads {
 	 * @return array
 	 */
 	public static function sanitize_submitted_description( $post_array ) {
-		if ( Registrations::get_post_type() !== ( $post_array['post_type'] ?? '' ) ) {
-			return $post_array;
-		}
-
 		if ( isset( $post_array['post_content'] ) ) {
 			$post_array['post_content'] = wp_slash( sanitize_textarea_field( wp_unslash( $post_array['post_content'] ) ) );
 		}

--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/uploads.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/uploads.php
@@ -102,7 +102,7 @@ class Uploads {
 
 		/* After submission, but before post is created. */
 
-		add_filter( 'fu_before_create_post',            [ __CLASS__, 'sanitize_submitted_description' ], 5 );
+		add_filter( 'fu_before_create_post', [ __CLASS__, 'sanitize_submitted_description' ], 5 );
 		add_filter( 'fu_before_create_post',            [ __CLASS__, 'make_post_pending_instead_of_private' ] );
 
 		/* After submission, after an upload completes. */

--- a/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-report-topic.php
+++ b/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-report-topic.php
@@ -593,7 +593,7 @@ The WordPress.org Team',
 			$this->add_modlook_history(
 				(int) $_POST['wporg-support-report-topic'],
 				wp_slash( sanitize_textarea_field( wp_unslash( $_POST['topic-report-reason-details'] ) ) ),
-				(int) $_POST['topic-report-reason']
+				$validate_term->term_id
 			);
 
 			wp_safe_redirect( get_the_permalink( $_POST['wporg-support-report-topic'] ) );

--- a/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-report-topic.php
+++ b/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-report-topic.php
@@ -590,7 +590,11 @@ The WordPress.org Team',
 			remove_action( 'set_object_terms', array( $this, 'detect_manual_modlook' ), 10 );
 			wp_add_object_terms( $_POST['wporg-support-report-topic'], 'modlook', 'topic-tag' );
 
-			$this->add_modlook_history( $_POST['wporg-support-report-topic'], $_POST['topic-report-reason-details'], (int) $_POST['topic-report-reason'] );
+			$this->add_modlook_history(
+				(int) $_POST['wporg-support-report-topic'],
+				wp_slash( sanitize_textarea_field( wp_unslash( $_POST['topic-report-reason-details'] ) ) ),
+				(int) $_POST['topic-report-reason']
+			);
 
 			wp_safe_redirect( get_the_permalink( $_POST['wporg-support-report-topic'] ) );
 

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
@@ -1483,7 +1483,8 @@ TICKET;
 				'post_author'    => $this->author->ID,
 				'post_title'     => $this->theme->get( 'Name' ),
 				'post_name'      => $this->theme_slug,
-				'post_content'   => $this->theme->get( 'Description' ),
+				// The description is a one-line header, not body content to run through the shortcode chain.
+				'post_content'   => strip_shortcodes( $this->theme->get( 'Description' ) ),
 				'post_parent'    => $this->theme->post_parent,
 				'post_date'      => $upload_date,
 				'post_date_gmt'  => $upload_date,


### PR DESCRIPTION
A few user-submitted fields across the directories are presented and handled as plain text, but are stored as a post's `post_content`. That routes them through the post allow-list on save even though they are never meant to carry markup. This normalizes them to the plain text they are, at the point each is written:

- **Photo Directory** — the submission form's "Alternative Text" is sanitized with `sanitize_textarea_field()` on the `fu_before_create_post` hook the plugin already registers.
- **Support Forums** — the "Report topic" reason is sanitized with `sanitize_textarea_field()` where the report post is written, and the topic id passed alongside it is cast.
- **Themes** — the `style.css` `Description` header has shortcodes stripped before it is stored, so a one-line description is not run through the `the_content` shortcode chain on the public theme page.

Each change is scoped to the writer and leaves the allowed presentation of these fields unchanged. Existing stored values are not rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved report submission handling by using validated report-reason values when recording moderation history.
  * Removed shortcodes from newly submitted theme descriptions for cleaner content.
  * Improved sanitization of submitted photo descriptions before they are saved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->