### PR TITLE
Theme Directory: rely on the automated scan result for child theme uploads

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
@@ -1237,11 +1237,6 @@ class WPORG_Themes_Upload {
 		echo '<ul class="tc-result">' . display_themechecks() . '</ul>';
 		echo '<div class="notice notice-info"><p>' . __( 'Note: While the automated theme scan is based on the Theme Review Guidelines, it is not a complete review. A successful result from the scan does not guarantee that the theme will pass review. All submitted themes are reviewed manually before approval.', 'wporg-themes' ) . '</p></div>';
 
-		// Override ALL of the upload checks for child themes.
-		if ( $this->theme->parent() ) {
-			$result = true;
-		}
-
 		return $result;
 	}
 


### PR DESCRIPTION
Child themes now pass the automated Theme Check scan on their own — the recent plugin updates skip only the requirements a parent provides (base template functions, `index.php`, title-tag support) while still scanning the child's own files.

Because of that, the upload handler no longer needs to special-case child themes in `check_theme()`. This removes that special-casing so a child theme's scan result is applied the same way as for any other theme.