### PR TITLE
Profiles: escape activity values passed to bp_activity_add()

### DIFF
--- a/profiles.wordpress.org/public_html/wp-content/plugins/wporg-profiles-activity-handler/wporg-profiles-activity-handler.php
+++ b/profiles.wordpress.org/public_html/wp-content/plugins/wporg-profiles-activity-handler/wporg-profiles-activity-handler.php
@@ -536,7 +536,7 @@ if ( ! class_exists( 'WPOrg_Profiles_Activity_Handler' ) ) {
 					esc_html( $data['title'] )
 				),
 				'content'           => '',
-				'primary_link'      => $data['url'],
+				'primary_link'      => sanitize_url( $data['url'] ),
 				'component'         => 'plugins',
 				'type'              => 'plugin_create',
 				'item_id'           => intval( $data['plugin_id'] ),
@@ -568,7 +568,7 @@ if ( ! class_exists( 'WPOrg_Profiles_Activity_Handler' ) ) {
 					esc_html( $data['title'] )
 				),
 				'content'           => '',
-				'primary_link'      => $data['url'],
+				'primary_link'      => sanitize_url( $data['url'] ),
 				'component'         => 'themes',
 				'type'              => 'theme_create',
 				'item_id'           => intval( $data['theme_id'] ),
@@ -748,7 +748,7 @@ if ( ! class_exists( 'WPOrg_Profiles_Activity_Handler' ) ) {
 				'user_id'           => $user->ID,
 				'action'            => $action,
 				'content'           => '',
-				'primary_link'      => $data['url'] ?? '',
+				'primary_link'      => sanitize_url( $data['url'] ?? '' ),
 				'component'         => 'wordcamp',
 				'type'              => $type,
 				'item_id'           => intval( $item_id ),
@@ -961,7 +961,7 @@ if ( ! class_exists( 'WPOrg_Profiles_Activity_Handler' ) ) {
 			$action_received = sprintf(
 				'<a href="%1$s">Received props</a> from <a href="https://profiles.wordpress.org/%2$s/">@%2$s</a> in <a href="https://make.wordpress.org/chat/">Slack</a>',
 				esc_url_raw( $url ),
-				$giver_username,
+				esc_html( $giver_username ),
 			);
 
 			$user_case_args[] = array(

--- a/profiles.wordpress.org/public_html/wp-content/plugins/wporg-profiles-activity-handler/wporg-profiles-activity-handler.php
+++ b/profiles.wordpress.org/public_html/wp-content/plugins/wporg-profiles-activity-handler/wporg-profiles-activity-handler.php
@@ -959,8 +959,9 @@ if ( ! class_exists( 'WPOrg_Profiles_Activity_Handler' ) ) {
 			);
 
 			$action_received = sprintf(
-				'<a href="%1$s">Received props</a> from <a href="https://profiles.wordpress.org/%2$s/">@%2$s</a> in <a href="https://make.wordpress.org/chat/">Slack</a>',
+				'<a href="%1$s">Received props</a> from <a href="%2$s">@%3$s</a> in <a href="https://make.wordpress.org/chat/">Slack</a>',
 				esc_url_raw( $url ),
+				esc_url( 'https://profiles.wordpress.org/' . rawurlencode( $giver_username ) . '/' ),
 				esc_html( $giver_username ),
 			);
 

--- a/profiles.wordpress.org/public_html/wp-content/plugins/wporg-profiles-activity-handler/wporg-profiles-activity-handler.php
+++ b/profiles.wordpress.org/public_html/wp-content/plugins/wporg-profiles-activity-handler/wporg-profiles-activity-handler.php
@@ -362,8 +362,10 @@ if ( ! class_exists( 'WPOrg_Profiles_Activity_Handler' ) ) {
 			$activity = array_intersect_key( $activity, $defaults );
 			$activity = array_merge( $defaults, $activity );
 
+			// Escaping `content` keeps it from being reinterpreted as block markup after BuddyPress unslashes it on output.
 			$filters = array(
-				'wp_kses_data'        => array( 'action', 'content' ),
+				'wp_kses_data'        => array( 'action' ),
+				'esc_html'            => array( 'content' ),
 				'sanitize_text_field' => array( 'component', 'type' ),
 				'intval'              => array( 'user_id', 'item_id', 'secondary_item_id' ),
 				'sanitize_url'        => array( 'primary_link' ),
@@ -531,7 +533,7 @@ if ( ! class_exists( 'WPOrg_Profiles_Activity_Handler' ) ) {
 				'action'            => sprintf(
 					'Released a new plugin, <a href="%s">%s</a>',
 					esc_url( $data['url'] ),
-					$data['title']
+					esc_html( $data['title'] )
 				),
 				'content'           => '',
 				'primary_link'      => $data['url'],
@@ -563,7 +565,7 @@ if ( ! class_exists( 'WPOrg_Profiles_Activity_Handler' ) ) {
 				'action'            => sprintf(
 					'Released a new theme, <a href="%s">%s</a>',
 					esc_url( $data['url'] ),
-					$data['title']
+					esc_html( $data['title'] )
 				),
 				'content'           => '',
 				'primary_link'      => $data['url'],
@@ -597,8 +599,8 @@ if ( ! class_exists( 'WPOrg_Profiles_Activity_Handler' ) ) {
 
 				$args = array(
 					'user_id'           => $user->ID,
-					'action'            => sprintf( 'Created a new ticket in %s Trac', $data['trac'] ),
-					'content'           => $data['title'],
+					'action'            => sprintf( 'Created a new ticket in %s Trac', esc_html( $data['trac'] ) ),
+					'content'           => esc_html( $data['title'] ),
 					'component'         => 'tracs',
 					'type'              => 'trac_ticket_create',
 					'item_id'           => intval( $data['id'] ),
@@ -612,8 +614,8 @@ if ( ! class_exists( 'WPOrg_Profiles_Activity_Handler' ) ) {
 
 				$args = array(
 					'user_id'           => $user->ID,
-					'action'            => sprintf( 'Posted a reply to <i>%s</i> in %s Trac', $data['title'], $data['trac'] ),
-					'content'           => $data['comment'],
+					'action'            => sprintf( 'Posted a reply to <i>%s</i> in %s Trac', esc_html( $data['title'] ), esc_html( $data['trac'] ) ),
+					'content'           => esc_html( $data['comment'] ),
 					'component'         => 'tracs',
 					'type'              => 'trac_comment_create',
 					'item_id'           => intval( $data['id'] ),
@@ -628,8 +630,8 @@ if ( ! class_exists( 'WPOrg_Profiles_Activity_Handler' ) ) {
 				// Record commit to committer's activity stream
 				$args = array(
 					'user_id'           => $user->ID,
-					'action'            => sprintf( 'Committed [%s] to %s Trac', $data['changeset'], $data['trac'] ),
-					'content'           => $data['message'],
+					'action'            => sprintf( 'Committed [%s] to %s Trac', esc_html( $data['changeset'] ), esc_html( $data['trac'] ) ),
+					'content'           => esc_html( $data['message'] ),
 					'component'         => 'tracs',
 					'type'              => 'trac_commit_create',
 					'item_id'           => intval( $data['changeset'] ),
@@ -652,8 +654,8 @@ if ( ! class_exists( 'WPOrg_Profiles_Activity_Handler' ) ) {
 					}
 					$args = array(
 						'user_id'           => $user->ID,
-						'action'            => sprintf( 'Received props in %s', $data['trac'] ),
-						'content'           => $data['message'],
+						'action'            => sprintf( 'Received props in %s', esc_html( $data['trac'] ) ),
+						'content'           => esc_html( $data['message'] ),
 						'component'         => 'tracs',
 						'type'              => 'trac_props_mention',
 						'item_id'           => intval( $data['changeset'] ),
@@ -685,7 +687,7 @@ if ( ! class_exists( 'WPOrg_Profiles_Activity_Handler' ) ) {
 				$action = sprintf(
 					'Confirmed as a speaker for <a href="%s">%s</a>',
 					esc_url( $data['url'] ),
-					$data['wordcamp_name']
+					esc_html( $data['wordcamp_name'] )
 				);
 
 			} elseif ( isset( $data['organizer_id'] ) && ! empty( $data['organizer_id'] ) ) {
@@ -695,7 +697,7 @@ if ( ! class_exists( 'WPOrg_Profiles_Activity_Handler' ) ) {
 				$action = sprintf(
 					'Joined the organizing team for <a href="%s">%s</a>',
 					esc_url( $data['url'] ),
-					$data['wordcamp_name']
+					esc_html( $data['wordcamp_name'] )
 				);
 
 			} elseif ( isset( $data['type'] ) && 'mentor_assign' === $data['type'] ) {
@@ -722,7 +724,7 @@ if ( ! class_exists( 'WPOrg_Profiles_Activity_Handler' ) ) {
 					$action = sprintf(
 						'Registered to attend <a href="%s">%s</a>',
 						esc_url( $data['url'] ),
-						$data['wordcamp_name']
+						esc_html( $data['wordcamp_name'] )
 					);
 
 				} elseif ( 'attendee_checked_in' == $data['activity_type'] ) {
@@ -733,7 +735,7 @@ if ( ! class_exists( 'WPOrg_Profiles_Activity_Handler' ) ) {
 						'Is the %s person to arrive at <a href="%s">%s</a>',
 						$this->append_ordinal_suffix( $order ),
 						esc_url( $data['url'] ),
-						$data['wordcamp_name']
+						esc_html( $data['wordcamp_name'] )
 					);
 				}
 			}
@@ -791,7 +793,7 @@ if ( ! class_exists( 'WPOrg_Profiles_Activity_Handler' ) ) {
 		 */
 		private function handle_wordpress_activity( array $data ) {
 			$user = self::get_user( $data['user'] );
-			$content      = $data['content'];
+			$content      = esc_html( $data['content'] );
 			$primary_link = sanitize_url( $data['url'] );
 
 			if ( ! $user ) {
@@ -804,8 +806,8 @@ if ( ! class_exists( 'WPOrg_Profiles_Activity_Handler' ) ) {
 				$action  = sprintf(
 					'Wrote a <a href="%s">comment</a> on the post <i>%s</i>, on the site %s',
 					esc_url( $data['url'] ),
-					$data['title'],
-					$data['blog']
+					esc_html( $data['title'] ),
+					esc_html( $data['blog'] )
 				);
 			} elseif ( isset( $data['type'] ) && 'new' === $data['type'] ) {
 				$type    = 'blog_post_create';
@@ -837,8 +839,8 @@ if ( ! class_exists( 'WPOrg_Profiles_Activity_Handler' ) ) {
 					'Wrote a new %s, <i><a href="%s">%s</a></i>, on the site %s',
 					$post_type,
 					esc_url( $data['url'] ),
-					$data['title'],
-					$data['blog']
+					esc_html( $data['title'] ),
+					esc_html( $data['blog'] )
 				);
 			} elseif ( isset( $data['type'] ) && 'update' === $data['type'] ) {
 				// Handbooks are currently the only post type that send notifications of updates.


### PR DESCRIPTION
The activity handler builds each activity's `action` and `content` from data posted by other sites in the network. The forum handler escapes those values; the Trac, WordPress, plugin, theme, and WordCamp handlers pass several of them through raw. This brings them in line.

- `handle_trac_activity()` — ticket title, comment, commit message, props message, and the Trac name in each action string
- `handle_wordpress_activity()` — post content, post title, and blog name
- `handle_plugin_activity()` / `handle_theme_activity()` — release title
- `handle_wordcamp_activity()` — WordCamp name in the four action strings that passed it raw
- `sanitize_activity()` — `content` now uses `esc_html()` instead of `wp_kses_data()`; `action` is composed markup and keeps KSES

Every current producer already sends plain text in `content` — `wp_trim_words()` and `get_comment_excerpt()` both strip tags before the value leaves the producer — so this is a no-op for them.

Left alone deliberately: the `sanitize_text_field()` calls in the WordCamp mentor and handbook digest branches. They strip tags, so they aren't a gap, and changing them would churn the digest path where there is `sprintf()` escaping to keep in step.

No new PHPCS findings; the file's existing count is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security and display consistency by safely escaping activity content, titles, site names, Trac values, blog names, and Slack usernames.
  * Sanitized activity links for plugin, theme, WordCamp, and Slack-related events.
  * Prevented unintended markup from appearing in activity actions and content while preserving functional, safely encoded links.
  * Improved the reliability of activity feeds by ensuring displayed text and links are handled consistently across supported event types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->