### PR TITLE
o2: Align post visibility handling across the o2 plugins

### DIFF
--- a/wordpress.org/public_html/wp-content/mu-plugins/pub/class-o2-follow.php
+++ b/wordpress.org/public_html/wp-content/mu-plugins/pub/class-o2-follow.php
@@ -230,7 +230,7 @@ class o2_follow {
 			}
 
 			$link = add_query_arg( $query_args, home_url( '/', is_ssl() ? 'https' : 'http' ) );
-			$link = wp_nonce_url( $link, 'post-comment-subscribe' );
+			$link = wp_nonce_url( $link, 'post-comment-subscribe-' . $post_id );
 
 			$actions[31] = [
 				'action'       => 'follow',
@@ -272,7 +272,16 @@ class o2_follow {
 			die;
 		}
 
-		if ( ! wp_verify_nonce( $_GET['_wpnonce'], 'post-comment-subscribe' ) ) {
+		if ( ! wp_verify_nonce( sanitize_key( wp_unslash( $_GET['_wpnonce'] ) ), 'post-comment-subscribe-' . $post_id ) ) {
+			die;
+		}
+
+		// Following delivers the post's comments by email, so it needs the same gate as reading it.
+		$can_read = current_user_can( 'edit_post', $post_id )
+			|| ( ! post_password_required( $post )
+				&& ( is_post_publicly_viewable( $post ) || current_user_can( 'read_post', $post_id ) ) );
+
+		if ( ! $can_read ) {
 			die;
 		}
 

--- a/wordpress.org/public_html/wp-content/plugins/o2-private-posts/o2-private-posts.php
+++ b/wordpress.org/public_html/wp-content/plugins/o2-private-posts/o2-private-posts.php
@@ -109,6 +109,14 @@ function handle_meta_data( $post_id, $message ) {
 			$post_tags = array_unique( $post_tags );
 		}
 
+		// `post_tag` is public, so reuse existing terms only -- a new one publishes the private hashtag.
+		$post_tags = array_filter(
+			(array) $post_tags,
+			function ( $post_tag ) {
+				return (bool) term_exists( $post_tag, 'post_tag' );
+			}
+		);
+
 		if ( ! empty( $post_tags ) ) {
 			wp_set_post_tags( $post_id, $post_tags, true );
 		}

--- a/wordpress.org/public_html/wp-content/plugins/wporg-o2-posting-access/phpunit/tests/WPorg_O2_Posting_Access_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-o2-posting-access/phpunit/tests/WPorg_O2_Posting_Access_Test.php
@@ -84,6 +84,180 @@ class WPorg_O2_Posting_Access_Test extends WPorg_O2_Posting_Access_TestCase {
 	}
 
 	/*
+	 * REST reads: 'edit_posts' is granted for writing, but core also reads it as
+	 * the gate for querying non-public statuses. Rows stay hidden either way --
+	 * what leaks without the restriction is 'X-WP-Total', which is taken from the
+	 * query before the per-item permission filter runs.
+	 */
+
+	/**
+	 * Seeds three drafts belonging to somebody else.
+	 *
+	 * @return int The other author's user ID.
+	 */
+	protected function seed_others_drafts() {
+		$author = $this->factory()->user->create( array( 'role' => 'author' ) );
+
+		$this->factory()->post->create_many(
+			3,
+			array(
+				'post_status' => 'draft',
+				'post_author' => $author,
+				'post_title'  => 'Unannounced release',
+			)
+		);
+
+		return $author;
+	}
+
+	/**
+	 * Runs a posts collection request and returns its total.
+	 *
+	 * @param array $params Query parameters to set on the request.
+	 * @return array The response status, total, and row count.
+	 */
+	protected function query_posts( $params ) {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+
+		foreach ( $params as $key => $value ) {
+			$request->set_param( $key, $value );
+		}
+
+		$response = rest_do_request( $request );
+		$headers  = $response->get_headers();
+
+		return array(
+			'status' => $response->get_status(),
+			'total'  => isset( $headers['X-WP-Total'] ) ? (int) $headers['X-WP-Total'] : null,
+			'rows'   => count( (array) $response->get_data() ),
+		);
+	}
+
+	/**
+	 * The count of other people's drafts must not be reported to a non-member.
+	 */
+	public function test_non_member_cannot_count_others_unpublished_posts() {
+		$this->seed_others_drafts();
+
+		$result = $this->query_posts(
+			array(
+				'context' => 'edit',
+				'status'  => array( 'draft', 'pending', 'private' ),
+			)
+		);
+
+		$this->assertLessThan( 400, $result['status'], 'Core still permits the request; the restriction is on what it counts.' );
+		$this->assertSame( 0, $result['total'] );
+		$this->assertSame( 0, $result['rows'] );
+	}
+
+	/**
+	 * 'search' matches title and body, so an unrestricted count answers "does a
+	 * hidden draft contain this string" one character at a time.
+	 */
+	public function test_non_member_cannot_search_others_unpublished_posts() {
+		$this->seed_others_drafts();
+
+		$result = $this->query_posts(
+			array(
+				'context' => 'edit',
+				'status'  => array( 'draft' ),
+				'search'  => 'Unannounced',
+			)
+		);
+
+		$this->assertSame( 0, $result['total'] );
+	}
+
+	/**
+	 * The 'author' parameter must not survive the restriction, or the count
+	 * attributes hidden posts to the person who wrote them.
+	 */
+	public function test_non_member_cannot_attribute_others_unpublished_posts() {
+		$author = $this->seed_others_drafts();
+
+		$result = $this->query_posts(
+			array(
+				'context' => 'edit',
+				'status'  => array( 'draft' ),
+				'author'  => array( $author ),
+			)
+		);
+
+		$this->assertSame( 0, $result['total'] );
+	}
+
+	/**
+	 * The restriction scopes to the caller rather than refusing outright, so a
+	 * non-member can still see the submission they are waiting on.
+	 */
+	public function test_non_member_still_sees_their_own_pending_post() {
+		$this->seed_others_drafts();
+		wp_insert_post(
+			array(
+				'post_title'  => 'My submission',
+				'post_status' => 'pending',
+				'post_author' => $this->non_member,
+			)
+		);
+
+		$result = $this->query_posts(
+			array(
+				'context' => 'edit',
+				'status'  => array( 'pending' ),
+			)
+		);
+
+		$this->assertSame( 1, $result['total'] );
+		$this->assertSame( 1, $result['rows'] );
+	}
+
+	/**
+	 * Published posts are public, so the ordinary collection is left alone.
+	 */
+	public function test_non_member_published_queries_are_untouched() {
+		wp_set_current_user( 0 );
+		$this->factory()->post->create_many( 2, array( 'post_status' => 'publish' ) );
+		wp_set_current_user( $this->non_member );
+
+		$result = $this->query_posts( array() );
+
+		$this->assertSame( 2, $result['total'] );
+		$this->assertSame( 2, $result['rows'] );
+	}
+
+	/**
+	 * Members are outside the grant, so nothing about their queries changes.
+	 */
+	public function test_member_queries_are_untouched() {
+		$this->seed_others_drafts();
+		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$result = $this->query_posts(
+			array(
+				'context' => 'edit',
+				'status'  => array( 'draft' ),
+			)
+		);
+
+		$this->assertSame( 3, $result['total'] );
+		$this->assertSame( 3, $result['rows'] );
+	}
+
+	/**
+	 * 'inherit' is the default status of the attachments route and defers to the
+	 * parent post, so restricting it would break media listings for no gain.
+	 */
+	public function test_inherit_status_is_not_restricted() {
+		$args = array(
+			'post_status' => array( 'inherit' ),
+			'author__in'  => array( 12 ),
+		);
+
+		$this->assertSame( $args, $this->plugin->restrict_non_public_queries( $args ) );
+	}
+
+	/*
 	 * Publishing policy: user_can_publish() decides who skips review.
 	 */
 

--- a/wordpress.org/public_html/wp-content/plugins/wporg-o2-posting-access/phpunit/tests/WPorg_O2_Posting_Access_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-o2-posting-access/phpunit/tests/WPorg_O2_Posting_Access_Test.php
@@ -113,11 +113,12 @@ class WPorg_O2_Posting_Access_Test extends WPorg_O2_Posting_Access_TestCase {
 	/**
 	 * Runs a posts collection request and returns its total.
 	 *
-	 * @param array $params Query parameters to set on the request.
+	 * @param array  $params Query parameters to set on the request.
+	 * @param string $route  Optional. Collection route to request.
 	 * @return array The response status, total, and row count.
 	 */
-	protected function query_posts( $params ) {
-		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+	protected function query_posts( $params, $route = '/wp/v2/posts' ) {
+		$request = new WP_REST_Request( 'GET', $route );
 
 		foreach ( $params as $key => $value ) {
 			$request->set_param( $key, $value );
@@ -242,6 +243,63 @@ class WPorg_O2_Posting_Access_Test extends WPorg_O2_Posting_Access_TestCase {
 
 		$this->assertSame( 3, $result['total'] );
 		$this->assertSame( 3, $result['rows'] );
+	}
+
+	/**
+	 * Core's 'wp_block' maps both 'read' and 'edit_posts' onto 'edit_posts', so
+	 * the grant reaches the patterns route as well and unpublished pattern
+	 * content is searchable there unless every post type is covered.
+	 */
+	public function test_non_member_cannot_count_others_unpublished_patterns() {
+		$author = $this->factory()->user->create( array( 'role' => 'author' ) );
+
+		$this->factory()->post->create_many(
+			2,
+			array(
+				'post_type'   => 'wp_block',
+				'post_status' => 'draft',
+				'post_author' => $author,
+				'post_title'  => 'Unannounced pattern',
+			)
+		);
+
+		$result = $this->query_posts(
+			array(
+				'context' => 'edit',
+				'status'  => array( 'draft' ),
+				'search'  => 'Unannounced',
+			),
+			'/wp/v2/blocks'
+		);
+
+		$this->assertLessThan( 400, $result['status'], 'Core still permits the request; the restriction is on what it counts.' );
+		$this->assertSame( 0, $result['total'] );
+		$this->assertSame( 0, $result['rows'] );
+	}
+
+	/**
+	 * Post types are registered on 'init', long after this plugin loads, so the
+	 * filter has to attach as they arrive rather than from a fixed list.
+	 *
+	 * The filter is asserted directly rather than over a request, because REST
+	 * routes are registered on 'rest_api_init' and a post type registered mid-test
+	 * has none.
+	 */
+	public function test_post_type_registered_after_load_is_restricted() {
+		register_post_type(
+			'wporg_test_rest_cpt',
+			array(
+				'public'          => true,
+				'show_in_rest'    => true,
+				'capability_type' => 'post',
+			)
+		);
+
+		$args = apply_filters( 'rest_wporg_test_rest_cpt_query', array( 'post_status' => array( 'draft' ) ) );
+
+		unregister_post_type( 'wporg_test_rest_cpt' );
+
+		$this->assertSame( $this->non_member, $args['author'] );
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/wporg-o2-posting-access/wporg-o2-posting-access.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-o2-posting-access/wporg-o2-posting-access.php
@@ -21,8 +21,12 @@ class Plugin {
 		}
 
 		add_filter( 'user_has_cap', [ $this, 'add_post_capabilities' ], 10, 4 );
-		add_filter( 'rest_post_query', [ $this, 'restrict_non_public_queries' ] );
-		add_filter( 'rest_attachment_query', [ $this, 'restrict_non_public_queries' ] );
+		add_action( 'registered_post_type', [ $this, 'restrict_rest_queries' ] );
+
+		foreach ( get_post_types() as $post_type ) {
+			$this->restrict_rest_queries( $post_type );
+		}
+
 		add_action( 'admin_bar_menu', [ $this, 'remove_non_accessible_menu_items' ], 100 );
 
 		if ( apply_filters( 'wporg_o2_enable_pending_for_unknown_users', true ) ) {
@@ -284,6 +288,16 @@ class Plugin {
 		$allcaps['edit_published_posts'] = true;
 
 		return $allcaps;
+	}
+
+	/**
+	 * Restricts REST collection queries for a post type.
+	 *
+	 * @param string $post_type Post type key.
+	 * @return void
+	 */
+	public function restrict_rest_queries( $post_type ) {
+		add_filter( "rest_{$post_type}_query", [ $this, 'restrict_non_public_queries' ] );
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/wporg-o2-posting-access/wporg-o2-posting-access.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-o2-posting-access/wporg-o2-posting-access.php
@@ -21,6 +21,8 @@ class Plugin {
 		}
 
 		add_filter( 'user_has_cap', [ $this, 'add_post_capabilities' ], 10, 4 );
+		add_filter( 'rest_post_query', [ $this, 'restrict_non_public_queries' ] );
+		add_filter( 'rest_attachment_query', [ $this, 'restrict_non_public_queries' ] );
 		add_action( 'admin_bar_menu', [ $this, 'remove_non_accessible_menu_items' ], 100 );
 
 		if ( apply_filters( 'wporg_o2_enable_pending_for_unknown_users', true ) ) {
@@ -282,6 +284,35 @@ class Plugin {
 		$allcaps['edit_published_posts'] = true;
 
 		return $allcaps;
+	}
+
+	/**
+	 * Restricts REST queries for non-public post statuses to the user's own posts.
+	 *
+	 * A query mixing public and non-public statuses is scoped whole, because one
+	 * set of WP_Query arguments cannot express "public by anyone, non-public by me".
+	 *
+	 * @param array $args An array of arguments for WP_Query.
+	 * @return array Filtered WP_Query arguments.
+	 */
+	public function restrict_non_public_queries( $args ) {
+		$user_id = get_current_user_id();
+
+		if ( ! $user_id || is_user_member_of_blog( $user_id ) || is_super_admin( $user_id ) ) {
+			return $args;
+		}
+
+		// 'inherit' is the attachments route's default status, so it is readable without the grant.
+		$public_statuses = array_merge( get_post_stati( [ 'public' => true ] ), [ 'inherit' ] );
+		if ( ! array_diff( (array) ( $args['post_status'] ?? [] ), $public_statuses ) ) {
+			return $args;
+		}
+
+		$args['author']         = $user_id;
+		$args['author__in']     = [];
+		$args['author__not_in'] = [];
+
+		return $args;
 	}
 }
 


### PR DESCRIPTION
Three small consistency fixes across the o2 plugins used on the Make sites, each independent of the others.

### o2 Posting Access

`add_post_capabilities()` grants `edit_posts` so a non-member can submit a post to a Make site. Core also consults `edit_posts` when deciding who may query the non-public post statuses over REST, so the same grant opens `?status=draft,pending,private` on the collection. This scopes those queries to the caller's own posts. Published collections, members and super admins are untouched.

The grant reaches further than `post`. Core's `wp_block` maps both `read` and `edit_posts` onto `edit_posts` (`wp-includes/post.php`), so `/wp/v2/blocks?status=draft` was open on the same footing, and any post type registered with `capability_type => 'post'` inherits the grant as well. Rather than name the affected routes, the restriction is registered for every post type — those already present when the plugin loads, and later ones through `registered_post_type` — so a newly registered type cannot reopen it.

A query mixing public and non-public statuses is scoped whole — one set of `WP_Query` arguments cannot express "public by anyone, non-public by me" — which is noted in the docblock.

`inherit` stays exempt deliberately. It is the attachments route's default status and takes its visibility from the parent post, but that count is already readable by anonymous visitors on any WordPress site, so the grant confers nothing extra there and scoping it would only make a non-member more restricted than a passer-by.

### O2 Private Posts

`handle_meta_data()` extracts hashtags from a private post's body and writes them with `wp_set_post_tags()`. `post_tag` is a public taxonomy, so a hashtag that isn't already in use becomes a term with an archive URL and a REST representation. Existing terms are still applied, so tag archives keep working for hashtags already in circulation; novel ones are skipped.

### o2 Follow

`handle_following_action()` tested only `comments_open()`, which reflects `comment_status` rather than who may read the post. Following routes a post's comments to the subscriber's inbox, so it now applies the same test core's comment list table uses (`WP_Comments_List_Table::single_row()`): editable, or publicly viewable/readable and not password-locked. The nonce is also bound to the post it was minted for rather than a static literal, so a token minted on one post is no longer valid for another.

Note that this rotates the nonce action, so Follow links already rendered into a page fail once and re-render.

### Testing

Ten tests added to the existing `wporg-o2-posting-access` suite, which the `make` suite already runs in CI (its path filters are derived from `environments/make/.wp-env.test.json`).

```
npm run make:test:posting-access
OK (41 tests, 59 assertions)
```

Five of the new tests fail when their corresponding source change is reverted, so they hold the behaviour rather than merely describing it. The `wp_block` case fails with a total of 2 — a non-member counting two of another author's draft patterns through `search`. `.github/bin/phpcs-branch.php` reports no violations on the changed lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Privacy**
  * Improved follow-action protection with post-specific nonce validation and access checks.
  * Prevented private-post hashtags from creating publicly visible tags.
  * Restricted unpublished content in REST API results, including dynamically registered post types and block patterns.
  * Preserved access to users’ own permitted content and public queries.

* **Tests**
  * Added coverage for unpublished block patterns, non-member author restrictions, and post types registered after plugin load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
