### PR TITLE
Showcase: Escape the `domain` post meta at output

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/404.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/404.php
@@ -17,7 +17,7 @@ $wp_query = new WP_Query( array( 'no_found_rows' => true, 'post_type' => 'post',
 								<p><?php _e( 'Sorry, we could not not find that site in the Showcase. We do have many others available though. Here&#8217;s one chosen at random!', 'wporg-showcase' ); ?></p>
 								<?php //breadcrumb(); ?>
 								<h2><?php the_title(); ?></h2>
-								<a href=' http://<?php get_site_domain( false ); ?>'>
+								<a href="<?php echo esc_url( 'http://' . get_site_domain( false, false ) ); ?>">
 									<?php site_screenshot_tag( 518, 'screenshot site-screenshot'); ?>
 								</a>
 								<?php the_content(); ?>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/feed-extras.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/feed-extras.php
@@ -57,7 +57,7 @@ $more = 1;
 		<wfw:commentRss><?php echo get_post_comments_feed_link(); ?></wfw:commentRss>
 
 		<showcase:screenshotURL><?php site_screenshot_src(); ?></showcase:screenshotURL>
-		<showcase:domain><?php get_site_domain(false, true, false); ?></showcase:domain>
+		<showcase:domain><?php echo esc_html( get_site_domain( false, false, false ) ); ?></showcase:domain>
 
 <?php rss_enclosure(); ?>
 	<?php do_action('rss2_item'); ?>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/functions.php
@@ -16,6 +16,18 @@ add_action( 'wp_head', function () {
 	}
 }, 1 );
 
+/**
+ * Returns the `domain` post meta of the current showcase entry.
+ *
+ * The return value is unescaped, so that callers can compose it into a URL
+ * before escaping for their own context. Every caller that prints it must
+ * escape it: `esc_url()` in an `href`, `esc_html()` in element content.
+ *
+ * @param bool $rep_slash       Percent-encode slashes, for the screenshot service.
+ * @param bool $echo            Print the value (escaped as element content) as well as returning it.
+ * @param bool $rem_trail_slash Drop a trailing slash.
+ * @return string The unescaped domain.
+ */
 function get_site_domain( $rep_slash = true, $echo = true, $rem_trail_slash = false ) {
 	global $post;
 
@@ -31,8 +43,11 @@ function get_site_domain( $rep_slash = true, $echo = true, $rem_trail_slash = fa
 	if ( $rep_slash )
 		$domain = str_replace('/', '%2F', $domain );
 
-	if ( $echo ) echo $domain;
-	else return $domain;
+	if ( $echo ) {
+		echo esc_html( $domain );
+	}
+
+	return $domain;
 }
 
 function site_screenshot_src( $width = '', $echo = true ) {
@@ -114,8 +129,16 @@ function wp_flavors() {
 }
 
 function blockquote_style( $content ) {
-	if ( is_single() )
-		$content = str_replace( '</blockquote>', '<cite>' . __( 'Source:', 'wporg-showcase' ). ' <a href="http://' . get_site_domain( false, false ) . '">' . get_site_domain( false, false, true ) . '</a></cite><div class="clear"></div></blockquote>', $content );
+	if ( is_single() ) {
+		$cite = sprintf(
+			'<cite>%1$s <a href="%2$s">%3$s</a></cite><div class="clear"></div></blockquote>',
+			esc_html__( 'Source:', 'wporg-showcase' ),
+			esc_url( 'http://' . get_site_domain( false, false ) ),
+			esc_html( get_site_domain( false, false, true ) )
+		);
+
+		$content = str_replace( '</blockquote>', $cite, $content );
+	}
 
 	return $content;
 }

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/sidebar-right-single.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/sidebar-right-single.php
@@ -1,7 +1,15 @@
+<?php
+/**
+ * Sidebar shown alongside a single showcase entry.
+ *
+ * @package wporg-showcase
+ */
+
+?>
 		<div class="col-3 rightsidebar">
 			<div class="rightsidebarwrapper">
 			<div class="currentSiteRating">
-				<p class="button"><a href="http://<?php get_site_domain( false ); ?>"><?php _e( 'Visit Site', 'wporg-showcase' ); ?></a></p>
+				<p class="button"><a href="<?php echo esc_url( 'http://' . get_site_domain( false, false ) ); ?>"><?php esc_html_e( 'Visit Site', 'wporg-showcase' ); ?></a></p>
 
 				<?php wp_flavors(); ?>
 				<br />

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/single.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/single.php
@@ -10,7 +10,7 @@
 					<div class="col-5">
 						<div class="storycontent">
 								<?php breadcrumb(); ?>
-								<a href='http://<?php get_site_domain( false ); ?>'>
+								<a href="<?php echo esc_url( 'http://' . get_site_domain( false, false ) ); ?>">
 									<?php site_screenshot_tag( 518, 'screenshot site-screenshot'); ?>
 								</a>
 								<?php the_content(); ?>


### PR DESCRIPTION
### Why

`get_site_domain()` in `wporg-showcase` returns the `domain` custom field after two transformations: it strips a leading `http(s)://`, and for the screenshot service it percent-encodes slashes. Neither touches `'`, `"`, `<` or `>`, and the function applies no escaper on the way out.

Five templates concatenate that return value straight into markup, and three of them build the anchor by hand as `href='http://<value>'`, so the attribute is terminated by whatever the value contains rather than by the template.

The theme escapes the value immediately beside it: `site_screenshot_tag()` runs `alt` through `the_title_attribute()` on the same line that builds the `src`. So this is an inconsistency inside one file rather than the theme's style. r15045 escaped the neighbouring `image` custom field in these same two templates and left `domain` as it was.

### What changed

- `single.php`, `404.php` and `sidebar-right-single.php` now compose the URL and pass it through `esc_url()`, rather than dropping the value inside a hand-written attribute. This also removes the stray leading space inside the `404.php` `href`, the same fix r10427 applied to `single.php`.
- `blockquote_style()` uses the value twice, once in an `href` and once as element content, so those get `esc_url()` and `esc_html()` respectively. The `Source:` string is escaped like the theme's other translated output.
- `feed-extras.php` prints it into the `<showcase:domain>` node, now through `esc_html()`.
- `get_site_domain()` keeps returning the raw value. `site_screenshot_src()` composes it into a URL that is escaped later, and escaping inside the accessor would corrupt query strings. That constraint is now written on the function. Its `$echo` branch has no callers left after this change, so it escapes as element content instead of staying a bare `echo`.
- `sidebar-right-single.php` also gains a file doc comment and `esc_html_e()`, which the changed-line linter asks for on the line this touches.

### Testing

Rendered inside wp-env on WordPress 7.2-alpha-63409. A `get_post_metadata` filter supplies the meta and the post is a fabricated `WP_Post`, so the run writes nothing and does not switch the site's theme. With a value carrying quote characters and angle brackets, all five positions render it as inert text and the attribute is no longer closed early.

Compatibility on real data: `env/showcase-posts.xml` in [wporg-showcase-2022](https://github.com/WordPress/wporg-showcase-2022) carries 76 unique `domain` values. Rendering each through the old and the new code in all six positions gives 456 comparisons, and the href value is byte-identical in 76 of 76. The only rendering differences are the two intentional ones: `single.php` and `404.php` move from a single-quoted to a double-quoted attribute, and the `404.php` leading space goes. `esc_url()` is a no-op across the whole corpus, since the only non-alphanumeric characters in any of the 76 values are `.`, `/` and `:`.

`BASE_REF=trunk php .github/bin/phpcs-branch.php` reports nothing on the changed lines. Note that `composer install` needs PHP 8.4 here, because the lock pins `doctrine/instantiator` 2.1.0.

### Notes

- The theme looks superseded by wporg-showcase-2022. Its last functional change was r11912 in June 2022; everything since is output escaping. r15045 already said that removing it would be the better close. I agree, and I have kept this PR to the escaping so the removal can be decided on its own.
- `site_screenshot_src()` builds the mshots URL by concatenating a `%2F`-encoded domain rather than `urlencode()`ing the whole thing, so a value carrying `?` or `&` produces a malformed URL. The output is escaped, so it is cosmetic. wporg-showcase-2022 uses `urlencode()` for this. Left alone.
- `single.php` and `404.php` were not rendered as whole files, which needs a running showcase site. The expression in both is byte-identical to the one in `sidebar-right-single.php`, which was rendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
