### PR TITLE
Translate: Escape the Language Packs list output

### DIFF
--- a/api.wordpress.org/public_html/translations/lib.php
+++ b/api.wordpress.org/public_html/translations/lib.php
@@ -117,7 +117,7 @@ function find_all_translations_for_type_and_domain( $type, $domain = 'default', 
 		$_translations[ $key ] = $translation;
 		$_translations[ $key ]->english_name = $locale->english_name;
 		$_translations[ $key ]->native_name = $locale->native_name;
-		$_translations[ $key ]->package = sprintf( "$base_url/%s/%s.zip", $translation->version, $translation->language );
+		$_translations[ $key ]->package = sprintf( "$base_url/%s/%s.zip", rawurlencode( $translation->version ), rawurlencode( $translation->language ) );
 		$_translations[ $key ]->iso = (object) $isos;
 
 		if ( 'core' === $type ) {

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/cli/class-language-pack.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/cli/class-language-pack.php
@@ -344,6 +344,11 @@ class Language_Pack extends WP_CLI_Command {
 	 * The version is interpolated into filesystem paths by build_language_packs(), so a value that could
 	 * step outside the directory it names has to be rejected before it gets there.
 	 *
+	 * This is a path guard only. It permits characters such as `"`, `<`, `>` and `=` that are unsafe in HTML
+	 * and URL contexts, so any consumer that renders the version into markup or a URL must escape it there
+	 * (the Language Packs templates use esc_html()/esc_url()). Passing this check does not make that escaping
+	 * redundant.
+	 *
 	 * @param mixed $version Version of a theme/plugin, from the API or the --version argument.
 	 * @return bool True if the version is safe to use in a path, false otherwise.
 	 */

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/projects-wp-plugins-language-packs.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/projects-wp-plugins-language-packs.php
@@ -50,11 +50,11 @@ gp_tmpl_header();
 		foreach ( $language_packs->translations as $language_pack ) {
 			printf(
 				'<li><strong>%s <span class="locale-code">(%s)</span>:</strong> Last updated %s for version %s (<a href="%s">zip</a>)</li>',
-				$language_pack->english_name,
-				$language_pack->language,
-				$language_pack->updated,
-				$language_pack->version,
-				$language_pack->package
+				esc_html( $language_pack->english_name ),
+				esc_html( $language_pack->language ),
+				esc_html( $language_pack->updated ),
+				esc_html( $language_pack->version ),
+				esc_url( $language_pack->package )
 			);
 		}
 		echo '</ul>';

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/projects-wp-themes-language-packs.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/projects-wp-themes-language-packs.php
@@ -50,11 +50,11 @@ gp_tmpl_header();
 		foreach ( $language_packs->translations as $language_pack ) {
 			printf(
 				'<li><strong>%s <span class="locale-code">(%s)</span>:</strong> Last updated %s for version %s (<a href="%s">zip</a>)</li>',
-				$language_pack->english_name,
-				$language_pack->language,
-				$language_pack->updated,
-				$language_pack->version,
-				$language_pack->package
+				esc_html( $language_pack->english_name ),
+				esc_html( $language_pack->language ),
+				esc_html( $language_pack->updated ),
+				esc_html( $language_pack->version ),
+				esc_url( $language_pack->package )
 			);
 		}
 		echo '</ul>';


### PR DESCRIPTION
## Why

The per-project Language Packs pages render the fields of each entry from the `api.wordpress.org/translations/{plugins,themes}/1.0/` response. Five of them (`english_name`, `language`, `updated`, `version`, `package`) are printed with no escaping. `package` is written into an `href` attribute and `version` into element text.

Both of those derive from a project's `Version:` header, which is free-form. The SVN importer only records a warning when a version header contains anything other than digits and dots (`cli/class-import.php`), and stores it as-is; the language-pack builder's `version_is_path_safe()` check rejects path-traversal characters only. So a published version string containing a quote or an angle bracket flows through to the page unchanged, and the rendered markup is not guaranteed to be well-formed.

The same repository already escapes the equivalent value one directory over: `stats-plugin-themes-overview.php` wraps its own attribute in `esc_attr()`. These two Language Packs templates are the only place an API-supplied value is emitted into markup raw.

## What changed

- **Escape each field at output**, in both `projects-wp-plugins-language-packs.php` and the byte-identical `projects-wp-themes-language-packs.php`: `esc_html()` for `english_name`, `language`, `updated` and `version`, and `esc_url()` for the `package` URL.
- **Build the package URL safely in the API.** `translations/lib.php` now interpolates the version and language segments with `rawurlencode()`, so every consumer of the JSON receives a well-formed URL rather than only the page inheriting the fix.
- **Document the path guard.** Added a note on `version_is_path_safe()` that it guards filesystem paths only and does not sanitise for HTML or URL output, so a reader does not take it for output escaping.

## Testing

Uses the repo's `translate` environment. From `environments/`, start it with `npm run translate:env -- start`. Each check below is a single command.

**1. Legitimate values render unchanged.** The escapers and `rawurlencode()` are no-ops for the values these fields actually carry (locale codes, dotted-numeric versions):

```
npm run translate:env -- run cli -- wp eval '$v="1.2.3";$l="de_DE";echo esc_html($v)." | ".esc_url("https://downloads.wordpress.org/translation/plugin/foo/$v/$l.zip")."\n";echo rawurlencode($v)." | ".rawurlencode($l)."\n";'
```

Output is identical to the input, so existing pages are unaffected:

```
1.2.3 | https://downloads.wordpress.org/translation/plugin/foo/1.2.3/de_DE.zip
1.2.3 | de_DE
```

**2. The template line stays well-formed for atypical values.** Run the `printf()` from the templates with a version that contains HTML-significant characters:

```
npm run translate:env -- run cli -- wp eval '$v="1.0 <b> \"x\"";$p="https://downloads.wordpress.org/translation/plugin/foo/$v/de_DE.zip";printf("for version %s (<a href=\"%s\">zip</a>)\n", esc_html($v), esc_url($p));'
```

On this branch the version is entity-encoded and the link stays a single, well-formed attribute:

```
for version 1.0 &lt;b&gt; &quot;x&quot; (<a href="https://downloads.wordpress.org/translation/plugin/foo/1.0%20b%20x/de_DE.zip">zip</a>)
```

For contrast, the same command with the `esc_html()`/`esc_url()` calls removed (i.e. `trunk`) prints the characters raw, and the `"` closes the `href` early:

```
for version 1.0 <b> "x" (<a href="https://downloads.wordpress.org/translation/plugin/foo/1.0 <b> "x"/de_DE.zip">zip</a>)
```

Both templates carry the identical change, so the plugins and themes pages behave the same.
