### PR TITLE
Plugin Directory: only keep regular files and directories in SVN exports

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Filesystem_Symlink_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Filesystem_Symlink_Test.php
@@ -52,8 +52,9 @@ class Filesystem_Symlink_Test extends TestCase {
 		mkdir( $this->dir . '/real-dir' );
 		file_put_contents( $this->dir . '/real.txt', 'real' );
 
-		symlink( $this->outside . '/secret.txt', $this->dir . '/readme.txt' );
-		symlink( $this->outside, $this->dir . '/linked-dir' );
+		// Without these the fixture holds only real entries and every assertion below passes vacuously.
+		$this->assertTrue( symlink( $this->outside . '/secret.txt', $this->dir . '/readme.txt' ) );
+		$this->assertTrue( symlink( $this->outside, $this->dir . '/linked-dir' ) );
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Filesystem_Symlink_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Filesystem_Symlink_Test.php
@@ -45,12 +45,14 @@ class Filesystem_Symlink_Test extends TestCase {
 
 		$this->outside = sys_get_temp_dir() . '/' . uniqid( 'fs-outside-', true );
 		mkdir( $this->outside );
-		file_put_contents( $this->outside . '/secret.txt', 'secret' );
+
+		// A missing target would leave a dangling symlink, which `isFile()` rejects even without the guard under test.
+		$this->assertNotFalse( file_put_contents( $this->outside . '/secret.txt', 'secret' ) );
 
 		$this->dir = sys_get_temp_dir() . '/' . uniqid( 'fs-tree-', true );
 		mkdir( $this->dir );
 		mkdir( $this->dir . '/real-dir' );
-		file_put_contents( $this->dir . '/real.txt', 'real' );
+		$this->assertNotFalse( file_put_contents( $this->dir . '/real.txt', 'real' ) );
 
 		// Without these the fixture holds only real entries and every assertion below passes vacuously.
 		$this->assertTrue( symlink( $this->outside . '/secret.txt', $this->dir . '/readme.txt' ) );

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Filesystem_Symlink_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Filesystem_Symlink_Test.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Tests that Filesystem::list() never hands a symlink to its callers.
+ *
+ * @package WordPressdotorg\Plugin_Directory\Tests
+ */
+
+declare( strict_types = 1 );
+
+use PHPUnit\Framework\TestCase;
+use WordPressdotorg\Plugin_Directory\Tools\Filesystem;
+
+/**
+ * Symlinks reach the plugin directory through `svn export`, which materialises `svn:special`
+ * entries as real symlinks. `isFile()` and `isDir()` stat the target, so without an explicit
+ * check a symlink is listed as whatever it points at and is then read by the caller.
+ *
+ * @group filesystem
+ */
+class Filesystem_Symlink_Test extends TestCase {
+
+	/**
+	 * Directory holding the tree under test.
+	 *
+	 * @var string
+	 */
+	protected string $dir = '';
+
+	/**
+	 * Directory outside the tree, holding the targets of the symlinks.
+	 *
+	 * @var string
+	 */
+	protected string $outside = '';
+
+	// phpcs:disable WordPress.WP.AlternativeFunctions -- WP_Filesystem cannot create the symlinks this fixture is made of.
+
+	/**
+	 * Builds a tree containing one real file, one real directory, and a symlink to each.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->outside = sys_get_temp_dir() . '/' . uniqid( 'fs-outside-', true );
+		mkdir( $this->outside );
+		file_put_contents( $this->outside . '/secret.txt', 'secret' );
+
+		$this->dir = sys_get_temp_dir() . '/' . uniqid( 'fs-tree-', true );
+		mkdir( $this->dir );
+		mkdir( $this->dir . '/real-dir' );
+		file_put_contents( $this->dir . '/real.txt', 'real' );
+
+		symlink( $this->outside . '/secret.txt', $this->dir . '/readme.txt' );
+		symlink( $this->outside, $this->dir . '/linked-dir' );
+	}
+
+	/**
+	 * Removes both trees, links first so the targets survive to be deleted themselves.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		foreach ( array( '/readme.txt', '/linked-dir' ) as $link ) {
+			if ( is_link( $this->dir . $link ) ) {
+				unlink( $this->dir . $link );
+			}
+		}
+
+		foreach ( array( $this->dir . '/real.txt', $this->outside . '/secret.txt' ) as $file ) {
+			if ( is_file( $file ) ) {
+				unlink( $file );
+			}
+		}
+
+		foreach ( array( $this->dir . '/real-dir', $this->dir, $this->outside ) as $dir ) {
+			if ( is_dir( $dir ) ) {
+				rmdir( $dir );
+			}
+		}
+
+		parent::tearDown();
+	}
+
+	// phpcs:enable WordPress.WP.AlternativeFunctions
+
+	/**
+	 * A symlink to a regular file must not be listed as a file.
+	 *
+	 * @return void
+	 */
+	public function test_symlinked_file_is_not_listed(): void {
+		$files = array_map( 'basename', Filesystem::list_files( $this->dir ) );
+
+		$this->assertContains( 'real.txt', $files );
+		$this->assertNotContains( 'readme.txt', $files );
+	}
+
+	/**
+	 * A symlink matching the caller's pattern must not be returned either — this is the
+	 * lookup `Import::find_readme_file()` performs on the SVN export.
+	 *
+	 * @return void
+	 */
+	public function test_symlinked_file_is_not_matched_by_pattern(): void {
+		$files = Filesystem::list_files( $this->dir, false, '!(?:^|/)readme\.(txt|md)$!i' );
+
+		$this->assertSame( array(), $files );
+	}
+
+	/**
+	 * A symlink to a directory must not be listed as a directory.
+	 *
+	 * @return void
+	 */
+	public function test_symlinked_directory_is_not_listed(): void {
+		$dirs = array_map( 'basename', Filesystem::list( $this->dir, 'directories' ) );
+
+		$this->assertContains( 'real-dir', $dirs );
+		$this->assertNotContains( 'linked-dir', $dirs );
+	}
+
+	/**
+	 * Neither symlink survives an unfiltered listing.
+	 *
+	 * @return void
+	 */
+	public function test_symlinks_are_absent_from_full_listing(): void {
+		$all = array_map( 'basename', Filesystem::list( $this->dir ) );
+
+		sort( $all );
+		$this->assertSame( array( 'real-dir', 'real.txt' ), $all );
+	}
+}

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Filesystem_Symlink_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Filesystem_Symlink_Test.php
@@ -59,34 +59,20 @@ class Filesystem_Symlink_Test extends TestCase {
 		$this->assertTrue( symlink( $this->outside, $this->dir . '/linked-dir' ) );
 	}
 
+	// phpcs:enable WordPress.WP.AlternativeFunctions
+
 	/**
-	 * Removes both trees, links first so the targets survive to be deleted themselves.
+	 * Removes both fixture roots.
 	 *
 	 * @return void
 	 */
 	protected function tearDown(): void {
-		foreach ( array( '/readme.txt', '/linked-dir' ) as $link ) {
-			if ( is_link( $this->dir . $link ) ) {
-				unlink( $this->dir . $link );
-			}
-		}
-
-		foreach ( array( $this->dir . '/real.txt', $this->outside . '/secret.txt' ) as $file ) {
-			if ( is_file( $file ) ) {
-				unlink( $file );
-			}
-		}
-
-		foreach ( array( $this->dir . '/real-dir', $this->dir, $this->outside ) as $dir ) {
-			if ( is_dir( $dir ) ) {
-				rmdir( $dir );
-			}
-		}
+		// `Filesystem::rmdir()` no-ops on the empty string an aborted `setUp()` leaves behind.
+		Filesystem::rmdir( $this->dir );
+		Filesystem::rmdir( $this->outside );
 
 		parent::tearDown();
 	}
-
-	// phpcs:enable WordPress.WP.AlternativeFunctions
 
 	/**
 	 * A symlink to a regular file must not be listed as a file.

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tools/class-filesystem.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tools/class-filesystem.php
@@ -125,6 +125,8 @@ class Filesystem {
 		foreach ( $filtered as $file ) {
 			if ( in_array( $file->getFilename(), [ '.', '..' ] ) ) {
 				continue;
+			} elseif ( $file->isLink() ) {
+				continue;
 			} elseif ( 'files' === $type && ! $file->isFile() ) {
 				continue;
 			} elseif ( 'directories' === $type && ! $file->isDir() ) {

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tools/class-svn.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tools/class-svn.php
@@ -132,6 +132,9 @@ class SVN {
 			$revision = (int) $m['revision'];
 			$result   = true;
 			$errors   = false;
+
+			// `svn export` materialises `svn:special` entries as real symlinks, which consumers would follow out of the export.
+			self::shell_exec( "find $esc_destination ! -type d ! -type f -delete" );
 		} else {
 			$result   = false;
 			$revision = false;

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tools/class-svn.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tools/class-svn.php
@@ -140,7 +140,12 @@ class SVN {
 			if ( trim( $scrub ) ) {
 				$result   = false;
 				$revision = false;
-				$errors   = array( array( 'error_message' => 'Could not remove non-regular files from the export: ' . trim( $scrub ) ) );
+				$errors   = array(
+					array(
+						'error_code'    => 'export_cleanup_failed',
+						'error_message' => 'Could not remove non-regular files from the export: ' . trim( $scrub ),
+					),
+				);
 			}
 		} else {
 			$result   = false;

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tools/class-svn.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tools/class-svn.php
@@ -134,7 +134,14 @@ class SVN {
 			$errors   = false;
 
 			// `svn export` materialises `svn:special` entries as real symlinks, which consumers would follow out of the export.
-			self::shell_exec( "find $esc_destination ! -type d ! -type f -delete" );
+			$scrub = self::shell_exec( "find $esc_destination ! -type d ! -type f -delete 2>&1" );
+
+			// A successful find is silent; consumers walk the export directly, so a partial scrub must not pass as success.
+			if ( trim( $scrub ) ) {
+				$result   = false;
+				$revision = false;
+				$errors   = array( array( 'error_message' => 'Could not remove non-regular files from the export: ' . trim( $scrub ) ) );
+			}
 		} else {
 			$result   = false;
 			$revision = false;


### PR DESCRIPTION
The plugin directory ingests plugins by two routes, and they treat an export differently.

`svn export` materialises `svn:special` entries as real symlinks, so an exported tree can contain entries that are not plain files or directories. The ZIP route already drops those — `Filesystem::unzip()` runs `find -type l -delete` right after `unzip`, and `Zip\Builder::export_plugin()` does the same after its own export. The import route does not, so `Import::export_and_parse_plugin()` works on a tree the other route would have cleaned up.

That matters because everything downstream stats with functions that resolve the link rather than the entry: `SplFileInfo::isFile()`, `filesize()`, `file_get_contents()`. A non-regular entry is therefore picked up and read as whatever it resolves to.

### Changes

**`Tools\SVN::export()`** — drop anything that is not a regular file or a directory after a successful export. Doing it here rather than at the call sites means all seven inherit it (`Import::export_and_parse_plugin()`'s two exports, `Zip\Builder`'s two, `Block_Plugin_Checker`, `Plugin_Scan`, `i18n\Code_Import`) instead of each one repeating the idiom. `! -type d ! -type f` also covers FIFOs and sockets, not just symlinks.

A cleanup that does not take effect now fails the export rather than returning success. `shell_exec()` cannot report an exit status, so the original version discarded the result entirely and any failure — `find` missing from `PATH`, an unreadable subdirectory, a `-delete` refusal — would have left the symlinks in place while `export()` still reported `result => true`. A successful `find` prints nothing, so any output is treated as a failure, with an `error_code`/`error_message` pair matching the shape `parse_svn_errors()` returns.

**`Tools\Filesystem::list()`** — skip symlinks, so callers of `list_files()`/`list()` never receive one regardless of how the tree was produced. `isFile()` and `isDir()` stat the target, so without this a symlink is listed as whatever it points at.

Both layers are deliberate, and the second is not merely belt-and-braces. `Filesystem::list()` protects the callers that go through it — `Import`, `Block_Plugin_Checker` — but two hand the export path to an external process that walks the tree itself and never touches it: `Plugin_Scan::export_plugin_locally()` returns the path to Plugin Check, and `i18n\Code_Import` passes it to `wp i18n make-pot`. For those the `find` is the only control, which is why its failure has to be loud.

### Notes

- `Zip\Builder::export_plugin()` still has its own `find -type l` after the export. It is redundant now, but it is the last gate before the ZIP that gets served, so I left it rather than fold an unrelated deletion into this change.
- I checked the one caller that uses `Filesystem::list()` as a rejection list rather than a read path — `Upload_Handler` at `class-upload-handler.php:232-233`, which looks for `.git`/`.phar`/`.sh` and friends. It is unaffected: `$this->plugin_dir` comes from `Filesystem::unzip()` at `:199`, which has already removed symlinks before that check runs. Every other caller opens what it is handed.
- `Filesystem::rmdir()` shells out to `rm -rf` rather than walking `list()`, so temp-directory cleanup is unaffected.
- `RecursiveDirectoryIterator::hasChildren()` defaults to `$allowLinks = false`, so a symlinked directory was never descended into. The new `continue` changes what is returned, not how the tree is walked.
- Failing the export on a failed cleanup means two callers can report a less specific cause than they could before: `Zip\Builder` retries `0.`-prefixed versions against a rewritten tag URL on `! $result`, and `Import` can reach its "no files in trunk, nor tags" branch. The `errors` array still carries `export_cleanup_failed`, and teaching those callers to distinguish "export failed" from "export unusable" felt like a separate change.

### Testing

`tests/Filesystem_Symlink_Test.php` covers a tree containing a real file, a real directory, a symlink to a file outside the tree, and a symlink to a directory outside it — including the exact pattern lookup `Import::find_readme_file()` performs. The four tests fail against `trunk` and pass with this change.

The fixture asserts its own construction. Both `symlink()` calls and both writes are checked, because a failed `symlink()` would leave a tree of only real entries and a failed write to the link's target would leave `readme.txt` dangling — and `isFile()` is false on a dangling link, so it would have been filtered out even without the guard under test. Either way the suite would have stayed green with the fix reverted. Teardown removes the two roots through `Filesystem::rmdir()`, which no-ops on the empty string that an aborted `setUp()` leaves behind.

The `SVN::export()` cleanup itself needs a live SVN server, so it is not covered by the suite. I verified the predicate by hand against a fixture containing a symlink to a file, a symlink to a directory, a FIFO, a regular file and a subdirectory: the first three are removed, the last two are kept, and it does not recurse through the symlinked directory it deletes. I also confirmed `find` is silent on success and prints to stderr on failure, which is what the new check keys on.

`phpcs` is clean on the new file (0 errors, 0 warnings) and neither modified file gains a violation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Symbolic links are now excluded from file and directory listings, including filtered and pattern-matched results.
  * Export cleanup now detects unsupported filesystem entries and reports failed exports appropriately.
  * Exported content and file listings now contain only supported regular files and directories, improving consistency and safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
