### PR TITLE
Plugin Directory: Readme Validator: fetch readmes from known hosts only

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/readme/class-validator.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/readme/class-validator.php
@@ -507,8 +507,9 @@ class Validator {
 			case 'trademarked_slug':
 			case 'trademarked':
 				$trademarks = (array) $data['trademark'];
-				$context    = $data['context'];
-				$messages   = [];
+				// Callers differ on whether they pre-escape the context, so normalise it first.
+				$context  = esc_html( wp_specialchars_decode( $data['context'], ENT_QUOTES ) );
+				$messages = [];
 	
 				$cannot_start_with = array_filter( $trademarks, function( $slug ) {
 					return str_ends_with( $slug, '-' );

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/readme/class-validator.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/readme/class-validator.php
@@ -19,6 +19,24 @@ class Validator {
 	public $last_content = '';
 
 	/**
+	 * Hosts a readme may be fetched from.
+	 *
+	 * @var string[]
+	 */
+	private static $allowed_hosts = array(
+		'plugins.svn.wordpress.org',
+		'themes.svn.wordpress.org',
+		'raw.githubusercontent.com',
+	);
+
+	/**
+	 * Maximum size of a readme fetched by URL, in bytes.
+	 *
+	 * @var int
+	 */
+	const MAX_FETCH_BYTES = 512 * KB_IN_BYTES;
+
+	/**
 	 * Fetch the instance of the Validator class.
 	 *
 	 * @static
@@ -36,7 +54,17 @@ class Validator {
 	 * @return array Array of the readme validation results.
 	 */
 	public function validate_url( $url ) {
-		$url = esc_url_raw( $url );
+		$url = esc_url_raw( $url, array( 'http', 'https' ) );
+
+		$host = strtolower( (string) wp_parse_url( $url, PHP_URL_HOST ) );
+		if ( ! in_array( $host, self::$allowed_hosts, true ) ) {
+			$error = sprintf(
+				/* translators: %s: Comma-separated list of hostnames. */
+				__( 'URL must be a readme hosted on one of %s. To validate a readme from anywhere else, paste its contents below.', 'wporg-plugins' ),
+				'<code>' . implode( '</code>, <code>', self::$allowed_hosts ) . '</code>'
+			);
+			return array( 'errors' => array( 'disallowed_url_host' => $error ) );
+		}
 
 		$path = wp_parse_url( $url, PHP_URL_PATH ) ?? '';
 		if (
@@ -48,17 +76,32 @@ class Validator {
 				__( 'URL must end in %s or %s!', 'wporg-plugins' ),
 				'<code>readme.txt</code>', '<code>readme.md</code>'
 			);
-			return array(
-				'errors' => array( $error ),
-			);
+			return array( 'errors' => array( 'invalid_url_extension' => $error ) );
 		}
 
-		$readme = wp_safe_remote_get( $url );
-		if ( ! $readme_text = wp_remote_retrieve_body( $readme ) ) {
+		// Every allowed host redirects plain HTTP to HTTPS, and redirects are not followed.
+		$url = set_url_scheme( $url, 'https' );
+
+		$args = array(
+			'redirection'         => 0,
+			'limit_response_size' => self::MAX_FETCH_BYTES,
+		);
+
+		$readme      = wp_safe_remote_get( $url, $args );
+		$readme_text = wp_remote_retrieve_body( $readme );
+
+		if ( 200 !== wp_remote_retrieve_response_code( $readme ) || ! $readme_text ) {
 			$error = __( 'Invalid readme.txt URL.', 'wporg-plugins' );
-			return array(
-				'errors' => array( $error ),
+			return array( 'errors' => array( 'invalid_url' => $error ) );
+		}
+
+		if ( strlen( $readme_text ) >= self::MAX_FETCH_BYTES ) {
+			$error = sprintf(
+				/* translators: %s: Maximum readme size, e.g. "512 KB". */
+				__( 'The readme at that URL is larger than %s, so it was not validated. Paste its contents below instead.', 'wporg-plugins' ),
+				size_format( self::MAX_FETCH_BYTES )
 			);
+			return array( 'errors' => array( 'readme_too_large' => $error ) );
 		}
 
 		return $this->validate_content( $readme_text );

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Readme_Validator_Message_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Readme_Validator_Message_Test.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Tests for Validator::translate_code_to_message().
+ *
+ * @package WordPressdotorg\Plugin_Directory\Tests
+ */
+
+declare( strict_types = 1 );
+
+use PHPUnit\Framework\TestCase;
+use WordPressdotorg\Plugin_Directory\Readme\Validator;
+
+/**
+ * Covers the escaping of caller-supplied values quoted in validation messages.
+ *
+ * The `[readme-validator]` shortcode prints these messages without escaping them again, and the
+ * plugin name they quote comes from a readme, so the escaping has to happen here.
+ *
+ * @group readme
+ */
+class Readme_Validator_Message_Test extends TestCase {
+
+	/**
+	 * The trademark message quotes the plugin name without leaving markup in it.
+	 *
+	 * @dataProvider trademark_context_provider
+	 *
+	 * @param string $context  The plugin name supplied by the caller.
+	 * @param string $expected The value the message is expected to quote.
+	 * @return void
+	 */
+	public function test_trademark_message_escapes_the_plugin_name( string $context, string $expected ): void {
+		$message = Validator::instance()->translate_code_to_message(
+			'trademarked_name',
+			array(
+				'trademark' => array( 'wordpress' ),
+				'context'   => $context,
+			)
+		);
+
+		preg_match( '!<code>(.*?)</code>!', $message, $matches );
+
+		$this->assertSame( $expected, $matches[1] ?? '' );
+	}
+
+	/**
+	 * Supplies plugin names and the value each should be quoted as.
+	 *
+	 * Callers differ: the readme parser escapes the name before it reaches this method, while the
+	 * plugin upload handler passes the raw `Plugin Name` header straight through. Neither may end
+	 * up double-escaped or unescaped.
+	 *
+	 * @return array<string, array<int, string>>
+	 */
+	public static function trademark_context_provider(): array {
+		return array(
+			// Format: name supplied, value expected in the message.
+			'plain'              => array( 'WordPress Toolkit', 'WordPress Toolkit' ),
+			'pre-escaped entity' => array( 'WordPress &amp; Friends', 'WordPress &amp; Friends' ),
+			'pre-escaped quote'  => array( 'WordPress&#039;s Helper', 'WordPress&#039;s Helper' ),
+			'raw ampersand'      => array( 'WordPress & Friends', 'WordPress &amp; Friends' ),
+			'raw script tag'     => array( 'WordPress <script>alert(1)</script>', 'WordPress &lt;script&gt;alert(1)&lt;/script&gt;' ),
+			'raw event handler'  => array( 'WordPress <img src=x onerror=alert(1)>', 'WordPress &lt;img src=x onerror=alert(1)&gt;' ),
+			'raw double quote'   => array( 'WordPress" onmouseover="x', 'WordPress&quot; onmouseover=&quot;x' ),
+		);
+	}
+}

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Readme_Validator_URL_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Readme_Validator_URL_Test.php
@@ -1,0 +1,293 @@
+<?php
+/**
+ * Tests for Validator::validate_url().
+ *
+ * @package WordPressdotorg\Plugin_Directory\Tests
+ */
+
+declare( strict_types = 1 );
+
+use PHPUnit\Framework\TestCase;
+use WordPressdotorg\Plugin_Directory\Readme\Validator;
+
+/**
+ * Covers which readme URLs the validator is willing to fetch.
+ *
+ * The validator prints the fetched body back to an anonymous caller, both from the
+ * `[readme-validator]` shortcode and from the `validate-readme` ability, so the set of
+ * destinations it will connect to is the boundary that keeps it from being a proxy.
+ *
+ * @group readme
+ */
+class Readme_Validator_URL_Test extends TestCase {
+
+	/**
+	 * Requests the validator attempted, as `url` / `args` pairs.
+	 *
+	 * @var array<int, array<string, mixed>>
+	 */
+	private array $requests = array();
+
+	/**
+	 * The `pre_http_request` callback recording requests, kept so it can be removed again.
+	 *
+	 * @var callable|null
+	 */
+	private $request_spy = null;
+
+	/**
+	 * Records outbound requests instead of making them.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->requests    = array();
+		$this->request_spy = function ( $preempt, $args, $url ) {
+			$this->requests[] = array(
+				'url'  => $url,
+				'args' => $args,
+			);
+
+			return self::http_response( '' );
+		};
+
+		add_filter( 'pre_http_request', $this->request_spy, 10, 3 );
+	}
+
+	/**
+	 * Builds a successful HTTP response for the request filter to return.
+	 *
+	 * @param string $body The response body.
+	 * @return array<string, mixed>
+	 */
+	private static function http_response( string $body ): array {
+		return array(
+			'headers'  => array(),
+			'body'     => $body,
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+			'cookies'  => array(),
+			'filename' => null,
+		);
+	}
+
+	/**
+	 * Removes the request spy.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		remove_filter( 'pre_http_request', $this->request_spy, 10 );
+		$this->request_spy = null;
+
+		parent::tearDown();
+	}
+
+	/**
+	 * An allowed readme is fetched over HTTPS, without following redirects.
+	 *
+	 * The scheme matters because two of the three allowed hosts answer plain HTTP with a
+	 * redirect, which would be reported as an invalid URL rather than followed.
+	 *
+	 * @dataProvider allowed_url_provider
+	 *
+	 * @param string $url The URL under test.
+	 * @return void
+	 */
+	public function test_allowed_url_is_fetched( string $url ): void {
+		Validator::instance()->validate_url( $url );
+
+		$this->assertCount( 1, $this->requests, "Expected '{$url}' to be fetched" );
+		$this->assertStringStartsWith( 'https://', $this->requests[0]['url'] );
+		$this->assertSame( 0, $this->requests[0]['args']['redirection'] );
+		$this->assertSame( Validator::MAX_FETCH_BYTES, $this->requests[0]['args']['limit_response_size'] );
+	}
+
+	/**
+	 * A readme within the size limit is handed to the parser.
+	 *
+	 * @return void
+	 */
+	public function test_readme_within_size_limit_is_validated(): void {
+		$readme = "=== Readme Validator Test ===\nStable tag: 1.0\n\nA readme served to the test suite.\n";
+		$result = $this->validate_with_body( $readme );
+
+		$this->assertSame( $readme, Validator::instance()->last_content );
+		$this->assertArrayNotHasKey( 'invalid_url', $result['errors'] );
+		$this->assertArrayNotHasKey( 'readme_too_large', $result['errors'] );
+	}
+
+	/**
+	 * A response that reached the size limit is reported rather than validated.
+	 *
+	 * @return void
+	 */
+	public function test_truncated_response_is_reported(): void {
+		$result = $this->validate_with_body( str_repeat( 'a', Validator::MAX_FETCH_BYTES ) );
+
+		$this->assertCount( 1, $result['errors'] );
+		$this->assertStringContainsString( '512 KB', $result['errors']['readme_too_large'] );
+	}
+
+	/**
+	 * A URL that does not resolve to a readme is reported rather than parsed.
+	 *
+	 * Every allowed host answers a missing file with a non-empty body, so the status code is
+	 * the only thing separating a readme from an error page. A redirect lands here too, since
+	 * redirects are not followed.
+	 *
+	 * @dataProvider non_200_response_provider
+	 *
+	 * @param int    $code The response status code.
+	 * @param string $body The response body.
+	 * @return void
+	 */
+	public function test_non_200_response_is_reported( int $code, string $body ): void {
+		$respond = function () use ( $code, $body ) {
+			$response                     = self::http_response( $body );
+			$response['response']['code'] = $code;
+
+			return $response;
+		};
+
+		add_filter( 'pre_http_request', $respond, 20 );
+		$result = Validator::instance()->validate_url( 'https://plugins.svn.wordpress.org/hello-dolly/trunk/readme.txt' );
+		remove_filter( 'pre_http_request', $respond, 20 );
+
+		$this->assertSame( array( 'invalid_url' ), array_keys( $result['errors'] ) );
+	}
+
+	/**
+	 * Supplies responses that do not carry a readme.
+	 *
+	 * @return array<string, array<int, int|string>>
+	 */
+	public static function non_200_response_provider(): array {
+		return array(
+			// Format: status code, response body.
+			'github not found' => array( 404, '404: Not Found' ),
+			'svn not found'    => array( 404, '<html><title>404 Not Found</title></html>' ),
+			'redirect'         => array( 301, '' ),
+			'server error'     => array( 500, 'Internal Server Error' ),
+		);
+	}
+
+	/**
+	 * Validates an allowed URL against a canned response body.
+	 *
+	 * @param string $body The body the fetch should return.
+	 * @return array The validation results.
+	 */
+	private function validate_with_body( string $body ): array {
+		$respond = function () use ( $body ) {
+			return self::http_response( $body );
+		};
+
+		add_filter( 'pre_http_request', $respond, 20 );
+		$result = Validator::instance()->validate_url( 'https://plugins.svn.wordpress.org/hello-dolly/trunk/readme.txt' );
+		remove_filter( 'pre_http_request', $respond, 20 );
+
+		return $result;
+	}
+
+	/**
+	 * A readme anywhere else is rejected, and no request is made for it.
+	 *
+	 * @dataProvider disallowed_host_provider
+	 *
+	 * @param string $url The URL under test.
+	 * @return void
+	 */
+	public function test_disallowed_host_is_not_fetched( string $url ): void {
+		$result = Validator::instance()->validate_url( $url );
+
+		$this->assertNotEmpty( $result['errors'] );
+		$this->assertSame( array(), $this->requests, "An outbound request was made for '{$url}'" );
+	}
+
+	/**
+	 * An allowed host still has to name a readme, and no request is made if it does not.
+	 *
+	 * @dataProvider disallowed_path_provider
+	 *
+	 * @param string $url The URL under test.
+	 * @return void
+	 */
+	public function test_disallowed_path_is_not_fetched( string $url ): void {
+		$result = Validator::instance()->validate_url( $url );
+
+		$this->assertNotEmpty( $result['errors'] );
+		$this->assertSame( array(), $this->requests, "An outbound request was made for '{$url}'" );
+	}
+
+	/**
+	 * Supplies the URLs the validator is meant to fetch.
+	 *
+	 * @return array<string, array<int, string>>
+	 */
+	public static function allowed_url_provider(): array {
+		return array(
+			// Format: [ $url ].
+			'plugin readme'   => array( 'https://plugins.svn.wordpress.org/hello-dolly/trunk/readme.txt' ),
+			'tagged readme'   => array( 'https://plugins.svn.wordpress.org/hello-dolly/tags/1.7.2/readme.txt' ),
+			'markdown readme' => array( 'https://plugins.svn.wordpress.org/hello-dolly/trunk/readme.md' ),
+			'theme readme'    => array( 'https://themes.svn.wordpress.org/twentytwentyfive/1.0/readme.txt' ),
+			'github raw'      => array( 'https://raw.githubusercontent.com/Automattic/jetpack/trunk/projects/plugins/jetpack/readme.txt' ),
+			'mixed case host' => array( 'https://Plugins.SVN.WordPress.org/hello-dolly/trunk/readme.txt' ),
+			'plain http'      => array( 'http://plugins.svn.wordpress.org/hello-dolly/trunk/readme.txt' ),
+			'query string'    => array( 'https://plugins.svn.wordpress.org/hello-dolly/trunk/readme.txt?p=1' ),
+		);
+	}
+
+	/**
+	 * Supplies hosts the validator must refuse to connect to.
+	 *
+	 * The addresses here are not all rejected by `wp_safe_remote_get()`: Core's private-range
+	 * check covers neither 169.254.0.0/16 nor 100.64.0.0/10, and any of them can be reached
+	 * through a hostname that resolves differently for the check and for the connection.
+	 *
+	 * @return array<string, array<int, string>>
+	 */
+	public static function disallowed_host_provider(): array {
+		return array(
+			// Format: [ $url ].
+			'unrelated host'      => array( 'https://example.org/readme.txt' ),
+			'loopback'            => array( 'http://127.0.0.1/readme.txt' ),
+			'loopback by name'    => array( 'http://localhost/readme.txt' ),
+			'private range'       => array( 'http://10.0.0.5:8080/readme.txt' ),
+			'link local'          => array( 'http://169.254.169.254/readme.txt' ),
+			'carrier grade nat'   => array( 'http://100.64.0.1/readme.txt' ),
+			'userinfo prefix'     => array( 'https://plugins.svn.wordpress.org@example.org/readme.txt' ),
+			'suffix lookalike'    => array( 'https://plugins.svn.wordpress.org.example.org/readme.txt' ),
+			'prefix lookalike'    => array( 'https://notplugins.svn.wordpress.org/readme.txt' ),
+			'subdomain lookalike' => array( 'https://a.plugins.svn.wordpress.org/readme.txt' ),
+			'directory front end' => array( 'https://wordpress.org/plugins/hello-dolly/readme.txt' ),
+			'github blob page'    => array( 'https://github.com/Automattic/jetpack/blob/trunk/readme.txt' ),
+			'github raw path'     => array( 'https://github.com/Automattic/jetpack/raw/trunk/readme.txt' ),
+			'github lookalike'    => array( 'https://raw.githubusercontent.com.example.org/readme.txt' ),
+			'ftp scheme'          => array( 'ftp://plugins.svn.wordpress.org/hello-dolly/trunk/readme.txt' ),
+			'file scheme'         => array( 'file:///etc/passwd' ),
+			'bare filename'       => array( 'readme.txt' ),
+			'empty string'        => array( '' ),
+		);
+	}
+
+	/**
+	 * Supplies allowed hosts whose path does not name a readme.
+	 *
+	 * @return array<string, array<int, string>>
+	 */
+	public static function disallowed_path_provider(): array {
+		return array(
+			// Format: [ $url ].
+			'directory'       => array( 'https://plugins.svn.wordpress.org/hello-dolly/trunk/' ),
+			'another file'    => array( 'https://plugins.svn.wordpress.org/hello-dolly/trunk/hello.php' ),
+			'readme in query' => array( 'https://plugins.svn.wordpress.org/hello-dolly/trunk/hello.php?f=readme.txt' ),
+			'host only'       => array( 'https://plugins.svn.wordpress.org' ),
+		);
+	}
+}

--- a/wordpress.org/public_html/wp-content/plugins/wporg-abilities/plugins/plugin-directory/tools/class-validate-readme.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-abilities/plugins/plugin-directory/tools/class-validate-readme.php
@@ -27,7 +27,7 @@ class Validate_Readme extends Ability_Base {
 			'wporg/plugins--plugin-directory--validate-readme',
 			array(
 				'label'               => 'Validate Plugin Readme',
-				'description'         => 'Validates a WordPress plugin readme.txt or readme.md file and returns errors, warnings, and notes. Accepts either the file content directly or a URL to fetch it from.',
+				'description'         => 'Validates a WordPress plugin readme.txt or readme.md file and returns errors, warnings, and notes. Accepts the file content directly, or the URL of a readme on the WordPress.org plugin or theme SVN or on raw.githubusercontent.com.',
 				'category'            => 'wporg-plugins-plugin-directory',
 				'input_schema'        => array(
 					'type'       => 'object',
@@ -39,7 +39,7 @@ class Validate_Readme extends Ability_Base {
 						'url'     => array(
 							'type'        => 'string',
 							'format'      => 'uri',
-							'description' => 'URL to a readme.txt or readme.md file to fetch and validate. Must end in readme.txt or readme.md. Provide either url or content, not both.',
+							'description' => 'URL of a readme.txt or readme.md file on plugins.svn.wordpress.org, themes.svn.wordpress.org, or raw.githubusercontent.com. A readme hosted anywhere else must be passed as content instead. Provide either url or content, not both.',
 						),
 					),
 				),


### PR DESCRIPTION
The readme validator fetches a URL the visitor supplies and renders the parsed result. It accepted any `http(s)` URL, which is wider than the tool needs, so this scopes it to the hosts readmes actually live on.

### Host allowlist

`Validator::validate_url()` checks the parsed host against `plugins.svn.wordpress.org`, `themes.svn.wordpress.org` and `raw.githubusercontent.com` before doing anything else, and otherwise returns an input error pointing at the paste box, which already handles readmes hosted anywhere.

The check lives in `Validator` rather than in the shortcode because `validate_url()` has two callers: the `[readme-validator]` shortcode and the `wporg/plugins--plugin-directory--validate-readme` ability. Its tool and `url` descriptions are updated to match.

### Fetch

* **HTTPS.** `themes.svn.wordpress.org` and `raw.githubusercontent.com` both answer plain HTTP with a `301`, so with redirects off an `http://` URL would fail. `set_url_scheme()` normalises it once the host is known good.
* **No redirects.** `redirection => 0`, so the host and extension checks describe the request that is actually made and not merely the URL that was typed.
* **200 only.** All three hosts answer a missing file with a non-empty body — `404: Not Found` from GitHub raw, an Apache error page from SVN — which was previously parsed as a readme and reported as a wall of unrelated errors.
* **512KB cap.** `limit_response_size` truncates silently, so anything reaching the limit is reported instead of validated against content the file does not have. For scale, across the 100 most-installed plugins the median readme is ~22KB and the largest ~290KB.

### Error codes

`validate_url()` returned numerically-keyed error arrays while `validate_content()` returns code-keyed ones. The ability declares `errors` as an object in its `output_schema`, which only held for the second path. Both use codes now.

### Escaping

Second commit, independent of the above. `translate_code_to_message()` escapes every caller-supplied value it quotes except the trademark context. `Parser::sanitize_text()` escapes the plugin name on the readme path and `Upload_Handler` passes the header through as-is, so this normalises and escapes at the point of use rather than depending on which caller supplied it. Decoding first keeps the already-escaped path from coming out double-escaped.

### Testing

`npm run plugins:test`

* `Readme_Validator_URL_Test` — 37 cases: which URLs are fetched and which are refused without any outbound request, HTTPS normalisation, redirect and size arguments, the truncation and non-200 branches.
* `Readme_Validator_Message_Test` — 7 cases: trademark notices for pre-escaped and raw plugin names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Readme URL validation now supports only approved WordPress.org SVN and GitHub raw URLs over HTTP or HTTPS.
  - Redirects are blocked, responses are limited to 512 KB, and invalid hosts, paths, responses, or oversized files return clear errors.
  - Trademark validation messages safely handle HTML, scripts, special characters, and pre-escaped plugin names.

- **Documentation**
  - Updated guidance explains supported readme URL sources and when to provide content directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->