### PR TITLE
Translation Events: Hide the attendees list on past event pages

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/templates/event-details.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/templates/event-details.php
@@ -109,7 +109,7 @@ Templates::header(
 				</ul>
 			</div>
 		<?php endif; ?>
-		<?php if ( ! empty( $attendees_not_contributing ) && current_user_can( 'edit_translation_event', $event->id() ) ) : ?>
+		<?php if ( ! empty( $attendees_not_contributing ) && ! $event->is_past() && current_user_can( 'edit_translation_event', $event->id() ) ) : ?>
 			<div class="event-attendees">
 				<h2>
 				<?php

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/tests/routes/Event_Details_Attendees_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/tests/routes/Event_Details_Attendees_Test.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Tests that the attendees section on the event details page is only shown
+ * while the event is active.
+ *
+ * @package wporg-gp-translation-events
+ */
+
+declare( strict_types = 1 );
+
+use Wporg\Tests\Base_Test as TestCase;
+use Wporg\TranslationEvents\Routes\Event\Details_Route;
+use Wporg\TranslationEvents\Tests\Event_Factory;
+
+/**
+ * The event details page lists attendees who pledged to help but did not end
+ * up contributing. Once an event is over, that list should no longer be
+ * shown, so a no-show is not called out publicly after the fact. This change
+ * hides the list in both the template renderer and the 2024 block theme
+ * renderer.
+ *
+ * These tests render the details route for an event that is still active and
+ * for one that has ended, and assert the attendees section is present only
+ * while the event is active. The current user is granted event management
+ * rights so the capability gate on the section is satisfied and the event
+ * state is the only variable under test.
+ */
+class Event_Details_Attendees_Test extends TestCase {
+	/**
+	 * Factory used to create events for the tests.
+	 *
+	 * @var Event_Factory
+	 */
+	private Event_Factory $event_factory;
+
+	/**
+	 * Set up the factory and a user who is allowed to see the section.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->event_factory = new Event_Factory();
+
+		wp_set_current_user( $this->factory->user->create() );
+		add_filter( 'gp_translation_events_can_crud_event', '__return_true' );
+	}
+
+	/**
+	 * Remove the capability filter.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		remove_filter( 'gp_translation_events_can_crud_event', '__return_true' );
+		parent::tearDown();
+	}
+
+	/**
+	 * The attendees section is shown while the event is active.
+	 *
+	 * @return void
+	 */
+	public function test_shows_attendees_for_active_event() {
+		$event_id = $this->event_factory->create_active( $this->now, array( $this->factory->user->create() ) );
+
+		$this->assertStringContainsString( 'event-attendees', $this->render_event_details( $event_id ) );
+	}
+
+	/**
+	 * The attendees section is hidden once the event has ended.
+	 *
+	 * @return void
+	 */
+	public function test_hides_attendees_for_past_event() {
+		$event_id = $this->event_factory->create_inactive_past( $this->now, array( $this->factory->user->create() ) );
+
+		$this->assertStringNotContainsString( 'event-attendees', $this->render_event_details( $event_id ) );
+	}
+
+	/**
+	 * Render the details route for an event and return the generated HTML.
+	 *
+	 * @param int $event_id Event to render.
+	 * @return string
+	 */
+	private function render_event_details( int $event_id ): string {
+		wp_cache_flush();
+
+		$route               = new Details_Route();
+		$route->fake_request = true;
+
+		ob_start();
+		$route->handle( get_post( $event_id )->post_name );
+		return (string) ob_get_clean();
+	}
+}

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/themes/wporg-translate-events-2024/blocks/pages/events/event-details/render.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-events/themes/wporg-translate-events-2024/blocks/pages/events/event-details/render.php
@@ -52,17 +52,19 @@ if ( $event->is_past() ) :
 
 <!-- wp:wporg-translate-events-2024/event-description <?php echo serialize_block_attributes( array( 'id' => $event->id() ) ); ?> /-->
 <!-- wp:wporg-translate-events-2024/contributor-list <?php echo serialize_block_attributes( array( 'id' => $event->id() ) ); ?> /-->
+<?php if ( ! $event->is_past() ) : ?>
 <!-- wp:wporg-translate-events-2024/attendee-list
-<?php
-echo serialize_block_attributes(
-	array(
-		'id'        => $event->id(),
-		'view_type' => 'list',
-	)
-);
-?>
+	<?php
+	echo serialize_block_attributes(
+		array(
+			'id'        => $event->id(),
+			'view_type' => 'list',
+		)
+	);
+	?>
 
 /-->
+<?php endif; ?>
 <!-- wp:wporg-translate-events-2024/event-stats <?php echo serialize_block_attributes( array( 'id' => $event->id() ) ); ?> /-->
 <!-- wp:wporg-translate-events-2024/event-projects <?php echo serialize_block_attributes( array( 'id' => $event->id() ) ); ?> /-->
 <!-- wp:wporg-translate-events-2024/event-contribution-summary <?php echo serialize_block_attributes( array( 'id' => $event->id() ) ); ?> /-->


### PR DESCRIPTION
Hides the attendees list on event details pages once the event has ended, in both renderers: the current template and the 2024 block theme renderer, which shows an event ended notice for past events but still rendered the attendee list after it.

The list names attendees who pledged to help but did not end up contributing, and showing it after the event quietly calls out the people who did not show up. The dedicated Manage Attendees page still lists everyone so hosts can review attendees afterwards, and the Contributors section is untouched since those users did contribute.

Adds a test rendering the details route for an active and a past event, asserting the attendees section is present only while the event is active. The test covers the template renderer path; the block theme hunk uses the same event-state gate but is not covered by the suite here.

This ports the archived standalone repository's pull request, closed when Translation Events moved into this repository: https://github.com/WordPress/wporg-gp-translation-events/pull/391 (issue https://github.com/WordPress/wporg-gp-translation-events/issues/339). Opening as a pull request per the closing guidance on that PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Attendee sections are no longer displayed on event details pages after an event has ended.
  * Attendee information remains visible for active events when applicable.
* **Tests**
  * Added coverage to verify attendee visibility for both active and past events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->