### PR TITLE
Trac PRs: format pull request text for the Trac comment

### DIFF
--- a/.github/unit-tests-suites.yml
+++ b/.github/unit-tests-suites.yml
@@ -54,6 +54,13 @@ suites:
     paths:
       - 'api.wordpress.org/public_html/events/1.0/**'
 
+  trac-pr:
+    type: standalone
+    name: Trac PR Syncer
+    working-directory: api.wordpress.org/public_html/dotorg/trac/pr
+    paths:
+      - 'api.wordpress.org/public_html/dotorg/trac/pr/**'
+
   slack-trac:
     type: standalone
     name: Slack Trac Bot

--- a/api.wordpress.org/public_html/dotorg/trac/pr/functions.php
+++ b/api.wordpress.org/public_html/dotorg/trac/pr/functions.php
@@ -380,14 +380,14 @@ function trac_comment_processors() {
 /**
  * Escapes the row separators of a line, leaving its inline code alone.
  *
- * Trac writes a row separator's parameters onto the `tr` element, but renders the
- * contents of an inline `{{{…}}}` literally, so only the text between them needs it.
+ * Trac writes a row separator's parameters onto the `tr` element, but renders inline
+ * code literally, so only the text outside a `{{{…}}}` or a backtick span needs it.
  *
  * @param string $line One line of composed wiki text.
  * @return string|false The line with its row separators escaped.
  */
 function trac_comment_escape_row_separators( $line ) {
-	$parts = preg_split( '#(\{\{\{.*?\}\}\})#', $line, -1, PREG_SPLIT_DELIM_CAPTURE );
+	$parts = preg_split( '#(\{\{\{.*?\}\}\}|`[^`\n]*`)#', $line, -1, PREG_SPLIT_DELIM_CAPTURE );
 	if ( false === $parts ) {
 		return false;
 	}
@@ -499,15 +499,16 @@ function trac_comment_code_block( $fence ) {
  * @return string|false The span as Trac wiki markup, or false if it cannot be built.
  */
 function trac_comment_wiki_text( $text ) {
-	// A one-line fence is Trac's inline code: its contents are not escaped with the prose.
-	$parts = preg_split( '#```(.*?)```#s', $text, -1, PREG_SPLIT_DELIM_CAPTURE );
+	// Trac renders inline code literally, so its contents are not escaped with the prose.
+	$parts = preg_split( '#(```.*?```|`[^`\n]*`)#s', $text, -1, PREG_SPLIT_DELIM_CAPTURE );
 	if ( false === $parts ) {
 		return false;
 	}
 
 	foreach ( $parts as $i => $part ) {
 		if ( $i % 2 ) {
-			$parts[ $i ] = '{{{' . $part . '}}}';
+			// A one-line fence becomes Trac's own inline code; a single backtick already is.
+			$parts[ $i ] = str_starts_with( $part, '```' ) ? '{{{' . substr( $part, 3, -3 ) . '}}}' : $part;
 			continue;
 		}
 

--- a/api.wordpress.org/public_html/dotorg/trac/pr/functions.php
+++ b/api.wordpress.org/public_html/dotorg/trac/pr/functions.php
@@ -460,9 +460,12 @@ function trac_comment_code_block( $fence ) {
 		// replace a blank indented line at the end of the code block with.. nothing.
 		if ( $m['indent'] ) {
 			$code = preg_replace( "#\n[ >]+$#", '', $code );
+			if ( null === $code ) {
+				return false;
+			}
 		}
 
-		$code = $inert( (string) $code );
+		$code = $inert( $code );
 		if ( ! is_string( $code ) ) {
 			return false;
 		}
@@ -477,7 +480,12 @@ function trac_comment_code_block( $fence ) {
 		return false;
 	}
 
-	$code = $inert( preg_replace( "#\n[ >]+$#", '', trim( $m['code'], "\n" ) ) );
+	$code = preg_replace( "#\n[ >]+$#", '', trim( $m['code'], "\n" ) );
+	if ( null === $code ) {
+		return false;
+	}
+
+	$code = $inert( $code );
 	if ( ! is_string( $code ) ) {
 		return false;
 	}
@@ -561,11 +569,20 @@ function trac_comment_wiki_text( $text ) {
 	}
 
 	// Convert Tables, and escape the row separators of every line that is not one.
-	$text = preg_replace_callback(
+	$escaped = true;
+	$text    = preg_replace_callback(
 		'#^.+$#m',
-		function ( $m ) {
+		function ( $m ) use ( &$escaped ) {
 			if ( ! preg_match( '#^[|].+[|]$#', $m[0] ) ) {
-				return trac_comment_escape_row_separators( $m[0] );
+				$line = trac_comment_escape_row_separators( $m[0] );
+				// A false here would be coerced to '', dropping the line from the comment.
+				if ( false === $line ) {
+					$escaped = false;
+
+					return $m[0];
+				}
+
+				return $line;
 			}
 
 			// Headers such as `| --- |---|`.
@@ -592,7 +609,7 @@ function trac_comment_wiki_text( $text ) {
 	);
 
 	// A conversion above that PCRE gave up on would otherwise empty the span.
-	if ( ! is_string( $text ) ) {
+	if ( ! $escaped || ! is_string( $text ) ) {
 		return false;
 	}
 

--- a/api.wordpress.org/public_html/dotorg/trac/pr/functions.php
+++ b/api.wordpress.org/public_html/dotorg/trac/pr/functions.php
@@ -511,11 +511,7 @@ function trac_comment_wiki_text( $text ) {
 			continue;
 		}
 
-		/*
-		 * `[[` opens a macro and `[=` an anchor, both of which take element attributes;
-		 * `{{{` opens a processor block. Markdown's own single `[` is left for the link
-		 * and image conversions below.
-		 */
+		// Only the openers Trac reads as markup; a lone `[` is left for the conversions below.
 		$parts[ $i ] = preg_replace( '~\[(?=[\[=])|\{(?=\{\{)~', '!$0', $part );
 		if ( null === $parts[ $i ] ) {
 			return false;
@@ -558,10 +554,7 @@ function trac_comment_wiki_text( $text ) {
 		$text
 	);
 
-	/*
-	 * PHP coerces a null subject to '' for the next call, so a pass that PCRE gave up
-	 * on has to be caught before the one after it hides the failure.
-	 */
+	// A null subject is coerced to '' by the next call, so every pass is checked.
 	if ( ! is_string( $text ) ) {
 		return false;
 	}
@@ -649,11 +642,6 @@ function format_github_content_for_trac_comment( $desc ) {
 		return false;
 	}
 
-	/*
-	 * Fenced code and the text around it need opposite treatment: a block renders
-	 * literally once opened, while everything else is wiki markup to escape. `!` is
-	 * text rather than an escape inside a block, so the two cannot share a pass.
-	 */
 	$parts = preg_split( '#(^[ >]*```(?:(?!```)[^\n])*\n.*?```[ \t]*$)#sm', $desc, -1, PREG_SPLIT_DELIM_CAPTURE );
 	if ( false === $parts ) {
 		return false;
@@ -672,11 +660,6 @@ function format_github_content_for_trac_comment( $desc ) {
 
 	$desc = trim( $desc );
 
-	/*
-	 * What Trac skips before a `{{{` or a `#!`: its own whitespace class, which is
-	 * Python's and so wider than PCRE's, plus the `>` of a citation, whose contents
-	 * it re-formats as wiki text in their own right.
-	 */
 	$skipped = trac_comment_skipped();
 
 	// After all this, if it names a processor we didn't pick, we're not interested in syncing it.

--- a/api.wordpress.org/public_html/dotorg/trac/pr/functions.php
+++ b/api.wordpress.org/public_html/dotorg/trac/pr/functions.php
@@ -378,6 +378,35 @@ function trac_comment_processors() {
 }
 
 /**
+ * Escapes the row separators of a line, leaving its inline code alone.
+ *
+ * Trac writes a row separator's parameters onto the `tr` element, but renders the
+ * contents of an inline `{{{…}}}` literally, so only the text between them needs it.
+ *
+ * @param string $line One line of composed wiki text.
+ * @return string|false The line with its row separators escaped.
+ */
+function trac_comment_escape_row_separators( $line ) {
+	$parts = preg_split( '#(\{\{\{.*?\}\}\})#', $line, -1, PREG_SPLIT_DELIM_CAPTURE );
+	if ( false === $parts ) {
+		return false;
+	}
+
+	foreach ( $parts as $i => $part ) {
+		if ( $i % 2 ) {
+			continue;
+		}
+
+		$parts[ $i ] = preg_replace( '~\|(?=-)~', '!|', $part );
+		if ( null === $parts[ $i ] ) {
+			return false;
+		}
+	}
+
+	return implode( '', $parts );
+}
+
+/**
  * What Trac skips within a line before a delimiter, plus the `>` of a citation.
  *
  * Python's whitespace class, which is wider than PCRE's, so a pattern using this
@@ -542,8 +571,7 @@ function trac_comment_wiki_text( $text ) {
 		'#^.+$#m',
 		function ( $m ) {
 			if ( ! preg_match( '#^[|].+[|]$#', $m[0] ) ) {
-				// Trac writes a row separator's parameters onto the `tr` element.
-				return preg_replace( '~\|(?=-)~', '!|', $m[0] );
+				return trac_comment_escape_row_separators( $m[0] );
 			}
 
 			// Headers such as `| --- |---|`.
@@ -626,7 +654,7 @@ function format_github_content_for_trac_comment( $desc ) {
 	 * literally once opened, while everything else is wiki markup to escape. `!` is
 	 * text rather than an escape inside a block, so the two cannot share a pass.
 	 */
-	$parts = preg_split( '#(^[ >]*```[^\n]*\n.*?```[ \t]*$)#sm', $desc, -1, PREG_SPLIT_DELIM_CAPTURE );
+	$parts = preg_split( '#(^[ >]*```(?:(?!```)[^\n])*\n.*?```[ \t]*$)#sm', $desc, -1, PREG_SPLIT_DELIM_CAPTURE );
 	if ( false === $parts ) {
 		return false;
 	}

--- a/api.wordpress.org/public_html/dotorg/trac/pr/functions.php
+++ b/api.wordpress.org/public_html/dotorg/trac/pr/functions.php
@@ -448,13 +448,6 @@ function trac_comment_code_block( $fence ) {
 		return false;
 	}
 
-	// A one-line fence is Trac's inline code, not a block.
-	if ( ! str_contains( $m['code'], "\n" ) ) {
-		$code = $inert( $m['code'] );
-
-		return is_string( $code ) ? $m['indent'] . '{{{' . $code . '}}}' : false;
-	}
-
 	$code = $inert( preg_replace( "#\n[ >]+$#", '', trim( $m['code'], "\n" ) ) );
 	if ( ! is_string( $code ) ) {
 		return false;
@@ -477,16 +470,30 @@ function trac_comment_code_block( $fence ) {
  * @return string|false The span as Trac wiki markup, or false if it cannot be built.
  */
 function trac_comment_wiki_text( $text ) {
-	/*
-	 * `[[` opens a macro and `[=` an anchor, both of which take element attributes;
-	 * `{{{` opens a processor block. Markdown's own single `[` is left for the link
-	 * and image conversions below.
-	 */
-	$text = preg_replace( '~\[(?=[\[=])|\{(?=\{\{)~', '!$0', $text );
-
-	if ( null === $text ) {
+	// A one-line fence is Trac's inline code: its contents are not escaped with the prose.
+	$parts = preg_split( '#```(.*?)```#s', $text, -1, PREG_SPLIT_DELIM_CAPTURE );
+	if ( false === $parts ) {
 		return false;
 	}
+
+	foreach ( $parts as $i => $part ) {
+		if ( $i % 2 ) {
+			$parts[ $i ] = '{{{' . $part . '}}}';
+			continue;
+		}
+
+		/*
+		 * `[[` opens a macro and `[=` an anchor, both of which take element attributes;
+		 * `{{{` opens a processor block. Markdown's own single `[` is left for the link
+		 * and image conversions below.
+		 */
+		$parts[ $i ] = preg_replace( '~\[(?=[\[=])|\{(?=\{\{)~', '!$0', $part );
+		if ( null === $parts[ $i ] ) {
+			return false;
+		}
+	}
+
+	$text = implode( '', $parts );
 
 	// Convert Images (Must happen prior to Links, as the only difference is a preceeding `!`).
 	$text = preg_replace_callback(
@@ -600,7 +607,7 @@ function trac_comment_link_target( $url ) {
  *  - Converts links
  *  - Converts tables
  *
- * @param string $desc.
+ * @param string $desc GitHub content to convert to Trac wiki markup.
  * @return string|false Converted PR Description, or false if it may not be synced.
  */
 function format_github_content_for_trac_comment( $desc ) {
@@ -608,7 +615,7 @@ function format_github_content_for_trac_comment( $desc ) {
 	$line_breaks = array( "\r\n", "\r", "\x0b", "\x0c", "\x1c", "\x1d", "\x1e", "\xc2\x85", "\xe2\x80\xa8", "\xe2\x80\xa9" );
 	$desc        = str_replace( $line_breaks, "\n", $desc );
 
-	// Remove HTML comments
+	// Remove HTML comments.
 	$desc = preg_replace( '#<!--.+?-->#s', '', $desc );
 	if ( null === $desc ) {
 		return false;
@@ -619,7 +626,7 @@ function format_github_content_for_trac_comment( $desc ) {
 	 * literally once opened, while everything else is wiki markup to escape. `!` is
 	 * text rather than an escape inside a block, so the two cannot share a pass.
 	 */
-	$parts = preg_split( '#(^[ >]*```.*?```[ \t]*$|```.*?```)#sm', $desc, -1, PREG_SPLIT_DELIM_CAPTURE );
+	$parts = preg_split( '#(^[ >]*```[^\n]*\n.*?```[ \t]*$)#sm', $desc, -1, PREG_SPLIT_DELIM_CAPTURE );
 	if ( false === $parts ) {
 		return false;
 	}

--- a/api.wordpress.org/public_html/dotorg/trac/pr/functions.php
+++ b/api.wordpress.org/public_html/dotorg/trac/pr/functions.php
@@ -350,7 +350,7 @@ function get_trac_instance( $trac ) {
  *  - format_github_content_for_trac_comment();
  *
  * @param string $desc.
- * @return string Converted PR Description
+ * @return string|false Converted PR Description, or false if it may not be synced.
  */
 function format_pr_desc_for_trac_comment( $desc ) {
 	$desc = trim( $desc );
@@ -365,6 +365,232 @@ function format_pr_desc_for_trac_comment( $desc ) {
 }
 
 /**
+ * The Trac wiki processors a synced comment may name.
+ *
+ * The rest render badly, or take element attributes as `#!div` and `#!span` do.
+ *
+ * @link https://trac.edgewall.org/wiki/1.1/WikiProcessors#AvailableProcessors
+ *
+ * @return array Supported processor names.
+ */
+function trac_comment_processors() {
+	return [ 'default', 'xml', 'php', 'js', 'javascript', 'css', 'sql', 'sh', 'diff' ];
+}
+
+/**
+ * What Trac skips within a line before a delimiter, plus the `>` of a citation.
+ *
+ * Python's whitespace class, which is wider than PCRE's, so a pattern using this
+ * needs the `u` modifier. `\n` is left out: it must not carry across a line.
+ *
+ * @return string A character class, for use inside a `/u` pattern.
+ */
+function trac_comment_skipped() {
+	return '[ \t\x1c-\x1f\p{Z}>]';
+}
+
+/**
+ * Turns one fenced code block into a Trac code block.
+ *
+ * The contents are rendered literally, so only the block's own delimiters and its
+ * processor line have to be taken away from the pull request.
+ *
+ * @param string $fence One ```-fenced span, delimiters included.
+ * @return string|false The span as Trac wiki markup, or false if it cannot be built.
+ */
+function trac_comment_code_block( $fence ) {
+	/*
+	 * Trac ends a block only on a line of exactly `}}}` and nests one only on a line
+	 * opening with `{{{`, so those two shapes are broken up and braces anywhere else
+	 * are left as the code wrote them.
+	 */
+	$inert = function ( $code ) {
+		$skipped = trac_comment_skipped();
+
+		return preg_replace(
+			array( "~^({$skipped}*)\}\}\}{$skipped}*$~mu", "~^({$skipped}*)\{\{\{(?![^\n]*\}\}\})~mu" ),
+			array( '$1} }}', '$1{ {{' ),
+			$code
+		);
+	};
+
+	// Anchored to the whole span: a match on part of it would drop the rest.
+	if ( preg_match( '#\A(?P<indent>[ >]*)```[ ]*(?P<format>[a-z]+)$(?P<code>.+?)```[ \t]*\z#sm', $fence, $m ) ) {
+		$format = trim( $m['format'] );
+
+		// The HTML code block in trac renders actual HTML, set it as an XML code block for syntax highlighting.
+		if ( 'html' === $format ) {
+			$format = 'xml';
+		}
+
+		if ( ! in_array( $format, trac_comment_processors(), true ) ) {
+			$format = 'default';
+		}
+
+		$code = trim( $m['code'] );
+		// replace a blank indented line at the end of the code block with.. nothing.
+		if ( $m['indent'] ) {
+			$code = preg_replace( "#\n[ >]+$#", '', $code );
+		}
+
+		$code = $inert( (string) $code );
+		if ( ! is_string( $code ) ) {
+			return false;
+		}
+
+		return $m['indent'] . "{{{\n" .
+			$m['indent'] . '#!' . $format . "\n" .
+			$code . "\n" .
+			$m['indent'] . "}}}\n";
+	}
+
+	if ( ! preg_match( '#\A(?P<indent>[ >]*)```(?P<code>.*?)```[ \t]*\z#s', $fence, $m ) ) {
+		return false;
+	}
+
+	// A one-line fence is Trac's inline code, not a block.
+	if ( ! str_contains( $m['code'], "\n" ) ) {
+		$code = $inert( $m['code'] );
+
+		return is_string( $code ) ? $m['indent'] . '{{{' . $code . '}}}' : false;
+	}
+
+	$code = $inert( preg_replace( "#\n[ >]+$#", '', trim( $m['code'], "\n" ) ) );
+	if ( ! is_string( $code ) ) {
+		return false;
+	}
+
+	// Naming the processor stops the fence's first line from choosing one.
+	return $m['indent'] . "{{{\n" .
+		$m['indent'] . "#!default\n" .
+		$code . "\n" .
+		$m['indent'] . '}}}';
+}
+
+/**
+ * Converts one span of pull request text to Trac wiki markup.
+ *
+ * The body's own wiki syntax is escaped before any is added, so only the markup
+ * this composer writes reaches Trac as markup.
+ *
+ * @param string $text A span of the pull request lying outside any code fence.
+ * @return string|false The span as Trac wiki markup, or false if it cannot be built.
+ */
+function trac_comment_wiki_text( $text ) {
+	/*
+	 * `[[` opens a macro and `[=` an anchor, both of which take element attributes;
+	 * `{{{` opens a processor block. Markdown's own single `[` is left for the link
+	 * and image conversions below.
+	 */
+	$text = preg_replace( '~\[(?=[\[=])|\{(?=\{\{)~', '!$0', $text );
+
+	if ( null === $text ) {
+		return false;
+	}
+
+	// Convert Images (Must happen prior to Links, as the only difference is a preceeding `!`).
+	$text = preg_replace_callback(
+		'#!\[(?!\[)(.+?)\]\((.+?)\)#',
+		function ( $m ) {
+			return '[[Image(' . trac_comment_link_target( $m[2] ) . ')]]';
+		},
+		$text
+	);
+	if ( ! is_string( $text ) ) {
+		return false;
+	}
+
+	// Convert Images embedded as `<img>`.
+	$text = preg_replace_callback(
+		'#<img[^>]+src=(["\'])(.+?)\\1[^>]*>#',
+		function ( $m ) {
+			return '[[Image(' . trac_comment_link_target( $m[2] ) . ')]]';
+		},
+		$text
+	);
+
+	if ( ! is_string( $text ) ) {
+		return false;
+	}
+
+	// Convert Links.
+	$text = preg_replace_callback(
+		'#\[(.+?)\]\((.+?)\)#',
+		function ( $m ) {
+			return '[' . trac_comment_link_target( $m[2] ) . ' ' . $m[1] . ']';
+		},
+		$text
+	);
+
+	/*
+	 * PHP coerces a null subject to '' for the next call, so a pass that PCRE gave up
+	 * on has to be caught before the one after it hides the failure.
+	 */
+	if ( ! is_string( $text ) ) {
+		return false;
+	}
+
+	// Convert Tables, and escape the row separators of every line that is not one.
+	$text = preg_replace_callback(
+		'#^.+$#m',
+		function ( $m ) {
+			if ( ! preg_match( '#^[|].+[|]$#', $m[0] ) ) {
+				// Trac writes a row separator's parameters onto the `tr` element.
+				return preg_replace( '~\|(?=-)~', '!|', $m[0] );
+			}
+
+			// Headers such as `| --- |---|`.
+			if ( preg_match( '#^[- |]+$#', $m[0] ) ) {
+				return '~~~TABLEHEADER~~~';
+			}
+
+			// Replace singular |'s but not double ||'s.
+			return preg_replace( '#(?<![|])[|](?![|])#', '||', $m[0] );
+		},
+		$text
+	);
+	// Markup the headers now. Trac table headers are in the format of `||= Header =||`.
+	$text = preg_replace_callback(
+		"#^([|].+[|])\n(~~~TABLEHEADER~~~)#m",
+		function ( $m ) {
+			$headers = $m[1];
+			$headers = preg_replace( '#[|]{2}([^|=])#', '||=$1', $headers );
+			$headers = preg_replace( '#([^|=])[|]{2}#', '$1=||', $headers );
+
+			return $headers;
+		},
+		$text
+	);
+
+	// A conversion above that PCRE gave up on would otherwise empty the span.
+	if ( ! is_string( $text ) ) {
+		return false;
+	}
+
+	// It shouldn't exist at this point, but if it does, replace it back with it's original content.
+	return str_replace( '~~~TABLEHEADER~~~', '|| ||', $text );
+}
+
+/**
+ * Encodes a URL for use as the target of a Trac macro or link.
+ *
+ * Macro arguments are comma-separated and Trac writes one it does not recognise onto
+ * the element as an attribute, while `|` would meet the row-separator escape below.
+ *
+ * @param string $url Link or image target taken from the pull request.
+ * @return string The target with the markup's own punctuation percent-encoded.
+ */
+function trac_comment_link_target( $url ) {
+	return preg_replace_callback(
+		'/[,()\[\]"\'|]/',
+		function ( $m ) {
+			return rawurlencode( $m[0] );
+		},
+		trim( $url )
+	);
+}
+
+/**
  * Formats github content for usage on Trac.
  *
  * This:
@@ -375,95 +601,53 @@ function format_pr_desc_for_trac_comment( $desc ) {
  *  - Converts tables
  *
  * @param string $desc.
- * @return string Converted PR Description
+ * @return string|false Converted PR Description, or false if it may not be synced.
  */
 function format_github_content_for_trac_comment( $desc ) {
-	// Standardise on \n.
-	$desc = str_replace( "\r\n", "\n", $desc );
+	// Standardise on \n, including the boundaries Trac breaks lines on but PCRE does not.
+	$line_breaks = array( "\r\n", "\r", "\x0b", "\x0c", "\x1c", "\x1d", "\x1e", "\xc2\x85", "\xe2\x80\xa8", "\xe2\x80\xa9" );
+	$desc        = str_replace( $line_breaks, "\n", $desc );
 
 	// Remove HTML comments
 	$desc = preg_replace( '#<!--.+?-->#s', '', $desc );
+	if ( null === $desc ) {
+		return false;
+	}
 
-	// Convert Code blocks.
-	$desc = preg_replace_callback(
-		'#^(?P<indent>[ >]*)```[ ]*(?P<format>[a-z]+$)(?P<code>.+?)```$#sm',
-		function( $m ) {
-			$format = trim( $m['format'] );
+	/*
+	 * Fenced code and the text around it need opposite treatment: a block renders
+	 * literally once opened, while everything else is wiki markup to escape. `!` is
+	 * text rather than an escape inside a block, so the two cannot share a pass.
+	 */
+	$parts = preg_split( '#(^[ >]*```.*?```[ \t]*$|```.*?```)#sm', $desc, -1, PREG_SPLIT_DELIM_CAPTURE );
+	if ( false === $parts ) {
+		return false;
+	}
 
-			// The HTML code block in trac renders actual HTML, set it as an XML code block for syntax highlighting.
-			if ( 'html' === $format ) {
-				$format = 'xml';
-			}
+	foreach ( $parts as $i => $part ) {
+		$part = ( $i % 2 ) ? trac_comment_code_block( $part ) : trac_comment_wiki_text( $part );
+		if ( false === $part ) {
+			return false;
+		}
 
-			/*
-			 * Some other code processor types can end up rendering badly on Trac, limit to expected safe types.
-			 *
-			 * See https://trac.edgewall.org/wiki/1.1/WikiProcessors#AvailableProcessors
-			 */
-			$supported_formats = [ 'xml', 'php', 'js', 'javascript', 'css', 'sql', 'sh', 'diff' ];
-			if ( ! in_array( $format, $supported_formats ) ) {
-				$format = 'default';
-			}
+		$parts[ $i ] = $part;
+	}
 
-			$code = trim( $m['code'] );
-			// replace a blank indented line at the end of the code block with.. nothing.
-			if ( $m['indent'] ) {
-				$code = preg_replace( "#\n[ >]+$#", '', $code );
-			}
-
-			return
-				$m['indent'] . "{{{\n" .
-				$m['indent'] . "#!" . $format . "\n" .
-				$code . "\n" .
-				$m['indent'] . "}}}\n";
-		},
-		$desc
-	);
-
-	$desc = preg_replace( '#```(.+?)```#s', '{{{$1}}}', $desc );
-
-	// Convert Images (Must happen prior to Links, as the only difference is a preceeding !)
-	$desc = preg_replace( '#!\[(.+?)\]\((.+?)\)#', '[[Image($2)]]', $desc );
-	// Convert Images embedded as `<img>`.
-	$desc = preg_replace( '#<img[^>]+src=(["\'])(.+?)\\1[^>]*>#', '[[Image($2)]]', $desc );
-
-	// Convert Links.
-	$desc = preg_replace( '#\[(.+?)\]\((.+?)\)#', '[$2 $1]', $desc );
-
-	// Convert Tables.
-	$desc = preg_replace_callback(
-		'#^[|].+[|]$#m', 
-		function( $m ) {
-			// Headers such as `| --- |---|`
-			if ( preg_match( '#^[- |]+$#', $m[0] ) ) {
-				return '~~~TABLEHEADER~~~';
-			}
-
-			// Replace singular |'s but not double ||'s
-			return preg_replace( '#(?<![|])[|](?![|])#', '||', $m[0] );
-		},
-		$desc
-	);
-	// Markup the headers now. Trac table headers are in the format of ||= Header =||
-	$desc = preg_replace_callback(
-		"#^([|].+[|])\n(~~~TABLEHEADER~~~)#m",
-		function( $m ) {
-			$headers = $m[1];
-			$headers = preg_replace( '#[|]{2}([^|=])#', '||=$1', $headers );
-			$headers = preg_replace( '#([^|=])[|]{2}#', '$1=||', $headers );
-
-			return $headers;
-		},
-		$desc
-	);
-
-	// It shouldn't exist at this point, but if it does, replace it back with it's original content.
-	$desc = str_replace( '~~~TABLEHEADER~~~', '|| ||', $desc );
+	$desc = implode( '', $parts );
 
 	$desc = trim( $desc );
 
-	// After all this, if it's a HTML comment, we're not interested in syncing it.
-	if ( preg_match( '/[{`]+\s*#!html/i', $desc ) ) {
+	/*
+	 * What Trac skips before a `{{{` or a `#!`: its own whitespace class, which is
+	 * Python's and so wider than PCRE's, plus the `>` of a citation, whose contents
+	 * it re-formats as wiki text in their own right.
+	 */
+	$skipped = trac_comment_skipped();
+
+	// After all this, if it names a processor we didn't pick, we're not interested in syncing it.
+	$block = "~^{$skipped}*\{\{\{(?![^\n]*\}\}\}){$skipped}*\n?{$skipped}*#!([\w+-][\w+/-]*)~mu";
+	$count = preg_match_all( $block, $desc, $processors );
+	if ( false === $count || array_diff( array_map( 'strtolower', $processors[1] ), trac_comment_processors() ) ) {
 		return false;
 	}
 

--- a/api.wordpress.org/public_html/dotorg/trac/pr/phpunit.xml
+++ b/api.wordpress.org/public_html/dotorg/trac/pr/phpunit.xml
@@ -1,0 +1,12 @@
+<phpunit
+	bootstrap="tests/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	>
+	<testsuites>
+		<testsuite name="trac-pr">
+			<directory suffix=".php">tests/</directory>
+			<exclude>tests/bootstrap.php</exclude>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/api.wordpress.org/public_html/dotorg/trac/pr/tests/Trac_Comment_Processor_Test.php
+++ b/api.wordpress.org/public_html/dotorg/trac/pr/tests/Trac_Comment_Processor_Test.php
@@ -412,6 +412,32 @@ class Trac_Comment_Processor_Test extends TestCase {
 	}
 
 	/**
+	 * A single backtick is Trac's inline code too, and its contents are literal.
+	 *
+	 * @dataProvider data_backtick_spans
+	 *
+	 * @param string $body A pull request body with markup inside a backtick span.
+	 * @return void
+	 */
+	public function test_a_backtick_span_is_left_alone( string $body ) {
+		$this->assertSame( trim( $body ), format_github_content_for_trac_comment( $body ) );
+	}
+
+	/**
+	 * Backtick spans whose contents would otherwise be escaped.
+	 *
+	 * @return array
+	 */
+	public static function data_backtick_spans() {
+		return array(
+			'macro'         => array( "Use `[[Image(x)]]` here.\n" ),
+			'anchor'        => array( "Use `[=#x]` here.\n" ),
+			'block opener'  => array( "Use `{{{` here.\n" ),
+			'row separator' => array( "Use `|-id=x` here.\n" ),
+		);
+	}
+
+	/**
 	 * A quoted fence must sit inside the citation, delimiters and all.
 	 *
 	 * Trac re-formats a citation's lines as their own document, so a block whose

--- a/api.wordpress.org/public_html/dotorg/trac/pr/tests/Trac_Comment_Processor_Test.php
+++ b/api.wordpress.org/public_html/dotorg/trac/pr/tests/Trac_Comment_Processor_Test.php
@@ -203,6 +203,10 @@ class Trac_Comment_Processor_Test extends TestCase {
 		$open = format_github_content_for_trac_comment( "Fixes #1.\n\n{$skipped}{{{\n#!html\nBODY\n}}}\n" );
 		$name = format_github_content_for_trac_comment( "Fixes #1.\n\n{{{\n{$skipped}#!html\nBODY\n}}}\n" );
 
+		// Asserted, or `live_processors()` would also pass on a comment that never synced.
+		$this->assertIsString( $open );
+		$this->assertIsString( $name );
+
 		$this->assertSame( array(), $this->live_processors( $open ), 'Skipped text before the block opener.' );
 		$this->assertSame( array(), $this->live_processors( $name ), 'Skipped text before the processor name.' );
 	}

--- a/api.wordpress.org/public_html/dotorg/trac/pr/tests/Trac_Comment_Processor_Test.php
+++ b/api.wordpress.org/public_html/dotorg/trac/pr/tests/Trac_Comment_Processor_Test.php
@@ -382,6 +382,36 @@ class Trac_Comment_Processor_Test extends TestCase {
 	}
 
 	/**
+	 * A line opening with inline code does not open a block.
+	 *
+	 * The opening line of a block must not reach past its own closing backticks, or
+	 * two one-line fences and everything between them are read as one block.
+	 *
+	 * @return void
+	 */
+	public function test_two_inline_fences_stay_separate() {
+		$desc = format_github_content_for_trac_comment(
+			"```wp_head()```\nsee [docs](https://e.org/d)\n```wp_footer()```\n"
+		);
+
+		$this->assertSame(
+			"{{{wp_head()}}}\nsee [https://e.org/d docs]\n{{{wp_footer()}}}",
+			$desc
+		);
+	}
+
+	/**
+	 * Inline code renders literally, so the row-separator escape stays out of it.
+	 *
+	 * @return void
+	 */
+	public function test_a_row_separator_inside_inline_code_is_untouched() {
+		$desc = format_github_content_for_trac_comment( "Use ```|-id=x``` in a row.\n" );
+
+		$this->assertSame( 'Use {{{|-id=x}}} in a row.', $desc );
+	}
+
+	/**
 	 * A quoted fence must sit inside the citation, delimiters and all.
 	 *
 	 * Trac re-formats a citation's lines as their own document, so a block whose

--- a/api.wordpress.org/public_html/dotorg/trac/pr/tests/Trac_Comment_Processor_Test.php
+++ b/api.wordpress.org/public_html/dotorg/trac/pr/tests/Trac_Comment_Processor_Test.php
@@ -1,0 +1,599 @@
+<?php
+/**
+ * Tests that pull request text cannot pick the Trac wiki processor of a synced comment.
+ *
+ * The webhook composes a Trac comment from a pull request body and posts it as
+ * `prbot`. Trac reads the first line of a `{{{` block as a processor name, and
+ * `#!div`, `#!span`, `#!td` and their siblings take their arguments as element
+ * attributes, so a body that names one writes attributes into the rendered ticket.
+ *
+ * @package trac-pr
+ */
+
+declare( strict_types = 1 );
+
+namespace WordPressdotorg\API\Trac\GithubPRs;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the processor handling of the GitHub to Trac comment composer.
+ */
+class Trac_Comment_Processor_Test extends TestCase {
+
+	/**
+	 * A processor whose arguments Trac writes into the element it builds.
+	 *
+	 * @var string
+	 */
+	const PROCESSOR = '#!div style="color: red\22\3e\3cimg src=zzz onerror=alert(1)\3e"';
+
+	/**
+	 * Builds a fenced code block for a pull request body.
+	 *
+	 * @param string $language Language token for the fence; empty for none.
+	 * @param string $body     Contents of the fence.
+	 * @return string The pull request body.
+	 */
+	protected function fence( string $language, string $body ): string {
+		return "Fixes #1.\n\n```{$language}\n{$body}\n```\n";
+	}
+
+	/**
+	 * Names the processors Trac would honour in a composed comment.
+	 *
+	 * Walks the lines the way `Formatter.format()` does rather than pattern-matching
+	 * the output, so a test cannot pass on markup that only looks escaped: a block
+	 * opens on `{{{`, takes its name from that line or the next, and closes on `}}}`.
+	 *
+	 * @param string|false $desc A composed comment, or false if it was refused.
+	 * @return array Processor names outside the set the composer may pick.
+	 */
+	protected function live_processors( $desc ): array {
+		if ( ! is_string( $desc ) ) {
+			return array();
+		}
+
+		$depth  = 0;
+		$naming = false;
+		$found  = array();
+
+		foreach ( explode( "\n", $desc ) as $line ) {
+			if ( $depth && '}}}' === trim( $line ) ) {
+				--$depth;
+				$naming = false;
+				continue;
+			}
+
+			if ( ! str_contains( $line, '}}}' ) && preg_match( '~^[ \t>]*\{\{\{[ \t]*(?:#!(\S+))?[ \t]*$~', $line, $match ) ) {
+				++$depth;
+				if ( 1 === $depth ) {
+					$naming = ! isset( $match[1] );
+					if ( isset( $match[1] ) ) {
+						$found[] = $match[1];
+					}
+				}
+				continue;
+			}
+
+			if ( $naming ) {
+				$naming = false;
+				if ( preg_match( '~^[ \t>]*#!(\S+)~', $line, $match ) ) {
+					$found[] = $match[1];
+				}
+			}
+		}
+
+		return array_values( array_diff( $found, trac_comment_processors() ) );
+	}
+
+	/**
+	 * A fence with no language token must not carry a processor into the comment.
+	 *
+	 * The callback that applies the supported-processor list only matches a fence
+	 * whose language token is `[a-z]+`, so this shape used to reach the fallback
+	 * conversion, which named no processor and left the first line to do it.
+	 *
+	 * @return void
+	 */
+	public function test_language_less_fence_cannot_pick_a_processor() {
+		$desc = format_github_content_for_trac_comment( $this->fence( '', self::PROCESSOR . "\nBODY" ) );
+
+		$this->assertIsString( $desc );
+		$this->assertStringContainsString( "{{{\n#!default\n", $desc );
+		$this->assertStringNotContainsString( "{{{\n#!div", $desc );
+	}
+
+	/**
+	 * A language token that is not plain lowercase reaches the same fallback.
+	 *
+	 * @return void
+	 */
+	public function test_nonalpha_language_fence_cannot_pick_a_processor() {
+		$desc = format_github_content_for_trac_comment( $this->fence( 'c++', self::PROCESSOR . "\nBODY" ) );
+
+		$this->assertIsString( $desc );
+		$this->assertStringContainsString( "{{{\n#!default\n", $desc );
+		$this->assertStringNotContainsString( "{{{\n#!div", $desc );
+	}
+
+	/**
+	 * A body may open a block without a fence at all, and that must not sync.
+	 *
+	 * @return void
+	 */
+	public function test_a_raw_processor_block_is_neutralised() {
+		$desc = format_github_content_for_trac_comment( "Fixes #1.\n\n{{{\n" . self::PROCESSOR . "\nBODY\n}}}\n" );
+
+		$this->assertIsString( $desc );
+		$this->assertStringContainsString( '!{{{', $desc );
+		$this->assertSame( array(), $this->live_processors( $desc ) );
+	}
+
+	/**
+	 * Trac starts a line on more than `\n`, and the composer must read lines its way.
+	 *
+	 * PCRE's `\s` covers neither the C1 separators nor NEL, LS and PS, so a block
+	 * opened with one of them used to leave the processor name unread.
+	 *
+	 * @dataProvider data_line_breaks
+	 *
+	 * @param string $line_break A character Trac breaks a line on.
+	 * @return void
+	 */
+	public function test_a_block_opened_with_any_line_break_is_neutralised( string $line_break ) {
+		$desc = format_github_content_for_trac_comment(
+			"Fixes #1.\n\n{{{{$line_break}" . self::PROCESSOR . "{$line_break}BODY{$line_break}}}}\n"
+		);
+
+		$this->assertIsString( $desc );
+		$this->assertSame( array(), $this->live_processors( $desc ) );
+	}
+
+	/**
+	 * A fence broken only by one of those characters is still pinned to `default`.
+	 *
+	 * @dataProvider data_line_breaks
+	 *
+	 * @param string $line_break A character Trac breaks a line on.
+	 * @return void
+	 */
+	public function test_a_fence_broken_by_any_line_break_is_pinned( string $line_break ) {
+		$desc = format_github_content_for_trac_comment(
+			"Fixes #1.\n\n```{$line_break}" . self::PROCESSOR . "{$line_break}BODY```\n"
+		);
+
+		$this->assertIsString( $desc );
+		$this->assertStringContainsString( "{{{\n#!default\n", $desc );
+		$this->assertStringNotContainsString( "{{{\n#!div", $desc );
+	}
+
+	/**
+	 * Every character Python's `str.splitlines()` starts a new line on.
+	 *
+	 * @return array
+	 */
+	public static function data_line_breaks() {
+		return array(
+			'line feed'        => array( "\n" ),
+			'carriage return'  => array( "\r" ),
+			'vertical tab'     => array( "\x0b" ),
+			'form feed'        => array( "\x0c" ),
+			'file separator'   => array( "\x1c" ),
+			'group separator'  => array( "\x1d" ),
+			'record separator' => array( "\x1e" ),
+			'next line'        => array( "\xc2\x85" ),
+			'line separator'   => array( "\xe2\x80\xa8" ),
+			'paragraph sep'    => array( "\xe2\x80\xa9" ),
+		);
+	}
+
+	/**
+	 * Trac skips more than a space before a block, and so must the guard.
+	 *
+	 * Its whitespace class is Python's, which covers the C0 separators and the
+	 * Unicode spaces that PCRE's own `\s` leaves out.
+	 *
+	 * @dataProvider data_skipped_before_a_block
+	 *
+	 * @param string $skipped Text Trac skips before `{{{` or before `#!`.
+	 * @return void
+	 */
+	public function test_a_block_behind_skipped_text_is_neutralised( string $skipped ) {
+		$open = format_github_content_for_trac_comment( "Fixes #1.\n\n{$skipped}{{{\n#!html\nBODY\n}}}\n" );
+		$name = format_github_content_for_trac_comment( "Fixes #1.\n\n{{{\n{$skipped}#!html\nBODY\n}}}\n" );
+
+		$this->assertSame( array(), $this->live_processors( $open ), 'Skipped text before the block opener.' );
+		$this->assertSame( array(), $this->live_processors( $name ), 'Skipped text before the processor name.' );
+	}
+
+	/**
+	 * Whitespace Trac reads as leading, and the `>` whose contents it re-formats.
+	 *
+	 * @return array
+	 */
+	public static function data_skipped_before_a_block() {
+		return array(
+			'space'             => array( ' ' ),
+			'tab'               => array( "\t" ),
+			'unit separator'    => array( "\x1f" ),
+			'no-break space'    => array( "\xc2\xa0" ),
+			'figure space'      => array( "\xe2\x80\x87" ),
+			'ideographic space' => array( "\xe3\x80\x80" ),
+			'citation'          => array( '> ' ),
+			'citation, no gap'  => array( '>' ),
+			'nested citation'   => array( '> > ' ),
+		);
+	}
+
+	/**
+	 * The composer indents its own blocks inside a quote, and those must still sync.
+	 *
+	 * @return void
+	 */
+	public function test_a_quoted_fence_still_syncs() {
+		$desc = format_github_content_for_trac_comment( "Fixes #1.\n\n> ```php\n> echo 'hi';\n> ```\n" );
+
+		$this->assertIsString( $desc );
+		$this->assertStringContainsString( '#!php', $desc );
+	}
+
+	/**
+	 * Nothing the body says may go missing on the way to the ticket.
+	 *
+	 * The composer converts each fenced span on its own, so a pattern matching only
+	 * part of a span would drop the rest of it without any other test noticing.
+	 *
+	 * @dataProvider data_bodies_that_must_survive
+	 *
+	 * @param string $body   A pull request body.
+	 * @param array  $tokens Text that must still appear in the comment.
+	 * @return void
+	 */
+	public function test_no_content_is_dropped( string $body, array $tokens ) {
+		$desc = format_github_content_for_trac_comment( $body );
+
+		$this->assertIsString( $desc );
+		foreach ( $tokens as $token ) {
+			$this->assertStringContainsString( $token, $desc );
+		}
+	}
+
+	/**
+	 * Bodies whose fences do not close cleanly, with the text each must keep.
+	 *
+	 * @return array
+	 */
+	public static function data_bodies_that_must_survive() {
+		return array(
+			'unbalanced fence'   => array( "```\nA\n``` x\n\n```\nB\n```\n", array( 'A', 'B' ) ),
+			'trailing space'     => array( "```php\n\$a = 1;\n```   \n", array( '#!php', '$a = 1;' ) ),
+			'text around fences' => array( "one\n```\nA\n```\ntwo\n```js\nB\n```\nthree\n", array( 'one', 'A', 'two', 'B', 'three' ) ),
+			'lone fence marker'  => array( "before\n```\nafter\n", array( 'before', 'after' ) ),
+		);
+	}
+
+	/**
+	 * Braces the code closes on one line are the code's own, and must survive.
+	 *
+	 * Trac ends a block only on a line of exactly `}}}`, so only that shape needs
+	 * breaking up. Rewriting every run instead rewrites ordinary source.
+	 *
+	 * @dataProvider data_code_with_brace_runs
+	 *
+	 * @param string $language Fence language token.
+	 * @param string $code     A line of code closing three or more braces.
+	 * @return void
+	 */
+	public function test_brace_runs_inside_code_are_left_alone( string $language, string $code ) {
+		$desc = format_github_content_for_trac_comment( "```{$language}\n{$code}\n```\n" );
+
+		$this->assertIsString( $desc );
+		$this->assertStringContainsString( $code, $desc );
+	}
+
+	/**
+	 * Source that closes three or more braces on a single line.
+	 *
+	 * @return array
+	 */
+	public static function data_code_with_brace_runs() {
+		return array(
+			'json' => array( 'json', '{"a":{"b":{"c":1}}}' ),
+			'js'   => array( 'js', 'const x = {a:{b:{c:1}}};' ),
+			'php'  => array( 'php', 'if ( $a ) { if ( $b ) { if ( $c ) { d(); }}}' ),
+		);
+	}
+
+	/**
+	 * A delimiter on its own line still cannot close or nest the block.
+	 *
+	 * Trac reads the line with Python's `strip()`, so the whitespace it will skip in
+	 * front of the delimiter is wider than PCRE's own and has to be matched as such.
+	 *
+	 * @dataProvider data_skipped_before_a_delimiter
+	 *
+	 * @param string $skipped Whitespace Trac strips before the delimiter.
+	 * @return void
+	 */
+	public function test_a_delimiter_on_its_own_line_is_still_broken_up( string $skipped ) {
+		$desc = format_github_content_for_trac_comment(
+			"```\ncode\n{$skipped}}}}\n{$skipped}{{{\n#!html\nx\n```\n"
+		);
+
+		$this->assertIsString( $desc );
+		$this->assertSame( 1, substr_count( $desc, "\n}}}" ) );
+		$this->assertSame( array(), $this->live_processors( $desc ) );
+	}
+
+	/**
+	 * Whitespace `str.strip()` removes that is not a `str.splitlines()` boundary.
+	 *
+	 * @return array
+	 */
+	public static function data_skipped_before_a_delimiter() {
+		return array(
+			'none'              => array( '' ),
+			'space'             => array( ' ' ),
+			'unit separator'    => array( "\x1f" ),
+			'no-break space'    => array( "\xc2\xa0" ),
+			'em space'          => array( "\xe2\x80\x83" ),
+			'ideographic space' => array( "\xe3\x80\x80" ),
+			'citation'          => array( '> ' ),
+		);
+	}
+
+	/**
+	 * A quoted fence must sit inside the citation, delimiters and all.
+	 *
+	 * Trac re-formats a citation's lines as their own document, so a block whose
+	 * opener is quoted and whose processor line is not opens in one and closes in
+	 * the other, and renders as loose text instead of code.
+	 *
+	 * @return void
+	 */
+	public function test_a_quoted_fence_keeps_every_line_in_the_citation() {
+		$desc = format_github_content_for_trac_comment( "> ```\n> #!div style=\"x\"\n> code\n> ```\n" );
+
+		$this->assertIsString( $desc );
+		foreach ( array( '> {{{', '> #!default', '> }}}' ) as $line ) {
+			$this->assertStringContainsString( $line, $desc );
+		}
+		$this->assertSame( array(), $this->live_processors( $desc ) );
+	}
+
+	/**
+	 * The row-separator escape must not reach inside the markup it runs after.
+	 *
+	 * Trac reads a `[[macro]]` or `[link]` whole, so a `|-` inside one is already
+	 * inert; escaping it there only corrupts the target.
+	 *
+	 * @dataProvider data_targets_with_a_pipe
+	 *
+	 * @param string $body   A pull request body whose target contains `|-`.
+	 * @param string $expect The encoded target the comment should carry.
+	 * @return void
+	 */
+	public function test_a_pipe_in_a_target_is_encoded_not_escaped( string $body, string $expect ) {
+		$desc = format_github_content_for_trac_comment( $body );
+
+		$this->assertIsString( $desc );
+		$this->assertStringContainsString( $expect, $desc );
+		$this->assertStringNotContainsString( '!|', $desc );
+	}
+
+	/**
+	 * Markdown whose link and image targets carry a pipe.
+	 *
+	 * @return array
+	 */
+	public static function data_targets_with_a_pipe() {
+		return array(
+			'image' => array( "![a](http://x/y?a,b|-c)\n", '[[Image(http://x/y?a%2Cb%7C-c)]]' ),
+			'link'  => array( "[a](http://x/y?a|-b)\n", '[http://x/y?a%7C-b a]' ),
+		);
+	}
+
+	/**
+	 * An image target is a macro argument, so a comma in it must not add one.
+	 *
+	 * Trac writes an argument it does not recognise onto the `img` as an attribute.
+	 *
+	 * @dataProvider data_image_bodies
+	 *
+	 * @param string $body A pull request body embedding an image.
+	 * @return void
+	 */
+	public function test_an_image_target_cannot_add_macro_arguments( string $body ) {
+		$desc = format_github_content_for_trac_comment( $body );
+
+		$this->assertIsString( $desc );
+		$this->assertStringContainsString( '[[Image(https://e.org/i.png%2C', $desc );
+		$this->assertStringNotContainsString( 'i.png, id=', $desc );
+	}
+
+	/**
+	 * Both shapes the composer turns into an `[[Image()]]` macro.
+	 *
+	 * @return array
+	 */
+	public static function data_image_bodies() {
+		return array(
+			'markdown' => array( "Fixes #1.\n\n![alt](https://e.org/i.png, id=wpTrac)\n" ),
+			'html tag' => array( "Fixes #1.\n\n<img src=\"https://e.org/i.png, id=wpTrac\">\n" ),
+		);
+	}
+
+	/**
+	 * A row separator's parameters are written onto the `tr`, so `|-` is escaped.
+	 *
+	 * @return void
+	 */
+	public function test_a_row_separator_cannot_carry_parameters() {
+		$desc = format_github_content_for_trac_comment(
+			"Fixes #1.\n\n|-style=\"color: red\\22\\3e\\3cimg src=zzz onerror=alert(1)\\3e\"\n"
+		);
+
+		$this->assertIsString( $desc );
+		$this->assertStringContainsString( '!|-style=', $desc );
+		$this->assertStringNotContainsString( "\n|-style=", $desc );
+	}
+
+	/**
+	 * The tables the composer builds must survive that escape.
+	 *
+	 * @return void
+	 */
+	public function test_a_markdown_table_still_converts() {
+		$desc = format_github_content_for_trac_comment( "Fixes #1.\n\n| a | b |\n| --- | --- |\n| 1 | 2 |\n" );
+
+		$this->assertIsString( $desc );
+		$this->assertStringContainsString( '||= a =||= b =||', $desc );
+		$this->assertStringContainsString( '|| 1 || 2 ||', $desc );
+	}
+
+	/**
+	 * Text that only mentions a processor must still reach the ticket.
+	 *
+	 * Trac honours a processor named on a line-opening `{{{`, so nothing else needs
+	 * refusing, and refusing it drops the comment with no word to the author.
+	 *
+	 * @dataProvider data_processor_mentions
+	 *
+	 * @param string $body A pull request body naming a processor inertly.
+	 * @return void
+	 */
+	public function test_an_inert_processor_mention_still_syncs( string $body ) {
+		$this->assertIsString( format_github_content_for_trac_comment( $body ) );
+	}
+
+	/**
+	 * Bodies naming a processor somewhere Trac would not read one.
+	 *
+	 * @return array
+	 */
+	public static function data_processor_mentions() {
+		return array(
+			'inline code'       => array( "Fixes #1.\n\nRun `#!bash` first.\n" ),
+			'quoted in a fence' => array( "Fixes #1.\n\n```php\n\$x = '{{{#!comment}}}';\n```\n" ),
+			'inline block'      => array( "Fixes #1.\n\nTrac writes {{{#!div class=x}}} inline.\n" ),
+		);
+	}
+
+	/**
+	 * Closing the composer's own block early must not free the rest of the body.
+	 *
+	 * @return void
+	 */
+	public function test_breaking_out_of_a_block_is_neutralised() {
+		$desc = format_github_content_for_trac_comment(
+			$this->fence( '', "BODY\n}}}\n{{{\n" . self::PROCESSOR )
+		);
+
+		$this->assertIsString( $desc );
+		$this->assertSame( array(), $this->live_processors( $desc ) );
+	}
+
+	/**
+	 * The `#!html` refusal the guard already made must be kept.
+	 *
+	 * @return void
+	 */
+	public function test_a_raw_html_block_is_neutralised() {
+		$desc = format_github_content_for_trac_comment( "Fixes #1.\n\n{{{\n#!html\n<img src=zzz onerror=alert(1)>\n}}}\n" );
+
+		$this->assertIsString( $desc );
+		$this->assertSame( array(), $this->live_processors( $desc ) );
+	}
+
+	/**
+	 * `#!html` written inside a fence is content rather than a processor.
+	 *
+	 * The guard used to drop the whole comment for this, because the fence handed the
+	 * line to Trac as the processor name. Naming `default` makes the line inert, so
+	 * the comment carries the code the author wrote instead of going missing.
+	 *
+	 * @return void
+	 */
+	public function test_html_inside_a_fence_is_inert_content() {
+		$desc = format_github_content_for_trac_comment( $this->fence( '', "#!html\n<img src=zzz onerror=alert(1)>" ) );
+
+		$this->assertIsString( $desc );
+		$this->assertStringContainsString( "{{{\n#!default\n#!html\n", $desc );
+	}
+
+	/**
+	 * A fence tagged `html` is still rewritten to the inert `xml` processor.
+	 *
+	 * @return void
+	 */
+	public function test_html_fence_is_still_rewritten_to_xml() {
+		$desc = format_github_content_for_trac_comment( $this->fence( 'html', '<img src=x onerror=alert(1)>' ) );
+
+		$this->assertIsString( $desc );
+		$this->assertStringContainsString( "{{{\n#!xml\n", $desc );
+	}
+
+	/**
+	 * A supported language must still reach Trac as that processor.
+	 *
+	 * @return void
+	 */
+	public function test_supported_language_is_kept() {
+		$desc = format_github_content_for_trac_comment( $this->fence( 'php', "echo 'hello';" ) );
+
+		$this->assertIsString( $desc );
+		$this->assertStringContainsString( "{{{\n#!php\necho 'hello';\n}}}", $desc );
+	}
+
+	/**
+	 * An unsupported language is still mapped to `default` rather than refused.
+	 *
+	 * @return void
+	 */
+	public function test_unsupported_language_is_mapped_to_default() {
+		$desc = format_github_content_for_trac_comment( $this->fence( 'bash', 'echo hello' ) );
+
+		$this->assertIsString( $desc );
+		$this->assertStringContainsString( "{{{\n#!default\necho hello\n}}}", $desc );
+	}
+
+	/**
+	 * A shebang is ordinary content, and a script quoting one must still sync.
+	 *
+	 * @return void
+	 */
+	public function test_a_shebang_in_a_block_is_not_a_processor() {
+		$desc = format_github_content_for_trac_comment( $this->fence( '', "#!/bin/bash\necho hello" ) );
+
+		$this->assertIsString( $desc );
+		$this->assertStringContainsString( "{{{\n#!default\n#!/bin/bash\necho hello\n}}}", $desc );
+	}
+
+	/**
+	 * A fence that opens and closes on one line is inline code, and stays inline.
+	 *
+	 * @return void
+	 */
+	public function test_a_single_line_fence_stays_inline() {
+		$desc = format_github_content_for_trac_comment( "Fixes #1.\n\nUse ```wp_head()``` here.\n" );
+
+		$this->assertSame( "Fixes #1.\n\nUse {{{wp_head()}}} here.", $desc );
+	}
+
+	/**
+	 * The conversions the composer exists for must be left alone.
+	 *
+	 * @return void
+	 */
+	public function test_ordinary_markdown_still_converts() {
+		$desc = format_github_content_for_trac_comment(
+			"See [the docs](https://example.org/doc) and ![shot](https://example.org/s.png).\n"
+		);
+
+		$this->assertSame(
+			'See [https://example.org/doc the docs] and [[Image(https://example.org/s.png)]].',
+			$desc
+		);
+	}
+}

--- a/api.wordpress.org/public_html/dotorg/trac/pr/tests/Trac_Comment_Processor_Test.php
+++ b/api.wordpress.org/public_html/dotorg/trac/pr/tests/Trac_Comment_Processor_Test.php
@@ -344,6 +344,44 @@ class Trac_Comment_Processor_Test extends TestCase {
 	}
 
 	/**
+	 * Markup around a one-line fence must still convert.
+	 *
+	 * A block is converted on its own because its contents are not wiki markup, but a
+	 * one-line fence is part of the line it sits on, and a table or link it appears in
+	 * has to be read whole.
+	 *
+	 * @dataProvider data_markup_around_inline_code
+	 *
+	 * @param string $body   A pull request body with inline code inside other markup.
+	 * @param string $expect The converted markup the comment should carry.
+	 * @return void
+	 */
+	public function test_markup_around_inline_code_still_converts( string $body, string $expect ) {
+		$desc = format_github_content_for_trac_comment( $body );
+
+		$this->assertIsString( $desc );
+		$this->assertStringContainsString( $expect, $desc );
+	}
+
+	/**
+	 * Constructs that span a one-line fence.
+	 *
+	 * @return array
+	 */
+	public static function data_markup_around_inline_code() {
+		return array(
+			'table row' => array(
+				"| ```wp_head()``` | OK |\n| --- | --- |\n| a | b |\n",
+				'||= {{{wp_head()}}} =||= OK =||',
+			),
+			'link label' => array(
+				"See [the ```wp_head()``` hook](https://example.org/d) here.\n",
+				'[https://example.org/d the {{{wp_head()}}} hook]',
+			),
+		);
+	}
+
+	/**
 	 * A quoted fence must sit inside the citation, delimiters and all.
 	 *
 	 * Trac re-formats a citation's lines as their own document, so a block whose

--- a/api.wordpress.org/public_html/dotorg/trac/pr/tests/bootstrap.php
+++ b/api.wordpress.org/public_html/dotorg/trac/pr/tests/bootstrap.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * PHPUnit bootstrap file.
+ *
+ * @package trac-pr
+ */
+
+declare( strict_types = 1 );
+
+namespace WordPressdotorg\API\Trac\GithubPRs;
+
+// Load the project's composer autoloader (PHPUnit, yoast/phpunit-polyfills).
+require_once dirname( __DIR__, 6 ) . '/vendor/autoload.php';
+
+// Declares functions only, so it loads without the API's WordPress bootstrap.
+require_once dirname( __DIR__ ) . '/functions.php';


### PR DESCRIPTION
The webhook composes one Trac comment per pull request event and posts it as `prbot`, where Trac renders it as wiki text. The converter turned Markdown into wiki markup in a single pass over the whole body, which meant fenced code and ordinary prose were treated the same way even though they need opposite handling — a code block renders literally once it is opened, while the text around it is markup.

The conversion is now done per span:

- A fence keeps its listing inside a code block that names its own format, so the listing cannot pick one, and a delimiter appearing in the listing itself cannot close the block early.
- The text around it is prepared for the wiki context before the links, images and tables are composed into it, so only the markup this composer writes reaches Trac as markup.
- Link and image targets are encoded for the markup they land in. A `,` in an image target used to read as an extra macro argument.
- Fence handling is anchored to the whole span. Previously a body with an unbalanced fence could drop the text around it, and a fence with trailing whitespace after its closing backticks lost its language.
- A conversion that cannot be completed declines to sync the comment rather than posting a partial one; the description is no longer silently emptied.

Ordinary bodies convert as before — links, images, tables, quoted fences and inline code all round-trip, including ASCII directory trees and JSON/JS/PHP snippets that close several braces on one line.

Adds a standalone PHPUnit suite for the composer (66 tests) and registers it in `.github/unit-tests-suites.yml` so it runs on changes to this directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub pull request comment formatting in Trac.
  * Preserved code blocks, inline code, links, tables, and line breaks more reliably.
  * Added safeguards against unsupported or malformed formatting instructions.
  * Improved handling of images and Markdown links during conversion.
  * Formatting now reports conversion failures instead of producing potentially corrupted content.

* **Tests**
  * Added comprehensive automated coverage for formatting and security-related edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->