### PR TITLE
Plugin Directory: Update the release hold notices.

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/metabox/class-controls.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/metabox/class-controls.php
@@ -29,7 +29,7 @@ class Controls {
 			<div id="misc-publishing-actions">
 				<?php
 				self::display_meta();
-				self::display_release_cooldown();
+				self::display_release_hold();
 				self::display_post_status();
 				?>
 			</div>
@@ -46,13 +46,15 @@ class Controls {
 	}
 
 	/**
-	 * Display the release cooldown status and (for reviewers) a force-release control.
+	 * Display the release hold status and (for reviewers) a force-release control.
 	 *
-	 * Bails when there's no current release to gate, when the release has no cooldown
-	 * delay (feature off at release-creation, or already force-released), or when the
-	 * cooldown window has elapsed.
+	 * A current release is held from the update API either by an automated security
+	 * review block, which has no expiry, or by the release cooldown while its window
+	 * runs. Bails when there's no current release, or when it is neither blocked nor
+	 * still in cooldown. A block takes precedence in the message, since it is the hold
+	 * that actually withholds the version and it outlasts the cooldown.
 	 */
-	protected static function display_release_cooldown() {
+	protected static function display_release_hold() {
 		$post = get_post();
 
 		// Resolved from the stable tag, so the hold shows even when the Version header is empty or disagrees.
@@ -62,28 +64,40 @@ class Controls {
 		}
 
 		$release_version = $release['version'];
+		$is_blocked      = API_Update_Updater::is_release_blocked( $release );
 
-		$release_delay = (int) ( $release['release_delay'] ?? 0 );
-		if ( ! $release_delay ) {
+		$release_delay  = (int) ( $release['release_delay'] ?? 0 );
+		$cooldown_until = $release_delay ? API_Update_Updater::compute_release_time( $post, $release ) + $release_delay : 0;
+		$in_cooldown    = $cooldown_until > time();
+
+		if ( ! $is_blocked && ! $in_cooldown ) {
 			return;
 		}
 
-		$cooldown_until = API_Update_Updater::compute_release_time( $post, $release ) + $release_delay;
-		if ( $cooldown_until <= time() ) {
-			return;
-		}
+		// The force-release reason justifies the override; a block is lifted on review, a cooldown bypassed for urgency.
+		$reason_placeholder = $is_blocked
+			? __( 'e.g. reviewed the findings, not exploitable', 'wporg-plugins' )
+			: __( 'e.g. urgent security fix for CVE-…', 'wporg-plugins' );
 
 		?>
-		<div class="misc-pub-section misc-pub-release-cooldown">
+		<div class="misc-pub-section misc-pub-release-hold">
 			<p>
 			<?php
-			printf(
-				/* translators: 1: version, 2: relative time until cooldown expires, 3: absolute UTC timestamp */
-				esc_html__( 'Version %1$s is in the release cooldown — it will be served to sites in %2$s (at %3$s UTC).', 'wporg-plugins' ),
-				esc_html( $release_version ),
-				esc_html( human_time_diff( time(), $cooldown_until ) ),
-				esc_html( gmdate( 'Y-m-d H:i', $cooldown_until ) )
-			);
+			if ( $is_blocked ) {
+				printf(
+					/* translators: %s: version */
+					esc_html__( 'Version %s is blocked by an automated security review, it is withheld from the update API, and sites keep receiving the previously distributed version.', 'wporg-plugins' ),
+					esc_html( $release_version )
+				);
+			} else {
+				printf(
+					/* translators: 1: version, 2: relative time until cooldown expires, 3: absolute UTC timestamp */
+					esc_html__( 'Version %1$s is in the release cooldown, it will be served to sites in %2$s (at %3$s UTC).', 'wporg-plugins' ),
+					esc_html( $release_version ),
+					esc_html( human_time_diff( time(), $cooldown_until ) ),
+					esc_html( gmdate( 'Y-m-d H:i', $cooldown_until ) )
+				);
+			}
 			?>
 			</p>
 			<?php if ( current_user_can( 'plugin_review', $post ) ) : ?>
@@ -94,7 +108,7 @@ class Controls {
 						name="force_release_reason"
 						rows="2"
 						style="width: 100%;"
-						placeholder="<?php esc_attr_e( 'e.g. urgent security fix for CVE-…', 'wporg-plugins' ); ?>"
+						placeholder="<?php echo esc_attr( $reason_placeholder ); ?>"
 					></textarea>
 				</p>
 				<p>

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-release-confirmation.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-release-confirmation.php
@@ -488,11 +488,14 @@ class Release_Confirmation {
 	}
 
 	/**
-	 * Surfaces an in-cooldown notice to committers on the plugin's public page.
+	 * Surfaces a release-hold notice to committers on the plugin's public page.
 	 *
-	 * Bails when the viewer isn't a committer, when there's no current release in
-	 * an active cooldown window, or when the release was force-released
-	 * (release_delay = 0 ⇒ no cooldown).
+	 * A current release is held from the update API either by an automated security
+	 * review block, which has no expiry, or by the release cooldown while its window
+	 * runs. Bails when the viewer isn't a committer, when there's no current release,
+	 * or when it is neither blocked nor still in cooldown. A block takes precedence,
+	 * since it is the hold that actually withholds the version and it outlasts the
+	 * cooldown.
 	 *
 	 * @param WP_Post $post The currently displayed post.
 	 */
@@ -509,15 +512,36 @@ class Release_Confirmation {
 			return;
 		}
 
-		$release_delay = (int) ( $release['release_delay'] ?? 0 );
-		if ( ! $release_delay ) {
+		$is_blocked = API_Update_Updater::is_release_blocked( $release );
+
+		// Match the enforced window: compute_release_time() is what update_single_plugin() gates on.
+		$release_delay  = (int) ( $release['release_delay'] ?? 0 );
+		$cooldown_until = $release_delay ? API_Update_Updater::compute_release_time( $post, $release ) + $release_delay : 0;
+		$in_cooldown    = $cooldown_until > time();
+
+		if ( ! $is_blocked && ! $in_cooldown ) {
 			return;
 		}
 
-		// Match the enforced window: compute_release_time() is what update_single_plugin() gates on.
-		$cooldown_until = API_Update_Updater::compute_release_time( $post, $release ) + $release_delay;
+		$allowed_html = array(
+			'code' => array(),
+			'a'    => array( 'href' => true ),
+		);
 
-		if ( $cooldown_until <= time() ) {
+		if ( $is_blocked ) {
+			printf(
+				'<div class="plugin-notice notice notice-error notice-alt"><p>%s</p></div>',
+				wp_kses(
+					sprintf(
+						/* translators: 1: plugin version, 2: URL to the automated security review documentation. */
+						__( 'Version %1$s is blocked by an automated security review and is not being served to sites, which keep receiving the previously distributed version. Review the findings in the email sent to the plugin committers, then address them and release a new version. Learn more in the <a href="%2$s">plugin developer handbook</a>.', 'wporg-plugins' ),
+						'<code>' . esc_html( $release['version'] ) . '</code>',
+						'https://developer.wordpress.org/plugins/wordpress-org/automated-security-review/'
+					),
+					$allowed_html
+				)
+			);
+
 			return;
 		}
 
@@ -532,10 +556,7 @@ class Release_Confirmation {
 					(int) ( $release_delay / HOUR_IN_SECONDS ),
 					'<a href="mailto:plugins@wordpress.org">plugins@wordpress.org</a>'
 				),
-				array(
-					'code' => array(),
-					'a'    => array( 'href' => true ),
-				)
+				$allowed_html
 			)
 		);
 	}


### PR DESCRIPTION
Updates the release-hold notice in the plugin Controls metabox and on the plugin page so a held release reads distinctly from one that is simply waiting out its cooldown, and keeps the force-release control available while the hold is in effect.

Previously the notice and the force-release control were tied to the cooldown window, so a hold with no cooldown left showed nothing and offered no control. The notice now also reflects the specific reason the version is held from the update API, while the plain cooldown notice is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release management now clearly indicates when a release is withheld by an automated security review.
  * Admins see block-specific messaging and guidance for documenting release decisions.
  * Release confirmation notices distinguish security-review holds from standard cooldown periods.
  * Security-review holds take precedence when both a hold and cooldown apply.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->