### PR TITLE
Photo Directory: Store every submitted field as text

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/uploads.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/uploads.php
@@ -486,12 +486,19 @@ class Uploads {
 	 * @return array
 	 */
 	public static function sanitize_submitted_description( $post_array ) {
-		foreach ( [ 'post_title', 'post_content', 'post_excerpt' ] as $field ) {
+		// The description is the photo's alternative text, so it keeps its line breaks; the other two are single lines.
+		$fields = [
+			'post_title'   => 'sanitize_text_field',
+			'post_content' => 'sanitize_textarea_field',
+			'post_excerpt' => 'sanitize_text_field',
+		];
+
+		foreach ( $fields as $field => $sanitize ) {
 			if ( ! isset( $post_array[ $field ] ) ) {
 				continue;
 			}
 
-			$value = sanitize_textarea_field( wp_unslash( $post_array[ $field ] ) );
+			$value = $sanitize( wp_unslash( $post_array[ $field ] ) );
 
 			$post_array[ $field ] = wp_slash( strip_shortcodes( $value ) );
 		}

--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/uploads.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/uploads.php
@@ -480,19 +480,20 @@ class Uploads {
 	}
 
 	/**
-	 * Sanitizes the submitted "Alternative Text" as the plain text it is.
+	 * Sanitizes the submitted free-text fields as the plain text they are.
 	 *
 	 * @param array $post_array Array of post settings.
 	 * @return array
 	 */
 	public static function sanitize_submitted_description( $post_array ) {
-		// The photo form is the only Frontend Uploader form here; scope to it should another ever be added.
-		if ( Registrations::get_post_type() !== ( $post_array['post_type'] ?? '' ) ) {
-			return $post_array;
-		}
+		foreach ( [ 'post_title', 'post_content', 'post_excerpt' ] as $field ) {
+			if ( ! isset( $post_array[ $field ] ) ) {
+				continue;
+			}
 
-		if ( isset( $post_array['post_content'] ) ) {
-			$post_array['post_content'] = wp_slash( sanitize_textarea_field( wp_unslash( $post_array['post_content'] ) ) );
+			$value = sanitize_textarea_field( wp_unslash( $post_array[ $field ] ) );
+
+			$post_array[ $field ] = wp_slash( strip_shortcodes( $value ) );
 		}
 
 		return $post_array;


### PR DESCRIPTION
The photo submit form's free-text fields are plain text. The description is the photo's alternative text — the form says "No HTML" and caps it at 350 characters — and `sanitize_submitted_description()` has stored it as such since 9fc0f0ae8.

Two gaps in that:

- Only `post_content` was sanitized. The title and excerpt travel through the same `fu_before_create_post` payload and are stored as they arrive.
- It ran only when the submission declared the photo post type, and the request supplies that value, so the check is on the wrong side of the trust boundary.

Sanitize all three fields for every submission, and strip shortcodes as well as markup — shortcode syntax uses none of the characters `sanitize_textarea_field()` acts on, so it survives unchanged.

Complements #860, which renders the stored description as text. This is the intake side; that is the output side, and it also covers photos submitted before either.

## Testing steps

1. Submit a photo with a description of `Example [caption width="1" caption="x"]y[/caption] text`.
2. The stored `post_content` reads `Example  text`; on `trunk` the shortcode is stored intact.
3. Repeat with a submission that declares a different `post_type`; the fields are sanitized either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sanitization for submitted titles, excerpts, and content using formatting appropriate to each field.
  * Content submitted as multi-line text now preserves line breaks while being sanitized.
  * Shortcodes continue to be removed from submitted fields before processing and saving.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->