### PR TITLE
Plugin Directory: Readme Validator: only resolve slugs for plugins that are visible

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-readme-validator.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-readme-validator.php
@@ -34,7 +34,10 @@ class Readme_Validator {
 		if ( $readme_url && preg_match( '!^https?://([^./]+\.)?wordpress.org/plugins/(?P<slug>[^/]+)!i', $readme_url, $m ) ) {
 			$plugin = Plugin_Directory::get_plugin_post( $m['slug'] );
 
-			if ( $plugin ) {
+			if ( $plugin && (
+				in_array( $plugin->post_status, array( 'publish', 'closed', 'disabled' ), true ) ||
+				current_user_can( 'plugin_admin_view', $plugin )
+			) ) {
 				$readme_url         = 'https://plugins.svn.wordpress.org/' . $plugin->post_name . '/' . ( ( $plugin->stable_tag && 'trunk' != $plugin->stable_tag ) ? 'tags/' . $plugin->stable_tag : 'trunk' ) . '/readme.txt';
 				$_REQUEST['readme'] = $readme_url;
 			}


### PR DESCRIPTION
The readme validator accepts a plugin slug, or a `wordpress.org/plugins/…` URL, as a shorthand: it looks the plugin up and rewrites the field to that plugin's SVN readme so the right file gets validated.

`Plugin_Directory::get_plugin_post()` matches every registered status, including the ones still in the review pipeline. The rewrite only happens when a post is found, and the rewritten value is rendered back into the form, so the response distinguished a slug that exists from one that does not and named the plugin's stable tag along with it — for submissions that have no public page yet.

Resolving now requires the plugin to be one the visitor could already see. The status list mirrors the front-end query in `Plugin_Directory::use_plugins_in_query()`, which serves `publish`, `closed` and `disabled` without a capability check and gates everything else on `plugin_admin_view`.

The fallback to that capability matters from `approved` onward: `Status_Transitions::approved()` is what creates the SVN repo and grants commit access, so that is the first status where a non-public plugin has a readme to resolve to at all. Committers keep the shorthand for those, and reviewers keep it throughout.

Unknown slugs were already left alone, and a `wordpress.org/plugins/…` URL is refused by the validator's host allow-list before any request is made, so a hidden plugin and an unknown slug now produce identical output with no network call either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
