### PR TITLE
BuddyPress.org/bbPress.org: Base theme: Cache topic lists for anonymous viewers only

### DIFF
--- a/buddypress.org/public_html/wp-content/themes/bb-base/functions.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/functions.php
@@ -407,6 +407,22 @@ function bb_base_homepage_topics( $args = false ) {
 }
 
 /**
+ * Whether the current viewer's topic list is the same one anonymous visitors see.
+ *
+ * The topic query widens per viewer: `?view=all` adds non-public statuses,
+ * `read_private_topics` adds private topics, and the forum read caps lift the
+ * private/hidden forum exclusion. None of those renders may be shared.
+ *
+ * @return bool
+ */
+function bb_base_can_cache_topics() {
+	return ! bbp_get_view_all( 'edit_others_topics' )
+		&& ! current_user_can( 'read_private_topics' )
+		&& ! current_user_can( 'read_private_forums' )
+		&& ! current_user_can( 'read_hidden_forums' );
+}
+
+/**
  * Get front page topics output and stash it for an hour
  *
  * @author johnjamesjacoby
@@ -418,7 +434,8 @@ function bb_base_get_homepage_topics( $args = false ) {
 	// Transient settings
 	$expiration    = MINUTE_IN_SECONDS * 5;
 	$transient_key = 'bb_base_homepage_topics';
-	$output        = get_transient( $transient_key );
+	$cacheable     = bb_base_can_cache_topics();
+	$output        = $cacheable ? get_transient( $transient_key ) : false;
 
 	// No transient found, so query for topics again
 	if ( false === $output ) {
@@ -440,7 +457,9 @@ function bb_base_get_homepage_topics( $args = false ) {
 		}
 
 		// Set the transient
-		set_transient( $transient_key, $output, $expiration );
+		if ( $cacheable ) {
+			set_transient( $transient_key, $output, $expiration );
+		}
 	}
 
 	// Return the output
@@ -485,7 +504,8 @@ function bb_base_get_support_topics() {
 	// Transient settings
 	$expiration    = MINUTE_IN_SECONDS * 5;
 	$transient_key = 'bb_base_support_topics';
-	$output        = get_transient( $transient_key );
+	$cacheable     = bb_base_can_cache_topics();
+	$output        = $cacheable ? get_transient( $transient_key ) : false;
 
 	// No transient found, so query for topics again
 	if ( false === $output ) {
@@ -494,7 +514,9 @@ function bb_base_get_support_topics() {
 		$output = bbp_buffer_template_part( 'content', 'archive-topic', false );
 
 		// Set the transient
-		set_transient( $transient_key, $output, $expiration );
+		if ( $cacheable ) {
+			set_transient( $transient_key, $output, $expiration );
+		}
 	}
 
 	// Return the output

--- a/buddypress.org/public_html/wp-content/themes/bb-base/functions.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/functions.php
@@ -407,22 +407,6 @@ function bb_base_homepage_topics( $args = false ) {
 }
 
 /**
- * Whether the current viewer's topic list is the same one anonymous visitors see.
- *
- * The topic query widens per viewer: `?view=all` adds non-public statuses,
- * `read_private_topics` adds private topics, and the forum read caps lift the
- * private/hidden forum exclusion. None of those renders may be shared.
- *
- * @return bool
- */
-function bb_base_can_cache_topics() {
-	return ! bbp_get_view_all( 'edit_others_topics' )
-		&& ! current_user_can( 'read_private_topics' )
-		&& ! current_user_can( 'read_private_forums' )
-		&& ! current_user_can( 'read_hidden_forums' );
-}
-
-/**
  * Get front page topics output and stash it for an hour
  *
  * @author johnjamesjacoby
@@ -434,8 +418,10 @@ function bb_base_get_homepage_topics( $args = false ) {
 	// Transient settings
 	$expiration    = MINUTE_IN_SECONDS * 5;
 	$transient_key = 'bb_base_homepage_topics';
-	$cacheable     = bb_base_can_cache_topics();
-	$output        = $cacheable ? get_transient( $transient_key ) : false;
+
+	// Logged-in viewers get per-user topic lists, so only anonymous renders are shared.
+	$cacheable = ! is_user_logged_in();
+	$output    = $cacheable ? get_transient( $transient_key ) : false;
 
 	// No transient found, so query for topics again
 	if ( false === $output ) {
@@ -504,8 +490,10 @@ function bb_base_get_support_topics() {
 	// Transient settings
 	$expiration    = MINUTE_IN_SECONDS * 5;
 	$transient_key = 'bb_base_support_topics';
-	$cacheable     = bb_base_can_cache_topics();
-	$output        = $cacheable ? get_transient( $transient_key ) : false;
+
+	// Logged-in viewers get per-user topic lists, so only anonymous renders are shared.
+	$cacheable = ! is_user_logged_in();
+	$output    = $cacheable ? get_transient( $transient_key ) : false;
 
 	// No transient found, so query for topics again
 	if ( false === $output ) {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -107,6 +107,9 @@
 				<element value="edit_topic"/>
 				<element value="edit_reply"/>
 				<element value="read_topic"/>
+				<element value="read_private_topics"/>
+				<element value="read_private_forums"/>
+				<element value="read_hidden_forums"/>
 				<element value="keep_gate"/>
 				<element value="moderate"/>
 				<element value="throttle"/>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -107,9 +107,6 @@
 				<element value="edit_topic"/>
 				<element value="edit_reply"/>
 				<element value="read_topic"/>
-				<element value="read_private_topics"/>
-				<element value="read_private_forums"/>
-				<element value="read_hidden_forums"/>
 				<element value="keep_gate"/>
 				<element value="moderate"/>
 				<element value="throttle"/>


### PR DESCRIPTION
The bb-base theme caches the rendered homepage and forum-archive topic lists in transients under a single shared key. bbPress and WordPress build that list per viewer: `?view=all` widens the statuses for moderators, the forum read capabilities lift the private/hidden forum exclusion, and WordPress adds a logged-in viewer's own private topics regardless of capability. Whichever viewer happened to fill the cache decided what everyone saw for the next five minutes.

Both cache functions now read from and write to the transient only for logged-out viewers, which is the one case where the list is the same for everyone. Logged-in viewers render live, which is what every page beyond the first already does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
