### PR TITLE
Trac oEmbed: Apply the iframe's sandbox flags to the embed response

### DIFF
--- a/api.wordpress.org/public_html/dotorg/trac/oembed/index.php
+++ b/api.wordpress.org/public_html/dotorg/trac/oembed/index.php
@@ -149,7 +149,12 @@ if ( ! isset( $_GET['embed'] ) ) {
 header( 'Content-Type: text/html; charset=UTF-8' );
 header( 'X-Content-Type-Options: nosniff' );
 
-// The iframe's sandbox covers that element, not this response, which is reachable directly.
+/*
+ * The iframe's sandbox covers that element, not this response, which is reachable directly.
+ * Re-serving third-party markup is the point of this endpoint, so the sandbox is the boundary
+ * rather than the markup: the document cannot act as this origin, and it shows nothing the Trac
+ * URL it mirrors does not already show to the same audience.
+ */
 header( 'Content-Security-Policy: sandbox allow-scripts allow-top-navigation-by-user-activation' );
 
 $cache_key = sha1( $url );

--- a/api.wordpress.org/public_html/dotorg/trac/oembed/index.php
+++ b/api.wordpress.org/public_html/dotorg/trac/oembed/index.php
@@ -311,6 +311,10 @@ foreach ( $elements_to_remove as $el ) {
 // Add a script to the header.
 $js = <<<JS
 (function() {
+	if ( window.parent === window ) {
+		return;
+	}
+
 	var id = ( document.location.hash.match(/el=([0-9a-f]+)(&|$)/) || [ '', '' ] )[1];
 
 	function send() {

--- a/api.wordpress.org/public_html/dotorg/trac/oembed/index.php
+++ b/api.wordpress.org/public_html/dotorg/trac/oembed/index.php
@@ -149,6 +149,9 @@ if ( ! isset( $_GET['embed'] ) ) {
 header( 'Content-Type: text/html; charset=UTF-8' );
 header( 'X-Content-Type-Options: nosniff' );
 
+// The iframe's sandbox covers that element, not this response, which is reachable directly.
+header( 'Content-Security-Policy: sandbox allow-scripts allow-top-navigation-by-user-activation' );
+
 $cache_key = sha1( $url );
 if ( $data = wp_cache_get( $cache_key, 'trac-oembed' ) ) {
 	die( $data );
@@ -323,7 +326,10 @@ $js = <<<JS
 	window.addEventListener( 'DOMContentLoaded', send );
 })();
 JS;
-$doc->getElementsByTagName( 'head' )[0]->appendChild( $doc->createElement( 'script', $js ) );
+
+$reporter = $doc->createElement( 'script' );
+$reporter->appendChild( $doc->createTextNode( $js ) );
+$doc->getElementsByTagName( 'head' )[0]->appendChild( $reporter );
 
 $css = <<<CSS
 html {


### PR DESCRIPTION
The oEmbed payload wraps the embed document in an iframe carrying `sandbox="allow-scripts allow-top-navigation-by-user-activation"`. Those flags sit on the element rather than on the response, so they only take effect when the document is loaded through that particular iframe. Consumers that rebuild the iframe from the payload's `src`, and requests made to the endpoint directly, get the document without them.

This sends the same flags as a `Content-Security-Policy: sandbox` header so they travel with the response however it is loaded. They are identical to the iframe's, so the framed path is unchanged.

Also builds the injected height reporter with a text node. Passing the script to `DOMDocument::createElement()` as a value parses it for entity references, which mangles or drops a script containing `&`. The current script is unaffected; this keeps a later edit to it from breaking silently.

Finally, the reporter now returns early when the document is not framed. It posts to `window.parent`, which is the window itself on a direct load, so the message comes straight back to its own `message` listener and the script spins for as long as the page is open. Measured in Chromium: an unframed load reached the probe's 25-message cap in under 1.5s, and reports 0 with the guard in place. A framed load posts twice — `DOMContentLoaded` and `load` — both before and after.

### Testing

- The header is sent before both early exits, so the cached and "Temporarily Unavailable" responses carry it too.
- The flags are byte-identical to the iframe attribute, so the framed path intersects to the same set.
- `phpcs` against `phpcs.xml.dist` reports nothing new.

The sandbox behaviour itself is from the spec and was not exercised in a browser; the reporter change was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Embedded iframe responses now use a restrictive Content Security Policy sandbox to strengthen isolation.
  - Reporting scripts only run when content is displayed within an embedded context.
  - Embedded scripts are handled more safely during creation and execution, improving the security of iframe content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->