### PR TITLE
Plugin Directory: Update the release scan threshold default.

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan-gandalf.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-plugin-scan-gandalf.php
@@ -41,7 +41,7 @@ class Plugin_Scan_Gandalf {
 	const EMAILED_META_KEY = '_gandalf_scan_emailed';
 
 	/** Completed scans with a max risk score at or above this have their release blocked. */
-	const BLOCK_RISK_SCORE = PHP_FLOAT_MAX;
+	const BLOCK_RISK_SCORE = 8.0;
 
 	/** Completed scans with a max risk score at or above this have their committers emailed. */
 	const NOTIFY_RISK_SCORE = self::BLOCK_RISK_SCORE;


### PR DESCRIPTION
Sets `Plugin_Scan_Gandalf::BLOCK_RISK_SCORE` to `8.0`; the committer-notification threshold follows it. No other behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Completed scans with a risk score of 8.0 or higher now block plugin releases from the update API.
  - Notifications are triggered at the same updated risk threshold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->