### PR TITLE
Plugin Directory: Print the plugin excerpt as plain text

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/build/blocks/plugin-card/render.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/build/blocks/plugin-card/render.php
@@ -20,7 +20,7 @@ do_blocks( '<!-- wp:wporg/link-wrapper /-->' ); // Import the styles
 		<?php echo wp_kses_post( Template::get_star_rating( $post, false ) ); ?>
 
 		<div class="entry-excerpt">
-			<?php the_excerpt(); ?>
+			<p><?php echo esc_html( wp_strip_all_tags( wptexturize( get_the_excerpt() ) ) ); ?></p>
 		</div><!-- .entry-excerpt -->
 	</div>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/build/blocks/plugin-card/render.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/build/blocks/plugin-card/render.php
@@ -2,6 +2,7 @@
 namespace WordPressdotorg\Theme\Plugins_2024\PluginCard;
 
 use WordPressdotorg\Plugin_Directory\Template;
+use function WordPressdotorg\Plugin_Directory\Theme\get_plugin_excerpt_text;
 
 $post = get_post();
 // Simulates wporg/link-wrapper block until this is migrated to a block, or it supports href=permalink.
@@ -20,7 +21,7 @@ do_blocks( '<!-- wp:wporg/link-wrapper /-->' ); // Import the styles
 		<?php echo wp_kses_post( Template::get_star_rating( $post, false ) ); ?>
 
 		<div class="entry-excerpt">
-			<p><?php echo esc_html( wp_strip_all_tags( wptexturize( get_the_excerpt() ) ) ); ?></p>
+			<p><?php echo esc_html( get_plugin_excerpt_text() ); ?></p>
 		</div><!-- .entry-excerpt -->
 	</div>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/embed-plugin.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/embed-plugin.php
@@ -129,7 +129,7 @@ if ( ! headers_sent() ) {
 		</p>
 
 		<div class="wp-embed-excerpt">
-			<?php the_excerpt(); ?>
+			<p><?php echo esc_html( wp_strip_all_tags( wptexturize( get_the_excerpt() ) ) ); ?></p>
 		</div>
 
 		<?php

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/embed-plugin.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/embed-plugin.php
@@ -129,7 +129,7 @@ if ( ! headers_sent() ) {
 		</p>
 
 		<div class="wp-embed-excerpt">
-			<p><?php echo esc_html( wp_strip_all_tags( wptexturize( get_the_excerpt() ) ) ); ?></p>
+			<p><?php echo esc_html( get_plugin_excerpt_text() ); ?></p>
 		</div>
 
 		<?php

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/inc/template-tags.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/inc/template-tags.php
@@ -822,7 +822,7 @@ function the_author_notice( $post = null ) {
  */
 function get_plugin_excerpt_text() {
 	$excerpt = wptexturize( get_the_excerpt() );
-	$excerpt = preg_replace( '#<br\s*/?>#i', ' ', $excerpt );
+	$excerpt = preg_replace( '#<br\b[^>]*>#i', ' ', $excerpt );
 
-	return trim( wp_strip_all_tags( $excerpt, true ) );
+	return wp_strip_all_tags( $excerpt, true );
 }

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/inc/template-tags.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/inc/template-tags.php
@@ -807,3 +807,22 @@ function the_author_notice( $post = null ) {
 		);
 	}
 }
+
+/**
+ * Returns the current plugin's excerpt as plain text, for the card and the embed.
+ *
+ * Excerpts are plain text by construction (the readme parser strips them), but
+ * excerpts imported from a plugin file header can still carry markup. Line
+ * breaks become spaces so the words on either side stay apart, then the tags
+ * go. Texturize runs first so that text inside <code> keeps its literal
+ * quotes, matching what the_excerpt() printed. The result is unescaped text:
+ * callers wrap it in esc_html().
+ *
+ * @return string The excerpt as plain text.
+ */
+function get_plugin_excerpt_text() {
+	$excerpt = wptexturize( get_the_excerpt() );
+	$excerpt = preg_replace( '#<br\s*/?>#i', ' ', $excerpt );
+
+	return trim( wp_strip_all_tags( $excerpt, true ) );
+}

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/src/blocks/plugin-card/render.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/src/blocks/plugin-card/render.php
@@ -20,7 +20,7 @@ do_blocks( '<!-- wp:wporg/link-wrapper /-->' ); // Import the styles
 		<?php echo wp_kses_post( Template::get_star_rating( $post, false ) ); ?>
 
 		<div class="entry-excerpt">
-			<?php the_excerpt(); ?>
+			<p><?php echo esc_html( wp_strip_all_tags( wptexturize( get_the_excerpt() ) ) ); ?></p>
 		</div><!-- .entry-excerpt -->
 	</div>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/src/blocks/plugin-card/render.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/src/blocks/plugin-card/render.php
@@ -2,6 +2,7 @@
 namespace WordPressdotorg\Theme\Plugins_2024\PluginCard;
 
 use WordPressdotorg\Plugin_Directory\Template;
+use function WordPressdotorg\Plugin_Directory\Theme\get_plugin_excerpt_text;
 
 $post = get_post();
 // Simulates wporg/link-wrapper block until this is migrated to a block, or it supports href=permalink.
@@ -20,7 +21,7 @@ do_blocks( '<!-- wp:wporg/link-wrapper /-->' ); // Import the styles
 		<?php echo wp_kses_post( Template::get_star_rating( $post, false ) ); ?>
 
 		<div class="entry-excerpt">
-			<p><?php echo esc_html( wp_strip_all_tags( wptexturize( get_the_excerpt() ) ) ); ?></p>
+			<p><?php echo esc_html( get_plugin_excerpt_text() ); ?></p>
 		</div><!-- .entry-excerpt -->
 	</div>
 


### PR DESCRIPTION
## Why

The plugin card block and the plugin embed template print the excerpt with `the_excerpt()`, as HTML. Every other consumer of the same value treats it as text: the `og:description` and `meta description` tags (`esc_attr( strip_tags( get_the_excerpt() ) )`), the JSON-LD (`wp_json_encode`), and the API's `short_description`. The readme parser only ever stores plain text in the excerpt; the 43 published plugins that still carry tags in it all predate readme short descriptions.

## What changed

- The plugin card (src and build) and the embed print `esc_html( get_plugin_excerpt_text() )` inside a `<p>` instead of calling `the_excerpt()`. The new template tag in `inc/template-tags.php` texturizes, turns `<br />` into a space, strips the remaining tags and collapses whitespace. `get_the_excerpt()` keeps the translation filter and the empty-excerpt fallback; `wptexturize` runs first so text inside `<code>` keeps its straight quotes as it does today; the `<p>` keeps the existing CSS working.
- Dropped from `the_excerpt()`'s filter chain on purpose: `convert_smilies`, `convert_chars`, `wpautop`, `shortcode_unautop`, `wp_replace_insecure_home_url` and `wp_filter_content_tags`. The last two are no-ops on text without tags.
- Visible effects: the 43 excerpts that still hold `<a>`, `<strong>`, `<em>`, `<code>` or `<br />` render as plain sentences, with a space where a line break was and runs of spaces collapsed. A literal `<` followed by a word now drops the rest of the excerpt, which is what the readme parser does with the same input.

## Testing

wp-env `environments/plugin-directory` (WP trunk), the same four plugin posts on trunk and on this branch, container restarted between the two. The card (search results) and the embed print the same string in both cases.

| excerpt in the database | trunk | branch |
|---|---|---|
| `Tools for A &amp; B -- it's "done"...` | `Tools for A &amp; B &#8212; it&#8217;s &#8220;done&#8221;&#8230;` | identical |
| `Use <code>&lt;?php getRSS('…', '5');?&gt;</code> to fetch a <a href="…">feed</a>.` | `<code>` and `<a>` rendered as elements, straight quotes inside `<code>` | `Use &lt;?php getRSS(&#039;…&#039;, &#039;5&#039;);?&gt; to fetch a feed.` |
| `(<p>,<div>,<span) and 5 < 6` | `(` then the browser closes the paragraph | `(,,` |
| `…aleatoriamente.<br />Uma forma…<br />No admin…` (random-thumbs) | four lines | `…aleatoriamente. Uma forma… No admin…` |
| `…of the blog.         To these…` (nine spaces) | nine spaces | one space |
| `START <a id="x" data-x="y" href="#">PCLICK</a> END` | element | `START PCLICK END` |

Production: the info API lists 71,547 published plugins, 43 with a tag in `short_description`, all of them `a`, `strong`, `em`, `code` or `br` from old-style plugin headers. Changed lines lint clean with `phpcs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin excerpt rendering across plugin cards and embedded plugin views.
  * Excerpts now consistently display as clean, plain text without HTML markup.
  * Line breaks in excerpts are converted to spaces for more natural, readable formatting.
  * Shared excerpt handling provides consistent results wherever plugin summaries appear.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->