### PR TITLE
Theme Directory: keep theme version strings consistent from import to download

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-repo-package.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-repo-package.php
@@ -65,8 +65,7 @@ class WPORG_Themes_Repo_Package {
 
 		$this->version = $version;
 		if ( $this->wp_post ) {
-			// String comparison: the canonical version '0' is falsy but not "latest".
-			if ( '' === (string) $version || 'latest' === $version || 'latest-stable' === $version ) {
+			if ( ! $version || 'latest' === $version || 'latest-stable' === $version ) {
 				$this->version = $this->latest_version();
 			}
 		}
@@ -126,8 +125,7 @@ class WPORG_Themes_Repo_Package {
 	 * @return string
 	 */
 	public function download_url( $version = false ) {
-		// String comparison: the canonical version '0' must address its own package.
-		$version = '' === (string) $version ? $this->version : $version;
+		$version = $version ?: $this->version;
 		if ( 'latest-stable' === $version ) {
 			$version = $this->latest_version();
 		}

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-repo-package.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-repo-package.php
@@ -65,7 +65,8 @@ class WPORG_Themes_Repo_Package {
 
 		$this->version = $version;
 		if ( $this->wp_post ) {
-			if ( ! $version || 'latest' === $version || 'latest-stable' === $version ) {
+			// String comparison: the canonical version '0' is falsy but not "latest".
+			if ( '' === (string) $version || 'latest' === $version || 'latest-stable' === $version ) {
 				$this->version = $this->latest_version();
 			}
 		}
@@ -125,7 +126,8 @@ class WPORG_Themes_Repo_Package {
 	 * @return string
 	 */
 	public function download_url( $version = false ) {
-		$version = $version ?: $this->version;
+		// String comparison: the canonical version '0' must address its own package.
+		$version = '' === (string) $version ? $this->version : $version;
 		if ( 'latest-stable' === $version ) {
 			$version = $this->latest_version();
 		}

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-repo-package.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-repo-package.php
@@ -130,8 +130,9 @@ class WPORG_Themes_Repo_Package {
 			$version = $this->latest_version();
 		}
 
+		// An empty version addresses the unversioned latest package.
 		$url  = 'http://downloads.wordpress.org/theme/';
-		$file = $this->wp_post->post_name . '.' . $version . '.zip';
+		$file = $this->wp_post->post_name . ( '' === (string) $version ? '' : '.' . $version ) . '.zip';
 
 		$file = preg_replace( '/[^a-z0-9_.-]/i', '', $file );
 

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-repo-package.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-repo-package.php
@@ -134,7 +134,6 @@ class WPORG_Themes_Repo_Package {
 		$file = $this->wp_post->post_name . '.' . $version . '.zip';
 
 		$file = preg_replace( '/[^a-z0-9_.-]/i', '', $file );
-		$file = preg_replace( '/[.]+/', '.', $file );
 
 		return set_url_scheme( $url . $file );
 	}

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
@@ -359,7 +359,8 @@ class WPORG_Themes_Upload {
 
 		return $this->import( array( // return true | WP_Error
 			// Since this version is already in SVN, we shouldn't try to import it again.
-			'commit_to_svn' => false,
+			'commit_to_svn'    => false,
+			'expected_version' => $version,
 		) );
 	}
 
@@ -401,6 +402,20 @@ class WPORG_Themes_Upload {
 	}
 
 	/**
+	 * Determines whether a version string is a canonical, unambiguous theme version.
+	 *
+	 * Canonical means decimal segments joined by single periods and nothing else: the one
+	 * shape that maps identically across the style.css header, SVN directory, meta key, API
+	 * value, and package filename, so review and downloads can't resolve different trees.
+	 *
+	 * @param string $version The version string to test.
+	 * @return bool True when the version is canonical.
+	 */
+	public static function is_canonical_version( $version ) {
+		return (bool) preg_match( '/^\d+(\.\d+)*$/', (string) $version );
+	}
+
+	/**
 	 * Processes a theme import.
 	 *
 	 * @return WP_Error|true Error object on failure, true on success.
@@ -417,6 +432,8 @@ class WPORG_Themes_Upload {
 				'block_on_themecheck' => true,
 				// Whether to create a Trac ticket for this import.
 				'create_trac_ticket'  => true,
+				// SVN directory version the tree's header must match; false to skip the check.
+				'expected_version'    => false,
 			)
 		);
 
@@ -625,13 +642,26 @@ class WPORG_Themes_Upload {
 
 			$style_errors->add( 'no_version', $error );
 
-		} else if ( preg_match( '|[^\d\.]|', $this->theme->get( 'Version' ) ) ) {
+		} else if ( ! self::is_canonical_version( $this->theme->get( 'Version' ) ) ) {
 			$style_errors->add(
 				'invalid_version',
 				sprintf(
 					/* translators: %s: style.css */
-					__( 'Version strings can only contain numeric and period characters (like 1.2). Please fix your Version: line in %s and upload your theme again.', 'wporg-themes' ),
+					__( 'Version strings must be a plain numeric version like 1.2 or 1.2.3. Please fix your Version: line in %s and upload your theme again.', 'wporg-themes' ),
 					'<code>style.css</code>'
+				)
+			);
+		}
+
+		// The exported directory name must equal the version its tree declares, or review and downloads diverge.
+		if ( ! empty( $args['expected_version'] ) && (string) $args['expected_version'] !== (string) $this->theme->get( 'Version' ) ) {
+			$style_errors->add(
+				'version_mismatch',
+				sprintf(
+					/* translators: 1: SVN directory version, 2: style.css version */
+					__( 'The SVN directory version (%1$s) does not match the version declared in style.css (%2$s).', 'wporg-themes' ),
+					'<code>' . esc_html( (string) $args['expected_version'] ) . '</code>',
+					'<code>' . esc_html( (string) $this->theme->get( 'Version' ) ) . '</code>'
 				)
 			);
 		}

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
@@ -407,12 +407,15 @@ class WPORG_Themes_Upload {
 	 * Canonical means decimal segments joined by single periods and nothing else: the one
 	 * shape that maps identically across the style.css header, SVN directory, meta key, API
 	 * value, and package filename, so review and downloads can't resolve different trees.
+	 * Version zero ('0', '0.0', ...) is rejected: version_compare() makes it the lowest
+	 * possible version, and the bare form's falsiness invites `! $version` bugs downstream.
 	 *
 	 * @param string $version The version string to test.
 	 * @return bool True when the version is canonical.
 	 */
 	public static function is_canonical_version( $version ) {
-		return (bool) preg_match( '/^\d+(\.\d+)*$/D', (string) $version );
+		return (bool) preg_match( '/^\d+(\.\d+)*$/D', (string) $version )
+			&& (bool) preg_match( '/[1-9]/', (string) $version );
 	}
 
 	/**
@@ -425,7 +428,7 @@ class WPORG_Themes_Upload {
 	public static function version_identity_errors( $version, $expected_version = false ) {
 		$errors = new WP_Error();
 
-		// Strict comparison: '0' is a canonical version, not a missing header.
+		// Strict comparison: a '0' header is reported as invalid below, not as missing.
 		if ( '' === $version ) {
 			$error = __( 'The theme has no version.', 'wporg-themes' ) . ' ';
 

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
@@ -412,7 +412,56 @@ class WPORG_Themes_Upload {
 	 * @return bool True when the version is canonical.
 	 */
 	public static function is_canonical_version( $version ) {
-		return (bool) preg_match( '/^\d+(\.\d+)*$/', (string) $version );
+		return (bool) preg_match( '/^\d+(\.\d+)*$/D', (string) $version );
+	}
+
+	/**
+	 * Collects the errors for a theme's Version header and its SVN directory identity.
+	 *
+	 * @param string       $version          The style.css Version header value.
+	 * @param string|false $expected_version SVN directory version the header must match; false to skip the check.
+	 * @return WP_Error The errors found; empty when the version is acceptable.
+	 */
+	public static function version_identity_errors( $version, $expected_version = false ) {
+		$errors = new WP_Error();
+
+		if ( ! $version ) {
+			$error = __( 'The theme has no version.', 'wporg-themes' ) . ' ';
+
+			$error .= sprintf(
+				/* translators: 1: comment header line, 2: style.css, 3: wporg URL */
+				__( 'Add a %1$s line to your %2$s file and upload the theme again. <a href="%3$s">Theme Style Sheets</a>', 'wporg-themes' ),
+				'<code>Version:</code>',
+				'<code>style.css</code>',
+				__( 'https://developer.wordpress.org/themes/basics/main-stylesheet-style-css/', 'wporg-themes' )
+			);
+
+			$errors->add( 'no_version', $error );
+
+		} elseif ( ! self::is_canonical_version( $version ) ) {
+			$errors->add(
+				'invalid_version',
+				sprintf(
+					/* translators: %s: style.css */
+					__( 'Version strings must be a plain numeric version like 1.2 or 1.2.3. Please fix your Version: line in %s and upload your theme again.', 'wporg-themes' ),
+					'<code>style.css</code>'
+				)
+			);
+
+		} elseif ( false !== $expected_version && (string) $expected_version !== $version ) {
+			// The exported directory name must equal the version its tree declares, or review and downloads diverge.
+			$errors->add(
+				'version_mismatch',
+				sprintf(
+					/* translators: 1: SVN directory version, 2: style.css version */
+					__( 'The SVN directory version (%1$s) does not match the version declared in style.css (%2$s).', 'wporg-themes' ),
+					'<code>' . esc_html( (string) $expected_version ) . '</code>',
+					'<code>' . esc_html( $version ) . '</code>'
+				)
+			);
+		}
+
+		return $errors;
 	}
 
 	/**
@@ -629,42 +678,9 @@ class WPORG_Themes_Upload {
 			$style_errors->add( 'no_tags', $error );
 		}
 
-		if ( ! $this->theme->get( 'Version' ) ) {
-			$error = __( 'The theme has no version.', 'wporg-themes' ) . ' ';
-
-			$error .= sprintf(
-				/* translators: 1: comment header line, 2: style.css, 3: wporg URL */
-				__( 'Add a %1$s line to your %2$s file and upload the theme again. <a href="%3$s">Theme Style Sheets</a>', 'wporg-themes' ),
-				'<code>Version:</code>',
-				'<code>style.css</code>',
-				__( 'https://developer.wordpress.org/themes/basics/main-stylesheet-style-css/', 'wporg-themes' )
-			);
-
-			$style_errors->add( 'no_version', $error );
-
-		} else if ( ! self::is_canonical_version( $this->theme->get( 'Version' ) ) ) {
-			$style_errors->add(
-				'invalid_version',
-				sprintf(
-					/* translators: %s: style.css */
-					__( 'Version strings must be a plain numeric version like 1.2 or 1.2.3. Please fix your Version: line in %s and upload your theme again.', 'wporg-themes' ),
-					'<code>style.css</code>'
-				)
-			);
-		}
-
-		// The exported directory name must equal the version its tree declares, or review and downloads diverge.
-		if ( ! empty( $args['expected_version'] ) && (string) $args['expected_version'] !== (string) $this->theme->get( 'Version' ) ) {
-			$style_errors->add(
-				'version_mismatch',
-				sprintf(
-					/* translators: 1: SVN directory version, 2: style.css version */
-					__( 'The SVN directory version (%1$s) does not match the version declared in style.css (%2$s).', 'wporg-themes' ),
-					'<code>' . esc_html( (string) $args['expected_version'] ) . '</code>',
-					'<code>' . esc_html( (string) $this->theme->get( 'Version' ) ) . '</code>'
-				)
-			);
-		}
+		$style_errors->merge_from(
+			self::version_identity_errors( (string) $this->theme->get( 'Version' ), $args['expected_version'] )
+		);
 
 		// Version is greater than current version happens after authorship checks.
 

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
@@ -425,7 +425,8 @@ class WPORG_Themes_Upload {
 	public static function version_identity_errors( $version, $expected_version = false ) {
 		$errors = new WP_Error();
 
-		if ( ! $version ) {
+		// Strict comparison: '0' is a canonical version, not a missing header.
+		if ( '' === $version ) {
 			$error = __( 'The theme has no version.', 'wporg-themes' ) . ' ';
 
 			$error .= sprintf(

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Version_Identity_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Version_Identity_Test.php
@@ -10,7 +10,8 @@ declare( strict_types = 1 );
 use PHPUnit\Framework\TestCase;
 
 /**
- * Covers WPORG_Themes_Upload::is_canonical_version() and the download URL identity.
+ * Covers WPORG_Themes_Upload::is_canonical_version(), version_identity_errors(),
+ * and the download URL identity.
  *
  * @group upload
  */
@@ -94,7 +95,53 @@ class Version_Identity_Test extends TestCase {
 			'non numeric'  => array( '1.4a' ),
 			'whitespace'   => array( '1.4 ' ),
 			'letters'      => array( 'v1.4' ),
+			'newline'      => array( "1.4\n" ),
 		);
+	}
+
+	/**
+	 * A canonical header matching the SVN directory version is error free.
+	 */
+	public function test_matching_canonical_version_yields_no_errors(): void {
+		$errors = WPORG_Themes_Upload::version_identity_errors( '1.4', '1.4' );
+
+		$this->assertFalse( $errors->has_errors() );
+	}
+
+	/**
+	 * A canonical header that differs from the SVN directory version is a mismatch.
+	 */
+	public function test_version_mismatch_detected(): void {
+		$errors = WPORG_Themes_Upload::version_identity_errors( '1.2', '1.4' );
+
+		$this->assertSame( array( 'version_mismatch' ), $errors->get_error_codes() );
+	}
+
+	/**
+	 * The directory identity check must also run for the falsy canonical version '0'.
+	 */
+	public function test_version_mismatch_detected_for_version_zero_directory(): void {
+		$errors = WPORG_Themes_Upload::version_identity_errors( '1.2', '0' );
+
+		$this->assertSame( array( 'version_mismatch' ), $errors->get_error_codes() );
+	}
+
+	/**
+	 * A missing header is one defect: no self-contradictory mismatch error on top.
+	 */
+	public function test_missing_header_reports_only_no_version(): void {
+		$errors = WPORG_Themes_Upload::version_identity_errors( '', '1.4' );
+
+		$this->assertSame( array( 'no_version' ), $errors->get_error_codes() );
+	}
+
+	/**
+	 * A noncanonical header is one defect: a mismatch error would just restate it.
+	 */
+	public function test_noncanonical_header_reports_only_invalid_version(): void {
+		$errors = WPORG_Themes_Upload::version_identity_errors( '1.4.', '1.4' );
+
+		$this->assertSame( array( 'invalid_version' ), $errors->get_error_codes() );
 	}
 
 	/**
@@ -122,6 +169,32 @@ class Version_Identity_Test extends TestCase {
 		$this->assertStringEndsWith(
 			'/identity-probe.1.4..zip',
 			$package->download_url( '1.4.' )
+		);
+	}
+
+	/**
+	 * A package whose version resolves to an empty string must fall back to the
+	 * unversioned latest-package URL, not a doubled-period filename.
+	 */
+	public function test_download_url_omits_empty_version(): void {
+		$post_id = wp_insert_post(
+			array(
+				'post_type'   => 'repopackage',
+				'post_status' => 'publish',
+				'post_title'  => 'Identity Probe Unversioned',
+				'post_name'   => 'identity-probe-unversioned',
+				'post_author' => 1,
+			)
+		);
+
+		$this->post_ids[] = $post_id;
+
+		// No `_status` meta, so latest_version() and the version property are ''.
+		$package = new WPORG_Themes_Repo_Package( get_post( $post_id ) );
+
+		$this->assertStringEndsWith(
+			'/identity-probe-unversioned.zip',
+			$package->download_url()
 		);
 	}
 }

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Version_Identity_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Version_Identity_Test.php
@@ -18,29 +18,24 @@ use PHPUnit\Framework\TestCase;
 class Version_Identity_Test extends TestCase {
 
 	/**
-	 * IDs of posts created during a test, deleted again on teardown.
+	 * Builds an in-memory repopackage package, no database rows needed.
 	 *
-	 * @var int[]
+	 * With post ID 0 there is no meta, so latest_version() resolves to ''.
+	 *
+	 * @param string       $post_name The theme slug for the package.
+	 * @param string|false $version   Optional. The version to construct with, or false for latest.
+	 * @return WPORG_Themes_Repo_Package The package under test.
 	 */
-	protected array $post_ids = array();
-
-	/**
-	 * Removes the fixture posts created during a test.
-	 */
-	protected function tearDown(): void {
-		/*
-		 * The plugin prevents repopackages from being deleted; detach that
-		 * specific guard while cleaning up the fixture posts.
-		 */
-		remove_filter( 'before_delete_post', 'wporg_theme_no_delete_repopackage' );
-		foreach ( $this->post_ids as $post_id ) {
-			wp_delete_post( $post_id, true );
-		}
-		add_filter( 'before_delete_post', 'wporg_theme_no_delete_repopackage' );
-
-		$this->post_ids = array();
-
-		parent::tearDown();
+	private function create_package( string $post_name, $version = false ): WPORG_Themes_Repo_Package {
+		return new WPORG_Themes_Repo_Package(
+			new WP_Post(
+				(object) array(
+					'ID'        => 0,
+					'post_name' => $post_name,
+				)
+			),
+			$version
+		);
 	}
 
 	/**
@@ -62,6 +57,7 @@ class Version_Identity_Test extends TestCase {
 	public static function data_canonical_versions(): array {
 		return array(
 			'integer'      => array( '1' ),
+			'zero'         => array( '0' ),
 			'major minor'  => array( '1.4' ),
 			'three parts'  => array( '1.2.3' ),
 			'four parts'   => array( '1.2.3.4' ),
@@ -109,6 +105,15 @@ class Version_Identity_Test extends TestCase {
 	}
 
 	/**
+	 * The falsy canonical header '0' is a real version, not a missing one.
+	 */
+	public function test_version_zero_header_is_not_reported_as_missing(): void {
+		$errors = WPORG_Themes_Upload::version_identity_errors( '0', '0' );
+
+		$this->assertFalse( $errors->has_errors() );
+	}
+
+	/**
 	 * A canonical header that differs from the SVN directory version is a mismatch.
 	 */
 	public function test_version_mismatch_detected(): void {
@@ -148,19 +153,7 @@ class Version_Identity_Test extends TestCase {
 	 * The download URL must address the exact version, never a period-collapsed alias.
 	 */
 	public function test_download_url_does_not_collapse_periods(): void {
-		$post_id = wp_insert_post(
-			array(
-				'post_type'   => 'repopackage',
-				'post_status' => 'publish',
-				'post_title'  => 'Identity Probe',
-				'post_name'   => 'identity-probe',
-				'post_author' => 1,
-			)
-		);
-
-		$this->post_ids[] = $post_id;
-
-		$package = new WPORG_Themes_Repo_Package( get_post( $post_id ) );
+		$package = $this->create_package( 'identity-probe' );
 
 		$this->assertStringEndsWith(
 			'/identity-probe.1.2.3.zip',
@@ -177,24 +170,22 @@ class Version_Identity_Test extends TestCase {
 	 * unversioned latest-package URL, not a doubled-period filename.
 	 */
 	public function test_download_url_omits_empty_version(): void {
-		$post_id = wp_insert_post(
-			array(
-				'post_type'   => 'repopackage',
-				'post_status' => 'publish',
-				'post_title'  => 'Identity Probe Unversioned',
-				'post_name'   => 'identity-probe-unversioned',
-				'post_author' => 1,
-			)
-		);
-
-		$this->post_ids[] = $post_id;
-
-		// No `_status` meta, so latest_version() and the version property are ''.
-		$package = new WPORG_Themes_Repo_Package( get_post( $post_id ) );
+		$package = $this->create_package( 'identity-probe-unversioned' );
 
 		$this->assertStringEndsWith(
 			'/identity-probe-unversioned.zip',
 			$package->download_url()
 		);
+	}
+
+	/**
+	 * The falsy canonical version '0' must address its own package, not the latest one.
+	 */
+	public function test_download_url_keeps_version_zero(): void {
+		$package = $this->create_package( 'identity-probe-zero', '0' );
+
+		$this->assertSame( '0', $package->version );
+		$this->assertStringEndsWith( '/identity-probe-zero.0.zip', $package->download_url() );
+		$this->assertStringEndsWith( '/identity-probe-zero.0.zip', $package->download_url( '0' ) );
 	}
 }

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Version_Identity_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Version_Identity_Test.php
@@ -22,19 +22,17 @@ class Version_Identity_Test extends TestCase {
 	 *
 	 * With post ID 0 there is no meta, so latest_version() resolves to ''.
 	 *
-	 * @param string       $post_name The theme slug for the package.
-	 * @param string|false $version   Optional. The version to construct with, or false for latest.
+	 * @param string $post_name The theme slug for the package.
 	 * @return WPORG_Themes_Repo_Package The package under test.
 	 */
-	private function create_package( string $post_name, $version = false ): WPORG_Themes_Repo_Package {
+	private function create_package( string $post_name ): WPORG_Themes_Repo_Package {
 		return new WPORG_Themes_Repo_Package(
 			new WP_Post(
 				(object) array(
 					'ID'        => 0,
 					'post_name' => $post_name,
 				)
-			),
-			$version
+			)
 		);
 	}
 
@@ -57,7 +55,7 @@ class Version_Identity_Test extends TestCase {
 	public static function data_canonical_versions(): array {
 		return array(
 			'integer'      => array( '1' ),
-			'zero'         => array( '0' ),
+			'below one'    => array( '0.9' ),
 			'major minor'  => array( '1.4' ),
 			'three parts'  => array( '1.2.3' ),
 			'four parts'   => array( '1.2.3.4' ),
@@ -83,15 +81,17 @@ class Version_Identity_Test extends TestCase {
 	 */
 	public static function data_noncanonical_versions(): array {
 		return array(
-			'empty'        => array( '' ),
-			'trailing dot' => array( '1.4.' ),
-			'repeated dot' => array( '1..4' ),
-			'leading dot'  => array( '.1.4' ),
-			'lone dot'     => array( '.' ),
-			'non numeric'  => array( '1.4a' ),
-			'whitespace'   => array( '1.4 ' ),
-			'letters'      => array( 'v1.4' ),
-			'newline'      => array( "1.4\n" ),
+			'empty'          => array( '' ),
+			'bare zero'      => array( '0' ),
+			'multipart zero' => array( '0.0.0' ),
+			'trailing dot'   => array( '1.4.' ),
+			'repeated dot'   => array( '1..4' ),
+			'leading dot'    => array( '.1.4' ),
+			'lone dot'       => array( '.' ),
+			'non numeric'    => array( '1.4a' ),
+			'whitespace'     => array( '1.4 ' ),
+			'letters'        => array( 'v1.4' ),
+			'newline'        => array( "1.4\n" ),
 		);
 	}
 
@@ -105,12 +105,12 @@ class Version_Identity_Test extends TestCase {
 	}
 
 	/**
-	 * The falsy canonical header '0' is a real version, not a missing one.
+	 * The falsy header '0' is rejected as an invalid version, not as a missing one.
 	 */
-	public function test_version_zero_header_is_not_reported_as_missing(): void {
+	public function test_version_zero_header_is_reported_as_invalid(): void {
 		$errors = WPORG_Themes_Upload::version_identity_errors( '0', '0' );
 
-		$this->assertFalse( $errors->has_errors() );
+		$this->assertSame( array( 'invalid_version' ), $errors->get_error_codes() );
 	}
 
 	/**
@@ -123,7 +123,7 @@ class Version_Identity_Test extends TestCase {
 	}
 
 	/**
-	 * The directory identity check must also run for the falsy canonical version '0'.
+	 * A falsy '0' directory version must still be compared, not treated as no directory.
 	 */
 	public function test_version_mismatch_detected_for_version_zero_directory(): void {
 		$errors = WPORG_Themes_Upload::version_identity_errors( '1.2', '0' );
@@ -176,16 +176,5 @@ class Version_Identity_Test extends TestCase {
 			'/identity-probe-unversioned.zip',
 			$package->download_url()
 		);
-	}
-
-	/**
-	 * The falsy canonical version '0' must address its own package, not the latest one.
-	 */
-	public function test_download_url_keeps_version_zero(): void {
-		$package = $this->create_package( 'identity-probe-zero', '0' );
-
-		$this->assertSame( '0', $package->version );
-		$this->assertStringEndsWith( '/identity-probe-zero.0.zip', $package->download_url() );
-		$this->assertStringEndsWith( '/identity-probe-zero.0.zip', $package->download_url( '0' ) );
 	}
 }

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Version_Identity_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Version_Identity_Test.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Tests that a theme version is one stable identity from review to download.
+ *
+ * @package theme-directory
+ */
+
+declare( strict_types = 1 );
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers WPORG_Themes_Upload::is_canonical_version() and the download URL identity.
+ *
+ * @group upload
+ */
+class Version_Identity_Test extends TestCase {
+
+	/**
+	 * IDs of posts created during a test, deleted again on teardown.
+	 *
+	 * @var int[]
+	 */
+	protected array $post_ids = array();
+
+	/**
+	 * Removes the fixture posts created during a test.
+	 */
+	protected function tearDown(): void {
+		/*
+		 * The plugin prevents repopackages from being deleted; detach that
+		 * specific guard while cleaning up the fixture posts.
+		 */
+		remove_filter( 'before_delete_post', 'wporg_theme_no_delete_repopackage' );
+		foreach ( $this->post_ids as $post_id ) {
+			wp_delete_post( $post_id, true );
+		}
+		add_filter( 'before_delete_post', 'wporg_theme_no_delete_repopackage' );
+
+		$this->post_ids = array();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Canonical numeric versions are accepted.
+	 *
+	 * @dataProvider data_canonical_versions
+	 *
+	 * @param string $version A version that should be accepted.
+	 */
+	public function test_accepts_canonical_versions( string $version ): void {
+		$this->assertTrue( WPORG_Themes_Upload::is_canonical_version( $version ) );
+	}
+
+	/**
+	 * Data provider of canonical versions.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public static function data_canonical_versions(): array {
+		return array(
+			'integer'      => array( '1' ),
+			'major minor'  => array( '1.4' ),
+			'three parts'  => array( '1.2.3' ),
+			'four parts'   => array( '1.2.3.4' ),
+			'wide numbers' => array( '10.20.30' ),
+		);
+	}
+
+	/**
+	 * Noncanonical version strings that create an identity split are rejected.
+	 *
+	 * @dataProvider data_noncanonical_versions
+	 *
+	 * @param string $version A version that should be rejected.
+	 */
+	public function test_rejects_noncanonical_versions( string $version ): void {
+		$this->assertFalse( WPORG_Themes_Upload::is_canonical_version( $version ) );
+	}
+
+	/**
+	 * Data provider of noncanonical versions, including the exploited aliases.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public static function data_noncanonical_versions(): array {
+		return array(
+			'empty'        => array( '' ),
+			'trailing dot' => array( '1.4.' ),
+			'repeated dot' => array( '1..4' ),
+			'leading dot'  => array( '.1.4' ),
+			'lone dot'     => array( '.' ),
+			'non numeric'  => array( '1.4a' ),
+			'whitespace'   => array( '1.4 ' ),
+			'letters'      => array( 'v1.4' ),
+		);
+	}
+
+	/**
+	 * The download URL must address the exact version, never a period-collapsed alias.
+	 */
+	public function test_download_url_does_not_collapse_periods(): void {
+		$post_id = wp_insert_post(
+			array(
+				'post_type'   => 'repopackage',
+				'post_status' => 'publish',
+				'post_title'  => 'Identity Probe',
+				'post_name'   => 'identity-probe',
+				'post_author' => 1,
+			)
+		);
+
+		$this->post_ids[] = $post_id;
+
+		$package = new WPORG_Themes_Repo_Package( get_post( $post_id ) );
+
+		$this->assertStringEndsWith(
+			'/identity-probe.1.2.3.zip',
+			$package->download_url( '1.2.3' )
+		);
+		$this->assertStringEndsWith(
+			'/identity-probe.1.4..zip',
+			$package->download_url( '1.4.' )
+		);
+	}
+}


### PR DESCRIPTION
## What

Tightens how theme version strings are handled so a version reads the same everywhere it is used — the `style.css` header, the SVN directory, the post meta key, the Themes API value, and the package filename.

Three small changes:

- **Canonical version grammar at intake.** `WPORG_Themes_Upload::import()` now requires a version to be plain numeric segments joined by single periods (`1.2`, `1.2.3`) before any SVN or metadata write, instead of accepting any digits-and-periods string. This rejects malformed forms like a trailing or repeated period that don't map cleanly to a directory or filename.
- **Bind an SVN-sourced import to its directory.** When the importer processes a commit, it now checks that the version declared in the exported tree's `style.css` matches the version its SVN directory is named for, and fails the import on a mismatch rather than keying metadata off the header alone.
- **Don't rewrite the version in the download URL.** `WPORG_Themes_Repo_Package::download_url()` no longer collapses repeated periods, so the URL addresses the exact version directory rather than a normalized alias.

## Tests

Adds `Version_Identity_Test` covering the canonical-version grammar (accepted and rejected forms) and the download URL, which must reflect the version verbatim.

## Notes

A small number of existing themes carry noncanonical historical versions; with the URL change their download links now resolve to the literal version directory (the actual bytes in SVN) rather than a collapsed alias. Worth a quick check before deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved theme version validation during imports, including detection of missing, malformed, and mismatched versions.
  * Added checks to ensure the version listed in `style.css` matches the expected directory version.
  * Treats version `0` as invalid during validation.
  * Preserved periods in theme download filenames.
  * Removes unnecessary version suffixes when no version is provided.
  * Resolves falsy version requests to the latest available version.
* **Tests**
  * Added coverage for version validation, mismatches, and download filename behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->