### PR TITLE
Theme Directory: refuse a shortcode in the name and author headers

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
@@ -788,13 +788,34 @@ class WPORG_Themes_Upload {
 			$style_errors->add( 'no_description', $error );
 		}
 
-		if ( preg_match( '/' . get_shortcode_regex() . '/', $theme_description ) ) {
+		/*
+		 * The one-line headers that can carry the syntax, as
+		 * `error code => [ style.css line, value that gets stored ]`. The description
+		 * reaches `post_content`, the name reaches `post_title`, and the author is stored
+		 * as the `_author` post meta that the themes API reads back. Each is read the way
+		 * `create_or_update_theme_post()` reads it, so the check sees the value that would
+		 * be stored rather than the one in the file.
+		 *
+		 * `Theme URI` and `Author URI` need no entry: `WP_Theme::get()` returns them
+		 * through `esc_url_raw()`, which percent-encodes the delimiters.
+		 */
+		$stored_headers = array(
+			'shortcode_in_description' => array( 'Description', $theme_description ),
+			'shortcode_in_name'        => array( 'Theme Name', (string) $this->theme->get( 'Name' ) ),
+			'shortcode_in_author'      => array( 'Author', (string) $this->theme->get( 'Author' ) ),
+		);
+
+		foreach ( $stored_headers as $code => list( $header, $value ) ) {
+			if ( ! preg_match( '/' . get_shortcode_regex() . '/', $value ) ) {
+				continue;
+			}
+
 			$style_errors->add(
-				'shortcode_in_description',
+				$code,
 				sprintf(
 					/* translators: 1: comment header line, 2: style.css */
 					__( 'The %1$s line in %2$s cannot contain shortcodes. Remove them and upload the theme again.', 'wporg-themes' ),
-					'<code>Description:</code>',
+					'<code>' . $header . ':</code>',
 					'<code>style.css</code>'
 				)
 			);
@@ -1694,9 +1715,7 @@ TICKET;
 
 			$post_id = wp_insert_post( array(
 				'post_author'    => $this->author->ID,
-				// The name and the description are one-line headers, not body content to run
-				// through the shortcode chain.
-				'post_title'     => strip_shortcodes( $this->theme->get( 'Name' ) ),
+				'post_title'     => $this->theme->get( 'Name' ),
 				'post_name'      => $this->theme_slug,
 				'post_content'   => $this->theme->get( 'Description' ),
 				'post_parent'    => $this->theme->post_parent,
@@ -1713,10 +1732,9 @@ TICKET;
 
 		// Finally, add post meta.
 		$post_meta = array(
-			// One-line headers, as above.
-			'_theme_url'    => strip_shortcodes( $this->theme->get( 'ThemeURI' ) ),
-			'_author'       => strip_shortcodes( $this->theme->get( 'Author' ) ),
-			'_author_url'   => strip_shortcodes( $this->theme->get( 'AuthorURI' ) ),
+			'_theme_url'    => $this->theme->get( 'ThemeURI' ),
+			'_author'       => $this->theme->get( 'Author' ),
+			'_author_url'   => $this->theme->get( 'AuthorURI' ),
 			'_requires'     => $this->sanitize_version_like_field( $this->theme->get( 'RequiresWP' ), 'requires' ),
 			'_requires_php' => $this->sanitize_version_like_field( $this->theme->get( 'RequiresPHP' ) ),
 			'_upload_date'  => $upload_date,

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
@@ -1694,7 +1694,9 @@ TICKET;
 
 			$post_id = wp_insert_post( array(
 				'post_author'    => $this->author->ID,
-				'post_title'     => $this->theme->get( 'Name' ),
+				// The name and the description are one-line headers, not body content to run
+				// through the shortcode chain.
+				'post_title'     => strip_shortcodes( $this->theme->get( 'Name' ) ),
 				'post_name'      => $this->theme_slug,
 				'post_content'   => $this->theme->get( 'Description' ),
 				'post_parent'    => $this->theme->post_parent,
@@ -1711,9 +1713,10 @@ TICKET;
 
 		// Finally, add post meta.
 		$post_meta = array(
-			'_theme_url'    => $this->theme->get( 'ThemeURI' ),
-			'_author'       => $this->theme->get( 'Author' ),
-			'_author_url'   => $this->theme->get( 'AuthorURI' ),
+			// One-line headers, as above.
+			'_theme_url'    => strip_shortcodes( $this->theme->get( 'ThemeURI' ) ),
+			'_author'       => strip_shortcodes( $this->theme->get( 'Author' ) ),
+			'_author_url'   => strip_shortcodes( $this->theme->get( 'AuthorURI' ) ),
 			'_requires'     => $this->sanitize_version_like_field( $this->theme->get( 'RequiresWP' ), 'requires' ),
 			'_requires_php' => $this->sanitize_version_like_field( $this->theme->get( 'RequiresPHP' ) ),
 			'_upload_date'  => $upload_date,

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Theme_Header_Storage_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Theme_Header_Storage_Test.php
@@ -140,8 +140,8 @@ class Theme_Header_Storage_Test extends TestCase {
 		$upload->theme      = new WP_Theme( $this->stylesheet, $this->theme_root );
 		$upload->theme_slug = 'fixture-theme-' . uniqid();
 		$upload->author     = get_user_by( 'id', 1 );
-		$upload->theme_post = null;
 
+		// `$theme_post` is left unset, which is what the class treats as a first submission.
 		$upload->create_or_update_theme_post();
 
 		$this->assertInstanceOf( WP_Post::class, $upload->theme_post );

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Theme_Header_Storage_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Theme_Header_Storage_Test.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * Tests that the one-line `style.css` headers are stored as text.
+ *
+ * The name, the description and the author headers are single lines an uploader
+ * types into `style.css`, not body content, so nothing in them is meant to run
+ * when the directory renders a theme page. `create_or_update_theme_post()` runs
+ * them through `strip_shortcodes()` on the way into the post.
+ *
+ * @package theme-directory
+ */
+
+declare( strict_types = 1 );
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the headers `WPORG_Themes_Upload::create_or_update_theme_post()` stores.
+ *
+ * @group upload
+ */
+class Theme_Header_Storage_Test extends TestCase {
+
+	/**
+	 * A header value that would run if it were stored verbatim.
+	 *
+	 * `[caption]` is registered by core, so it is present wherever the directory
+	 * renders, and it builds its output from an attribute rather than from the
+	 * enclosed text.
+	 *
+	 * @var string
+	 */
+	const SHORTCODE_HEADER = 'Fixture [caption width="1" caption="x"]y[/caption] Theme';
+
+	/**
+	 * What is left of SHORTCODE_HEADER once the shortcode has been removed.
+	 *
+	 * @var string
+	 */
+	const STRIPPED_HEADER = 'Fixture  Theme';
+
+	/**
+	 * Absolute path of the temporary theme root holding the fixture.
+	 *
+	 * @var string
+	 */
+	protected $theme_root = '';
+
+	/**
+	 * Directory name of the fixture theme within the theme root.
+	 *
+	 * @var string
+	 */
+	protected $stylesheet = 'fixture-theme';
+
+	/**
+	 * IDs of posts created during a test, deleted again on teardown.
+	 *
+	 * @var array
+	 */
+	protected $post_ids = array();
+
+	/**
+	 * Writes a fixture theme whose one-line headers all carry the payload.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		// A unique root per test, so WP_Theme's header cache cannot be reused.
+		$this->theme_root = untrailingslashit( get_temp_dir() ) . '/wporg-theme-storage-' . uniqid();
+		wp_mkdir_p( $this->theme_root . '/' . $this->stylesheet );
+
+		$style_css = "/*\n"
+			. 'Theme Name: ' . self::SHORTCODE_HEADER . "\n"
+			. 'Description: ' . self::SHORTCODE_HEADER . "\n"
+			. 'Author: ' . self::SHORTCODE_HEADER . "\n"
+			. 'Theme URI: https://example.org/' . self::SHORTCODE_HEADER . "\n"
+			. 'Author URI: https://example.org/' . self::SHORTCODE_HEADER . "\n"
+			. "Version: 1.0\n*/\n";
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test fixture in a temporary directory.
+		file_put_contents( $this->theme_root . '/' . $this->stylesheet . '/style.css', $style_css );
+	}
+
+	/**
+	 * Removes the fixture theme and the posts the test created.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		/*
+		 * The plugin prevents repopackages from being deleted; detach that
+		 * specific guard while cleaning up the fixture posts.
+		 */
+		remove_filter( 'before_delete_post', 'wporg_theme_no_delete_repopackage' );
+		foreach ( $this->post_ids as $post_id ) {
+			wp_delete_post( $post_id, true );
+		}
+		add_filter( 'before_delete_post', 'wporg_theme_no_delete_repopackage' );
+
+		$this->post_ids = array();
+
+		$this->remove_fixture( $this->theme_root );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Recursively removes a fixture directory.
+	 *
+	 * @param string $path Absolute path to remove.
+	 * @return void
+	 */
+	protected function remove_fixture( string $path ): void {
+		if ( ! is_dir( $path ) ) {
+			return;
+		}
+
+		foreach ( (array) glob( $path . '/*' ) as $item ) {
+			if ( is_dir( $item ) ) {
+				$this->remove_fixture( $item );
+			} else {
+				wp_delete_file( $item );
+			}
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- Test fixture in a temporary directory.
+		rmdir( $path );
+	}
+
+	/**
+	 * Runs the fixture through the first-submission branch and returns the post.
+	 *
+	 * @return WP_Post
+	 */
+	protected function store_fixture(): WP_Post {
+		$upload             = new WPORG_Themes_Upload();
+		$upload->theme      = new WP_Theme( $this->stylesheet, $this->theme_root );
+		$upload->theme_slug = 'fixture-theme-' . uniqid();
+		$upload->author     = get_user_by( 'id', 1 );
+		$upload->theme_post = null;
+
+		$upload->create_or_update_theme_post();
+
+		$this->assertInstanceOf( WP_Post::class, $upload->theme_post );
+		$this->post_ids[] = $upload->theme_post->ID;
+
+		return $upload->theme_post;
+	}
+
+	/**
+	 * The stored title keeps the header's text and none of its shortcode.
+	 *
+	 * @return void
+	 */
+	public function test_name_header_is_stored_as_text(): void {
+		$theme_post = $this->store_fixture();
+
+		$this->assertSame( self::STRIPPED_HEADER, $theme_post->post_title );
+		$this->assertSame( $theme_post->post_title, do_shortcode( $theme_post->post_title ) );
+	}
+
+	/**
+	 * The description gets the same treatment, which it already had.
+	 *
+	 * @return void
+	 */
+	public function test_description_header_is_stored_as_text(): void {
+		$theme_post = $this->store_fixture();
+
+		$this->assertSame( self::STRIPPED_HEADER, $theme_post->post_content );
+	}
+
+	/**
+	 * The remaining one-line headers stored as post meta get it too.
+	 *
+	 * These are written through `update_versioned_meta()`, so each is an array
+	 * keyed by the version the upload carried.
+	 *
+	 * @return void
+	 */
+	public function test_author_headers_are_stored_as_text(): void {
+		$theme_post = $this->store_fixture();
+
+		foreach ( array( '_author', '_theme_url', '_author_url' ) as $key ) {
+			$stored = get_post_meta( $theme_post->ID, $key, true );
+
+			$this->assertIsArray( $stored, "No versioned value was stored in {$key}." );
+			$this->assertArrayHasKey( '1.0', $stored, "The upload's version is missing from {$key}." );
+
+			$value = $stored['1.0'];
+
+			$this->assertStringNotContainsString( '[caption', $value, "Stored a shortcode in {$key}." );
+			$this->assertSame( $value, do_shortcode( $value ), "The value stored in {$key} is parsed as a shortcode." );
+		}
+
+		$this->assertSame( self::STRIPPED_HEADER, get_post_meta( $theme_post->ID, '_author', true )['1.0'] );
+	}
+}

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Theme_Header_Storage_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/tests/Theme_Header_Storage_Test.php
@@ -1,11 +1,17 @@
 <?php
 /**
- * Tests that the one-line `style.css` headers are stored as text.
+ * Tests the shortcode handling of the one-line `style.css` headers other than the description.
  *
- * The name, the description and the author headers are single lines an uploader
- * types into `style.css`, not body content, so nothing in them is meant to run
- * when the directory renders a theme page. `create_or_update_theme_post()` runs
- * them through `strip_shortcodes()` on the way into the post.
+ * `Description:` is covered by `Theme_Description_Shortcodes_Test`. The name and the
+ * author headers reach the directory through the same two writers and are stored the
+ * same way: the upload refuses a header carrying shortcode syntax, and
+ * `wporg_themes_approve_version()` — which re-reads `style.css` from SVN when a version
+ * goes live, without passing the upload's check — encodes the delimiters of the one
+ * header it writes, the name.
+ *
+ * Neither writer edits the shortcode out, for the reasons pinned in the description
+ * test: removing one can splice the remaining text into another, and `strip_shortcodes()`
+ * unwraps an escaped `[[tag]]` into a live `[tag]`.
  *
  * @package theme-directory
  */
@@ -15,43 +21,53 @@ declare( strict_types = 1 );
 use PHPUnit\Framework\TestCase;
 
 /**
- * Tests for the headers `WPORG_Themes_Upload::create_or_update_theme_post()` stores.
+ * Tests for the `Name`, `Author`, `Theme URI` and `Author URI` headers.
  *
  * @group upload
  */
 class Theme_Header_Storage_Test extends TestCase {
 
 	/**
-	 * A header value that would run if it were stored verbatim.
+	 * A header value whose shortcode is written plainly.
 	 *
-	 * `[caption]` is registered by core, so it is present wherever the directory
-	 * renders, and it builds its output from an attribute rather than from the
-	 * enclosed text.
+	 * `[caption]` is registered by core at file scope, so it is present in every
+	 * process, and it builds its output from an attribute rather than from the
+	 * enclosed text. The attributes are unquoted because `WP_Theme` runs the two URI
+	 * headers through `esc_url_raw()`, which drops quotes.
 	 *
 	 * @var string
 	 */
-	const SHORTCODE_HEADER = 'Fixture [caption width="1" caption="x"]y[/caption] Theme';
+	const DIRECT = '[caption width=1 caption=x]y[/caption]';
 
 	/**
-	 * What is left of SHORTCODE_HEADER once the shortcode has been removed.
+	 * The same shortcode in core's escaped form.
 	 *
 	 * @var string
 	 */
-	const STRIPPED_HEADER = 'Fixture  Theme';
+	const ESCAPED_TWIN = '[[caption width=1 caption=x]y[/caption]]';
 
 	/**
-	 * Absolute path of the temporary theme root holding the fixture.
+	 * A value that becomes a shortcode only once one is removed from it.
+	 *
+	 * Deleting the inner `[caption]` splices the remainder into `[gallery ids=1]`.
 	 *
 	 * @var string
 	 */
-	protected $theme_root = '';
+	const SPLICE = '[gal[caption]lery ids=1]';
 
 	/**
-	 * Directory name of the fixture theme within the theme root.
+	 * Bracketed prose, which is not a shortcode and must be left alone.
 	 *
 	 * @var string
 	 */
-	protected $stylesheet = 'fixture-theme';
+	const PROSE = '[developers] and designers';
+
+	/**
+	 * Uploads created during a test, cleaned up again on teardown.
+	 *
+	 * @var array
+	 */
+	protected $uploads = array();
 
 	/**
 	 * IDs of posts created during a test, deleted again on teardown.
@@ -61,48 +77,43 @@ class Theme_Header_Storage_Test extends TestCase {
 	protected $post_ids = array();
 
 	/**
-	 * Writes a fixture theme whose one-line headers all carry the payload.
+	 * The `pre_http_request` callback, kept so it can be removed again.
 	 *
-	 * @return void
+	 * @var callable|null
 	 */
-	protected function setUp(): void {
-		parent::setUp();
-
-		// A unique root per test, so WP_Theme's header cache cannot be reused.
-		$this->theme_root = untrailingslashit( get_temp_dir() ) . '/wporg-theme-storage-' . uniqid();
-		wp_mkdir_p( $this->theme_root . '/' . $this->stylesheet );
-
-		$style_css = "/*\n"
-			. 'Theme Name: ' . self::SHORTCODE_HEADER . "\n"
-			. 'Description: ' . self::SHORTCODE_HEADER . "\n"
-			. 'Author: ' . self::SHORTCODE_HEADER . "\n"
-			. 'Theme URI: https://example.org/' . self::SHORTCODE_HEADER . "\n"
-			. 'Author URI: https://example.org/' . self::SHORTCODE_HEADER . "\n"
-			. "Version: 1.0\n*/\n";
-
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test fixture in a temporary directory.
-		file_put_contents( $this->theme_root . '/' . $this->stylesheet . '/style.css', $style_css );
-	}
+	protected $http_callback = null;
 
 	/**
-	 * Removes the fixture theme and the posts the test created.
+	 * Removes the fixtures, posts and hooks the test created.
 	 *
 	 * @return void
 	 */
 	protected function tearDown(): void {
+		if ( $this->http_callback ) {
+			remove_filter( 'pre_http_request', $this->http_callback, 10 );
+			$this->http_callback = null;
+		}
+
+		foreach ( $this->uploads as $upload ) {
+			remove_filter( 'override_load_textdomain', array( $upload, 'block_upload_textdomain' ), 10 );
+			remove_action( 'shutdown', array( $upload, 'remove_files' ), 10 );
+
+			if ( $upload->tmp_dir ) {
+				$this->remove_fixture( $upload->tmp_dir );
+			}
+		}
+		$this->uploads = array();
+
 		/*
-		 * The plugin prevents repopackages from being deleted; detach that
-		 * specific guard while cleaning up the fixture posts.
+		 * The plugin prevents repopackages from being deleted; detach that specific
+		 * guard while cleaning up the fixture posts.
 		 */
 		remove_filter( 'before_delete_post', 'wporg_theme_no_delete_repopackage' );
 		foreach ( $this->post_ids as $post_id ) {
 			wp_delete_post( $post_id, true );
 		}
 		add_filter( 'before_delete_post', 'wporg_theme_no_delete_repopackage' );
-
 		$this->post_ids = array();
-
-		$this->remove_fixture( $this->theme_root );
 
 		parent::tearDown();
 	}
@@ -131,71 +142,309 @@ class Theme_Header_Storage_Test extends TestCase {
 	}
 
 	/**
-	 * Runs the fixture through the first-submission branch and returns the post.
+	 * Builds the `style.css` contents, overriding the given headers.
 	 *
-	 * @return WP_Post
+	 * @param array<string, string> $overrides Header lines to override, e.g. `Theme Name`.
+	 * @return string
 	 */
-	protected function store_fixture(): WP_Post {
-		$upload             = new WPORG_Themes_Upload();
-		$upload->theme      = new WP_Theme( $this->stylesheet, $this->theme_root );
-		$upload->theme_slug = 'fixture-theme-' . uniqid();
-		$upload->author     = get_user_by( 'id', 1 );
+	protected function style_css( array $overrides ): string {
+		$headers = array_merge(
+			array(
+				'Theme Name'  => 'Fixture Theme',
+				'Description' => 'A fixture theme.',
+				'Author'      => 'Fixture Author',
+				'Theme URI'   => 'https://example.org/theme',
+				'Author URI'  => 'https://example.org/author',
+				'Version'     => '1.0',
+			),
+			$overrides
+		);
 
-		// `$theme_post` is left unset, which is what the class treats as a first submission.
-		$upload->create_or_update_theme_post();
-
-		$this->assertInstanceOf( WP_Post::class, $upload->theme_post );
-		$this->post_ids[] = $upload->theme_post->ID;
-
-		return $upload->theme_post;
-	}
-
-	/**
-	 * The stored title keeps the header's text and none of its shortcode.
-	 *
-	 * @return void
-	 */
-	public function test_name_header_is_stored_as_text(): void {
-		$theme_post = $this->store_fixture();
-
-		$this->assertSame( self::STRIPPED_HEADER, $theme_post->post_title );
-		$this->assertSame( $theme_post->post_title, do_shortcode( $theme_post->post_title ) );
-	}
-
-	/**
-	 * The description gets the same treatment, which it already had.
-	 *
-	 * @return void
-	 */
-	public function test_description_header_is_stored_as_text(): void {
-		$theme_post = $this->store_fixture();
-
-		$this->assertSame( self::STRIPPED_HEADER, $theme_post->post_content );
-	}
-
-	/**
-	 * The remaining one-line headers stored as post meta get it too.
-	 *
-	 * These are written through `update_versioned_meta()`, so each is an array
-	 * keyed by the version the upload carried.
-	 *
-	 * @return void
-	 */
-	public function test_author_headers_are_stored_as_text(): void {
-		$theme_post = $this->store_fixture();
-
-		foreach ( array( '_author', '_theme_url', '_author_url' ) as $key ) {
-			$stored = get_post_meta( $theme_post->ID, $key, true );
-
-			$this->assertIsArray( $stored, "No versioned value was stored in {$key}." );
-			$this->assertArrayHasKey( '1.0', $stored, "The upload's version is missing from {$key}." );
-
-			$value = $stored['1.0'];
-
-			$this->assertStringNotContainsString( '[caption', $value, "Stored a shortcode in {$key}." );
-			$this->assertSame( $value, do_shortcode( $value ), "The value stored in {$key} is parsed as a shortcode." );
+		$lines = '';
+		foreach ( $headers as $name => $line ) {
+			$lines .= "{$name}: {$line}\n";
 		}
 
-		$this->assertSame( self::STRIPPED_HEADER, get_post_meta( $theme_post->ID, '_author', true )['1.0'] );
+		return "/*\n{$lines}*/\n";
+	}
+
+	/**
+	 * Runs an upload of a fixture theme carrying the given header.
+	 *
+	 * @param string $header Header line to set.
+	 * @param string $value  Value for that header.
+	 * @return WP_Error The accumulated header errors.
+	 */
+	protected function import_header( string $header, string $value ): WP_Error {
+		$upload = new WPORG_Themes_Upload();
+		$upload->create_tmp_dirs( 'fixture' );
+
+		$this->uploads[] = $upload;
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test fixture in a temporary directory.
+		file_put_contents( $upload->theme_dir . '/style.css', $this->style_css( array( $header => $value ) ) );
+
+		$args = array(
+			'create_trac_ticket' => false,
+			'commit_to_svn'      => false,
+		);
+
+		$import = new ReflectionMethod( WPORG_Themes_Upload::class, 'import' );
+		$result = $import->invoke( $upload, $args );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+
+		return $result;
+	}
+
+	/**
+	 * Serves the fixture `style.css` to the SVN read in place of a real request.
+	 *
+	 * `wporg_themes_get_header_data()` streams the file to the path it passes in
+	 * `filename`, so the body is written there rather than returned.
+	 *
+	 * @param string $name Value of the `Theme Name:` header.
+	 * @return void
+	 */
+	protected function serve_style_css( string $name ): void {
+		$css = $this->style_css( array( 'Theme Name' => $name ) );
+
+		$this->http_callback = function ( $preempt, $args, $url ) use ( $css ) {
+			if ( ! str_ends_with( $url, '/style.css' ) ) {
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '',
+				);
+			}
+
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test fixture in a temporary directory.
+			file_put_contents( $args['filename'], $css );
+
+			return array(
+				'response' => array( 'code' => 200 ),
+				'filename' => $args['filename'],
+				'body'     => '',
+			);
+		};
+
+		add_filter( 'pre_http_request', $this->http_callback, 10, 3 );
+	}
+
+	/**
+	 * The slug `wporg_themes_approve_version()` derives from a name.
+	 *
+	 * A renamed theme only keeps the new name if it still sanitizes to the stored
+	 * `post_name`, so a test that wants that branch has to store this.
+	 *
+	 * @param string $name Value of the `Theme Name:` header.
+	 * @return string
+	 */
+	protected function slug_for( string $name ): string {
+		$slugified = remove_accents( $name );
+		$slugified = preg_replace( '/%[a-f0-9]{2}/i', '', $slugified );
+
+		return sanitize_title_with_dashes( $slugified );
+	}
+
+	/**
+	 * Creates a published repopackage to stand in for a listed theme.
+	 *
+	 * @param string $title Stored `post_title`.
+	 * @param string $slug  Stored `post_name`.
+	 * @return int The post ID.
+	 */
+	protected function create_theme_post( string $title = 'Fixture Theme', string $slug = 'fixture-theme' ): int {
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => 'repopackage',
+				'post_status'  => 'publish',
+				'post_title'   => $title,
+				'post_name'    => $slug,
+				'post_content' => 'The description that is already stored.',
+				'post_author'  => 1,
+			)
+		);
+
+		$this->post_ids[] = $post_id;
+
+		return $post_id;
+	}
+
+	/**
+	 * The headers the upload refuses besides the description, with the code each is refused under.
+	 *
+	 * @return array
+	 */
+	public static function data_stored_headers(): array {
+		return array(
+			'name'   => array( 'Theme Name', 'shortcode_in_name' ),
+			'author' => array( 'Author', 'shortcode_in_author' ),
+		);
+	}
+
+	/**
+	 * The payload shapes a single removal pass would leave a shortcode in.
+	 *
+	 * @return array
+	 */
+	public static function data_payloads(): array {
+		return array(
+			'direct'       => array( self::DIRECT ),
+			'escaped twin' => array( self::ESCAPED_TWIN ),
+			'splice'       => array( self::SPLICE ),
+		);
+	}
+
+	/**
+	 * Every header × every payload, for the refusal test.
+	 *
+	 * @return array
+	 */
+	public static function data_headers_and_payloads(): array {
+		$cases = array();
+
+		foreach ( self::data_stored_headers() as $header_label => $header ) {
+			foreach ( self::data_payloads() as $payload_label => $payload ) {
+				$cases[ "{$header_label}: {$payload_label}" ] = array( $header[0], $header[1], $payload[0] );
+			}
+		}
+
+		return $cases;
+	}
+
+	/**
+	 * A header carrying shortcode syntax is refused at upload.
+	 *
+	 * @dataProvider data_headers_and_payloads
+	 *
+	 * @param string $header  Header line to set.
+	 * @param string $code    Error code the header is refused under.
+	 * @param string $payload Value for that header.
+	 * @return void
+	 */
+	public function test_upload_refuses_a_shortcode_in_a_stored_header( string $header, string $code, string $payload ): void {
+		$this->assertContains(
+			$code,
+			$this->import_header( $header, "Fixture {$payload} Theme" )->get_error_codes(),
+			"A shortcode in the {$header} header must be refused."
+		);
+	}
+
+	/**
+	 * Bracketed prose is not a shortcode, and is not refused.
+	 *
+	 * @dataProvider data_stored_headers
+	 *
+	 * @param string $header Header line to set.
+	 * @param string $code   Error code the header would be refused under.
+	 * @return void
+	 */
+	public function test_upload_accepts_bracketed_prose( string $header, string $code ): void {
+		$this->assertNotContains(
+			$code,
+			$this->import_header( $header, 'A theme for ' . self::PROSE )->get_error_codes(),
+			"Bracketed prose in the {$header} header must not be refused."
+		);
+	}
+
+	/**
+	 * The URI headers cannot carry the syntax, which is why they are not checked.
+	 *
+	 * `WP_Theme::get()` returns them through `esc_url_raw()`, which percent-encodes the
+	 * delimiters. If that ever stops being true, this fails and the two belong in the
+	 * list above.
+	 *
+	 * @dataProvider data_payloads
+	 *
+	 * @param string $payload Value appended to the URL.
+	 * @return void
+	 */
+	public function test_uri_headers_are_inert_before_the_check( string $payload ): void {
+		$upload = new WPORG_Themes_Upload();
+		$upload->create_tmp_dirs( 'fixture' );
+
+		$this->uploads[] = $upload;
+
+		$url = 'https://example.org/' . $payload;
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test fixture in a temporary directory.
+		file_put_contents(
+			$upload->theme_dir . '/style.css',
+			$this->style_css(
+				array(
+					'Theme URI'  => $url,
+					'Author URI' => $url,
+				)
+			)
+		);
+
+		$theme = new WP_Theme( basename( $upload->theme_dir ), dirname( $upload->theme_dir ) );
+
+		foreach ( array( 'ThemeURI', 'AuthorURI' ) as $header ) {
+			$stored = (string) $theme->get( $header );
+
+			$this->assertNotSame( '', $stored, "The {$header} header did not survive at all." );
+			$this->assertSame( 0, preg_match( '/' . get_shortcode_regex() . '/', $stored ) );
+		}
+	}
+
+	/**
+	 * A version going live encodes the delimiters of a name that carries a shortcode.
+	 *
+	 * The name only reaches `post_title` from SVN when it still sanitizes to the stored
+	 * `post_name`, which is the branch this exercises.
+	 *
+	 * @return void
+	 */
+	public function test_live_version_stores_an_inert_name(): void {
+		$name    = 'Fixture ' . self::DIRECT . ' Theme';
+		$post_id = $this->create_theme_post( 'Fixture Theme', $this->slug_for( $name ) );
+
+		$this->serve_style_css( $name );
+		wporg_themes_approve_version( $post_id, '1.0', 'old' );
+
+		$stored = get_post( $post_id )->post_title;
+
+		$this->assertStringNotContainsString( '[', $stored );
+		$this->assertSame( $stored, do_shortcode( $stored ) );
+
+		// The wording survives; only the delimiters the parser reads are encoded.
+		$this->assertSame( $name, html_entity_decode( $stored ) );
+	}
+
+	/**
+	 * A title stored before this change is encoded the next time a version goes live.
+	 *
+	 * Here the SVN name matches what is stored, so the existing title is what gets
+	 * written back.
+	 *
+	 * @return void
+	 */
+	public function test_live_version_encodes_an_already_stored_name(): void {
+		$name    = 'Fixture ' . self::ESCAPED_TWIN . ' Theme';
+		$post_id = $this->create_theme_post( $name, 'fixture-theme' );
+
+		$this->serve_style_css( $name );
+		wporg_themes_approve_version( $post_id, '1.0', 'old' );
+
+		$stored = get_post( $post_id )->post_title;
+
+		$this->assertStringNotContainsString( '[', $stored );
+		$this->assertSame( $stored, do_shortcode( $stored ) );
+		$this->assertSame( $name, html_entity_decode( $stored ) );
+	}
+
+	/**
+	 * Encoding a name that carries none of the syntax changes nothing.
+	 *
+	 * @return void
+	 */
+	public function test_live_version_leaves_an_ordinary_name_alone(): void {
+		$post_id = $this->create_theme_post();
+
+		$this->serve_style_css( 'Fixture Theme' );
+		wporg_themes_approve_version( $post_id, '1.0', 'old' );
+
+		$this->assertSame( 'Fixture Theme', get_post( $post_id )->post_title );
 	}
 }

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/theme-directory.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/theme-directory.php
@@ -593,6 +593,7 @@ function wporg_themes_approve_version( $post_id, $version, $old_status ) {
 		);
 
 		// SVN commits skip the upload's shortcode check, so make the delimiters inert here.
+		$theme_post_name           = str_replace( array( '[', ']' ), array( '&#91;', '&#93;' ), $theme_post_name );
 		$theme_data['Description'] = str_replace( array( '[', ']' ), array( '&#91;', '&#93;' ), $theme_data['Description'] );
 
 		wp_update_post( array(


### PR DESCRIPTION
Follow-up to [15147], which handled `Description:` this way. The `Theme Name:` and `Author:` headers reach
`post_title` and the `_author` post meta through the same writers, so they are handled the same way: refused at
upload rather than edited into shape.

`strip_shortcodes()`, which this PR used to do, is a single pass, and a single pass can leave a shortcode in place:

- It unwraps an escaped `[[tag]]` into a live `[tag]` — `strip_shortcode_tag()` returns `substr( $match, 1, -1 )`
  for that syntax by design.
- Removing one shortcode can splice the surrounding text into another. `[gal[caption]lery ids="1"]` carries no
  shortcode until the inner `[caption]` is taken out, at which point the remainder joins into a live
  `[gallery ids="1"]`.

Matching a shortcode has neither failing, and the uploader is told rather than having their header quietly rewritten.

`Theme URI` and `Author URI` come back out of scope. `WP_Theme::get()` returns them through `esc_url_raw()`, which
percent-encodes the delimiters, so those two cannot carry the syntax in the first place and the strip on them was a
no-op. `test_uri_headers_are_inert_before_the_check()` pins that, so they come back if it ever stops being true.

The name has the second writer the description has — `wporg_themes_approve_version()` re-reads `style.css` from SVN
when a version goes live, and a commit reaches it without passing the upload's check — so its delimiters are encoded
there alongside the description's. That also covers names stored before this change.

Bracketed prose is unaffected: `[developers]` is not a registered shortcode, so nothing matches it.

## Testing steps

1. Upload a theme whose `style.css` has `Theme Name: Fixture [caption width="1" caption="x"]y[/caption] Theme`. The
   upload is refused with a message pointing at the `Theme Name:` line. Try `[[caption …]y[/caption]]` and
   `[gal[caption]lery ids="1"]` too, and the same three in `Author:`; all are refused.
2. Upload a theme named `A theme for [developers]`. It is accepted, and the name reads as written.
3. Commit a `style.css` to SVN renaming a listed theme to a name carrying a shortcode, then take the version live.
   The stored title shows the brackets as text rather than running them.
4. `npm run themes:test` from `environments/`
   → 159 tests, 250 assertions, all passing. The pre-existing `Search_Published_Filter_Test` risky-test notice and
   the `has_screenshot()` deprecation from a fixture without a screenshot are both unrelated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Theme uploads now reject shortcode markup in theme names, descriptions, and author information before storage.
  * Theme names and descriptions are safely stored without interpreting shortcode syntax, while ordinary bracketed text remains supported.
  * Upload validation now identifies files omitted from automated review and filenames that may not work across supported platforms, with concise file lists in error messages.

* **Tests**
  * Expanded coverage for shortcode handling, URL sanitization, and live-version metadata storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->