### PR TITLE
Photo Directory: refuse submitted shortcodes instead of editing them out

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/uploads.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/uploads.php
@@ -707,7 +707,12 @@ class Uploads {
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Read raw: sanitizing before the check would hide what it looks for.
 			$submitted = isset( $_POST[ $field ] ) ? wp_unslash( $_POST[ $field ] ) : '';
 
-			if ( $submitted && preg_match( '/' . get_shortcode_regex() . '/', $submitted ) ) {
+			// A field can arrive as an array; `sanitize_text_field()` stores those as an empty string.
+			if ( ! is_string( $submitted ) || '' === $submitted ) {
+				continue;
+			}
+
+			if ( preg_match( '/' . get_shortcode_regex() . '/', $submitted ) ) {
 				return 'shortcode-in-text';
 			}
 		}

--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/uploads.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/uploads.php
@@ -429,6 +429,9 @@ class Uploads {
 				case 'file-not-jpg':
 					$rejection = __( 'Your submission must be an image in the JPEG format.', 'wporg-photos' );
 					break;
+				case 'shortcode-in-text':
+					$rejection = __( 'The title, description, and caption cannot contain shortcodes. Please remove them and submit again.', 'wporg-photos' );
+					break;
 				case 'file-too-large':
 					$rejection = sprintf(
 						__( 'The file size for your submission is too large. Please submit a photo smaller than %d MB in size.', 'wporg-photos' ),
@@ -498,9 +501,7 @@ class Uploads {
 				continue;
 			}
 
-			$value = $sanitize( wp_unslash( $post_array[ $field ] ) );
-
-			$post_array[ $field ] = wp_slash( strip_shortcodes( $value ) );
+			$post_array[ $field ] = wp_slash( $sanitize( wp_unslash( $post_array[ $field ] ) ) );
 		}
 
 		return $post_array;
@@ -700,6 +701,15 @@ class Uploads {
 
 		if ( ! isset( $_POST['photo_license'] ) || ! $_POST['photo_license'] ) {
 			return 'checkbox_unchecked_license';
+		}
+
+		foreach ( [ 'post_title', 'post_content', 'post_excerpt' ] as $field ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Read raw: sanitizing before the check would hide what it looks for.
+			$submitted = isset( $_POST[ $field ] ) ? wp_unslash( $_POST[ $field ] ) : '';
+
+			if ( $submitted && preg_match( '/' . get_shortcode_regex() . '/', $submitted ) ) {
+				return 'shortcode-in-text';
+			}
 		}
 
 		return false;

--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/uploads.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/uploads.php
@@ -707,7 +707,7 @@ class Uploads {
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Read raw: sanitizing before the check would hide what it looks for.
 			$submitted = isset( $_POST[ $field ] ) ? wp_unslash( $_POST[ $field ] ) : '';
 
-			// A field can arrive as an array; `sanitize_text_field()` stores those as an empty string.
+			// A field can arrive as an array, which Frontend Uploader drops before it builds the post.
 			if ( ! is_string( $submitted ) || '' === $submitted ) {
 				continue;
 			}


### PR DESCRIPTION
Follow-up to [a3bbd339e], which ran the submitted fields through `strip_shortcodes()`.

`strip_shortcodes()` is a single pass, and a single pass can leave a shortcode in place:

- It unwraps an escaped `[[tag]]` into a live `[tag]` — `strip_shortcode_tag()` returns `substr( $match, 1, -1 )` for
  that syntax by design.
- Removing one shortcode can splice the surrounding text into another. `[gal[caption]lery ids="1"]` carries no
  shortcode until the inner `[caption]` is taken out, at which point the remainder joins into a live
  `[gallery ids="1"]`.

Both survive the strip, so a submission can store a shortcode that was never in it.

`validate_upload_form()` now refuses a title, description or caption containing shortcode syntax, which is where the
form already turns a submission away and explains why. Matching a shortcode cannot manufacture one, so detection has
neither failing, and the submitter is told rather than having their wording quietly rewritten.

`sanitize_submitted_description()` goes back to sanitizing markup only. It runs on `fu_before_create_post`, which an
upload cannot reach without passing `fu_should_process_content_upload` and therefore the check above.

Bracketed prose is unaffected — `[developers]` is not a registered shortcode, so nothing matches it.

Complements #860, which renders the stored description as text. That is the output side and also covers photos
submitted before either change; this is the intake side.

## Testing steps

1. Submit a photo with a description of `Alt [[caption width="1" caption="x"]y[/caption]] text`. The submission is
   refused with a message about shortcodes; on `trunk` it stores a live `[caption …]`.
2. Repeat with `Alt [gal[caption]lery ids="1"] text` in the title. Same result.
3. Submit `A photo of [developers] at work`. It is accepted and stored unchanged.
4. Submit an ordinary photo with ordinary text; nothing about the flow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Upload submissions containing shortcodes in titles, descriptions, or captions are now rejected with a dedicated message.
  - Validation checks the original submitted text before sanitization, improving detection accuracy.
  - Shortcodes are no longer silently removed during sanitization; affected uploads are clearly rejected so the content can be corrected before submission.
  - Empty or non-text field values are skipped during shortcode validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->