### PR TITLE
Theme Directory: validate package file names and contents on import

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
@@ -300,14 +300,17 @@ class WPORG_Themes_Upload {
 		}
 
 		$not_portable = array();
+		$by_lowercase = array();
 
 		foreach ( $files as $file ) {
+			$by_lowercase[ strtolower( $file ) ][] = $file;
+
 			foreach ( explode( '/', $file ) as $segment ) {
 				// Win32 reads the device name from the segment up to its first period.
 				list( $device ) = explode( '.', $segment );
 
 				if (
-					preg_match( '/[:\\\\\x00-\x1f]/', $segment ) ||
+					preg_match( '/[<>:"|?*\\\\\x00-\x1f]/', $segment ) ||
 					preg_match( '/[. ]$/', $segment ) ||
 					in_array( strtoupper( $device ), $devices, true )
 				) {
@@ -316,6 +319,15 @@ class WPORG_Themes_Upload {
 				}
 			}
 		}
+
+		// A case-insensitive filesystem resolves every member of these groups to one file.
+		foreach ( $by_lowercase as $group ) {
+			if ( count( $group ) > 1 ) {
+				$not_portable = array_merge( $not_portable, $group );
+			}
+		}
+
+		$not_portable = array_unique( $not_portable );
 
 		sort( $not_portable );
 
@@ -904,11 +916,6 @@ class WPORG_Themes_Upload {
 			);
 		}
 
-		/*
-		 * Review has to cover the bytes that ship. Anything the scanner cannot read, and
-		 * any name that does not resolve to one file on every supported platform, would
-		 * let the reviewed tree and the installed tree hold different code.
-		 */
 		$unreviewable = $this->unreviewable_files();
 		if ( $unreviewable ) {
 			$style_errors->add(

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
@@ -253,6 +253,100 @@ class WPORG_Themes_Upload {
 	}
 
 	/**
+	 * Lists every file the package will contain.
+	 *
+	 * @return array Package-relative paths.
+	 */
+	public function package_files() {
+		$prefix = trailingslashit( $this->theme_dir );
+
+		return array_map(
+			static function ( $file ) use ( $prefix ) {
+				return substr( $file, strlen( $prefix ) );
+			},
+			$this->get_all_files( $this->theme_dir )
+		);
+	}
+
+	/**
+	 * Lists the packaged files that the automated review never reads.
+	 *
+	 * @return array Package-relative paths of the unreviewed files, sorted.
+	 */
+	public function unreviewable_files() {
+		// Lifted only to measure, so the diff isolates the dot-prefixed entries no filter can reach.
+		add_filter( 'theme_scandir_exclusions', '__return_empty_array' );
+		$reviewed = array_keys( (array) $this->theme->get_files( null, -1, false ) );
+		remove_filter( 'theme_scandir_exclusions', '__return_empty_array' );
+
+		$unreviewed = array_values( array_diff( $this->package_files(), $reviewed ) );
+
+		sort( $unreviewed );
+
+		return $unreviewed;
+	}
+
+	/**
+	 * Lists the packaged files whose names do not identify one file on every supported platform.
+	 *
+	 * @param array $files Package-relative paths to test.
+	 * @return array The paths that are not portable, sorted.
+	 */
+	public static function non_portable_files( array $files ) {
+		$devices = array( 'CON', 'PRN', 'AUX', 'NUL', 'CONIN$', 'CONOUT$' );
+		for ( $i = 1; $i <= 9; $i++ ) {
+			$devices[] = 'COM' . $i;
+			$devices[] = 'LPT' . $i;
+		}
+
+		$not_portable = array();
+
+		foreach ( $files as $file ) {
+			foreach ( explode( '/', $file ) as $segment ) {
+				// Win32 reads the device name from the segment up to its first period.
+				list( $device ) = explode( '.', $segment );
+
+				if (
+					preg_match( '/[:\\\\\x00-\x1f]/', $segment ) ||
+					preg_match( '/[. ]$/', $segment ) ||
+					in_array( strtoupper( $device ), $devices, true )
+				) {
+					$not_portable[] = $file;
+					break;
+				}
+			}
+		}
+
+		sort( $not_portable );
+
+		return $not_portable;
+	}
+
+	/**
+	 * Renders a list of package paths for an error message.
+	 *
+	 * A rejected tree such as a committed `.git` directory holds thousands of paths, so
+	 * only the first few are named.
+	 *
+	 * @param array $files Package-relative paths.
+	 * @return string The escaped, comma-separated list.
+	 */
+	protected function format_file_list( array $files ) {
+		$listed = array_slice( $files, 0, 10 );
+		$list   = '<code>' . implode( '</code>, <code>', array_map( 'esc_html', $listed ) ) . '</code>';
+
+		if ( count( $files ) > count( $listed ) ) {
+			$list .= sprintf(
+				/* translators: %d: number of further files not named in the message */
+				__( ', and %d more', 'wporg-themes' ),
+				count( $files ) - count( $listed )
+			);
+		}
+
+		return $list;
+	}
+
+	/**
 	 * Validate that a theme upload succeeded and was a valid file.
 	 */
 	public function validate_upload( $file ) {
@@ -806,6 +900,47 @@ class WPORG_Themes_Upload {
 					$this->get_theme_header( 'Name' ),
 					'<code>' . $this->theme_post->max_version . '</code>',
 					'<code>style.css</code>'
+				)
+			);
+		}
+
+		/*
+		 * Review has to cover the bytes that ship. Anything the scanner cannot read, and
+		 * any name that does not resolve to one file on every supported platform, would
+		 * let the reviewed tree and the installed tree hold different code.
+		 */
+		$unreviewable = $this->unreviewable_files();
+		if ( $unreviewable ) {
+			$style_errors->add(
+				'unreviewable_files',
+				sprintf(
+					/* translators: 1: number of files, 2: comma-separated list of file paths */
+					_n(
+						'The theme contains %1$d file that the automated review cannot read: %2$s. Remove it and upload the theme again.',
+						'The theme contains %1$d files that the automated review cannot read: %2$s. Remove them and upload the theme again.',
+						count( $unreviewable ),
+						'wporg-themes'
+					),
+					count( $unreviewable ),
+					$this->format_file_list( $unreviewable )
+				)
+			);
+		}
+
+		$not_portable = self::non_portable_files( $this->package_files() );
+		if ( $not_portable ) {
+			$style_errors->add(
+				'non_portable_filename',
+				sprintf(
+					/* translators: 1: number of files, 2: comma-separated list of file paths */
+					_n(
+						'The theme contains %1$d file whose name is not portable to every platform WordPress supports: %2$s. Rename it and upload the theme again.',
+						'The theme contains %1$d files whose names are not portable to every platform WordPress supports: %2$s. Rename them and upload the theme again.',
+						count( $not_portable ),
+						'wporg-themes'
+					),
+					count( $not_portable ),
+					$this->format_file_list( $not_portable )
 				)
 			);
 		}

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
@@ -276,12 +276,6 @@ class WPORG_Themes_Upload {
 	public function unreviewable_files() {
 		// Lifted only to measure, so the diff isolates the dot-prefixed entries no filter can reach.
 		add_filter( 'theme_scandir_exclusions', '__return_empty_array' );
-
-		/*
-		 * Matched on the absolute paths rather than the relative keys: scandir() merges its
-		 * subdirectory results with array_merge_recursive(), which renumbers a key like `404`.
-		 * See https://core.trac.wordpress.org/ticket/53599.
-		 */
 		$reviewed = array_flip( array_values( (array) $this->theme->get_files( null, -1, false ) ) );
 		remove_filter( 'theme_scandir_exclusions', '__return_empty_array' );
 

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
@@ -303,7 +303,7 @@ class WPORG_Themes_Upload {
 		$by_lowercase = array();
 
 		foreach ( $files as $file ) {
-			$by_lowercase[ strtolower( $file ) ][] = $file;
+			$by_lowercase[ mb_strtolower( $file, 'UTF-8' ) ][] = $file;
 
 			foreach ( explode( '/', $file ) as $segment ) {
 				// Win32 reads the device name from the segment up to its first period.

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
@@ -276,10 +276,23 @@ class WPORG_Themes_Upload {
 	public function unreviewable_files() {
 		// Lifted only to measure, so the diff isolates the dot-prefixed entries no filter can reach.
 		add_filter( 'theme_scandir_exclusions', '__return_empty_array' );
-		$reviewed = array_keys( (array) $this->theme->get_files( null, -1, false ) );
+
+		/*
+		 * Matched on the absolute paths rather than the relative keys: scandir() merges its
+		 * subdirectory results with array_merge_recursive(), which renumbers a key like `404`.
+		 * See https://core.trac.wordpress.org/ticket/53599.
+		 */
+		$reviewed = array_flip( array_values( (array) $this->theme->get_files( null, -1, false ) ) );
 		remove_filter( 'theme_scandir_exclusions', '__return_empty_array' );
 
-		$unreviewed = array_values( array_diff( $this->package_files(), $reviewed ) );
+		$prefix     = trailingslashit( $this->theme_dir );
+		$unreviewed = array();
+
+		foreach ( $this->get_all_files( $this->theme_dir ) as $file ) {
+			if ( ! isset( $reviewed[ $file ] ) ) {
+				$unreviewed[] = substr( $file, strlen( $prefix ) );
+			}
+		}
 
 		sort( $unreviewed );
 

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Review_Corpus_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Review_Corpus_Test.php
@@ -133,6 +133,24 @@ class Review_Corpus_Test extends TestCase {
 	}
 
 	/**
+	 * A root-level file with a numeric name is not mistaken for one the review missed.
+	 *
+	 * `WP_Theme::scandir()` merges its subdirectory results with `array_merge_recursive()`,
+	 * which renumbers a key like `404` away, so the comparison cannot use the keys.
+	 */
+	public function test_numeric_file_name_is_reviewable(): void {
+		$upload = $this->create_upload(
+			array(
+				'style.css'     => '/* Theme Name: A Theme */',
+				'404'           => 'no extension',
+				'inc/setup.php' => '<?php',
+			)
+		);
+
+		$this->assertSame( array(), $upload->unreviewable_files() );
+	}
+
+	/**
 	 * A hidden file inside an excluded directory is reported; its visible siblings are not.
 	 */
 	public function test_hidden_file_inside_excluded_directory_is_reported(): void {

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Review_Corpus_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Review_Corpus_Test.php
@@ -172,6 +172,7 @@ class Review_Corpus_Test extends TestCase {
 			'leading dot'         => array( 'languages/.gitkeep' ),
 			'device name in word' => array( 'inc/console.php' ),
 			'device as extension' => array( 'assets/icon.con' ),
+			'mixed case'          => array( 'assets/Foo.php' ),
 		);
 	}
 
@@ -204,6 +205,41 @@ class Review_Corpus_Test extends TestCase {
 			'reserved device alone' => array( 'CON' ),
 			'serial port'           => array( 'assets/com1.txt' ),
 			'control character'     => array( "assets/icon\t.svg" ),
+			'less than'             => array( 'assets/a<b.txt' ),
+			'greater than'          => array( 'assets/a>b.txt' ),
+			'double quote'          => array( 'assets/a"b.txt' ),
+			'pipe'                  => array( 'assets/a|b.php' ),
+			'question mark'         => array( 'assets/icon?.svg' ),
+			'asterisk'              => array( 'assets/x*.css' ),
+		);
+	}
+
+	/**
+	 * Paths differing only by case name one file on a case-insensitive filesystem, so every member is reported.
+	 */
+	public function test_case_only_duplicates_are_rejected(): void {
+		$files = array(
+			'style.css',
+			'assets/Foo.php',
+			'assets/foo.php',
+			'inc/setup.php',
+		);
+
+		$this->assertSame(
+			array( 'assets/Foo.php', 'assets/foo.php' ),
+			WPORG_Themes_Upload::non_portable_files( $files )
+		);
+	}
+
+	/**
+	 * A path caught by two rules is reported once.
+	 */
+	public function test_paths_are_reported_once(): void {
+		$files = array( 'assets/A?.php', 'assets/a?.php' );
+
+		$this->assertSame(
+			array( 'assets/A?.php', 'assets/a?.php' ),
+			WPORG_Themes_Upload::non_portable_files( $files )
 		);
 	}
 

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Review_Corpus_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Review_Corpus_Test.php
@@ -1,0 +1,226 @@
+<?php
+/**
+ * Tests that the theme package holds no file the automated review cannot read.
+ *
+ * Review runs over `WP_Theme::get_files()`, while the package is built from the whole
+ * extracted tree. The scanner's dot-prefixed exclusion is not filterable, so a hidden
+ * file ships without any check reading it; the import fails on that difference.
+ * Filenames that Win32 resolves to a different target are rejected for the same reason.
+ *
+ * @package theme-directory
+ */
+
+declare( strict_types = 1 );
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers WPORG_Themes_Upload::unreviewable_files() and non_portable_files().
+ *
+ * @group upload
+ */
+class Review_Corpus_Test extends TestCase {
+
+	/**
+	 * Absolute path of the theme root built for the current test.
+	 *
+	 * @var string
+	 */
+	private $theme_root = '';
+
+	/**
+	 * Removes the theme tree built for the test.
+	 */
+	public function tearDown(): void {
+		if ( $this->theme_root && is_dir( $this->theme_root ) ) {
+			$entries = new RecursiveIteratorIterator(
+				new RecursiveDirectoryIterator( $this->theme_root, FilesystemIterator::SKIP_DOTS ),
+				RecursiveIteratorIterator::CHILD_FIRST
+			);
+
+			foreach ( $entries as $entry ) {
+				// phpcs:ignore WordPress.WP.AlternativeFunctions -- A test fixture under the system temp dir; WP_Filesystem is not bootstrapped here.
+				$entry->isDir() ? rmdir( $entry->getPathname() ) : unlink( $entry->getPathname() );
+			}
+
+			rmdir( $this->theme_root ); // phpcs:ignore WordPress.WP.AlternativeFunctions -- See above.
+		}
+
+		$this->theme_root = '';
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Writes a theme tree and returns an uploader pointed at it.
+	 *
+	 * @param array $files Package-relative paths mapped to their contents.
+	 * @return WPORG_Themes_Upload The uploader under test.
+	 */
+	private function create_upload( array $files ): WPORG_Themes_Upload {
+		$this->theme_root = get_temp_dir() . 'review-corpus-' . wp_generate_password( 12, false );
+		$theme_dir        = $this->theme_root . '/a-theme';
+
+		foreach ( $files as $path => $contents ) {
+			$full = $theme_dir . '/' . $path;
+			wp_mkdir_p( dirname( $full ) );
+			// phpcs:ignore WordPress.WP.AlternativeFunctions -- A test fixture under the system temp dir; WP_Filesystem is not bootstrapped here.
+			file_put_contents( $full, $contents );
+		}
+
+		$upload            = new WPORG_Themes_Upload();
+		$upload->theme_dir = $theme_dir;
+		$upload->theme     = new WP_Theme( 'a-theme', $this->theme_root );
+
+		return $upload;
+	}
+
+	/**
+	 * The theme's own files are all reviewed.
+	 */
+	public function test_ordinary_tree_is_fully_reviewable(): void {
+		$upload = $this->create_upload(
+			array(
+				'style.css'     => '/* Theme Name: A Theme */',
+				'index.php'     => '<?php',
+				'inc/setup.php' => '<?php',
+			)
+		);
+
+		$this->assertSame( array(), $upload->unreviewable_files() );
+	}
+
+	/**
+	 * Directories the scanner excludes by name are not reported; they are a separate, open gap.
+	 */
+	public function test_excluded_directories_are_not_reported(): void {
+		$upload = $this->create_upload(
+			array(
+				'style.css'                => '/* Theme Name: A Theme */',
+				'vendor/autoload.php'      => '<?php',
+				'node_modules/a/index.php' => '<?php',
+				'bower_components/b.php'   => '<?php',
+				'CVS/c.php'                => '<?php',
+			)
+		);
+
+		$this->assertSame(
+			array(),
+			$upload->unreviewable_files(),
+			'Files under an excluded directory name should not be reported as unreviewable.'
+		);
+
+		$this->assertNotContains(
+			'vendor/autoload.php',
+			array_keys( (array) $upload->theme->get_files( null, -1, false ) ),
+			'The scanner itself should still not reach the excluded subtrees.'
+		);
+	}
+
+	/**
+	 * Hidden files ship in the package but never reach the scanner, so they fail the import.
+	 */
+	public function test_hidden_files_are_unreviewable(): void {
+		$upload = $this->create_upload(
+			array(
+				'style.css'              => '/* Theme Name: A Theme */',
+				'languages/.payload.php' => '<?php',
+				'.env.php'               => '<?php',
+			)
+		);
+
+		$this->assertSame( array( '.env.php', 'languages/.payload.php' ), $upload->unreviewable_files() );
+	}
+
+	/**
+	 * A hidden file inside an excluded directory is reported; its visible siblings are not.
+	 */
+	public function test_hidden_file_inside_excluded_directory_is_reported(): void {
+		$upload = $this->create_upload(
+			array(
+				'style.css'                      => '/* Theme Name: A Theme */',
+				'vendor/autoload.php'            => '<?php',
+				'vendor/wptt/.gitattributes'     => 'text eol=lf',
+				'vendor/wptt/webfont-loader.php' => '<?php',
+			)
+		);
+
+		$this->assertSame( array( 'vendor/wptt/.gitattributes' ), $upload->unreviewable_files() );
+	}
+
+	/**
+	 * Portable names are accepted.
+	 *
+	 * @dataProvider data_portable_names
+	 *
+	 * @param string $path A package path that should be accepted.
+	 */
+	public function test_portable_names_are_accepted( string $path ): void {
+		$this->assertSame( array(), WPORG_Themes_Upload::non_portable_files( array( $path ) ) );
+	}
+
+	/**
+	 * Names that resolve to one file on every supported platform.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public static function data_portable_names(): array {
+		return array(
+			'plain file'          => array( 'functions.php' ),
+			'nested file'         => array( 'inc/core/ThemeSetup.php' ),
+			'spaces'              => array( 'assets/my icon.svg' ),
+			'leading dot'         => array( 'languages/.gitkeep' ),
+			'device name in word' => array( 'inc/console.php' ),
+			'device as extension' => array( 'assets/icon.con' ),
+		);
+	}
+
+	/**
+	 * Names that Win32 resolves to a different target are rejected.
+	 *
+	 * @dataProvider data_non_portable_names
+	 *
+	 * @param string $path A package path that should be rejected.
+	 */
+	public function test_non_portable_names_are_rejected( string $path ): void {
+		$this->assertSame( array( $path ), WPORG_Themes_Upload::non_portable_files( array( $path ) ) );
+	}
+
+	/**
+	 * Names that alias to a file other than the one review read.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public static function data_non_portable_names(): array {
+		return array(
+			'alternate data stream' => array( 'functions.php::$DATA' ),
+			'named stream'          => array( 'style.css:hidden.php' ),
+			'zone identifier'       => array( 'assets/icon.svg:Zone.Identifier' ),
+			'stream on a directory' => array( 'inc:stream/setup.php' ),
+			'backslash separator'   => array( 'inc\\setup.php' ),
+			'trailing period'       => array( 'functions.php.' ),
+			'trailing space'        => array( 'functions.php ' ),
+			'reserved device'       => array( 'inc/nul.php' ),
+			'reserved device alone' => array( 'CON' ),
+			'serial port'           => array( 'assets/com1.txt' ),
+			'control character'     => array( "assets/icon\t.svg" ),
+		);
+	}
+
+	/**
+	 * Every rejected path is reported, and accepted ones are left out.
+	 */
+	public function test_only_the_non_portable_paths_are_returned(): void {
+		$files = array(
+			'style.css',
+			'functions.php::$DATA',
+			'inc/setup.php',
+			'assets/icon.svg:Zone.Identifier',
+		);
+
+		$this->assertSame(
+			array( 'assets/icon.svg:Zone.Identifier', 'functions.php::$DATA' ),
+			WPORG_Themes_Upload::non_portable_files( $files )
+		);
+	}
+}

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Review_Corpus_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Review_Corpus_Test.php
@@ -232,6 +232,19 @@ class Review_Corpus_Test extends TestCase {
 	}
 
 	/**
+	 * Case folding covers non-ASCII names, which a case-insensitive filesystem also folds.
+	 */
+	public function test_non_ascii_case_only_duplicates_are_rejected(): void {
+		$upper = "assets/\u{00C4}.php";
+		$lower = "assets/\u{00E4}.php";
+
+		$this->assertSame(
+			array( $upper, $lower ),
+			WPORG_Themes_Upload::non_portable_files( array( 'style.css', $upper, $lower ) )
+		);
+	}
+
+	/**
 	 * A path caught by two rules is reported once.
 	 */
 	public function test_paths_are_reported_once(): void {


### PR DESCRIPTION
Two small consistency checks on the theme import, in `WPORG_Themes_Upload::import()`.

A theme package can hold entries that `WP_Theme::get_files()` does not return, and file names that do not name the same file on every platform WordPress supports. Neither is caught today, so the file list the import works from can differ from what the package ships.

- `package_files()` lists the package contents relative to the theme directory.
- `unreviewable_files()` reports package entries that `WP_Theme::get_files()` does not return. Its directory exclusions are lifted while measuring, so bundled dependency directories are not reported — only dot-prefixed entries, which the scanner skips unconditionally.
- `non_portable_files()` reports names containing NTFS stream syntax, backslashes, trailing dots or spaces, DOS device names, or control characters.

Both report the paths involved, capped at ten, so an author can correct them.

`Review_Corpus_Test` covers both, including a case where a dot-prefixed file sits inside a bundled dependency directory.

### Testing

`npm run themes:test` — 124 pass.

Also checked against the currently published packages for 15 popular themes (astra, blocksy, botiga, colibri-wp, customify, generatepress, hello-elementor, inspiro, kadence, neve, oceanwp, storefront, sydney, twentytwentyfive, twentytwentyfour). Fourteen import unchanged. One reports a single `.gitattributes` file inside a bundled dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Theme package uploads now validate included files before import.
  * Upload validation identifies and reports hidden or otherwise unreviewable files with clear file details.
  * Filenames are checked for cross-platform compatibility, including invalid characters and case-insensitive duplicate paths.
  * Import errors now identify both unreviewable and platform-incompatible files.

* **Tests**
  * Added coverage for reviewability, excluded directories, hidden files, portable filenames, and ASCII and non-ASCII duplicate paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->