### PR TITLE
Photo Directory: check the value that gets stored, not the one submitted

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/uploads.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/uploads.php
@@ -703,8 +703,15 @@ class Uploads {
 			return 'checkbox_unchecked_license';
 		}
 
-		foreach ( [ 'post_title', 'post_content', 'post_excerpt' ] as $field ) {
-			// phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Read raw: sanitizing before the check would hide what it looks for.
+		// The same fields and sanitizers `sanitize_submitted_description()` stores them with.
+		$fields = [
+			'post_title'   => 'sanitize_text_field',
+			'post_content' => 'sanitize_textarea_field',
+			'post_excerpt' => 'sanitize_text_field',
+		];
+
+		foreach ( $fields as $field => $sanitize ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized on the next line, by whichever callback stores the field.
 			$submitted = isset( $_POST[ $field ] ) ? wp_unslash( $_POST[ $field ] ) : '';
 
 			// A field can arrive as an array, which Frontend Uploader drops before it builds the post.
@@ -712,7 +719,7 @@ class Uploads {
 				continue;
 			}
 
-			if ( preg_match( '/' . get_shortcode_regex() . '/', $submitted ) ) {
+			if ( 1 === preg_match( '/' . get_shortcode_regex() . '/', $sanitize( $submitted ) ) ) {
 				return 'shortcode-in-text';
 			}
 		}

--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/uploads.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/uploads.php
@@ -719,7 +719,8 @@ class Uploads {
 				continue;
 			}
 
-			if ( 1 === preg_match( '/' . get_shortcode_regex() . '/', $sanitize( $submitted ) ) ) {
+			// Anything but a clean no-match is refused: preg_match() returns false when PCRE gives up.
+			if ( 0 !== preg_match( '/' . get_shortcode_regex() . '/', $sanitize( $submitted ) ) ) {
 				return 'shortcode-in-text';
 			}
 		}


### PR DESCRIPTION
Follow-up to [c2b3b50f4], which refuses a submission whose title, description or caption carries shortcode syntax.

The check read `$_POST`, but the field is stored sanitized, and sanitizing can close a gap that kept the submitted
value from matching:

```
              | before       | after        | stored value
tag splice    | ACCEPTED     | rejected     | ** would be LIVE
nested tag    | ACCEPTED     | rejected     | ** would be LIVE
direct        | rejected     | rejected     |
escaped twin  | rejected     | rejected     |
splice        | rejected     | rejected     |
prose         | ACCEPTED     | ACCEPTED     | inert
```

`Alt [cap<x>tion width="1"]y[/caption] text` carries no shortcode as submitted — `cap<x>tion` is not a tag name, so
nothing matches. `sanitize_text_field()` then removes the `<x>`, and a live `[caption]` is what lands in
`post_content`. Same shape as the splice this check was added to catch, only the edit happens after the decision
instead of during it.

Run the check through the same field-to-sanitizer map `sanitize_submitted_description()` stores them with, so the
decision is made about the exact bytes that get written and nothing edits them afterwards.

Also compares `preg_match()` against `1` rather than truthiness — it returns `false`, not `0`, when PCRE gives up,
which a long enough description can provoke, and that read as "no shortcode found".

Bracketed prose is still accepted; `[developers]` is not a registered shortcode before or after sanitizing.

The equivalent check in the Theme Directory does not need this: `WP_Theme::sanitize_header()` runs `wp_kses()` on
`Description` before `get()` returns it, so that check already sees the post-kses value and it is the same string
that gets stored.

## Testing steps

1. Submit a photo with a description of `Alt [cap<x>tion width="1"]y[/caption] text`. The submission is refused; on
   `trunk` it is accepted and stores a live `[caption …]`.
2. Repeat with `Alt [gal<b></b>lery ids="1"] text`. Same.
3. Submit `A photo of [developers] at work`. Still accepted, stored unchanged.
4. Submit an ordinary photo with ordinary text; nothing about the flow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upload form validation to reject fields containing shortcodes.
  * Validation now also rejects fields when pattern matching encounters an error, helping prevent invalid submissions.
  * Fields are accepted only when validation confirms no shortcode is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->