### PR TITLE
Jobs: Tidy up template output

### DIFF
--- a/jobs.wordpress.net/public_html/wp-content/plugins/jobswp/jobswp-moderation.php
+++ b/jobs.wordpress.net/public_html/wp-content/plugins/jobswp/jobswp-moderation.php
@@ -84,14 +84,12 @@ class Jobs_Dot_WP_Moderation {
 				echo '<tr>';
 				echo '<td><a href="' . esc_url( get_edit_post_link( $similar_job->ID ) ) . '">' . esc_html( $similar_job->post_title ) . '</a></td>';
 				echo '<td>' . esc_html( $similar_job->post_status ) . '</td>';
-    // Output job categories
-    echo '<td>';
-    $job_categories = get_the_terms($similar_job->ID, 'job_category');
-    if ($job_categories && !is_wp_error($job_categories)) {
-        $category_names = wp_list_pluck($job_categories, 'name');
-        echo esc_html( implode( ', ', $category_names ) );
-    }
-    echo '</td>';
+				echo '<td>';
+				$job_categories = get_the_terms( $similar_job->ID, 'job_category' );
+				if ( $job_categories && ! is_wp_error( $job_categories ) ) {
+					echo esc_html( implode( ', ', wp_list_pluck( $job_categories, 'name' ) ) );
+				}
+				echo '</td>';
 				echo '<td>' . esc_html( get_post_meta( $similar_job->ID, 'first_name', true ) . ' ' . get_post_meta( $similar_job->ID, 'last_name', true ) ) . '</td>';
 				echo '<td>' . esc_html( get_post_meta( $similar_job->ID, 'email', true ) ) . '</td>';
 echo '<td>';

--- a/jobs.wordpress.net/public_html/wp-content/plugins/jobswp/jobswp-moderation.php
+++ b/jobs.wordpress.net/public_html/wp-content/plugins/jobswp/jobswp-moderation.php
@@ -83,17 +83,17 @@ class Jobs_Dot_WP_Moderation {
 			foreach ($similar_jobs as $similar_job) {
 				echo '<tr>';
 				echo '<td><a href="' . esc_url( get_edit_post_link( $similar_job->ID ) ) . '">' . esc_html( $similar_job->post_title ) . '</a></td>';
-				echo '<td>' . $similar_job->post_status . '</td>';
+				echo '<td>' . esc_html( $similar_job->post_status ) . '</td>';
     // Output job categories
     echo '<td>';
     $job_categories = get_the_terms($similar_job->ID, 'job_category');
     if ($job_categories && !is_wp_error($job_categories)) {
         $category_names = wp_list_pluck($job_categories, 'name');
-        echo implode(', ', $category_names);
+        echo esc_html( implode( ', ', $category_names ) );
     }
     echo '</td>';
-				echo '<td>' . get_post_meta( $similar_job->ID, 'first_name', true ) . ' ' . get_post_meta( $similar_job->ID, 'last_name', true ) . '</td>';
-				echo '<td>' . get_post_meta( $similar_job->ID, 'email', true ) . '</td>';
+				echo '<td>' . esc_html( get_post_meta( $similar_job->ID, 'first_name', true ) . ' ' . get_post_meta( $similar_job->ID, 'last_name', true ) ) . '</td>';
+				echo '<td>' . esc_html( get_post_meta( $similar_job->ID, 'email', true ) ) . '</td>';
 echo '<td>';
 if ( $similar_job->post_content === $post->post_content ) {
 	echo 'Same job description';

--- a/jobs.wordpress.net/public_html/wp-content/plugins/jobswp/jobswp-template.php
+++ b/jobs.wordpress.net/public_html/wp-content/plugins/jobswp/jobswp-template.php
@@ -18,6 +18,8 @@ function jobswp_get_job_meta( $post_id, $meta_key ) {
 		case 'location':
 			if ( empty( $val ) )
 				$val = 'N/A';
+			else
+				$val = esc_html( $val );
 			break;
 		case 'jobtype':
 			if ( 'ppt' == $val )
@@ -62,6 +64,8 @@ function jobswp_get_job_meta( $post_id, $meta_key ) {
 				$val = esc_html( $val );
 			}
 			break;
+		default:
+			$val = esc_html( $val );
 	endswitch;
 
 	return apply_filters( 'jobswp_metadata', $val, $post_id, $meta_key );
@@ -80,16 +84,14 @@ function jobswp_archive_header( $before = '', $after = '', $jobscnt = 0, $catego
 	$output = '<div class="row row-head">';
 	$link = $before;
 	if ( $category ) {
-			$link .= '<a href="' . get_term_feed_link( $category->term_id, $category->taxonomy ) . '"';
-			$title = ' title="' . $category->name . '"';
-			$alt = ' alt="' . $category->name . '"';
-			$link .= $title;
-			$link .= '>';
-			$link .= '</a> ';
-			$link .= '<a href="' . get_term_link( $category, 'job_category' ) . '" ';
-			$link .= 'title="' . sprintf( __( 'View all jobs listed under %s', 'jobswp' ), esc_attr( $category->name ) ) . '"';
-			$link .= '>';
-			$link .= apply_filters( 'list_cats', $category->name, $category ).'</a>';
+		$link .= sprintf(
+			'<a href="%1$s" title="%2$s"></a> <a href="%3$s" title="%4$s">%5$s</a>',
+			esc_url( get_term_feed_link( $category->term_id, $category->taxonomy ) ),
+			esc_attr( $category->name ),
+			esc_url( get_term_link( $category, 'job_category' ) ),
+			esc_attr( sprintf( __( 'View all jobs listed under %s', 'jobswp' ), $category->name ) ),
+			esc_html( apply_filters( 'list_cats', $category->name, $category ) )
+		);
 	}
 
 	$orig_jobscnt = $jobscnt;
@@ -105,7 +107,7 @@ function jobswp_archive_header( $before = '', $after = '', $jobscnt = 0, $catego
 	$output .= $link;
 	$output .= '<div class="jobs-count">';
 
-	$output .= '<a href="' . $feed_link . '">RSS</a> <span>' . $jobscnt . '</span></div>
+	$output .= '<a href="' . esc_url( $feed_link ) . '">RSS</a> <span>' . $jobscnt . '</span></div>
 		</div>
 		<div class="row job-list-col-labels">
 			<div class="job-date">Date Posted</div>

--- a/jobs.wordpress.net/public_html/wp-content/plugins/jobswp/jobswp-template.php
+++ b/jobs.wordpress.net/public_html/wp-content/plugins/jobswp/jobswp-template.php
@@ -16,10 +16,7 @@ function jobswp_get_job_meta( $post_id, $meta_key ) {
 
 	switch ( $meta_key ) :
 		case 'location':
-			if ( empty( $val ) )
-				$val = 'N/A';
-			else
-				$val = esc_html( $val );
+			$val = empty( $val ) ? 'N/A' : esc_html( $val );
 			break;
 		case 'jobtype':
 			if ( 'ppt' == $val )
@@ -89,6 +86,7 @@ function jobswp_archive_header( $before = '', $after = '', $jobscnt = 0, $catego
 			esc_url( get_term_feed_link( $category->term_id, $category->taxonomy ) ),
 			esc_attr( $category->name ),
 			esc_url( get_term_link( $category, 'job_category' ) ),
+			/* translators: %s: Job category name. */
 			esc_attr( sprintf( __( 'View all jobs listed under %s', 'jobswp' ), $category->name ) ),
 			esc_html( apply_filters( 'list_cats', $category->name, $category ) )
 		);

--- a/jobs.wordpress.net/public_html/wp-content/plugins/jobswp/jobswp.php
+++ b/jobs.wordpress.net/public_html/wp-content/plugins/jobswp/jobswp.php
@@ -397,7 +397,7 @@ class Jobs_Dot_WP {
 		}
 
 		echo '<div class="error"><p>';
-		printf( __( 'ERROR: The username configured for posting jobs &mdash; %s &mdash; does not exist.', 'jobswp' ), $this->get_jobposter( false ) );
+		printf( __( 'ERROR: The username configured for posting jobs &mdash; %s &mdash; does not exist.', 'jobswp' ), esc_html( $this->get_jobposter( false ) ) );
 		echo '</p></div>';
 	}
 
@@ -433,7 +433,7 @@ class Jobs_Dot_WP {
 		$close_link = add_query_arg( 'action', $action, admin_url( sprintf( $post_type_object->_edit_link, $post->ID ) ) );
 		$close_link = wp_nonce_url( $close_link, "$action-post_{$post->ID}" );
 
-		$link = '<a href="' . $close_link . '"';
+		$link = '<a href="' . esc_url( $close_link ) . '"';
 		if ( $class )
 			$link .= ' class="' . esc_attr( $class ) . '"';
 		$link .= ' title="' . esc_attr__( 'Close this job', 'jobswp' ) . '">';
@@ -503,7 +503,7 @@ class Jobs_Dot_WP {
 
 		if ( $user_id = wp_check_post_lock( $post_id ) ) {
 			$user = get_userdata( $user_id );
-			wp_die( sprintf( __( 'You cannot close this job. %s is currently editing.', 'jobswp' ), $user->display_name ) );
+			wp_die( sprintf( __( 'You cannot close this job. %s is currently editing.', 'jobswp' ), esc_html( $user->display_name ) ) );
 		}
 
 		if ( ! $this->close_job( $post ) )

--- a/jobs.wordpress.net/public_html/wp-content/plugins/jobswp/jobswp.php
+++ b/jobs.wordpress.net/public_html/wp-content/plugins/jobswp/jobswp.php
@@ -397,7 +397,8 @@ class Jobs_Dot_WP {
 		}
 
 		echo '<div class="error"><p>';
-		printf( __( 'ERROR: The username configured for posting jobs &mdash; %s &mdash; does not exist.', 'jobswp' ), esc_html( $this->get_jobposter( false ) ) );
+		/* translators: %s: Configured job poster username. */
+		printf( esc_html__( 'ERROR: The username configured for posting jobs &mdash; %s &mdash; does not exist.', 'jobswp' ), esc_html( $this->get_jobposter( false ) ) );
 		echo '</p></div>';
 	}
 
@@ -503,7 +504,8 @@ class Jobs_Dot_WP {
 
 		if ( $user_id = wp_check_post_lock( $post_id ) ) {
 			$user = get_userdata( $user_id );
-			wp_die( sprintf( __( 'You cannot close this job. %s is currently editing.', 'jobswp' ), esc_html( $user->display_name ) ) );
+			/* translators: %s: Display name of the user editing the job. */
+			wp_die( sprintf( esc_html__( 'You cannot close this job. %s is currently editing.', 'jobswp' ), esc_html( $user->display_name ) ) );
 		}
 
 		if ( ! $this->close_job( $post ) )

--- a/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-post-job.php
+++ b/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-post-job.php
@@ -83,6 +83,7 @@
 			<select name="category" id="category" class="<?php echo jobswp_required_field_classes( 'category' ); ?>" required>
 				<option value="" selected="selected" disabled="disabled"></option>
 				<?php foreach ( Jobs_Dot_WP::get_job_categories() as $cat ) : ?>
+					<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- jobswp_field_value() returns selected() markup. ?>
 					<option value="<?php echo esc_attr( $cat->slug ); ?>" <?php echo jobswp_field_value( 'category', esc_attr( $cat->slug ) ); ?>><?php echo esc_html( $cat->name ); ?></option>
 				<?php endforeach; ?>
 			</select>

--- a/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-post-job.php
+++ b/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-post-job.php
@@ -83,7 +83,7 @@
 			<select name="category" id="category" class="<?php echo jobswp_required_field_classes( 'category' ); ?>" required>
 				<option value="" selected="selected" disabled="disabled"></option>
 				<?php foreach ( Jobs_Dot_WP::get_job_categories() as $cat ) : ?>
-					<option value="<?php echo esc_attr( $cat->slug ); ?>" <?php echo jobswp_field_value( 'category', esc_attr( $cat->slug ) ); ?>><?php echo $cat->name; ?></option>
+					<option value="<?php echo esc_attr( $cat->slug ); ?>" <?php echo jobswp_field_value( 'category', esc_attr( $cat->slug ) ); ?>><?php echo esc_html( $cat->name ); ?></option>
 				<?php endforeach; ?>
 			</select>
 		</div>


### PR DESCRIPTION
Some housekeeping in the jobswp plugin and theme:

- Consolidates the archive header link markup in `jobswp_archive_header()` into a single `sprintf()` call with numbered placeholders, and removes an unused variable.
- Brings the remaining template, form, and admin output in line with the usual escaping conventions (`esc_html()`, `esc_attr()`, `esc_url()`), including the Similar Jobs metabox and the job meta getter's plain-text branches.

No functional change intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection against unsafe HTML in job moderation details, category names, poster information, email addresses, job metadata, and admin messages.
  * Ensured translated status and administrative messages safely display user-provided values.
  * Preserved correct escaping for category selections and location values in job posting and listing views.

* **Documentation**
  * Added translator guidance for messages containing dynamic job category, poster, and editing-user information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->