### PR TITLE
Plugin Directory: treat screenshot captions as text, not block markup

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/readme/class-parser.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/readme/class-parser.php
@@ -697,6 +697,10 @@ class Parser {
 		// $text = make_clickable( $text );
 		$text = wp_kses( $text, $allowed );
 
+		// Readme text has no use for HTML comments, and dropping them keeps
+		// comment syntax out of the fields that are later composed into markup.
+		$text = preg_replace( '#<!--.*?(?:-->|$)#s', '', $text );
+
 		// wpautop() will eventually replace all \n's with <br>s, and that isn't what we want (The text may be line-wrapped in the readme, we don't want that, we want paragraph-wrapped text)
 		// TODO: This incorrectly also applies within `<code>` tags which we don't want either.
 		// $text = preg_replace( "/(?<![> ])\n/", ' ', $text );

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-screenshots.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-screenshots.php
@@ -424,13 +424,31 @@ class Screenshots {
 		if ( '' !== $caption ) {
 			$figure .= sprintf(
 				'<figcaption class="wp-element-caption">%s</figcaption>',
-				wp_kses_post( $caption )
+				self::escape_block_delimiters( wp_kses_post( $caption ) )
 			);
 		}
 
 		$figure .= '</figure>';
 
 		return "<!-- wp:image {$attrs} -->\n{$figure}\n<!-- /wp:image -->\n";
+	}
+
+	/**
+	 * Encodes block-comment delimiters in a caption.
+	 *
+	 * The caption is concatenated into the Image block markup that display()
+	 * hands to do_blocks(), so it has to stay a text leaf of that block rather
+	 * than something the block parser can read as grammar of its own.
+	 *
+	 * @param string $caption Caption HTML.
+	 * @return string Caption HTML with no block-comment delimiters left in it.
+	 */
+	protected static function escape_block_delimiters( $caption ) {
+		return str_replace(
+			array( '<!--', '-->' ),
+			array( '&lt;!--', '--&gt;' ),
+			$caption
+		);
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Screenshot_Caption_Block_Delimiters_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Screenshot_Caption_Block_Delimiters_Test.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Tests that screenshot captions cannot contribute block grammar.
+ *
+ * @package WordPressdotorg\Plugin_Directory\Tests
+ */
+
+declare( strict_types = 1 );
+
+namespace WordPressdotorg\Plugin_Directory\Shortcodes;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use WordPressdotorg\Plugin_Directory\Readme\Parser;
+
+require_once __DIR__ . '/fixtures/production-environment.php';
+
+/**
+ * A caption is display text. It travels from the readme into post meta and is
+ * then composed into the Image block markup that Screenshots::display() hands
+ * to do_blocks(), so it has to stay a text leaf of that block at both ends.
+ *
+ * @group shortcodes
+ */
+#[Group( 'shortcodes' )]
+class Screenshot_Caption_Block_Delimiters_Test extends TestCase {
+
+	/**
+	 * A caption carrying block-comment syntax.
+	 *
+	 * @var string
+	 */
+	const CAPTION = 'Caption <!-- /wp:image --><!-- wp:post-navigation-link {"type":"next","label":"x"} /--><!-- wp:image -->';
+
+	/**
+	 * The parser keeps comment syntax out of the stored caption.
+	 */
+	public function test_parser_drops_comments_from_screenshot_captions(): void {
+		$readme = implode(
+			"\n",
+			array(
+				'=== Test Plugin ===',
+				'Contributors: testuser',
+				'Tags: testing',
+				'Tested up to: 6.9',
+				'Stable tag: 1.0.0',
+				'',
+				'Short description.',
+				'',
+				'== Screenshots ==',
+				'',
+				'1. ' . self::CAPTION,
+				'',
+			)
+		);
+
+		$file = wp_tempnam( 'readme.txt' );
+		file_put_contents( $file, $readme ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test fixture, no filesystem abstraction in play.
+
+		try {
+			$parser = new Parser( $file );
+		} finally {
+			wp_delete_file( $file );
+		}
+
+		$this->assertArrayHasKey( 1, $parser->screenshots );
+		$this->assertStringNotContainsString( '<!--', $parser->screenshots[1] );
+		$this->assertStringNotContainsString( '-->', $parser->screenshots[1] );
+		$this->assertStringContainsString( 'Caption', $parser->screenshots[1] );
+	}
+
+	/**
+	 * A caption already stored with comment syntax stays inside its own block.
+	 */
+	public function test_stored_caption_cannot_open_a_sibling_block(): void {
+		$method  = new ReflectionMethod( Screenshots::class, 'build_image_block' );
+		$post_id = wp_insert_post(
+			array(
+				'post_name'         => 'caption-delimiters',
+				'post_title'        => 'Caption Delimiters',
+				'post_type'         => 'plugin',
+				'post_status'       => 'publish',
+				'post_modified'     => current_time( 'mysql' ),
+				'post_modified_gmt' => current_time( 'mysql', true ),
+			)
+		);
+
+		setup_postdata( get_post( $post_id ) );
+
+		try {
+			$markup = $method->invoke(
+				null,
+				array(
+					'src'      => 'https://ps.w.org/caption-delimiters/assets/screenshot-1.png',
+					'filename' => 'screenshot-1.png',
+					'caption'  => self::CAPTION,
+				),
+				9000002,
+				true,
+				array( 1200, 800 )
+			);
+		} finally {
+			wp_reset_postdata();
+			wp_delete_post( $post_id, true );
+		}
+
+		$names = array_values(
+			array_filter(
+				wp_list_pluck( parse_blocks( $markup ), 'blockName' )
+			)
+		);
+
+		$this->assertSame( array( 'core/image' ), $names );
+	}
+}


### PR DESCRIPTION
A screenshot caption is display text. It is composed into the Image block markup that `Screenshots::display()` hands to `do_blocks()`, so it should stay a text leaf of that block.

- `Screenshots::build_image_block()` encodes block-comment delimiters in the caption before it goes into the `<figcaption>`.
- `Readme\Parser::filter_text()` drops HTML comments, so newly imported captions do not carry the syntax at all.

Both layers are covered by `tests/Screenshot_Caption_Block_Delimiters_Test.php`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T1kfkymZDgMdeVRpDUUQL7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sanitized readme text and screenshot captions now prevent HTML and Gutenberg block-comment delimiters from disrupting rendered content.
  * Screenshot captions containing comment syntax remain correctly contained within their image blocks.

* **Tests**
  * Added coverage for comment removal and safe screenshot block rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->