### PR TITLE
Photo Directory: make EXIF value handling consistent and escape metadata output

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/admin.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/admin.php
@@ -166,8 +166,8 @@ class Admin {
 			esc_attr( $notice_type ),
 			sprintf(
 				$notice,
-				'https://profiles.wordpress.org/' . $user->user_nicename . '/',
-				sanitize_text_field( $user->display_name )
+				esc_url( 'https://profiles.wordpress.org/' . $user->user_nicename . '/' ),
+				esc_html( $user->display_name )
 			)
 		);
 	}

--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/flagged.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/flagged.php
@@ -286,7 +286,7 @@ class Flagged {
 				. sprintf(
 					/* translators: %s: Count of user's flagged photos possibly linked to listing of their flagged photos. */
 					_n( 'Flagged: <strong>%s</strong>', 'Flagged: <strong>%s</strong>', $flagged_count, 'wporg-photos' ),
-					$flagged_link ? sprintf( '<a href="%s">%d</a>', $flagged_link, $flagged_count ) : $flagged_count
+					$flagged_link ? sprintf( '<a href="%s">%d</a>', esc_url( $flagged_link ), $flagged_count ) : $flagged_count
 				)
 				. "</div>\n";
 		}

--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/moderation.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/moderation.php
@@ -759,7 +759,7 @@ https://wordpress.org/photos/
 		foreach ( $pending as $post ) {
 			$content .= sprintf(
 				"<tr><td>%s</td><td>%s</td><td>%s</td></tr>\n",
-				esc_html( get_post_meta( $post->ID, Registrations::get_meta_key( 'original_filename' ), true ) ?: __( "(unknown)", 'wporg-photos' ) ),
+				esc_html( get_post_meta( $post->ID, Registrations::get_meta_key( 'original_filename' ), true ) ?: __( '(unknown)', 'wporg-photos' ) ),
 				esc_html( get_the_date( 'Y-m-d', $post ) ),
 				esc_html( get_the_content( null, false, $post ) ?: __( '(none provided)', 'wporg-photos' ) ),
 			);

--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/moderation.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/moderation.php
@@ -759,8 +759,8 @@ https://wordpress.org/photos/
 		foreach ( $pending as $post ) {
 			$content .= sprintf(
 				"<tr><td>%s</td><td>%s</td><td>%s</td></tr>\n",
-				get_post_meta( $post->ID, Registrations::get_meta_key( 'original_filename' ), true ) ?: __( "(unknown)", 'wporg-photos' ),
-				get_the_date( 'Y-m-d', $post ),
+				esc_html( get_post_meta( $post->ID, Registrations::get_meta_key( 'original_filename' ), true ) ?: __( "(unknown)", 'wporg-photos' ) ),
+				esc_html( get_the_date( 'Y-m-d', $post ) ),
 				esc_html( get_the_content( null, false, $post ) ?: __( '(none provided)', 'wporg-photos' ) ),
 			);
 		}

--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/photo.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/photo.php
@@ -956,6 +956,11 @@ $exif = self::exif_read_data_as_data_stream( $file );
 					break;
 				case 'iso':
 					$label = 'ISO';
+					// Cast to discard the arbitrary string EXIF can supply for this tag.
+					$value = (int) $value;
+					if ( 0 >= $value ) {
+						continue 2;
+					}
 					break;
 				case 'shutter_speed':
 					$label = 'Shutter Speed';
@@ -1124,7 +1129,7 @@ $exif = self::exif_read_data_as_data_stream( $file );
 			$link = sprintf(
 				'<span id="photo-moderator"><a href="%s">%s</a></span>',
 				esc_url( 'https://profiles.wordpress.org/' . $moderator->user_nicename . '/' ),
-				sanitize_text_field( $moderator->display_name )
+				esc_html( $moderator->display_name )
 			);
 		}
 

--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/template-tags.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/template-tags.php
@@ -37,7 +37,7 @@ function show_colors( $post = 0, $echo = true ) {
 			'<span class="photo-color photo-color-%s"><a href="%s">%s</a></span>',
 			esc_attr( $color->slug ),
 			esc_url( get_term_link( $color->slug, Registrations::get_taxonomy( 'colors' ) ) ),
-			$color->name
+			esc_html( $color->name )
 		);
 	}
 	$output .= implode( ', ', $colors_output );
@@ -82,7 +82,7 @@ function show_categories( $post = 0, $echo = true ) {
 			'<a class="photo-category photo-category-%s" href="%s">%s</a>',
 			esc_attr( $cat->slug ),
 			esc_url( get_term_link( $cat->slug, Registrations::get_taxonomy( 'categories' ) ) ),
-			$cat->name
+			esc_html( $cat->name )
 		);
 	}
 	$output .= implode( ', ', $cats_output );
@@ -127,7 +127,7 @@ function show_tags( $post = 0, $echo = true ) {
 			'<li class="photo-tag photo-tag-%s"><a href="%s">%s</a></li>',
 			esc_attr( $tag->slug ),
 			esc_url( get_term_link( $tag->slug, Registrations::get_taxonomy( 'tags' ) ) ),
-			$tag->name
+			esc_html( $tag->name )
 		);
 	}
 
@@ -206,8 +206,8 @@ function show_exif( $post = 0, $echo = true ) {
 		$exif_output[] = sprintf(
 			'<li><span class="photo-exif photo-exif-%s">%s: <strong>%s</strong></span></li>',
 			esc_attr( $key ),
-			$item['label'],
-			$item['value']
+			esc_html( $item['label'] ),
+			esc_html( $item['value'] )
 		);
 	}
 	$output .= implode( "\n", $exif_output );


### PR DESCRIPTION
`Photo::get_exif()` normalises the camera settings it returns, but the `iso` case only sets a label and passes its value straight through, while `aperture`, `focal_length` and `shutter_speed` each cast or reformat theirs. This casts `iso` to an integer for consistency and skips non-positive values the same way `focal_length` does.

While in there, metadata is now escaped where it is rendered rather than assumed safe from its storage path:

- `show_exif()` — label and value
- `show_colors()` / `show_categories()` / `show_tags()` — term names
- `Photo::get_moderator_link()` and the flag/unflag admin notice — `esc_html()` for the display name instead of `sanitize_text_field()`, which is a sanitiser rather than an escaper, plus `esc_url()` on the adjacent profile link
- the pending-submissions table — stored original filename and date
- the flagged-photos count link — `esc_url()`

No behaviour change beyond ISO now rendering as a plain integer.

Companion change in the theme: WordPress/wporg-photo-directory (meta-list block renders these same values).