### PR TITLE
Plugin Directory: Resolve the served release by ref in the update-source writer

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-api-update-updater.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/jobs/class-api-update-updater.php
@@ -89,23 +89,21 @@ class API_Update_Updater {
 		$release_time     = self::compute_release_time( $post, $release );
 		$existing_row     = $wpdb->get_row(
 			$wpdb->prepare(
-				"SELECT version, meta FROM {$wpdb->prefix}update_source WHERE plugin_slug = %s",
+				"SELECT version, stable_tag, meta FROM {$wpdb->prefix}update_source WHERE plugin_slug = %s",
 				$post->post_name
 			)
 		);
-		$existing_version = (string) ( $existing_row->version ?? '' );
 
 		$release_delay = (int) ( $release['release_delay'] ?? 0 );
 
-		// `update_source.version` is varchar(128); mirror cron_trigger()'s `left( pm.meta_value, 128 )` truncation allowance.
-		$is_new_version = substr( (string) $version, 0, 128 ) !== $existing_version;
+		// Never judged by the Version header: an author can keep the served version's label on a new tag.
+		$is_new_release = ! $existing_row || ! self::is_current_ref_served( $post, $existing_row );
 
 		/*
 		 * Hold a blocked release out of the row: the previous version keeps being
 		 * served, the deferred serve is cancelled, and status changes still reach
-		 * the row. Gated on the block alone — a header renamed to the served
-		 * version turns the $is_new_version proxy false, and block_release()
-		 * refuses served releases, so a held release is never already in the row.
+		 * the row. Gated on the block alone — block_release() refuses served
+		 * releases, so a held release is never already in the row.
 		 */
 		if ( self::is_release_blocked( $release ) ) {
 			wp_clear_scheduled_hook( "release_to_update_api:{$post->post_name}" );
@@ -133,7 +131,7 @@ class API_Update_Updater {
 		 * expires, cron_trigger() keeps re-selecting the plugin and this write
 		 * repeats as a no-op.
 		 */
-		if ( $release_delay && $is_new_version ) {
+		if ( $release_delay && $is_new_release ) {
 			$cooldown_until = $release_time + $release_delay;
 			if ( $cooldown_until > time() ) {
 				self::queue_release_to_update_api( $post->post_name, $cooldown_until );
@@ -150,7 +148,7 @@ class API_Update_Updater {
 		// to now — that's the moment the version is actually available to sites. Keeps
 		// phased_rollout()'s `manual-updates-24hr` window measuring from public availability,
 		// even if the commit/confirmation was long ago because the cooldown deferred the write.
-		if ( $release_delay && $is_new_version ) {
+		if ( $release_delay && $is_new_release ) {
 			$release_time = time();
 		}
 
@@ -234,6 +232,54 @@ class API_Update_Updater {
 	}
 
 	/**
+	 * The ref a plugin's current version is served from: its stable tag, or
+	 * `trunk@{version}` for trunk-stable plugins, as release rows are keyed.
+	 *
+	 * @param \WP_Post $post The plugin post.
+	 * @return string The ref.
+	 */
+	public static function get_current_ref( $post ) {
+		return self::build_ref(
+			get_post_meta( $post->ID, 'stable_tag', true ),
+			get_post_meta( $post->ID, 'version', true )
+		);
+	}
+
+	/**
+	 * Whether a plugin's current ref is the one its `update_source` row serves.
+	 *
+	 * Compared by ref rather than by the release the ref resolves to: a
+	 * fallback-resolved release keeps its own tag, and the Version header alone
+	 * can be kept at the served label on a new tag. The row's columns are
+	 * varchar(128), so the meta is truncated to match before the refs are built.
+	 *
+	 * @param \WP_Post $post   The plugin post.
+	 * @param object   $served The `update_source` row, with `version` and `stable_tag`.
+	 * @return bool
+	 */
+	public static function is_current_ref_served( $post, $served ) {
+		$current_ref = self::build_ref(
+			substr( (string) get_post_meta( $post->ID, 'stable_tag', true ), 0, 128 ),
+			substr( (string) get_post_meta( $post->ID, 'version', true ), 0, 128 )
+		);
+
+		return self::build_ref( $served->stable_tag, $served->version ) === $current_ref;
+	}
+
+	/**
+	 * Build the ref a stable tag and version are served from.
+	 *
+	 * @param string $stable_tag The stable tag; empty or 'trunk' for trunk-stable plugins.
+	 * @param string $version    The version, keying trunk-stable refs.
+	 * @return string The ref.
+	 */
+	protected static function build_ref( $stable_tag, $version ) {
+		return ( ! $stable_tag || 'trunk' === $stable_tag )
+			? 'trunk@' . $version
+			: (string) $stable_tag;
+	}
+
+	/**
 	 * The release being served or held for a plugin's current version.
 	 *
 	 * Resolved strictly by the stable tag — the source of the served package —
@@ -253,12 +299,7 @@ class API_Update_Updater {
 	 * @return array|false The matching release row, or false when none exists.
 	 */
 	public static function get_current_release( $post ) {
-		$stable_tag = get_post_meta( $post->ID, 'stable_tag', true );
-
-		$target = ( ! $stable_tag || 'trunk' === $stable_tag )
-			? 'trunk@' . get_post_meta( $post->ID, 'version', true )
-			: $stable_tag;
-
+		$target   = self::get_current_ref( $post );
 		$releases = (array) Plugin_Directory::get_releases( $post );
 
 		foreach ( $releases as $release ) {
@@ -325,19 +366,10 @@ class API_Update_Updater {
 			return false;
 		}
 
-		// Already live: a block can't un-ship a served release — compared by identity (the ref for tagged rows, the version for ref-less trunk-stable rows), with the columns' varchar(128) truncation.
+		// Already live: a block can't un-ship a served release.
 		$served = self::get_served_release( $plugin_slug );
-		if ( $served ) {
-			if ( $served->stable_tag && 'trunk' !== $served->stable_tag ) {
-				$is_served = substr( (string) $release['tag'], 0, 128 ) === (string) $served->stable_tag;
-			} else {
-				$is_served = '' !== (string) $served->version
-					&& substr( (string) ( $release['version'] ?? '' ), 0, 128 ) === (string) $served->version;
-			}
-
-			if ( $is_served ) {
-				return false;
-			}
+		if ( $served && self::is_current_ref_served( $post, $served ) ) {
+			return false;
 		}
 
 		// Already held; recording a second block would merge it into the first.
@@ -454,22 +486,23 @@ class API_Update_Updater {
 	/**
 	 * Determine the release timestamp for a plugin version.
 	 *
-	 * Anchored on the version's commit time (`version_date`), falling back to the
-	 * release row's own date — unlike post_modified, neither slides on unrelated
-	 * post edits — and replaced by the latest committer-confirmation time when
-	 * release confirmations are required (the version isn't really "released"
-	 * until the last confirmation lands).
+	 * Anchored on the later of the version's commit time (`version_date`) and the
+	 * release row's own date — a new tag at an unchanged version, or a re-opened
+	 * release, moves only the latter, and unlike post_modified neither slides on
+	 * unrelated post edits — and replaced by the latest committer-confirmation
+	 * time when release confirmations are required (the version isn't really
+	 * "released" until the last confirmation lands).
 	 *
 	 * @param \WP_Post   $post    The plugin post.
 	 * @param array|bool $release The release row from Plugin_Directory::get_release(), or false.
 	 * @return int Unix timestamp.
 	 */
 	public static function compute_release_time( $post, $release ) {
-		if ( $post->version_date ) {
-			$release_time = strtotime( $post->version_date );
-		} elseif ( ! empty( $release['date'] ) ) {
-			$release_time = (int) $release['date'];
-		} else {
+		$release_time = max(
+			$post->version_date ? (int) strtotime( $post->version_date ) : 0,
+			(int) ( $release['date'] ?? 0 )
+		);
+		if ( ! $release_time ) {
 			$release_time = strtotime( $post->post_modified );
 		}
 

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Current_Release_Resolution_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Current_Release_Resolution_Test.php
@@ -137,6 +137,15 @@ class Current_Release_Resolution_Test extends TestCase {
 	}
 
 	/**
+	 * The stable tag currently in the plugin's update_source row.
+	 *
+	 * @return string The served stable tag.
+	 */
+	private function served_stable_tag(): string {
+		return (string) ( API_Update_Updater::get_served_release( $this->plugin->post_name )->stable_tag ?? '' );
+	}
+
+	/**
 	 * A renamed Version header inside a tag under cooldown keeps the hold.
 	 */
 	public function test_renamed_header_keeps_cooldown_hold(): void {
@@ -145,6 +154,130 @@ class Current_Release_Resolution_Test extends TestCase {
 		$this->assertTrue( API_Update_Updater::update_single_plugin( $this->plugin->post_name ) );
 
 		$this->assertSame( self::SERVED_VERSION, $this->served_version() );
+		$this->assertNotFalse( wp_next_scheduled( "release_to_update_api:{$this->plugin->post_name}" ) );
+	}
+
+	/**
+	 * A new tag whose header keeps the served version is still a new release:
+	 * the cooldown gate keys on the release's identity, not the header proxy.
+	 */
+	public function test_new_tag_with_served_header_keeps_cooldown_hold(): void {
+		update_post_meta( $this->plugin->ID, 'version', self::SERVED_VERSION );
+		$this->add_release( self::HELD_TAG, self::SERVED_VERSION );
+
+		$this->assertTrue( API_Update_Updater::update_single_plugin( $this->plugin->post_name ) );
+
+		$this->assertSame( self::SERVED_VERSION, $this->served_stable_tag() );
+		$this->assertNotFalse( wp_next_scheduled( "release_to_update_api:{$this->plugin->post_name}" ) );
+	}
+
+	/**
+	 * The full evasion: a new tag keeps the served header, so the importer bumps
+	 * neither the version nor its version_date. The hold must survive the stale
+	 * plugin-wide anchor and measure the cooldown from the release itself.
+	 */
+	public function test_new_tag_with_served_header_and_stale_version_date_keeps_cooldown_hold(): void {
+		update_post_meta( $this->plugin->ID, 'version', self::SERVED_VERSION );
+		update_post_meta( $this->plugin->ID, 'version_date', gmdate( 'Y-m-d H:i:s', time() - WEEK_IN_SECONDS ) );
+		$this->add_release( self::HELD_TAG, self::SERVED_VERSION );
+
+		$this->assertTrue( API_Update_Updater::update_single_plugin( $this->plugin->post_name ) );
+
+		$this->assertSame( self::SERVED_VERSION, $this->served_stable_tag() );
+		$this->assertNotFalse( wp_next_scheduled( "release_to_update_api:{$this->plugin->post_name}" ) );
+	}
+
+	/**
+	 * Switching a trunk-stable plugin to a tag at an unchanged version is a new
+	 * release: the trunk row's identity is trunk@{version}, which no tag matches.
+	 */
+	public function test_tag_switch_from_served_trunk_keeps_cooldown_hold(): void {
+		global $wpdb;
+
+		$wpdb->update(
+			$wpdb->prefix . 'update_source',
+			array( 'stable_tag' => 'trunk' ),
+			array( 'plugin_slug' => $this->plugin->post_name )
+		);
+		update_post_meta( $this->plugin->ID, 'version', self::SERVED_VERSION );
+		$this->add_release( self::HELD_TAG, self::SERVED_VERSION );
+
+		$this->assertTrue( API_Update_Updater::update_single_plugin( $this->plugin->post_name ) );
+
+		$this->assertSame( 'trunk', $this->served_stable_tag() );
+		$this->assertNotFalse( wp_next_scheduled( "release_to_update_api:{$this->plugin->post_name}" ) );
+	}
+
+	/**
+	 * A tag-to-trunk flip at an unchanged version creates no trunk release, so
+	 * the current version resolves to the old tag's record. Once the row serves
+	 * trunk, that fallback is the served release and a block is refused.
+	 */
+	public function test_block_refused_for_served_trunk_fallback_release(): void {
+		$this->serve_trunk_fallback();
+
+		$this->assertFalse( API_Update_Updater::block_release( $this->plugin->post_name, array( 'risk_score' => 9.8 ) ) );
+		$this->assertFalse( API_Update_Updater::is_release_blocked( Plugin_Directory::get_release( get_post( $this->plugin->ID ), self::SERVED_VERSION ) ) );
+	}
+
+	/**
+	 * The served trunk fallback is not a new release: the row is rewritten
+	 * without a cooldown hold.
+	 */
+	public function test_served_trunk_fallback_release_schedules_no_cooldown(): void {
+		$this->serve_trunk_fallback();
+
+		$this->assertTrue( API_Update_Updater::update_single_plugin( $this->plugin->post_name ) );
+
+		$this->assertSame( 'trunk', $this->served_stable_tag() );
+		$this->assertFalse( wp_next_scheduled( "release_to_update_api:{$this->plugin->post_name}" ) );
+	}
+
+	/**
+	 * Serve trunk at the served version with only the old tag's release record,
+	 * so the current version resolves through the version-named fallback.
+	 */
+	private function serve_trunk_fallback(): void {
+		global $wpdb;
+
+		$wpdb->update(
+			$wpdb->prefix . 'update_source',
+			array( 'stable_tag' => 'trunk' ),
+			array( 'plugin_slug' => $this->plugin->post_name )
+		);
+		update_post_meta( $this->plugin->ID, 'version', self::SERVED_VERSION );
+		update_post_meta( $this->plugin->ID, 'stable_tag', 'trunk' );
+		$this->add_release( self::SERVED_VERSION, self::SERVED_VERSION );
+
+		$this->assertSame( self::SERVED_VERSION, API_Update_Updater::get_current_release( get_post( $this->plugin->ID ) )['tag'] );
+	}
+
+	/**
+	 * Trunk versions are compared on the full 128 bytes the row stores: the
+	 * `trunk@` prefix must not eat into the allowance, or two long versions
+	 * differing past byte 122 read as the same release.
+	 */
+	public function test_long_trunk_versions_differing_past_prefix_allowance_are_distinct(): void {
+		global $wpdb;
+
+		$served_version = str_repeat( '1', 130 );
+		$new_version    = substr_replace( $served_version, '2', 124, 1 );
+
+		$wpdb->update(
+			$wpdb->prefix . 'update_source',
+			array(
+				'stable_tag' => 'trunk',
+				'version'    => substr( $served_version, 0, 128 ),
+			),
+			array( 'plugin_slug' => $this->plugin->post_name )
+		);
+		update_post_meta( $this->plugin->ID, 'stable_tag', 'trunk' );
+		update_post_meta( $this->plugin->ID, 'version', $new_version );
+		$this->add_release( 'trunk@' . $new_version, $new_version );
+
+		$this->assertTrue( API_Update_Updater::update_single_plugin( $this->plugin->post_name ) );
+
+		$this->assertSame( substr( $served_version, 0, 128 ), $this->served_version() );
 		$this->assertNotFalse( wp_next_scheduled( "release_to_update_api:{$this->plugin->post_name}" ) );
 	}
 
@@ -437,6 +570,23 @@ class Current_Release_Resolution_Test extends TestCase {
 		);
 
 		$this->assertSame( $version_time, API_Update_Updater::compute_release_time( get_post( $this->plugin->ID ), $release ) );
+	}
+
+	/**
+	 * A release row newer than the plugin's version_date anchors the clock: a
+	 * new tag at an unchanged version, or a re-commit that re-opens a release,
+	 * bumps only the release date.
+	 */
+	public function test_release_time_prefers_newer_release_date_over_version_date(): void {
+		update_post_meta( $this->plugin->ID, 'version_date', gmdate( 'Y-m-d H:i:s', time() - WEEK_IN_SECONDS ) );
+
+		$release = array(
+			'date'                   => time() - DAY_IN_SECONDS,
+			'confirmations_required' => 0,
+			'confirmations'          => array(),
+		);
+
+		$this->assertSame( $release['date'], API_Update_Updater::compute_release_time( get_post( $this->plugin->ID ), $release ) );
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Update_Source_Hold_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Update_Source_Hold_Test.php
@@ -359,6 +359,7 @@ class Update_Source_Hold_Test extends TestCase {
 		$release['version'] = $long_version;
 
 		update_post_meta( $this->plugin->ID, 'version', $long_version );
+		update_post_meta( $this->plugin->ID, 'stable_tag', $long_version );
 		update_post_meta( $this->plugin->ID, 'releases', array( $release ) );
 		$this->insert_served_row( substr( $long_version, 0, 128 ) );
 
@@ -378,6 +379,7 @@ class Update_Source_Hold_Test extends TestCase {
 		$release['version'] = $long_version;
 
 		update_post_meta( $this->plugin->ID, 'version', $long_version );
+		update_post_meta( $this->plugin->ID, 'stable_tag', $long_version );
 		update_post_meta( $this->plugin->ID, 'releases', array( $release ) );
 		$this->insert_served_row( substr( $long_version, 0, 128 ) );
 


### PR DESCRIPTION
The update-source writer decided whether a plugin's current release was already being served by comparing the plugin's `Version` header with the served row's version, and anchored the release clock on the plugin-wide `version_date`. `block_release()` had already moved its already-served guard to the release ref; this brings the cooldown gate and the release-time re-anchor in line with it, so all three agree on what "served" means.

- `get_current_ref()` / `build_ref()`: the ref a plugin's current version is served from, the stable tag or `trunk@{version}`, as release rows are keyed. `get_current_release()` resolves through it.
- `is_current_ref_served()`: compares that ref with the served row's, with the meta truncated to the columns' 128 bytes before the refs are built. Used by the cooldown gate, the release-time re-anchor, and `block_release()`, replacing the latter's inline copy.
- `compute_release_time()`: takes the later of `version_date` and the release row's own date, so a release re-opened by `add_release()` re-arms its clock as intended.

Tests: eight new cases in `Current_Release_Resolution_Test`. The two long-version fixtures in `Update_Source_Hold_Test` now set the stable tag the importer would have written alongside the version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin release detection when stable tags change without a version-number change.
  * Correctly distinguishes trunk-based releases from tagged releases, including long version identifiers.
  * Prevented outdated version dates from incorrectly affecting release holds and cooldown periods.
  * Release timing now uses the most recent relevant release or version date.
  * Updated release blocking and deferral behavior to reflect the currently served release accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->