### PR TITLE
Support Forums: use the topic ID passed to `user_can_resolve()`

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-directory-compat.php
+++ b/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-directory-compat.php
@@ -462,6 +462,13 @@ abstract class Directory_Compat {
 		if ( ! $user ) {
 			return $retval;
 		}
+
+		// The compat object is loaded from the request, not from $topic_id.
+		$terms = get_the_terms( $topic_id, $this->taxonomy() );
+		if ( empty( $terms ) || is_wp_error( $terms ) || ! in_array( (string) $this->slug(), wp_list_pluck( $terms, 'slug' ), true ) ) {
+			return $retval;
+		}
+
 		if (
 			( ! empty( $this->authors ) && in_array( $user->user_nicename, $this->authors, true ) )
 		||

--- a/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-support-compat.php
+++ b/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-support-compat.php
@@ -330,7 +330,7 @@ class Support_Compat {
 	public function is_enabled_on_forum( $retval, $forum_id = 0 ) {
 		// An explicit forum id wins over whatever the request happens to be rendering.
 		if ( ! empty( $forum_id ) ) {
-			return ( Plugin::REVIEWS_FORUM_ID != $forum_id );
+			return ( Plugin::REVIEWS_FORUM_ID !== (int) $forum_id );
 		}
 
 		// Check the current forum.

--- a/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-support-compat.php
+++ b/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-support-compat.php
@@ -328,9 +328,9 @@ class Support_Compat {
 	 * @return bool True if enabled, otherwise false
 	 */
 	public function is_enabled_on_forum( $retval, $forum_id = 0 ) {
-		// Check the passed forum id.
+		// An explicit forum id wins over whatever the request happens to be rendering.
 		if ( ! empty( $forum_id ) ) {
-			$retval = ( $forum_id != Plugin::REVIEWS_FORUM_ID );
+			return ( Plugin::REVIEWS_FORUM_ID != $forum_id );
 		}
 
 		// Check the current forum.

--- a/wordpress.org/public_html/wp-content/plugins/wporg-bbp-topic-resolution/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-bbp-topic-resolution/inc/class-plugin.php
@@ -264,10 +264,6 @@ class Plugin {
 	 * @param string $action The requested action to compare this function to
 	 */
 	public function topic_resolution_handler( $action = '' ) {
-		if ( ! $this->is_enabled_on_forum() ) {
-			return false;
-		}
-
 		// Bail if the action isn't meant for this function.
 		if ( $action != 'wporg_bbp_topic_resolution' ) {
 			return;
@@ -283,6 +279,11 @@ class Plugin {
 		$topic      = bbp_get_topic( $topic_id );
 		$user_id    = get_current_user_id();
 		$resolution = $_POST[ self::META_KEY ];
+
+		// Resolution must be enabled on the topic's forum, not on the one being viewed.
+		if ( $topic && ! $this->is_enabled_on_forum( bbp_get_topic_forum_id( $topic->ID ) ) ) {
+			return false;
+		}
 
 		// Check for empty topic id.
 		if ( empty( $topic_id ) || ! $topic ) {

--- a/wordpress.org/public_html/wp-content/plugins/wporg-bbp-topic-resolution/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-bbp-topic-resolution/inc/class-plugin.php
@@ -509,11 +509,9 @@ class Plugin {
 	 * @return bool True if allowed, false if not
 	 */
 	public function user_can_resolve( $user_id, $topic_id ) {
-		$post     = false;
-		$topic_id = bbp_get_topic_id();
-		if ( $topic_id ) {
-			$post = get_post( $topic_id );
-		}
+		// Authorize against the requested topic, only falling back to the displayed one.
+		$topic_id = bbp_get_topic_id( $topic_id );
+		$post     = $topic_id ? bbp_get_topic( $topic_id ) : false;
 
 		if ( $user_id && $post && ( user_can( $user_id, 'moderate', $topic_id ) || $user_id == $post->post_author ) ) {
 			$retval = true;


### PR DESCRIPTION
`Topic_Resolution\Plugin::user_can_resolve()` takes a `$topic_id` argument and then discards it on the next line, replacing it with `bbp_get_topic_id()`. It has done that since the method was introduced in [3797]. The result is that the method reports on whichever topic the current request is rendering, not the one the caller asked about.

That is fine for the two callers that read the topic from the page anyway, but `Hooks::handle_extra_reply_actions()` and `Plugin::topic_resolution_handler()` both pass an ID that came in with the request, and the answer they get back doesn't correspond to it.

This passes the argument through to `bbp_get_topic_id()`, which returns it when it's a usable number and otherwise falls back to the displayed topic, so callers that legitimately pass nothing behave as before. It also swaps `get_post()` for `bbp_get_topic()`, so an ID that points at some other post type can no longer match on `post_author`.

`Directory_Compat::user_can_resolve()`, which filters the result, has the same mismatch in a different form: it ignores `$topic_id` entirely and answers from `$this->authors`, `$this->contributors`, and `$this->support_reps`, all populated from the plugin or theme loaded for the current request. So the answer for a topic belonging to one plugin could be decided by another plugin's author list. The filter now returns early unless the topic carries the term for the loaded object, which is the same condition under which `check_topic_for_compat()` loads that object in the first place.

### Testing instructions

1. Open a topic you authored in a forum with topic resolution enabled. The "Reply and mark as resolved" checkbox should appear, and using it should still resolve the topic.
2. Open a topic authored by someone else. The checkbox should not appear, and the status should render as text rather than as the update form.
3. As a plugin author, confirm you can still resolve topics in your own plugin's support forum, and that the status is read-only on topics belonging to other plugins.
4. As a moderator, confirm both remain editable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved topic resolution permission checks to ensure actions apply only to the correct support forum.
  - Added safer handling for missing or invalid topic information.
  - Resolution permissions now correctly evaluate the requested topic, including when working outside the currently displayed topic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
