### PR TITLE
Theme Previews: only persist registered style variations in links

### DIFF
--- a/wp-themes.com/public_html/wp-content/plugins/style-variations/inc/page-intercept.php
+++ b/wp-themes.com/public_html/wp-content/plugins/style-variations/inc/page-intercept.php
@@ -5,7 +5,7 @@ namespace WordPressdotorg\Theme_Preview\Style_Variations\Page_Intercept;
 use function WordPressdotorg\Theme_Preview\Style_Variations\get_style_variations;
 
 /**
- * Return the name of the pattern from the $_GET request.
+ * Return the requested style variation title from the $_GET request.
  *
  * @return string
  */
@@ -14,74 +14,62 @@ function get_style_variation_from_url() {
 		return '';
 	}
 
-	return sanitize_text_field( urldecode( wp_unslash( $_GET['style_variation'] ) ) );
+	return sanitize_text_field( wp_unslash( $_GET['style_variation'] ) );
 }
 
 /**
- * Retrieves the variation based on presense of query string.
+ * Retrieves the variation registered by the theme that matches the query string.
  *
- * @return false|array
+ * The result is cached per theme, as the link filters below call this once per link on the page.
+ *
+ * @return false|array The variation, or false when the query string is absent or matches nothing.
  */
 function get_variation_from_query() {
+	static $cache = array();
+
+	$stylesheet = get_stylesheet();
+	if ( array_key_exists( $stylesheet, $cache ) ) {
+		return $cache[ $stylesheet ];
+	}
+
+	$cache[ $stylesheet ] = false;
+
 	$variation_title = get_style_variation_from_url();
 	if ( empty( $variation_title ) ) {
 		return false;
 	}
 
-	/**
-	 * Retrieve all variations and match to make sure we have one with the same title.
-	 */
 	$variations = get_style_variations();
 	if ( empty( $variations ) ) {
 		return false;
 	}
 
-	return current(
+	$cache[ $stylesheet ] = current(
 		array_filter(
 			$variations,
-			function( $variation ) use ( $variation_title ) {
-				return strtolower( $variation['title'] ) == strtolower( $variation_title );
+			function ( $variation ) use ( $variation_title ) {
+				return strtolower( $variation['title'] ) === strtolower( $variation_title );
 			}
 		)
 	);
+
+	return $cache[ $stylesheet ];
 }
 
 /**
  * Update the theme's variation if valid query string is present.
  *
- * @param WP_Theme_JSON_Data_Gutenberg $theme_json
+ * @param WP_Theme_JSON_Data_Gutenberg $theme_json The theme JSON data.
  * @return WP_Theme_JSON_Data_Gutenberg
  */
 function filter_theme_json_user( $theme_json ) {
-	$variation_title = get_style_variation_from_url();
-	if ( empty( $variation_title ) ) {
-		return $theme_json;
-	}
-
-	/**
-	 * Retrieve all variations and match to make sure we have one with the same title.
-	 */
-	$variations = \WP_Theme_JSON_Resolver::get_style_variations();
-	if ( empty( $variations ) ) {
-		return $theme_json;
-	}
-
-	$variation_details = current(
-		array_filter(
-			$variations,
-			function( $variation ) use ( $variation_title ) {
-				return strtolower( $variation['title'] ) == strtolower( $variation_title );
-			}
-		)
-	);
-
 	$variation_details = get_variation_from_query();
 
 	if ( ! $variation_details ) {
 		return $theme_json;
 	}
 
-	// Override styles with variation
+	// Override styles with variation.
 	$new_data = array(
 		'version' => 2,
 	);
@@ -107,7 +95,6 @@ function filter_theme_json_user( $theme_json ) {
  * Hopefully this code can be remove when we have a better component to use.
  *
  * Ref: https://github.com/WordPress/gutenberg/issues/44886
-
  */
 add_filter( 'theme_json_user', __NAMESPACE__ . '\filter_theme_json_user' );
 add_filter( 'wp_theme_json_data_user', __NAMESPACE__ . '\filter_theme_json_user' );
@@ -115,20 +102,23 @@ add_filter( 'wp_theme_json_data_user', __NAMESPACE__ . '\filter_theme_json_user'
 /**
  * Appends a query string to maintain the style variation state.
  *
- * @param string $link
+ * Only a variation the theme actually registers is carried across, using the same
+ * lower-cased, URL-encoded form the styles endpoint generates.
+ *
+ * @param string $link The link being filtered.
  * @return string URL
  */
 function persist_query_string( $link ) {
-	$variation_title = get_style_variation_from_url();
+	$variation = get_variation_from_query();
 
-	if ( $variation_title ) {
-		return add_query_arg( 'style_variation', $variation_title, $link );
+	if ( ! $variation || empty( $variation['title'] ) ) {
+		return $link;
 	}
 
-	return $link;
+	return add_query_arg( 'style_variation', rawurlencode( strtolower( $variation['title'] ) ), $link );
 }
 
-add_filter( 'page_link', __NAMESPACE__ . '\persist_query_string', 10, 2 );
-add_filter( 'post_link', __NAMESPACE__ . '\persist_query_string', 10, 2 );
-add_filter( 'term_link', __NAMESPACE__ . '\persist_query_string', 10, 2 );
-add_filter( 'home_url', __NAMESPACE__ . '\persist_query_string', 10, 2 );
+add_filter( 'page_link', __NAMESPACE__ . '\persist_query_string' );
+add_filter( 'post_link', __NAMESPACE__ . '\persist_query_string' );
+add_filter( 'term_link', __NAMESPACE__ . '\persist_query_string' );
+add_filter( 'home_url', __NAMESPACE__ . '\persist_query_string' );

--- a/wp-themes.com/public_html/wp-content/plugins/style-variations/inc/page-intercept.php
+++ b/wp-themes.com/public_html/wp-content/plugins/style-variations/inc/page-intercept.php
@@ -3,6 +3,7 @@
 namespace WordPressdotorg\Theme_Preview\Style_Variations\Page_Intercept;
 
 use function WordPressdotorg\Theme_Preview\Style_Variations\get_style_variations;
+use function WordPressdotorg\Theme_Preview\Style_Variations\get_variation_query_value;
 
 /**
  * Return the requested style variation title from the $_GET request.
@@ -32,6 +33,9 @@ function get_variation_from_query() {
 		return $cache[ $stylesheet ];
 	}
 
+	// Written before the lookup on purpose: the lookup below reads the theme's styles and can
+	// call home_url(), which runs persist_query_string() and lands back here. The early miss
+	// turns that into a no-op instead of a recursion.
 	$cache[ $stylesheet ] = false;
 
 	$variation_title = get_style_variation_from_url();
@@ -115,7 +119,7 @@ function persist_query_string( $link ) {
 		return $link;
 	}
 
-	return add_query_arg( 'style_variation', rawurlencode( strtolower( $variation['title'] ) ), $link );
+	return add_query_arg( 'style_variation', get_variation_query_value( $variation ), $link );
 }
 
 add_filter( 'page_link', __NAMESPACE__ . '\persist_query_string' );

--- a/wp-themes.com/public_html/wp-content/plugins/style-variations/inc/styles-endpoint.php
+++ b/wp-themes.com/public_html/wp-content/plugins/style-variations/inc/styles-endpoint.php
@@ -3,6 +3,7 @@
 namespace WordPressdotorg\Theme_Preview\Style_Variations\API_Endpoint;
 
 use function WordPressdotorg\Theme_Preview\Style_Variations\get_style_variations;
+use function WordPressdotorg\Theme_Preview\Style_Variations\get_variation_query_value;
 
 function endpoint_handler() {
 	$variations    = get_style_variations();
@@ -28,7 +29,7 @@ function endpoint_handler() {
 		 */
 		foreach ( $variations as $variation ) {
 			$title = strtolower( $variation['title'] );
-			$link  = add_query_arg( 'style_variation', urlencode( $title ), $base );
+			$link  = add_query_arg( 'style_variation', get_variation_query_value( $variation ), $base );
 
 			$styles[] = array(
 				'title'        => $title,

--- a/wp-themes.com/public_html/wp-content/plugins/style-variations/style-variations.php
+++ b/wp-themes.com/public_html/wp-content/plugins/style-variations/style-variations.php
@@ -53,6 +53,18 @@ function get_style_variations() {
 	return $variations;
 }
 
+/**
+ * Returns the value used for the `style_variation` query argument of a variation.
+ *
+ * Shared by the styles endpoint and the link persistence so a variation has one URL spelling.
+ *
+ * @param array $variation Variation, as returned by get_style_variations().
+ * @return string Lower-cased, URL-encoded title.
+ */
+function get_variation_query_value( $variation ) {
+	return rawurlencode( strtolower( $variation['title'] ) );
+}
+
 require_once __DIR__ . '/inc/global-style-page.php';
 require_once __DIR__ . '/inc/page-intercept.php';
 require_once __DIR__ . '/inc/styles-endpoint.php';


### PR DESCRIPTION
## Why

`?style_variation=` on a wp-themes.com preview picks one of the theme's style variations, and `persist_query_string()` carries it across every page, post, term and home link so navigation keeps the selection. The styles endpoint (`styles-endpoint.php:31`) builds those links only from variations the theme registers, lower-cased and URL-encoded (r13301). The persistence filter took the request value as-is: any non-empty string was appended to every link on the page, unencoded, whether or not the theme had such a variation.

A registered title with `&` or a space also broke on trunk: the endpoint link `?style_variation=mint+%26+sea+foam` rendered a page whose persisted links read `?style_variation=mint%20&#038;%20sea%20foam&#038;sea_foam/`, and the next click arrived as `mint ` and matched nothing (r13301 fixed the endpoint link, not these).

Two smaller things in the same file: `get_style_variation_from_url()` ran `urldecode()` on a value PHP has already decoded, and `filter_theme_json_user()` did the variation lookup twice, with the first result thrown away.

## What changed

- `persist_query_string()` goes through `get_variation_from_query()`, so only a registered variation is appended, in the same lower-cased, `rawurlencode`d form the endpoint produces. Anything else is left out of the links.
- `get_variation_from_query()` caches per stylesheet. The link filters call it once per link, and `WP_Theme_JSON_Resolver::get_style_variations()` re-reads the `styles/` directory on every call.
- The `urldecode()` is gone, and `filter_theme_json_user()` uses the single lookup. Title comparison is `===`, both sides are strings.
- Filter registrations drop the unused accepted-args count.
- One helper, `get_variation_query_value()`, feeds both the styles endpoint and the persistence, so a variation has a single URL spelling (the endpoint used `urlencode`, persistence `rawurlencode`; same variation, two cache keys).
- The early `false` write in the lookup cache is commented as re-entrancy protection, since the lookup can reach `home_url()` and land back in the same function.

Visible effect: a visitor on `?style_variation=<something the theme does not have>` sees the parameter drop from the links on their next click instead of being carried along. Dropping the `urldecode()` is also more than a redundancy fix, because `sanitize_text_field()` strips percent-encoded octets, so decoding first changed what reached it.

## Testing

Ran the filter chain in wp-env against Twenty Twenty-Five with the trunk copy and this branch side by side, forcing the theme through `pre_option_stylesheet`. `evening` and `Evening` persist as `?style_variation=evening` on `get_permalink()` and `home_url()` in both. `nope` and other unregistered values were carried across on trunk and aren't here. The endpoint and the persisted links now agree byte for byte (`mint%20%26%20sea%20foam` on both, re-checked in wp-env after the helper). php -l and phpcs are clean on the changed lines (the file docblock and the nonce warnings on the GET read predate this).

Also checked with a variation titled `Mint & Sea Foam` (a copy of Noon added to the env theme): trunk mangles the persisted link as above and drops the variation on the next page, the branch keeps `mint%20%26%20sea%20foam` across clicks and applies the variation on every page, same as `noon`. The endpoint uses `urlencode` and this uses `rawurlencode`; PHP decodes both the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
