### PR TITLE
Style: Stop link colours repainting block button labels

### DIFF
--- a/wordpress.org/public_html/style/wp4-rtl.css
+++ b/wordpress.org/public_html/style/wp4-rtl.css
@@ -47,7 +47,7 @@ pre {
 
 pre a { font-weight: normal; }
 
-a {
+a:where(:not(.wp-element-button)) {
 	color: #21759b;
 	text-decoration: none;
 	font-weight: normal;
@@ -57,7 +57,7 @@ strong a {
 	font-weight: bold;
 }
 
-a:visited {
+a:visited:where(:not(.wp-element-button)) {
 	color: #4ca6cf;
 }
 
@@ -71,7 +71,27 @@ h3 a { font-weight: bold; }
 
 p a:hover { border-bottom: 1px solid #d54e21; }
 
-a:hover { color: #d54e21; }
+a:hover:where(:not(.wp-element-button)) { color: #d54e21; }
+
+/*
+ * Buttons are not body links. The link colours above are more specific than the
+ * button colours the block theme emits, which is `:root :where( .wp-block-button
+ * .wp-block-button__link )`, so without the `:not( .wp-element-button )` guards
+ * they repaint button labels. These rules restore the hover, focus and active
+ * states from the same button custom properties the wporg parent theme uses, for
+ * pages that load wp4.css and not the parent theme's button stylesheet.
+ * See https://meta.trac.wordpress.org/ticket/8418
+ */
+.wp-block-button__link:hover,
+.wp-block-button__link:focus {
+	color: var( --wp--custom--button--hover--color--text, #fff );
+	background-color: var( --wp--custom--button--hover--color--background, #213fd4 );
+}
+
+.wp-block-button__link:active {
+	color: var( --wp--custom--button--active--color--text, #fff );
+	background-color: var( --wp--custom--button--active--color--background, #1e1e1e );
+}
 
 h2,
 h1.heading {

--- a/wordpress.org/public_html/style/wp4.css
+++ b/wordpress.org/public_html/style/wp4.css
@@ -47,8 +47,8 @@ pre {
 
 pre a { font-weight: normal; }
 
-a:link, /* https://wordpress.slack.com/archives/C02QB2JS7/p1768980644711199 */
-a {
+a:link:where(:not(.wp-element-button)), /* https://wordpress.slack.com/archives/C02QB2JS7/p1768980644711199 */
+a:where(:not(.wp-element-button)) {
 	color: #21759b;
 	text-decoration: none;
 	font-weight: normal;
@@ -58,7 +58,7 @@ strong a {
 	font-weight: bold;
 }
 
-a:visited {
+a:visited:where(:not(.wp-element-button)) {
 	color: #4ca6cf;
 }
 
@@ -72,7 +72,27 @@ h3 a { font-weight: bold; }
 
 p a:hover { border-bottom: 1px solid #d54e21; }
 
-a:hover { color: #d54e21; }
+a:hover:where(:not(.wp-element-button)) { color: #d54e21; }
+
+/*
+ * Buttons are not body links. The link colours above are more specific than the
+ * button colours the block theme emits, which is `:root :where( .wp-block-button
+ * .wp-block-button__link )`, so without the `:not( .wp-element-button )` guards
+ * they repaint button labels. These rules restore the hover, focus and active
+ * states from the same button custom properties the wporg parent theme uses, for
+ * pages that load wp4.css and not the parent theme's button stylesheet.
+ * See https://meta.trac.wordpress.org/ticket/8418
+ */
+.wp-block-button__link:hover,
+.wp-block-button__link:focus {
+	color: var( --wp--custom--button--hover--color--text, #fff );
+	background-color: var( --wp--custom--button--hover--color--background, #213fd4 );
+}
+
+.wp-block-button__link:active {
+	color: var( --wp--custom--button--active--color--text, #fff );
+	background-color: var( --wp--custom--button--active--color--background, #1e1e1e );
+}
 
 h2,
 h1.heading {


### PR DESCRIPTION
Trac ticket: https://meta.trac.wordpress.org/ticket/8418

## The problem

Buttons on https://planet.wordpress.org/ render their label in the body link colour on top of the button's own background, so the label is close to invisible.

| State | Colours | Ratio |
| --- | --- | --- |
| rest | `#21759b` on `#3858e9` | **1.09:1** |
| hover | `#d54e21` on `#3858e9` | **1.32:1** |
| visited | `#4ca6cf` on `#3858e9` | **2.05:1** |

## Why it happens

The block theme emits its button colours through global styles:

```css
:root :where( .wp-block-button .wp-block-button__link ) {
	background-color: var( --wp--custom--button--color--background );
	color: var( --wp--custom--button--color--text );
}
```

That selector is specificity **(0,1,0)** — `:root` is the only thing that counts, `:where()` adds nothing.

The link rules in `wp4.css` are **(0,1,1)**:

```css
a:link,
a { color: #21759b; }

a:visited { color: #4ca6cf; }

a:hover   { color: #d54e21; }
```

So the link colour wins on `color` while the button keeps its own `background-color`. The custom properties are fine, `--wp--custom--button--color--text` resolves to `#ffffff`; they are simply being overridden.

`a:hover` and `a:visited` have always been (0,1,1), so those two states have been wrong for a while. The rest state broke when `a:link` was added alongside `a`: `a` on its own is (0,0,1), which loses to the button rule. `wp4-rtl.css` has not been regenerated since that change, which is why it still has a bare `a` and why the rest state still looks correct in RTL.

## The change

Guard the three link rules with `:where( :not( .wp-element-button ) )`. `:where()` contributes zero specificity, so **(0,1,1) and (0,0,1) are unchanged** and nothing else in the cascade shifts; only the match set narrows. This is the idiom core already uses on the same pages, for example `:root :where( a:where( :not( .wp-element-button ) ):hover )`.

Excluding buttons from `a:hover` also removes the only hover feedback Planet had, so this adds the hover, focus and active states from the button custom properties the wporg parent theme already defines. Pages that load the parent theme's button stylesheet are unaffected: those rules are `[class*="wp-block"] .wp-block-button__link:hover` at (0,2,0) and load after `wp4.css`.

The same change is applied to `wp4-rtl.css`, which is generated by `grunt css`. That file already looks out of date relative to `wp4.css`, so this PR makes the equivalent change rather than regenerating it, to keep the diff reviewable.

## Testing

Measured on https://planet.wordpress.org/ with `wp4.css` swapped for the patched file at the same position in the cascade.

| State | Before | After |
| --- | --- | --- |
| rest | `#21759b` on `#3858e9`, 1.09:1 | `#ffffff` on `#3858e9`, **5.61:1** |
| hover | `#d54e21` on `#3858e9`, 1.32:1 | `#ffffff` on `#213fd4`, **7.70:1** |
| active | not styled | `#ffffff` on `#1e1e1e`, **16.67:1** |

The hover result matches https://wordpress.org/download/, which does not load `wp4.css` and gets these states from the parent theme.

No regressions found on the Planet front page:

- 1,335 non-button links keep `#21759b`. The full link colour census is identical before and after.
- The search icon button is unchanged at `rgb(30, 30, 30)`.
- Buttons no longer match the link rules; ordinary links still do.

### Steps to reproduce the original bug

1. Visit https://planet.wordpress.org/
2. Look at the "Read the Letter", "Download WordPress 7.1" and "Check out what's new in 7.1" buttons.
3. The labels are the body link colour on the button background, and turn orange on hover.

Screenshots of the before and after states are on the Trac ticket.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved button link styling for clearer hover, focus, and active states.
  * Prevented generic link colors from overriding block button appearance.
  * Added fallback colors to maintain consistent button styling across themes and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->