### PR TITLE
Temporarily disable Photon screenshot srcset in Plugin Directory

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-screenshots.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-screenshots.php
@@ -183,10 +183,9 @@ class Screenshots {
 	}
 
 	/**
-	 * Adds preconnect / dns-prefetch hints to the Photon CDN host on
+	 * Adds preconnect / dns-prefetch hints to the screenshot host on
 	 * single-plugin pages so the browser can warm up the TLS handshake
-	 * while the page HTML is still streaming. Saves ~50–150 ms on the
-	 * first thumbnail paint for cold visitors. Hooked from
+	 * while the page HTML is still streaming. Hooked from
 	 * `class-plugin-directory.php` via the `wp_resource_hints` filter.
 	 *
 	 * @param array  $urls          Resource hint URLs already queued for $relation_type.
@@ -200,11 +199,11 @@ class Screenshots {
 
 		if ( 'preconnect' === $relation_type ) {
 			$urls[] = array(
-				'href'        => 'https://i0.wp.com',
+				'href'        => 'https://ps.w.org',
 				'crossorigin' => 'anonymous',
 			);
 		} elseif ( 'dns-prefetch' === $relation_type ) {
-			$urls[] = 'https://i0.wp.com';
+			$urls[] = 'https://ps.w.org';
 		}
 
 		return $urls;
@@ -369,10 +368,9 @@ class Screenshots {
 		$class  = 'wp-block-image size-large';
 
 		// Record the full-resolution source and intrinsic dimensions for the
-		// lightbox-state repair in fix_lightbox_metadata(). The grid thumbnail
-		// loads a Photon-shrunk srcset candidate, so core (which has no real
-		// attachment to query) would otherwise enlarge that small image; this
-		// hands the lightbox the lossless original at its true size.
+		// lightbox-state repair in fix_lightbox_metadata(). Core has no real
+		// attachment to query for these external assets, so this hands the
+		// lightbox the lossless original at its true size.
 		self::$lightbox_meta[ (int) $id ] = array(
 			'url'    => $src,
 			'width'  => ( is_array( $dimensions ) && ! empty( $dimensions[0] ) ) ? (int) $dimensions[0] : 'none',
@@ -450,12 +448,8 @@ class Screenshots {
 	 *   $targetHeight= $meta['height'] ?? 'none';           // → 'none'
 	 *
 	 * The empty `uploadedSrc` leaves the lightbox with no full-resolution
-	 * image to enlarge, and the `'none'` dimensions make core's view
-	 * script fall back to the *thumbnail's* natural size — which on
-	 * production is a Photon-shrunk srcset candidate (≤900px, often the
-	 * 300px tile). The enlarged view therefore renders tiny. On
-	 * environments without Photon the thumbnail is the full-resolution
-	 * original, which is why the bug is invisible on local / staging.
+	 * image to enlarge, and the `'none'` dimensions leave core's view script
+	 * without the source image's intrinsic size.
 	 *
 	 * Core keys its lightbox metadata by a per-render `uniqid()` (exposed
 	 * on the figure's `data-wp-context`), not by the attachment id, so the
@@ -463,9 +457,8 @@ class Screenshots {
 	 * rendered markup and re-set the affected fields. `wp_interactivity_state()`
 	 * merges with `array_replace_recursive()` (later call wins), and this
 	 * filter runs at priority 20 — after core's priority-15 pass — so the
-	 * corrected values override the broken ones. `lightboxSrcset` is
-	 * cleared so the enlarged image loads the lossless original rather than
-	 * a capped Photon candidate.
+	 * corrected values override the broken ones. `lightboxSrcset` is cleared
+	 * so the enlarged image loads the lossless original.
 	 *
 	 * @param string $block_content Rendered Image block markup.
 	 * @param array  $parsed_block  Parsed block, including `attrs['id']`.
@@ -557,35 +550,22 @@ class Screenshots {
 	}
 
 	/**
-	 * Builds a revision-aware Photon `srcset` for a screenshot.
+	 * Temporarily disables the Photon `srcset` for screenshots.
+	 *
+	 * Photon drops the revision query string when transform arguments are
+	 * present, which can leave resized screenshots pinned to stale source data.
+	 *
+	 * @see https://meta.trac.wordpress.org/ticket/8331
+	 * @see https://code.trac.wordpress.org/ticket/79#comment:1
 	 *
 	 * @param array $screenshot Screenshot metadata.
-	 * @return string Attribute fragment ready to interpolate into `<img>`,
-	 *                including the leading space, or empty string.
+	 * @return string Empty string while Photon resizing is disabled.
 	 */
 	protected static function photon_srcset( $screenshot ) {
-		$env = function_exists( 'wp_get_environment_type' ) ? wp_get_environment_type() : 'production';
-		if ( 'production' !== $env && 'staging' !== $env ) {
-			return '';
-		}
 
-		$source_url   = Template::get_asset_url( null, $screenshot, false );
-		$source_query = wp_parse_url( $source_url, PHP_URL_QUERY );
-		$photon_base  = str_replace( 'https://', 'https://i0.wp.com/', remove_query_arg( 'rev', $source_url ) );
+		unset( $screenshot );
 
-		// Photon only forwards the source query string when it is passed through `q`.
-		$photon_base = add_query_arg( 'q', $source_query, $photon_base );
-		$widths      = array( 300, 600, 900 );
-		$srcset      = array();
-
-		foreach ( $widths as $width ) {
-			$srcset[] = add_query_arg( 'w', $width, $photon_base ) . ' ' . $width . 'w';
-		}
-
-		return sprintf(
-			' srcset="%1$s" sizes="(max-width: 599px) 50vw, 33vw"',
-			esc_attr( implode( ', ', $srcset ) )
-		);
+		return '';
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Screenshots_Photon_Srcset_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Screenshots_Photon_Srcset_Test.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Tests for screenshot image sources.
+ *
+ * @package WordPressdotorg\Plugin_Directory\Tests
+ */
+
+declare( strict_types = 1 );
+
+namespace WordPressdotorg\Plugin_Directory\Shortcodes;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+require_once __DIR__ . '/fixtures/production-environment.php';
+
+/**
+ * Tests that screenshot markup avoids Photon resize candidates.
+ *
+ * @group shortcodes
+ */
+#[Group( 'shortcodes' )]
+class Screenshots_Photon_Srcset_Test extends TestCase {
+
+	/**
+	 * Screenshot markup keeps the revision-aware source without a Photon srcset.
+	 */
+	public function test_image_block_uses_direct_source_without_photon_srcset(): void {
+		$source  = 'https://ps.w.org/srcset-regression/assets/screenshot-1.png?rev=123';
+		$method  = new ReflectionMethod( Screenshots::class, 'build_image_block' );
+		$post_id = wp_insert_post(
+			array(
+				'post_name'         => 'srcset-regression',
+				'post_title'        => 'Srcset Regression',
+				'post_type'         => 'plugin',
+				'post_status'       => 'publish',
+				'post_modified'     => current_time( 'mysql' ),
+				'post_modified_gmt' => current_time( 'mysql', true ),
+			)
+		);
+
+		setup_postdata( get_post( $post_id ) );
+
+		try {
+			$markup = $method->invoke(
+				null,
+				array(
+					'src'      => $source,
+					'filename' => 'screenshot-1.png',
+					'revision' => 123,
+				),
+				9000001,
+				true,
+				array( 1200, 800 )
+			);
+		} finally {
+			wp_reset_postdata();
+			wp_delete_post( $post_id, true );
+		}
+
+		$this->assertStringContainsString( 'src="' . $source . '"', $markup );
+		$this->assertStringNotContainsString( 'srcset=', $markup );
+		$this->assertStringNotContainsString( 'i0.wp.com', $markup );
+	}
+}

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/fixtures/production-environment.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/fixtures/production-environment.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Production environment fixture for shortcode tests.
+ *
+ * @package WordPressdotorg\Plugin_Directory\Tests
+ */
+
+namespace WordPressdotorg\Plugin_Directory\Shortcodes;
+
+/**
+ * Forces the production path in the shortcode namespace.
+ *
+ * @return string The environment type.
+ */
+function wp_get_environment_type() {
+	return 'production';
+}


### PR DESCRIPTION
See https://meta.trac.wordpress.org/ticket/8331.

This temporarily disables the Photon screenshot srcset because transformed variants can lose the revision and serve stale images. The revision-aware ps.w.org src and lightbox source remain unchanged, and resource hints now point to ps.w.org.

A focused regression test confirms that no Photon candidates are emitted.

Tested

- Focused PHPUnit, 1 test and 3 assertions
- Full Plugin Directory PHPUnit, 334 tests and 939 assertions
- PHP syntax, PHPCS, and git diff --check
- Full local wporg-plugins-2024 theme
- Gallery and lightbox for the known cases, including Open, Next, Previous, and Close

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Plugin screenshots now load directly from `ps.w.org` without Photon resizing URLs.
  * Screenshot markup no longer includes Photon-generated `srcset` candidates, preserving revision-aware image sources.
  * Lightbox behavior and metadata now support restoring the original lossless image and dimensions.

* **Tests**
  * Added coverage to verify direct screenshot sources and the absence of Photon URLs and `srcset` attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->