### PR TITLE
Planet: Keep syndicated entry content inside the column

### DIFF
--- a/wordpress.org/public_html/style/wp4-rtl.css
+++ b/wordpress.org/public_html/style/wp4-rtl.css
@@ -232,6 +232,23 @@ a img.aligncenter {
 	height: auto;
 }
 
+/*
+ * Syndicated entries can arrive with pixel widths baked into the markup by the
+ * source site, for example the 560px email column that newsletter plugins put on
+ * separators. `.wrapper img` above is constrained for the same reason; these are
+ * the other elements that turn up with a hardcoded width and push the page
+ * sideways on narrow screens.
+ * See https://meta.trac.wordpress.org/ticket/8419
+ */
+.wrapper .entry hr,
+.wrapper .entry table,
+.wrapper .entry iframe,
+.wrapper .entry video,
+.wrapper .entry embed,
+.wrapper .entry object {
+	max-width: 100%;
+}
+
 #wporg-header {
 	position: relative;
 	height: 140px;

--- a/wordpress.org/public_html/style/wp4.css
+++ b/wordpress.org/public_html/style/wp4.css
@@ -233,6 +233,23 @@ a img.aligncenter {
 	height: auto;
 }
 
+/*
+ * Syndicated entries can arrive with pixel widths baked into the markup by the
+ * source site, for example the 560px email column that newsletter plugins put on
+ * separators. `.wrapper img` above is constrained for the same reason; these are
+ * the other elements that turn up with a hardcoded width and push the page
+ * sideways on narrow screens.
+ * See https://meta.trac.wordpress.org/ticket/8419
+ */
+.wrapper .entry hr,
+.wrapper .entry table,
+.wrapper .entry iframe,
+.wrapper .entry video,
+.wrapper .entry embed,
+.wrapper .entry object {
+	max-width: 100%;
+}
+
 #wporg-header {
 	position: relative;
 	height: 140px;


### PR DESCRIPTION
Trac ticket: https://meta.trac.wordpress.org/ticket/8419

## The problem

At a 375px viewport, https://planet.wordpress.org/ scrolls **234px sideways**.

The cause is content Planet republished from another site. A post currently in the feed was written with newsletter blocks, and those emit separators with the email column width baked into the markup:

```html
<hr style="background-color: transparent; color: transparent; margin: 0; border: 0; border-top: 1px solid #666666; width: 560px; height: 0;">
```

560px is the width the newsletter plugin renders for. Planet puts that inside a column that is 342px wide at a 360px viewport.

Measured on the live page at 375px: three of these separators, each overhanging by 234px, and they are the **only** elements escaping the viewport. At 768px and above nothing overflows, because the column is wider than 560px.

## The change

`wp4.css` already guards against exactly this, for one element type:

```css
.wrapper img {
	max-width: 100%;
	height: auto;
}
```

This extends the same guard to the other elements that arrive from a feed with a hardcoded width, scoped to `.entry` so it only affects syndicated content and not wordpress.org's own layout.

## Testing

Measured on https://planet.wordpress.org/ by injecting the rule and re-measuring real horizontal scrollability.

| | Before | After |
| --- | --- | --- |
| Horizontal scroll at 375px | **234px** | **0px** |
| Elements escaping the viewport | 3 (`hr`) | 0 |
| The 560px separator | 560px wide | 302px, inside its 342px parent |

**No regressions at 1440px.** The rule is a no-op there: 40 `hr`, 14 `table` and 90 `img` elements all keep their existing widths, the document height is identical at 75,139px, and horizontal scroll is 0 before and after.

Screenshots of the same viewport before and after, showing the horizontal scrollbar disappear, are attached to the Trac ticket.

## On the second half of the ticket

The ticket also reports missing article images. **I could not reproduce that.** On the current page all 91 images load, from `i0.wp.com` and `s.w.org`, with zero broken images and zero failed network requests.

The post in the reporter's screenshot is still in the feed, and both of the images that appear broken there load correctly now, so that looks like a transient CDN failure rather than a defect in Planet.

Worth recording why it looked so severe: those images sit in a gallery block whose own background is `rgb(0, 0, 0)`, set by the source post. When an image fails, the fallback is alt text on black, which is why the screenshot shows black rectangles. That styling comes from the syndicated content, so it is not something Planet sets.

This PR therefore only addresses the overflow, which is reproducible and measurable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsive display of embedded content, tables, videos, iframes, and other entry elements.
  * Prevented fixed-width content from overflowing its container on different screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->