### PR TITLE
Jobs theme: Style ordered lists

### DIFF
--- a/jobs.wordpress.net/public_html/wp-content/themes/jobswp/style.css
+++ b/jobs.wordpress.net/public_html/wp-content/themes/jobswp/style.css
@@ -871,14 +871,23 @@ label {
 	margin-bottom: var(--space-20);
 }
 
+.job-detail__body ol,
 .job-detail__body ul {
 	margin-bottom: var(--space-20);
 	padding-left: var(--space-20);
 }
 
+.job-detail__body ol {
+	padding-left: var(--space-30);
+}
+
 .job-detail__body li {
 	margin-bottom: 8px;
 	list-style: disc;
+}
+
+.job-detail__body ol li {
+	list-style: decimal;
 }
 
 /* Sidebar */


### PR DESCRIPTION
The Jobs theme currently does not offer any styling for ordered lists.

<img width="645" height="914" alt="jobs-no-ol-styling" src="https://github.com/user-attachments/assets/e5e09247-539c-45b9-a282-8a6168cc50b8" />

The PR adds styling to depict ordered list items using decimal values and shares margin used for unordered lists, with an overridden left padding.

<img width="645" height="914" alt="jobs-old-styling" src="https://github.com/user-attachments/assets/a68927ef-3f22-4b3c-b5b3-199d6faf7d24" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing and indentation for ordered and unordered lists in job-detail content.
  * Ordered lists now use deeper indentation with decimal numbering, while unordered lists retain disc bullets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->