### PR TITLE
Directories: process file-only SVN commits and ignore externals on review exports

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan.php
@@ -383,7 +383,7 @@ class Plugin_Scan {
 		$svn_url    = Import::PLUGIN_SVN_BASE . '/' . $plugin_slug . ( 'trunk' === $tag ? '/trunk' : '/tags/' . $tag );
 
 		// Create a checkout of the ZIP SVN
-		$res = SVN::export( $svn_url, $local_path, [ '--force' /* Overwrite the folder contents */ ] );
+		$res = SVN::export( $svn_url, $local_path, [ '--force' /* Overwrite the folder contents */, '--ignore-externals' /* Don't pull committer-controlled remote trees into the scan */ ] );
 
 		if ( ! $res['result'] ) {
 			return false;

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
@@ -315,7 +315,8 @@ class WPORG_Themes_Upload {
 		$esc_svn       = escapeshellarg( "https://themes.svn.wordpress.org/{$slug}/{$version}/" );
 		$esc_theme_dir = escapeshellarg( $this->theme_dir );
 		$this->exec_with_notify(
-			self::SVN . " export {$esc_svn} {$esc_theme_dir} --force", // force as we've created the directory already.
+			// --ignore-externals: never let a committer's svn:externals pull a remote tree into the export.
+			self::SVN . " export {$esc_svn} {$esc_theme_dir} --force --ignore-externals", // force as we've created the directory already.
 			$output,
 			$return_var
 		);

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/jobs/class-svn-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/jobs/class-svn-import.php
@@ -32,7 +32,8 @@ class SVN_Import {
 		$versions = array();
 
 		foreach ( $element->xpath( 'paths/path' ) as $path ) {
-			if ( ! preg_match( '!^/(?P<slug>[^/]+)/(?P<version>[^/]+)(?P<subpath>/.+)?$!', (string) $path, $m ) ) {
+			// The version segment must start with a digit, so a non-version dir like /slug/assets is skipped.
+			if ( ! preg_match( '!^/(?P<slug>[^/]+)/(?P<version>\d[^/]*)(?P<subpath>/.+)?$!', (string) $path, $m ) ) {
 				continue;
 			}
 

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/jobs/class-svn-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/jobs/class-svn-import.php
@@ -20,31 +20,31 @@ class SVN_Import {
 	use Exec_With_Logging;
 
 	/**
-	 * Determines the theme slug and version a changeset touched.
+	 * Determines the theme slug/version pairs a changeset touched.
+	 *
+	 * Every changed version is returned, so a commit that edits files across several
+	 * versions re-imports and re-scans all of them, not only the first.
 	 *
 	 * @param SimpleXMLElement $element A single `<logentry>` from `svn log -v --xml`.
-	 * @return array{0: string, 1: string} The slug and version, or empty strings when none matched.
+	 * @return array<int, array{0: string, 1: string}> Distinct slug/version pairs, in commit order.
 	 */
-	public static function changed_slug_version( $element ) {
-		$file_match = array( '', '' );
+	public static function changed_slug_versions( $element ) {
+		$versions = array();
 
 		foreach ( $element->xpath( 'paths/path' ) as $path ) {
 			if ( ! preg_match( '!^/(?P<slug>[^/]+)/(?P<version>[^/]+)(?P<subpath>/.+)?$!', (string) $path, $m ) ) {
 				continue;
 			}
 
-			// A directory node names the version; prefer it, as the watcher did before it looked at files.
-			if ( 'file' !== (string) $path['kind'] ) {
-				return array( $m['slug'], $m['version'] );
+			// A version is named by a directory node, or by a file inside a version directory; a bare /slug/file names none.
+			if ( 'dir' !== (string) $path['kind'] && empty( $m['subpath'] ) ) {
+				continue;
 			}
 
-			// A file counts only inside a version directory, and only as a fallback if no version directory changed.
-			if ( ! empty( $m['subpath'] ) && '' === $file_match[0] ) {
-				$file_match = array( $m['slug'], $m['version'] );
-			}
+			$versions[ "{$m['slug']}/{$m['version']}" ] = array( $m['slug'], $m['version'] );
 		}
 
-		return $file_match;
+		return array_values( $versions );
 	}
 
 	/**
@@ -81,33 +81,28 @@ class SVN_Import {
 			return false;
 		}
 
-		$theme_changes = array_filter( array_map( function( $element ) { 
+		$theme_changes = array();
 
-			// Get slug/version.
-			list( $slug, $version ) = self::changed_slug_version( $element );
-			if ( ! $slug || ! $version ) {
-				return false;
-			}
-
+		foreach ( $xml->xpath( '/log/logentry' ) as $element ) {
 			$changeset = (int) $element->xpath( '@revision' )[0];
 			$author    = trim( (string) $element->xpath( 'author' )[0] );
 			$msg       = trim( (string) $element->xpath( 'msg' )[0] );
 
-			$info = compact( 'slug', 'version', 'changeset', 'author', 'msg' );
+			foreach ( self::changed_slug_versions( $element ) as list( $slug, $version ) ) {
+				$info = compact( 'slug', 'version', 'changeset', 'author', 'msg' );
 
-			// Allow for including/skipping revisions based on external conditionals.
-			$should_import = 'themedropbox' !== $author;
-			$should_import = apply_filters( 'themes_svn_should_import', $should_import, $info );
+				// Allow for including/skipping revisions based on external conditionals.
+				$should_import = 'themedropbox' !== $author;
+				$should_import = apply_filters( 'themes_svn_should_import', $should_import, $info );
 
-			// DEBUG visible in cron log.
-			echo "[{$changeset}] $slug: $version by $author " . ( $should_import ? 'Importing from SVN.' : 'Skipping.' ) . "\n";
+				// DEBUG visible in cron log.
+				echo "[{$changeset}] $slug: $version by $author " . ( $should_import ? 'Importing from SVN.' : 'Skipping.' ) . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Plain-text cron log output, not a web response.
 
-			if ( ! $should_import ) {
-				return false;
+				if ( $should_import ) {
+					$theme_changes[] = $info;
+				}
 			}
-
-			return $info;
-		}, $xml->xpath('/log/logentry') ) );
+		}
 
 		$theme_changes = array_unique( $theme_changes, SORT_REGULAR );
 

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/jobs/class-svn-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/jobs/class-svn-import.php
@@ -20,6 +20,33 @@ class SVN_Import {
 	use Exec_With_Logging;
 
 	/**
+	 * Determines the theme slug and version a changeset touched.
+	 *
+	 * Considers every changed path, not only directory nodes, so a file-only commit that
+	 * rewrites bytes inside an existing version is still routed to that version for
+	 * re-import and re-scan. Returns the first version path found in commit order.
+	 *
+	 * @param SimpleXMLElement $element A single `<logentry>` from `svn log -v --xml`.
+	 * @return array{0: string, 1: string} The slug and version, or empty strings when none matched.
+	 */
+	public static function changed_slug_version( $element ) {
+		foreach ( $element->xpath( 'paths/path' ) as $path ) {
+			if ( ! preg_match( '!^/(?P<slug>[^/]+)/(?P<version>[^/]+)(?P<subpath>/.+)?$!', (string) $path, $m ) ) {
+				continue;
+			}
+
+			// A bare /slug/file names no version, so a changed file must sit inside the version directory to count.
+			if ( 'file' === (string) $path['kind'] && empty( $m['subpath'] ) ) {
+				continue;
+			}
+
+			return array( $m['slug'], $m['version'] );
+		}
+
+		return array( '', '' );
+	}
+
+	/**
 	 * Check for new SVN revisions on the target repo, and queue an import job for each matching.
 	 */
 	public static function watcher_trigger() {
@@ -56,15 +83,7 @@ class SVN_Import {
 		$theme_changes = array_filter( array_map( function( $element ) { 
 
 			// Get slug/version.
-			$slug = '';
-			$version = '';
-			foreach ( $element->xpath( 'paths/path[@kind="dir"]') as $path ) {
-				if ( preg_match( '!^/(?P<slug>[^/]+)/(?P<version>[^/]+)(/.+)?$!', (string) $path, $m ) ) {
-					$slug    = $m['slug'];
-					$version = $m['version'];
-					break;
-				}
-			}
+			list( $slug, $version ) = self::changed_slug_version( $element );
 			if ( ! $slug || ! $version ) {
 				return false;
 			}
@@ -87,7 +106,7 @@ class SVN_Import {
 			}
 
 			return $info;
-		}, $xml->xpath('/log/logentry') ) );
+		}, $xml->xpath( '/log/logentry' ) ) );
 
 		$theme_changes = array_unique( $theme_changes, SORT_REGULAR );
 

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/jobs/class-svn-import.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/jobs/class-svn-import.php
@@ -22,28 +22,29 @@ class SVN_Import {
 	/**
 	 * Determines the theme slug and version a changeset touched.
 	 *
-	 * Considers every changed path, not only directory nodes, so a file-only commit that
-	 * rewrites bytes inside an existing version is still routed to that version for
-	 * re-import and re-scan. Returns the first version path found in commit order.
-	 *
 	 * @param SimpleXMLElement $element A single `<logentry>` from `svn log -v --xml`.
 	 * @return array{0: string, 1: string} The slug and version, or empty strings when none matched.
 	 */
 	public static function changed_slug_version( $element ) {
+		$file_match = array( '', '' );
+
 		foreach ( $element->xpath( 'paths/path' ) as $path ) {
 			if ( ! preg_match( '!^/(?P<slug>[^/]+)/(?P<version>[^/]+)(?P<subpath>/.+)?$!', (string) $path, $m ) ) {
 				continue;
 			}
 
-			// A bare /slug/file names no version, so a changed file must sit inside the version directory to count.
-			if ( 'file' === (string) $path['kind'] && empty( $m['subpath'] ) ) {
-				continue;
+			// A directory node names the version; prefer it, as the watcher did before it looked at files.
+			if ( 'file' !== (string) $path['kind'] ) {
+				return array( $m['slug'], $m['version'] );
 			}
 
-			return array( $m['slug'], $m['version'] );
+			// A file counts only inside a version directory, and only as a fallback if no version directory changed.
+			if ( ! empty( $m['subpath'] ) && '' === $file_match[0] ) {
+				$file_match = array( $m['slug'], $m['version'] );
+			}
 		}
 
-		return array( '', '' );
+		return $file_match;
 	}
 
 	/**
@@ -106,7 +107,7 @@ class SVN_Import {
 			}
 
 			return $info;
-		}, $xml->xpath( '/log/logentry' ) ) );
+		}, $xml->xpath('/log/logentry') ) );
 
 		$theme_changes = array_unique( $theme_changes, SORT_REGULAR );
 

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Svn_Import_Changed_Version_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Svn_Import_Changed_Version_Test.php
@@ -37,9 +37,12 @@ class Svn_Import_Changed_Version_Test extends TestCase {
 			);
 		}
 
-		return simplexml_load_string(
+		$element = simplexml_load_string(
 			'<logentry revision="123"><author>author</author><msg>m</msg><paths>' . $path_xml . '</paths></logentry>'
 		);
+		$this->assertNotFalse( $element, 'The fixture XML failed to parse.' );
+
+		return $element;
 	}
 
 	/**
@@ -82,16 +85,33 @@ class Svn_Import_Changed_Version_Test extends TestCase {
 	}
 
 	/**
-	 * The first version path in commit order wins, whatever its node kind.
+	 * A changed version directory wins over a file edited in an older version.
+	 *
+	 * SVN lists paths alphabetically, so the older version's file comes first; the import
+	 * must still route to the newly added version, not re-import the old one.
 	 */
-	public function test_first_version_path_wins(): void {
+	public function test_directory_wins_over_older_version_file(): void {
 		$entry = $this->log_entry(
 			array(
-				array( 'file', '/my-theme/2.0/style.css' ),
-				array( 'dir', '/other-theme/1.0' ),
+				array( 'file', '/my-theme/1.4/functions.php' ),
+				array( 'dir', '/my-theme/2.0' ),
 			)
 		);
 
 		$this->assertSame( array( 'my-theme', '2.0' ), SVN_Import::changed_slug_version( $entry ) );
+	}
+
+	/**
+	 * With no version directory in the commit, the first changed file's version wins.
+	 */
+	public function test_first_file_version_wins_without_directory(): void {
+		$entry = $this->log_entry(
+			array(
+				array( 'file', '/my-theme/1.4/functions.php' ),
+				array( 'file', '/my-theme/1.5/style.css' ),
+			)
+		);
+
+		$this->assertSame( array( 'my-theme', '1.4' ), SVN_Import::changed_slug_version( $entry ) );
 	}
 }

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Svn_Import_Changed_Version_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Svn_Import_Changed_Version_Test.php
@@ -1,10 +1,11 @@
 <?php
 /**
- * Tests that the SVN watcher routes a changeset to the version it touched.
+ * Tests that the SVN watcher finds every version a changeset touched.
  *
  * A file-only commit rewrites bytes inside an existing version without adding or
- * removing a directory node. Such a commit must still be scheduled for re-import
- * and re-scan, so the path selection considers file paths, not only directories.
+ * removing a directory node, and one commit may touch several versions. Each must
+ * be scheduled for re-import and re-scan, so the path selection considers file
+ * paths, not only directories, and returns every version it finds.
  *
  * @package theme-directory
  */
@@ -15,7 +16,7 @@ use PHPUnit\Framework\TestCase;
 use WordPressdotorg\Theme_Directory\Jobs\SVN_Import;
 
 /**
- * Covers SVN_Import::changed_slug_version().
+ * Covers SVN_Import::changed_slug_versions().
  *
  * @group svn-import
  */
@@ -46,16 +47,16 @@ class Svn_Import_Changed_Version_Test extends TestCase {
 	}
 
 	/**
-	 * A directory node for a version routes to that version, as it always has.
+	 * A directory node for a version selects that version.
 	 */
 	public function test_directory_commit_selects_version(): void {
 		$entry = $this->log_entry( array( array( 'dir', '/my-theme/1.4' ) ) );
 
-		$this->assertSame( array( 'my-theme', '1.4' ), SVN_Import::changed_slug_version( $entry ) );
+		$this->assertSame( array( array( 'my-theme', '1.4' ) ), SVN_Import::changed_slug_versions( $entry ) );
 	}
 
 	/**
-	 * A file-only commit inside a version routes to that version.
+	 * A file-only commit inside a version selects that version.
 	 *
 	 * This is the case the watcher previously skipped, letting post-review bytes
 	 * ship without a re-scan.
@@ -63,7 +64,7 @@ class Svn_Import_Changed_Version_Test extends TestCase {
 	public function test_file_only_commit_selects_version(): void {
 		$entry = $this->log_entry( array( array( 'file', '/my-theme/1.4/functions.php' ) ) );
 
-		$this->assertSame( array( 'my-theme', '1.4' ), SVN_Import::changed_slug_version( $entry ) );
+		$this->assertSame( array( array( 'my-theme', '1.4' ) ), SVN_Import::changed_slug_versions( $entry ) );
 	}
 
 	/**
@@ -72,7 +73,17 @@ class Svn_Import_Changed_Version_Test extends TestCase {
 	public function test_theme_root_file_selects_nothing(): void {
 		$entry = $this->log_entry( array( array( 'file', '/my-theme/readme.txt' ) ) );
 
-		$this->assertSame( array( '', '' ), SVN_Import::changed_slug_version( $entry ) );
+		$this->assertSame( array(), SVN_Import::changed_slug_versions( $entry ) );
+	}
+
+	/**
+	 * A node with no `kind` attribute makes no version from a bare `/slug/x` path,
+	 * matching the watcher's former directory-only guard.
+	 */
+	public function test_kindless_theme_root_node_selects_nothing(): void {
+		$entry = $this->log_entry( array( array( '', '/my-theme/assets' ) ) );
+
+		$this->assertSame( array(), SVN_Import::changed_slug_versions( $entry ) );
 	}
 
 	/**
@@ -81,16 +92,13 @@ class Svn_Import_Changed_Version_Test extends TestCase {
 	public function test_no_version_path_selects_nothing(): void {
 		$entry = $this->log_entry( array( array( 'dir', '/my-theme' ) ) );
 
-		$this->assertSame( array( '', '' ), SVN_Import::changed_slug_version( $entry ) );
+		$this->assertSame( array(), SVN_Import::changed_slug_versions( $entry ) );
 	}
 
 	/**
-	 * A changed version directory wins over a file edited in an older version.
-	 *
-	 * SVN lists paths alphabetically, so the older version's file comes first; the import
-	 * must still route to the newly added version, not re-import the old one.
+	 * A commit that adds a version and edits an older version's files selects both.
 	 */
-	public function test_directory_wins_over_older_version_file(): void {
+	public function test_mixed_commit_selects_every_version(): void {
 		$entry = $this->log_entry(
 			array(
 				array( 'file', '/my-theme/1.4/functions.php' ),
@@ -98,13 +106,16 @@ class Svn_Import_Changed_Version_Test extends TestCase {
 			)
 		);
 
-		$this->assertSame( array( 'my-theme', '2.0' ), SVN_Import::changed_slug_version( $entry ) );
+		$this->assertSame(
+			array( array( 'my-theme', '1.4' ), array( 'my-theme', '2.0' ) ),
+			SVN_Import::changed_slug_versions( $entry )
+		);
 	}
 
 	/**
-	 * With no version directory in the commit, the first changed file's version wins.
+	 * A file-only commit editing several versions selects each of them.
 	 */
-	public function test_first_file_version_wins_without_directory(): void {
+	public function test_file_only_commit_selects_every_version(): void {
 		$entry = $this->log_entry(
 			array(
 				array( 'file', '/my-theme/1.4/functions.php' ),
@@ -112,6 +123,23 @@ class Svn_Import_Changed_Version_Test extends TestCase {
 			)
 		);
 
-		$this->assertSame( array( 'my-theme', '1.4' ), SVN_Import::changed_slug_version( $entry ) );
+		$this->assertSame(
+			array( array( 'my-theme', '1.4' ), array( 'my-theme', '1.5' ) ),
+			SVN_Import::changed_slug_versions( $entry )
+		);
+	}
+
+	/**
+	 * Several changed paths within one version collapse to a single entry.
+	 */
+	public function test_paths_in_one_version_are_deduplicated(): void {
+		$entry = $this->log_entry(
+			array(
+				array( 'dir', '/my-theme/2.0' ),
+				array( 'file', '/my-theme/2.0/style.css' ),
+			)
+		);
+
+		$this->assertSame( array( array( 'my-theme', '2.0' ) ), SVN_Import::changed_slug_versions( $entry ) );
 	}
 }

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Svn_Import_Changed_Version_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Svn_Import_Changed_Version_Test.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Tests that the SVN watcher routes a changeset to the version it touched.
+ *
+ * A file-only commit rewrites bytes inside an existing version without adding or
+ * removing a directory node. Such a commit must still be scheduled for re-import
+ * and re-scan, so the path selection considers file paths, not only directories.
+ *
+ * @package theme-directory
+ */
+
+declare( strict_types = 1 );
+
+use PHPUnit\Framework\TestCase;
+use WordPressdotorg\Theme_Directory\Jobs\SVN_Import;
+
+/**
+ * Covers SVN_Import::changed_slug_version().
+ *
+ * @group svn-import
+ */
+class Svn_Import_Changed_Version_Test extends TestCase {
+
+	/**
+	 * Builds a `<logentry>` element from a list of changed paths.
+	 *
+	 * @param array<int, array{0: string, 1: string}> $paths Pairs of SVN node kind and path.
+	 * @return SimpleXMLElement
+	 */
+	private function log_entry( array $paths ): SimpleXMLElement {
+		$path_xml = '';
+		foreach ( $paths as $path ) {
+			$path_xml .= sprintf(
+				'<path kind="%1$s" action="M">%2$s</path>',
+				$path[0],
+				$path[1]
+			);
+		}
+
+		return simplexml_load_string(
+			'<logentry revision="123"><author>author</author><msg>m</msg><paths>' . $path_xml . '</paths></logentry>'
+		);
+	}
+
+	/**
+	 * A directory node for a version routes to that version, as it always has.
+	 */
+	public function test_directory_commit_selects_version(): void {
+		$entry = $this->log_entry( array( array( 'dir', '/my-theme/1.4' ) ) );
+
+		$this->assertSame( array( 'my-theme', '1.4' ), SVN_Import::changed_slug_version( $entry ) );
+	}
+
+	/**
+	 * A file-only commit inside a version routes to that version.
+	 *
+	 * This is the case the watcher previously skipped, letting post-review bytes
+	 * ship without a re-scan.
+	 */
+	public function test_file_only_commit_selects_version(): void {
+		$entry = $this->log_entry( array( array( 'file', '/my-theme/1.4/functions.php' ) ) );
+
+		$this->assertSame( array( 'my-theme', '1.4' ), SVN_Import::changed_slug_version( $entry ) );
+	}
+
+	/**
+	 * A file directly under the theme root names no version and is ignored.
+	 */
+	public function test_theme_root_file_selects_nothing(): void {
+		$entry = $this->log_entry( array( array( 'file', '/my-theme/readme.txt' ) ) );
+
+		$this->assertSame( array( '', '' ), SVN_Import::changed_slug_version( $entry ) );
+	}
+
+	/**
+	 * A commit that touches no theme version path selects nothing.
+	 */
+	public function test_no_version_path_selects_nothing(): void {
+		$entry = $this->log_entry( array( array( 'dir', '/my-theme' ) ) );
+
+		$this->assertSame( array( '', '' ), SVN_Import::changed_slug_version( $entry ) );
+	}
+
+	/**
+	 * The first version path in commit order wins, whatever its node kind.
+	 */
+	public function test_first_version_path_wins(): void {
+		$entry = $this->log_entry(
+			array(
+				array( 'file', '/my-theme/2.0/style.css' ),
+				array( 'dir', '/other-theme/1.0' ),
+			)
+		);
+
+		$this->assertSame( array( 'my-theme', '2.0' ), SVN_Import::changed_slug_version( $entry ) );
+	}
+}

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Svn_Import_Changed_Version_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Svn_Import_Changed_Version_Test.php
@@ -96,6 +96,24 @@ class Svn_Import_Changed_Version_Test extends TestCase {
 	}
 
 	/**
+	 * A non-version directory (a name not starting with a digit) is not a version.
+	 */
+	public function test_non_version_directory_selects_nothing(): void {
+		$entry = $this->log_entry( array( array( 'dir', '/my-theme/assets' ) ) );
+
+		$this->assertSame( array(), SVN_Import::changed_slug_versions( $entry ) );
+	}
+
+	/**
+	 * A file nested under a non-version directory is not a version either.
+	 */
+	public function test_file_under_non_version_directory_selects_nothing(): void {
+		$entry = $this->log_entry( array( array( 'file', '/my-theme/assets/app.js' ) ) );
+
+		$this->assertSame( array(), SVN_Import::changed_slug_versions( $entry ) );
+	}
+
+	/**
 	 * A commit that adds a version and edits an older version's files selects both.
 	 */
 	public function test_mixed_commit_selects_every_version(): void {


### PR DESCRIPTION
Two small robustness fixes to the SVN import/scan pipeline.

## Schedule imports for file-only SVN commits

`SVN_Import`'s revision watcher extracted the theme slug and version only from changed paths whose SVN node kind was a directory (`paths/path[@kind="dir"]`). A commit that changes only files inside an existing version directory produces no directory path, so it scheduled no import — yet the watcher still advanced `svn_import_last_revision` past it, so the change was never picked up.

The slug/version regex already handles file paths, so the fix is to consider every changed path. A bare `/slug/file` (a file directly under the theme root) names no version, so a changed file must sit inside a version directory to count. The path selection is extracted into `SVN_Import::changed_slug_version()` and covered by a new test.

## Ignore SVN externals on review exports

The theme import (`WPORG_Themes_Upload::process_update_from_svn()`) and the plugin scan (`Plugin_Scan::export_plugin_locally()`) both `svn export` a committer-controlled tree for review. Neither passed `--ignore-externals`, so Subversion would resolve any `svn:externals` property on the tree and pull in the referenced content. Both exports now restrict themselves to the tree's own contents.

## Tests

`Svn_Import_Changed_Version_Test` covers the path selection (directory, file-only, theme-root file, no-version, and first-match ordering). New test 5/5; full theme-directory suite green (66). The plugin scan change is a single additional export flag.

## Follow-up (not in this PR)

The watcher still selects only the first matching version in a commit and advances the checkpoint regardless; scheduling every affected version and gating the checkpoint on their success would be a further improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented external repository content from being unintentionally included in plugin and theme exports.
  * Improved theme update detection across multiple versions and changed files.
  * Ignored unrelated root-level and non-version changes during theme imports.
  * Prevented duplicate processing when multiple paths affect the same theme version.

* **Tests**
  * Added coverage for directory changes, file-only changes, multiple affected versions, unrelated paths, and duplicate paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->