### PR TITLE
Add Existing Users: resolve the invite role through the editable list

### DIFF
--- a/wordpress.org/public_html/wp-content/mu-plugins/pub/wporg-add-existing-users-via-username.php
+++ b/wordpress.org/public_html/wp-content/mu-plugins/pub/wporg-add-existing-users-via-username.php
@@ -44,7 +44,7 @@ function add_existing_user_to_site() {
 	check_admin_referer( 'add-user', '_wpnonce_add-user' );
 
 	$user_details = null;
-	$user_email   = isset( $_REQUEST['email'] ) && is_string( $_REQUEST['email'] ) ? wp_unslash( $_REQUEST['email'] ) : '';
+	$user_email   = isset( $_REQUEST['email'] ) && is_string( $_REQUEST['email'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['email'] ) ) : '';
 	if ( false !== strpos( $user_email, '@' ) ) {
 		$user_details = get_user_by( 'email', $user_email );
 	} else {
@@ -61,7 +61,7 @@ function add_existing_user_to_site() {
 	}
 
 	// The role travels with the invite and is applied when the invite is opened.
-	$requested_role = isset( $_REQUEST['role'] ) && is_string( $_REQUEST['role'] ) ? wp_unslash( $_REQUEST['role'] ) : '';
+	$requested_role = isset( $_REQUEST['role'] ) && is_string( $_REQUEST['role'] ) ? sanitize_key( wp_unslash( $_REQUEST['role'] ) ) : '';
 	wp_ensure_editable_role( $requested_role );
 
 	// Adding an existing user to this blog.

--- a/wordpress.org/public_html/wp-content/mu-plugins/pub/wporg-add-existing-users-via-username.php
+++ b/wordpress.org/public_html/wp-content/mu-plugins/pub/wporg-add-existing-users-via-username.php
@@ -44,7 +44,7 @@ function add_existing_user_to_site() {
 	check_admin_referer( 'add-user', '_wpnonce_add-user' );
 
 	$user_details = null;
-	$user_email   = wp_unslash( $_REQUEST['email'] );
+	$user_email   = isset( $_REQUEST['email'] ) && is_string( $_REQUEST['email'] ) ? wp_unslash( $_REQUEST['email'] ) : '';
 	if ( false !== strpos( $user_email, '@' ) ) {
 		$user_details = get_user_by( 'email', $user_email );
 	} else {
@@ -60,6 +60,10 @@ function add_existing_user_to_site() {
 		wp_die( esc_html__( 'Cheatin&#8217; uh?' ), 403 );
 	}
 
+	// The role travels with the invite and is applied when the invite is opened.
+	$requested_role = isset( $_REQUEST['role'] ) && is_string( $_REQUEST['role'] ) ? wp_unslash( $_REQUEST['role'] ) : '';
+	wp_ensure_editable_role( $requested_role );
+
 	// Adding an existing user to this blog.
 	$blog_id        = get_current_blog_id();
 	$new_user_email = $user_details->user_email;
@@ -69,15 +73,15 @@ function add_existing_user_to_site() {
 	if ( ( null !== $username && ! is_super_admin( $user_id ) ) && array_key_exists( $blog_id, get_blogs_of_user( $user_id ) ) ) {
 		$redirect = add_query_arg( array( 'update' => 'addexisting' ), 'user-new.php' );
 	} else {
-		$new_user_key = substr( md5( $user_id ), 0, 5 );
+		$new_user_key = wp_generate_password( 20, false );
 		add_option( 'new_user_' . $new_user_key, array(
 			'user_id' => $user_id,
 			'email'   => $user_details->user_email,
-			'role'    => $_REQUEST['role'],
+			'role'    => $requested_role,
 		) );
 
 		$roles = get_editable_roles();
-		$role  = $roles[ $_REQUEST['role'] ];
+		$role  = $roles[ $requested_role ];
 		/* translators: 1: Site name, 2: site URL, 3: role, 4: activation URL */
 		$message = wp_specialchars_decode( esc_html__(
 			'Hi,


### PR DESCRIPTION
The invite created by `admin_action_adduser` carries a role that core applies later, when `/newbloguser/{key}/` is opened. That role should therefore be one the inviting user is allowed to assign at the moment the invite is written.

- `wp_ensure_editable_role()` is called before the invite is stored, the same check core uses on its own `user-new.php` paths, and the stored role is the value that was checked.
- The invite key comes from `wp_generate_password( 20, false )`, matching core, instead of being derived from the invited user's ID.
- `$_REQUEST['email']` and `$_REQUEST['role']` are read as strings, so a missing or non-scalar value takes the normal path instead of a PHP warning or a `TypeError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016iz3Ho52xV2mFqe4HoVnNX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security Improvements**
  - Improved validation and sanitization of email addresses and requested roles.
  - Strengthened invitation key generation with more secure, unpredictable values.
  - Ensured only editable roles are accepted when inviting existing users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->