### PR TITLE
Escape translated strings on output

### DIFF
--- a/browsehappy.com/public_html/functions.php
+++ b/browsehappy.com/public_html/functions.php
@@ -269,7 +269,7 @@ function browsehappy_browser_notice() {
 	<?php if ( $results['name'] == 'Internet Explorer' && strpos( $ua, 'Windows NT 5.' ) !== false ) : ?>
 		<?php if ( $results['insecure'] ) : ?>
 			<?php /* translators: %s: Browser name. */ ?>
-			<p><?php printf( esc_html__( 'It looks like you&#8217;re using an insecure version of %s.', 'browsehappy' ), $results['name'] ); ?>
+			<p><?php printf( esc_html__( 'It looks like you&#8217;re using an insecure version of %s.', 'browsehappy' ), esc_html( $results['name'] ) ); ?>
 						<?php esc_html_e( 'Using an outdated browser makes your computer unsafe.', 'browsehappy' ); ?>
 		<?php else : ?>
 			<p><?php esc_html_e( 'It looks like you&#8217;re using an old version of Internet Explorer.', 'browsehappy' ); ?>
@@ -277,13 +277,13 @@ function browsehappy_browser_notice() {
 			<?php esc_html_e( 'On Windows XP, you are unable to update to the latest version. For the best experience on the web, we suggest you try a new browser.', 'browsehappy' ); ?></p>
 	<?php elseif ( $results['insecure'] ) : ?>
 		<?php /* translators: %s: Browser name. */ ?>
-		<p class="browser-status-text"><?php printf( esc_html__( 'It looks like you&#8217;re using an insecure version of %s.', 'browsehappy' ), $results['name'] ); ?>
+		<p class="browser-status-text"><?php printf( esc_html__( 'It looks like you&#8217;re using an insecure version of %s.', 'browsehappy' ), esc_html( $results['name'] ) ); ?>
 			<?php esc_html_e( 'Using an outdated browser makes your computer unsafe.', 'browsehappy' ); ?>
 			<?php esc_html_e( 'For the best experience on the web, please update your browser.', 'browsehappy' ); ?></p>
 		<p class="browser-status-action"><a href="<?php echo esc_url( $results['update_url'] ); ?>"><?php esc_html_e( 'Upgrade now!', 'browsehappy' ); ?></a></p>
 	<?php else : ?>
 		<?php /* translators: %s: Browser name. */ ?>
-		<p class="browser-status-text"><?php printf( esc_html__( 'Your browser is out of date! It looks like you&#8217;re using an old version of %s.', 'browsehappy' ), $results['name'] ); ?>
+		<p class="browser-status-text"><?php printf( esc_html__( 'Your browser is out of date! It looks like you&#8217;re using an old version of %s.', 'browsehappy' ), esc_html( $results['name'] ) ); ?>
 			<?php esc_html_e( 'For the best experience on the web, please update your browser.', 'browsehappy' ); ?></p>
 		<p class="browser-status-action"><a href="<?php echo esc_url( $results['update_url'] ); ?>"><?php esc_html_e( 'Upgrade now!', 'browsehappy' ); ?></a></p>
 	<?php endif; ?>

--- a/browsehappy.com/public_html/functions.php
+++ b/browsehappy.com/public_html/functions.php
@@ -268,6 +268,7 @@ function browsehappy_browser_notice() {
 	<div id="browser-status" class="wrap">
 	<?php if ( $results['name'] == 'Internet Explorer' && strpos( $ua, 'Windows NT 5.' ) !== false ) : ?>
 		<?php if ( $results['insecure'] ) : ?>
+			<?php /* translators: %s: Browser name. */ ?>
 			<p><?php printf( esc_html__( 'It looks like you&#8217;re using an insecure version of %s.', 'browsehappy' ), $results['name'] ); ?>
 						<?php esc_html_e( 'Using an outdated browser makes your computer unsafe.', 'browsehappy' ); ?>
 		<?php else : ?>
@@ -275,11 +276,13 @@ function browsehappy_browser_notice() {
 		<?php endif; ?>
 			<?php esc_html_e( 'On Windows XP, you are unable to update to the latest version. For the best experience on the web, we suggest you try a new browser.', 'browsehappy' ); ?></p>
 	<?php elseif ( $results['insecure'] ) : ?>
+		<?php /* translators: %s: Browser name. */ ?>
 		<p class="browser-status-text"><?php printf( esc_html__( 'It looks like you&#8217;re using an insecure version of %s.', 'browsehappy' ), $results['name'] ); ?>
 			<?php esc_html_e( 'Using an outdated browser makes your computer unsafe.', 'browsehappy' ); ?>
 			<?php esc_html_e( 'For the best experience on the web, please update your browser.', 'browsehappy' ); ?></p>
 		<p class="browser-status-action"><a href="<?php echo esc_url( $results['update_url'] ); ?>"><?php esc_html_e( 'Upgrade now!', 'browsehappy' ); ?></a></p>
 	<?php else : ?>
+		<?php /* translators: %s: Browser name. */ ?>
 		<p class="browser-status-text"><?php printf( esc_html__( 'Your browser is out of date! It looks like you&#8217;re using an old version of %s.', 'browsehappy' ), $results['name'] ); ?>
 			<?php esc_html_e( 'For the best experience on the web, please update your browser.', 'browsehappy' ); ?></p>
 		<p class="browser-status-action"><a href="<?php echo esc_url( $results['update_url'] ); ?>"><?php esc_html_e( 'Upgrade now!', 'browsehappy' ); ?></a></p>

--- a/browsehappy.com/public_html/functions.php
+++ b/browsehappy.com/public_html/functions.php
@@ -268,21 +268,21 @@ function browsehappy_browser_notice() {
 	<div id="browser-status" class="wrap">
 	<?php if ( $results['name'] == 'Internet Explorer' && strpos( $ua, 'Windows NT 5.' ) !== false ) : ?>
 		<?php if ( $results['insecure'] ) : ?>
-			<p><?php printf( __( 'It looks like you&#8217;re using an insecure version of %s.', 'browsehappy' ), $results['name'] ); ?>
-                        <?php _e( 'Using an outdated browser makes your computer unsafe.', 'browsehappy' ); ?>
+			<p><?php printf( esc_html__( 'It looks like you&#8217;re using an insecure version of %s.', 'browsehappy' ), $results['name'] ); ?>
+						<?php esc_html_e( 'Using an outdated browser makes your computer unsafe.', 'browsehappy' ); ?>
 		<?php else : ?>
-			<p><?php _e( 'It looks like you&#8217;re using an old version of Internet Explorer.', 'browsehappy' ); ?>
+			<p><?php esc_html_e( 'It looks like you&#8217;re using an old version of Internet Explorer.', 'browsehappy' ); ?>
 		<?php endif; ?>
-			<?php _e( 'On Windows XP, you are unable to update to the latest version. For the best experience on the web, we suggest you try a new browser.', 'browsehappy' ); ?></p>
+			<?php esc_html_e( 'On Windows XP, you are unable to update to the latest version. For the best experience on the web, we suggest you try a new browser.', 'browsehappy' ); ?></p>
 	<?php elseif ( $results['insecure'] ) : ?>
-		<p class="browser-status-text"><?php printf( __( 'It looks like you&#8217;re using an insecure version of %s.', 'browsehappy' ), $results['name'] ); ?>
-			<?php _e( 'Using an outdated browser makes your computer unsafe.', 'browsehappy' ); ?>
-			<?php _e( 'For the best experience on the web, please update your browser.', 'browsehappy' ); ?></p>
-		<p class="browser-status-action"><a href="<?php echo esc_url( $results['update_url'] ); ?>"><?php _e( 'Upgrade now!', 'browsehappy' ); ?></a></p>
+		<p class="browser-status-text"><?php printf( esc_html__( 'It looks like you&#8217;re using an insecure version of %s.', 'browsehappy' ), $results['name'] ); ?>
+			<?php esc_html_e( 'Using an outdated browser makes your computer unsafe.', 'browsehappy' ); ?>
+			<?php esc_html_e( 'For the best experience on the web, please update your browser.', 'browsehappy' ); ?></p>
+		<p class="browser-status-action"><a href="<?php echo esc_url( $results['update_url'] ); ?>"><?php esc_html_e( 'Upgrade now!', 'browsehappy' ); ?></a></p>
 	<?php else : ?>
-		<p class="browser-status-text"><?php printf( __( 'Your browser is out of date! It looks like you&#8217;re using an old version of %s.', 'browsehappy' ), $results['name'] ); ?>
-			<?php _e( 'For the best experience on the web, please update your browser.', 'browsehappy' ); ?></p>
-		<p class="browser-status-action"><a href="<?php echo esc_url( $results['update_url'] ); ?>"><?php _e( 'Upgrade now!', 'browsehappy' ); ?></a></p>
+		<p class="browser-status-text"><?php printf( esc_html__( 'Your browser is out of date! It looks like you&#8217;re using an old version of %s.', 'browsehappy' ), $results['name'] ); ?>
+			<?php esc_html_e( 'For the best experience on the web, please update your browser.', 'browsehappy' ); ?></p>
+		<p class="browser-status-action"><a href="<?php echo esc_url( $results['update_url'] ); ?>"><?php esc_html_e( 'Upgrade now!', 'browsehappy' ); ?></a></p>
 	<?php endif; ?>
 	</div>
 	<?php
@@ -298,7 +298,7 @@ function browsehappy_locale_notice() {
 	<div id="i18n-alert">
 		<p><?php
 			/* translators: "English" should be translated directly and not to the name of your language. */
-			printf( __( 'Browse Happy is also available in English. <a href="%s">Click here to change the language to English</a>.', 'browsehappy' ), '/?locale=en' );
+			printf( wp_kses_post( __( 'Browse Happy is also available in English. <a href="%s">Click here to change the language to English</a>.', 'browsehappy' ) ), '/?locale=en' );
 		?></p>
 	</div>
 	<?php

--- a/browsehappy.com/public_html/index.php
+++ b/browsehappy.com/public_html/index.php
@@ -48,7 +48,7 @@ defined( 'ABSPATH' ) || die();
 					<h2 lang="en"><?php echo $data->name; ?></h2>
 					<p class="info"><?php echo $data->info; ?></p>
 					<?php /* translators: %s: Browser version. */ ?>
-					<p class="version"><?php printf( esc_html__( 'Latest Version: %s', 'browsehappy' ), '<strong>' . apply_filters( 'get_browsehappy_version', $browser ) . '</strong>' ); ?></p>
+					<p class="version"><?php printf( esc_html__( 'Latest Version: %s', 'browsehappy' ), '<strong>' . esc_html( apply_filters( 'get_browsehappy_version', $browser ) ) . '</strong>' ); ?></p>
 					<p class="website"><?php esc_html_e( 'Visit website for more info', 'browsehappy' ); ?></p>
 				</a>
 				<?php do_action( 'browsehappy_browser_after', $browser ); ?>

--- a/browsehappy.com/public_html/index.php
+++ b/browsehappy.com/public_html/index.php
@@ -47,6 +47,7 @@ defined( 'ABSPATH' ) || die();
 					<div class="icon"></div>
 					<h2 lang="en"><?php echo $data->name; ?></h2>
 					<p class="info"><?php echo $data->info; ?></p>
+					<?php /* translators: %s: Browser version. */ ?>
 					<p class="version"><?php printf( esc_html__( 'Latest Version: %s', 'browsehappy' ), '<strong>' . apply_filters( 'get_browsehappy_version', $browser ) . '</strong>' ); ?></p>
 					<p class="website"><?php esc_html_e( 'Visit website for more info', 'browsehappy' ); ?></p>
 				</a>
@@ -105,6 +106,7 @@ $facebook_pieces = array(
 				</nav>
 			</section><!-- #share -->
 			<div id="byline">
+				<?php /* translators: %s: WordPress, in bold. */ ?>
 				<a href="<?php echo esc_url( __( 'https://wordpress.org/', 'browsehappy' ) ); ?>" title="WordPress"><?php printf( esc_html__( 'Brought to you by %s', 'browsehappy' ), '<strong>WordPress</strong>' ); ?></a>
 			</div><!-- #byline -->
 		</div>

--- a/browsehappy.com/public_html/index.php
+++ b/browsehappy.com/public_html/index.php
@@ -106,8 +106,7 @@ $facebook_pieces = array(
 				</nav>
 			</section><!-- #share -->
 			<div id="byline">
-				<?php /* translators: %s: WordPress, in bold. */ ?>
-				<a href="<?php echo esc_url( __( 'https://wordpress.org/', 'browsehappy' ) ); ?>" title="WordPress"><?php printf( esc_html__( 'Brought to you by %s', 'browsehappy' ), '<strong>WordPress</strong>' ); ?></a>
+				<a href="<?php echo esc_url( __( 'https://wordpress.org/', 'browsehappy' ) ); ?>" title="WordPress"><?php printf( /* translators: %s: WordPress, in bold. */ esc_html__( 'Brought to you by %s', 'browsehappy' ), '<strong>WordPress</strong>' ); ?></a>
 			</div><!-- #byline -->
 		</div>
 	</footer>

--- a/browsehappy.com/public_html/index.php
+++ b/browsehappy.com/public_html/index.php
@@ -15,7 +15,7 @@ defined( 'ABSPATH' ) || die();
 
 <head>
 	<meta charset="utf-8">
-	<title><?php _e( 'Browse Happy', 'browsehappy' ); ?></title>
+	<title><?php esc_html_e( 'Browse Happy', 'browsehappy' ); ?></title>
 	<meta name="description" content="<?php esc_attr_e( 'Online. Worry-free. Upgrade your browser today!', 'browsehappy' ); ?>" />
 	<meta name="author" content="WordPress" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -34,8 +34,8 @@ defined( 'ABSPATH' ) || die();
 
 	<header>
 		<hgroup class="wrap">
-			<h1><?php _e( 'Browse <em>Happy</em>', 'browsehappy' ); ?></h1>
-			<h2><?php _e( 'Online. Worry-free. <em>Upgrade your browser today</em>!', 'browsehappy' ); ?></h2>
+			<h1><?php echo wp_kses_post( __( 'Browse <em>Happy</em>', 'browsehappy' ) ); ?></h1>
+			<h2><?php echo wp_kses_post( __( 'Online. Worry-free. <em>Upgrade your browser today</em>!', 'browsehappy' ) ); ?></h2>
 		</hgroup>
 	</header>
 	<?php do_action( 'browsehappy_browser_notice' ); ?>
@@ -47,8 +47,8 @@ defined( 'ABSPATH' ) || die();
 					<div class="icon"></div>
 					<h2 lang="en"><?php echo $data->name; ?></h2>
 					<p class="info"><?php echo $data->info; ?></p>
-					<p class="version"><?php printf( __( 'Latest Version: %s', 'browsehappy' ), '<strong>' . apply_filters( 'get_browsehappy_version', $browser ) . '</strong>' ); ?></p>
-					<p class="website"><?php _e( 'Visit website for more info', 'browsehappy' ); ?></p>
+					<p class="version"><?php printf( esc_html__( 'Latest Version: %s', 'browsehappy' ), '<strong>' . apply_filters( 'get_browsehappy_version', $browser ) . '</strong>' ); ?></p>
+					<p class="website"><?php esc_html_e( 'Visit website for more info', 'browsehappy' ); ?></p>
 				</a>
 				<?php do_action( 'browsehappy_browser_after', $browser ); ?>
 			</li><!-- #<?php echo $browser; ?> -->
@@ -59,12 +59,12 @@ defined( 'ABSPATH' ) || die();
 	<footer>
 		<div class="wrap">
 			<section id="about">
-				<h2><?php _e( 'What is Browse Happy?', 'browsehappy' ); ?></h2>
+				<h2><?php esc_html_e( 'What is Browse Happy?', 'browsehappy' ); ?></h2>
 				<p><?php $what = __( 'Using an outdated browser makes your computer unsafe. Browse Happy is a way for you to find out what are the latest versions of the major browsers around. You can also learn about alternative browsers that may fit you even better than the one you are currently using.', 'browsehappy' );
 echo $what; ?></p>
 			</section><!-- #about -->
 			<section id="share">
-				<h2><?php _e( 'Share the Happiness', 'browsehappy' ); ?></h2>
+				<h2><?php esc_html_e( 'Share the Happiness', 'browsehappy' ); ?></h2>
 				<nav>
 					<ul>
 						<li class="tumblr">
@@ -105,7 +105,7 @@ $facebook_pieces = array(
 				</nav>
 			</section><!-- #share -->
 			<div id="byline">
-				<a href="<?php echo esc_url( __( 'https://wordpress.org/', 'browsehappy' ) ); ?>" title="WordPress"><?php printf( __( 'Brought to you by %s', 'browsehappy' ), '<strong>WordPress</strong>' ); ?></a>
+				<a href="<?php echo esc_url( __( 'https://wordpress.org/', 'browsehappy' ) ); ?>" title="WordPress"><?php printf( esc_html__( 'Brought to you by %s', 'browsehappy' ), '<strong>WordPress</strong>' ); ?></a>
 			</div><!-- #byline -->
 		</div>
 	</footer>

--- a/buddypress.org/public_html/wp-content/themes/bb-base/archive-forum.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/archive-forum.php
@@ -1,6 +1,6 @@
 <?php get_header(); ?>
 
-<h2 id="post-home"><?php _e( 'Support', 'bborg' ); ?></h2>
+<h2 id="post-home"><?php esc_html_e( 'Support', 'bborg' ); ?></h2>
 
 <?php if ( 1 === bbp_get_paged() ) : // cached first page ?>
 

--- a/buddypress.org/public_html/wp-content/themes/bb-base/archive.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/archive.php
@@ -7,12 +7,11 @@ if ( have_posts() ) :
 			<h2 id="post-<?php the_ID(); ?>"><a href="<?php the_permalink() ?>" rel="bookmark"><?php the_title(); ?></a></h2>
 			<cite>
 				<?php
-				/* translators: 1: post date, 2: post author */
 				printf(
 					/* translators: 1: Publication date, 2: Author link. */
 					esc_html__( 'Published on %1$s by %2$s', 'bborg' ),
-					get_the_time( 'F jS, Y' ),
-					get_the_author_link()
+					esc_html( get_the_time( 'F jS, Y' ) ),
+					wp_kses_post( get_the_author_link() )
 				);
 				?>
 			</cite>

--- a/buddypress.org/public_html/wp-content/themes/bb-base/archive.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/archive.php
@@ -9,6 +9,7 @@ if ( have_posts() ) :
 				<?php
 				/* translators: 1: post date, 2: post author */
 				printf(
+					/* translators: 1: Publication date, 2: Author link. */
 					esc_html__( 'Published on %1$s by %2$s', 'bborg' ),
 					get_the_time( 'F jS, Y' ),
 					get_the_author_link()

--- a/buddypress.org/public_html/wp-content/themes/bb-base/archive.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/archive.php
@@ -8,7 +8,8 @@ if ( have_posts() ) :
 			<cite>
 				<?php
 				/* translators: 1: post date, 2: post author */
-				printf( __( 'Published on %1$s by %2$s', 'bborg' ),
+				printf(
+					esc_html__( 'Published on %1$s by %2$s', 'bborg' ),
 					get_the_time( 'F jS, Y' ),
 					get_the_author_link()
 				);
@@ -25,7 +26,7 @@ if ( have_posts() ) :
 		'before_page_number' => '<span class="screen-reader-text">' . __( 'Page', 'bborg' ) . ' </span>',
 	) );
 else : ?>
-	<p><em><?php _e( 'Sorry, no posts matched your criteria.', 'bborg' ); ?></em></p>
+	<p><em><?php esc_html_e( 'Sorry, no posts matched your criteria.', 'bborg' ); ?></em></p>
 <?php endif; ?>
 	<hr class="hidden" />
 <?php

--- a/buddypress.org/public_html/wp-content/themes/bb-base/bbpress/feedback-search.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/bbpress/feedback-search.php
@@ -1,3 +1,11 @@
+<?php
+/**
+ * Notice shown when a forum search has no terms.
+ *
+ * @package bbPress
+ */
+
+?>
 <div class="bbp-template-notice">
 	<p><?php esc_html_e( 'Please enter some search terms above', 'bbpress' ); ?></p>
 </div>

--- a/buddypress.org/public_html/wp-content/themes/bb-base/bbpress/feedback-search.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/bbpress/feedback-search.php
@@ -1,3 +1,3 @@
 <div class="bbp-template-notice">
-	<p><?php _e( 'Please enter some search terms above', 'bbpress' ); ?></p>
+	<p><?php esc_html_e( 'Please enter some search terms above', 'bbpress' ); ?></p>
 </div>

--- a/buddypress.org/public_html/wp-content/themes/bb-base/bbpress/form-topic-merge.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/bbpress/form-topic-merge.php
@@ -22,7 +22,7 @@
 				<fieldset class="bbp-form">
 
 					<?php /* translators: %s: Topic title. */ ?>
-					<legend><?php printf( esc_html__( 'Merge topic "%s"', 'bbpress' ), bbp_get_topic_title() ); ?></legend>
+					<legend><?php printf( esc_html__( 'Merge topic "%s"', 'bbpress' ), esc_html( bbp_get_topic_title() ) ); ?></legend>
 
 					<div>
 

--- a/buddypress.org/public_html/wp-content/themes/bb-base/bbpress/form-topic-merge.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/bbpress/form-topic-merge.php
@@ -21,25 +21,25 @@
 
 				<fieldset class="bbp-form">
 
-					<legend><?php printf( __( 'Merge topic "%s"', 'bbpress' ), bbp_get_topic_title() ); ?></legend>
+					<legend><?php printf( esc_html__( 'Merge topic "%s"', 'bbpress' ), bbp_get_topic_title() ); ?></legend>
 
 					<div>
 
 						<div class="bbp-template-notice info">
-							<p><?php _e( 'Select the topic to merge this one into. The destination topic will remain the lead topic, and this one will change into a reply.', 'bbpress' ); ?></p>
-							<p><?php _e( 'To keep this topic as the lead, go to the other topic and use the merge tool from there instead.', 'bbpress' ); ?></p>
+							<p><?php esc_html_e( 'Select the topic to merge this one into. The destination topic will remain the lead topic, and this one will change into a reply.', 'bbpress' ); ?></p>
+							<p><?php esc_html_e( 'To keep this topic as the lead, go to the other topic and use the merge tool from there instead.', 'bbpress' ); ?></p>
 						</div>
 
 						<div class="bbp-template-notice">
-							<p><?php _e( 'All replies within both the topics will be merged chronologically. The order of the merged replies is based on the time they were posted. If the destination topic was created after this one, its post date will be updated to a second earlier than this one.', 'bbpress' ); ?></p>
+							<p><?php esc_html_e( 'All replies within both the topics will be merged chronologically. The order of the merged replies is based on the time they were posted. If the destination topic was created after this one, its post date will be updated to a second earlier than this one.', 'bbpress' ); ?></p>
 						</div>
 
 						<fieldset class="bbp-form">
-							<legend><?php _e( 'Destination', 'bbpress' ); ?></legend>
+							<legend><?php esc_html_e( 'Destination', 'bbpress' ); ?></legend>
 							<div>
 								<?php if ( bbp_has_topics( array( 'show_stickies' => false, 'post_parent' => bbp_get_topic_forum_id( bbp_get_topic_id() ), 'post__not_in' => array( bbp_get_topic_id() ) ) ) ) : ?>
 
-									<label for="bbp_destination_topic"><?php _e( 'Merge with this topic:', 'bbpress' ); ?></label>
+									<label for="bbp_destination_topic"><?php esc_html_e( 'Merge with this topic:', 'bbpress' ); ?></label>
 
 									<?php
 										bbp_dropdown( array(
@@ -57,7 +57,7 @@
 
 								<?php else : ?>
 
-									<label><?php _e( 'There are no other topics in this forum to merge with.', 'bbpress' ); ?></label>
+									<label><?php esc_html_e( 'There are no other topics in this forum to merge with.', 'bbpress' ); ?></label>
 
 								<?php endif; ?>
 
@@ -65,24 +65,24 @@
 						</fieldset>
 
 						<fieldset class="bbp-form">
-							<legend><?php _e( 'Topic Extras', 'bbpress' ); ?></legend>
+							<legend><?php esc_html_e( 'Topic Extras', 'bbpress' ); ?></legend>
 
 							<div>
 
 								<?php if ( bbp_is_subscriptions_active() ) : ?>
 
 									<input name="bbp_topic_subscribers" id="bbp_topic_subscribers" type="checkbox" value="1" checked="checked" />
-									<label for="bbp_topic_subscribers"><?php _e( 'Merge topic subscribers', 'bbpress' ); ?></label><br />
+									<label for="bbp_topic_subscribers"><?php esc_html_e( 'Merge topic subscribers', 'bbpress' ); ?></label><br />
 
 								<?php endif; ?>
 
 								<input name="bbp_topic_favoriters" id="bbp_topic_favoriters" type="checkbox" value="1" checked="checked" />
-								<label for="bbp_topic_favoriters"><?php _e( 'Merge topic favoriters', 'bbpress' ); ?></label><br />
+								<label for="bbp_topic_favoriters"><?php esc_html_e( 'Merge topic favoriters', 'bbpress' ); ?></label><br />
 
 								<?php if ( bbp_allow_topic_tags() ) : ?>
 
 									<input name="bbp_topic_tags" id="bbp_topic_tags" type="checkbox" value="1" checked="checked" />
-									<label for="bbp_topic_tags"><?php _e( 'Merge topic tags', 'bbpress' ); ?></label><br />
+									<label for="bbp_topic_tags"><?php esc_html_e( 'Merge topic tags', 'bbpress' ); ?></label><br />
 
 								<?php endif; ?>
 
@@ -90,11 +90,11 @@
 						</fieldset>
 
 						<div class="bbp-template-notice error">
-							<p><?php _e( '<strong>WARNING:</strong> This process cannot be undone.', 'bbpress' ); ?></p>
+							<p><?php echo wp_kses_post( __( '<strong>WARNING:</strong> This process cannot be undone.', 'bbpress' ) ); ?></p>
 						</div>
 
 						<div class="bbp-submit-wrapper">
-							<button type="submit" id="bbp_merge_topic_submit" name="bbp_merge_topic_submit" class="button submit"><?php _e( 'Submit', 'bbpress' ); ?></button>
+							<button type="submit" id="bbp_merge_topic_submit" name="bbp_merge_topic_submit" class="button submit"><?php esc_html_e( 'Submit', 'bbpress' ); ?></button>
 						</div>
 					</div>
 
@@ -107,7 +107,7 @@
 	<?php else : ?>
 
 		<div id="no-topic-<?php bbp_topic_id(); ?>" class="bbp-no-topic">
-			<div class="entry-content"><?php is_user_logged_in() ? _e( 'You do not have the permissions to edit this topic!', 'bbpress' ) : _e( 'You cannot edit this topic.', 'bbpress' ); ?></div>
+			<div class="entry-content"><?php is_user_logged_in() ? esc_html_e( 'You do not have the permissions to edit this topic!', 'bbpress' ) : esc_html_e( 'You cannot edit this topic.', 'bbpress' ); ?></div>
 		</div>
 
 	<?php endif; ?>

--- a/buddypress.org/public_html/wp-content/themes/bb-base/bbpress/form-topic-merge.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/bbpress/form-topic-merge.php
@@ -21,6 +21,7 @@
 
 				<fieldset class="bbp-form">
 
+					<?php /* translators: %s: Topic title. */ ?>
 					<legend><?php printf( esc_html__( 'Merge topic "%s"', 'bbpress' ), bbp_get_topic_title() ); ?></legend>
 
 					<div>

--- a/buddypress.org/public_html/wp-content/themes/bb-base/bbpress/form-topic-split.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/bbpress/form-topic-split.php
@@ -21,24 +21,24 @@
 
 				<fieldset class="bbp-form">
 
-					<legend><?php printf( __( 'Split topic "%s"', 'bbpress' ), bbp_get_topic_title() ); ?></legend>
+					<legend><?php printf( esc_html__( 'Split topic "%s"', 'bbpress' ), bbp_get_topic_title() ); ?></legend>
 
 					<div>
 
 						<div class="bbp-template-notice info">
-							<p><?php _e( 'When you split a topic, you are slicing it in half starting with the reply you just selected. Choose to use that reply as a new topic with a new title, or merge those replies into an existing topic.', 'bbpress' ); ?></p>
+							<p><?php esc_html_e( 'When you split a topic, you are slicing it in half starting with the reply you just selected. Choose to use that reply as a new topic with a new title, or merge those replies into an existing topic.', 'bbpress' ); ?></p>
 						</div>
 
 						<div class="bbp-template-notice">
-							<p><?php _e( 'If you use the existing topic option, replies within both topics will be merged chronologically. The order of the merged replies is based on the time and date they were posted.', 'bbpress' ); ?></p>
+							<p><?php esc_html_e( 'If you use the existing topic option, replies within both topics will be merged chronologically. The order of the merged replies is based on the time and date they were posted.', 'bbpress' ); ?></p>
 						</div>
 
 						<fieldset class="bbp-form">
-							<legend><?php _e( 'Split Method', 'bbpress' ); ?></legend>
+							<legend><?php esc_html_e( 'Split Method', 'bbpress' ); ?></legend>
 
 							<div>
 								<input name="bbp_topic_split_option" id="bbp_topic_split_option_reply" type="radio" checked="checked" value="reply" />
-								<label for="bbp_topic_split_option_reply"><?php printf( __( 'New topic in <strong>%s</strong> titled:', 'bbpress' ), bbp_get_forum_title( bbp_get_topic_forum_id( bbp_get_topic_id() ) ) ); ?></label>
+								<label for="bbp_topic_split_option_reply"><?php printf( wp_kses_post( __( 'New topic in <strong>%s</strong> titled:', 'bbpress' ) ), bbp_get_forum_title( bbp_get_topic_forum_id( bbp_get_topic_id() ) ) ); ?></label>
 								<input type="text" id="bbp_topic_split_destination_title" value="<?php echo esc_attr( sprintf( __( 'Split: %s', 'bbpress' ), bbp_get_topic_title() ) ); ?>" size="35" name="bbp_topic_split_destination_title" />
 							</div>
 
@@ -46,7 +46,7 @@
 
 								<div>
 									<input name="bbp_topic_split_option" id="bbp_topic_split_option_existing" type="radio" value="existing" />
-									<label for="bbp_topic_split_option_existing"><?php _e( 'Use an existing topic in this forum:', 'bbpress' ); ?></label>
+									<label for="bbp_topic_split_option_existing"><?php esc_html_e( 'Use an existing topic in this forum:', 'bbpress' ); ?></label>
 
 									<?php
 										bbp_dropdown( array(
@@ -68,24 +68,24 @@
 						</fieldset>
 
 						<fieldset class="bbp-form">
-							<legend><?php _e( 'Topic Extras', 'bbpress' ); ?></legend>
+							<legend><?php esc_html_e( 'Topic Extras', 'bbpress' ); ?></legend>
 
 							<div>
 
 								<?php if ( bbp_is_subscriptions_active() ) : ?>
 
 									<input name="bbp_topic_subscribers" id="bbp_topic_subscribers" type="checkbox" value="1" checked="checked" />
-									<label for="bbp_topic_subscribers"><?php _e( 'Copy subscribers to the new topic', 'bbpress' ); ?></label><br />
+									<label for="bbp_topic_subscribers"><?php esc_html_e( 'Copy subscribers to the new topic', 'bbpress' ); ?></label><br />
 
 								<?php endif; ?>
 
 								<input name="bbp_topic_favoriters" id="bbp_topic_favoriters" type="checkbox" value="1" checked="checked" />
-								<label for="bbp_topic_favoriters"><?php _e( 'Copy favoriters to the new topic', 'bbpress' ); ?></label><br />
+								<label for="bbp_topic_favoriters"><?php esc_html_e( 'Copy favoriters to the new topic', 'bbpress' ); ?></label><br />
 
 								<?php if ( bbp_allow_topic_tags() ) : ?>
 
 									<input name="bbp_topic_tags" id="bbp_topic_tags" type="checkbox" value="1" checked="checked" />
-									<label for="bbp_topic_tags"><?php _e( 'Copy topic tags to the new topic', 'bbpress' ); ?></label><br />
+									<label for="bbp_topic_tags"><?php esc_html_e( 'Copy topic tags to the new topic', 'bbpress' ); ?></label><br />
 
 								<?php endif; ?>
 
@@ -93,11 +93,11 @@
 						</fieldset>
 
 						<div class="bbp-template-notice error">
-							<p><?php _e( '<strong>WARNING:</strong> This process cannot be undone.', 'bbpress' ); ?></p>
+							<p><?php echo wp_kses_post( __( '<strong>WARNING:</strong> This process cannot be undone.', 'bbpress' ) ); ?></p>
 						</div>
 
 						<div class="bbp-submit-wrapper">
-							<button type="submit" id="bbp_merge_topic_submit" name="bbp_merge_topic_submit" class="button submit"><?php _e( 'Submit', 'bbpress' ); ?></button>
+							<button type="submit" id="bbp_merge_topic_submit" name="bbp_merge_topic_submit" class="button submit"><?php esc_html_e( 'Submit', 'bbpress' ); ?></button>
 						</div>
 					</div>
 
@@ -110,7 +110,7 @@
 	<?php else : ?>
 
 		<div id="no-topic-<?php bbp_topic_id(); ?>" class="bbp-no-topic">
-			<div class="entry-content"><?php is_user_logged_in() ? _e( 'You do not have the permissions to edit this topic!', 'bbpress' ) : _e( 'You cannot edit this topic.', 'bbpress' ); ?></div>
+			<div class="entry-content"><?php is_user_logged_in() ? esc_html_e( 'You do not have the permissions to edit this topic!', 'bbpress' ) : esc_html_e( 'You cannot edit this topic.', 'bbpress' ); ?></div>
 		</div>
 
 	<?php endif; ?>

--- a/buddypress.org/public_html/wp-content/themes/bb-base/bbpress/form-topic-split.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/bbpress/form-topic-split.php
@@ -22,7 +22,7 @@
 				<fieldset class="bbp-form">
 
 					<?php /* translators: %s: Topic title. */ ?>
-					<legend><?php printf( esc_html__( 'Split topic "%s"', 'bbpress' ), bbp_get_topic_title() ); ?></legend>
+					<legend><?php printf( esc_html__( 'Split topic "%s"', 'bbpress' ), esc_html( bbp_get_topic_title() ) ); ?></legend>
 
 					<div>
 
@@ -40,7 +40,7 @@
 							<div>
 								<input name="bbp_topic_split_option" id="bbp_topic_split_option_reply" type="radio" checked="checked" value="reply" />
 								<?php /* translators: %s: Forum title. */ ?>
-								<label for="bbp_topic_split_option_reply"><?php printf( wp_kses_post( __( 'New topic in <strong>%s</strong> titled:', 'bbpress' ) ), bbp_get_forum_title( bbp_get_topic_forum_id( bbp_get_topic_id() ) ) ); ?></label>
+								<label for="bbp_topic_split_option_reply"><?php printf( wp_kses_post( __( 'New topic in <strong>%s</strong> titled:', 'bbpress' ) ), esc_html( bbp_get_forum_title( bbp_get_topic_forum_id( bbp_get_topic_id() ) ) ) ); ?></label>
 								<input type="text" id="bbp_topic_split_destination_title" value="<?php echo esc_attr( sprintf( __( 'Split: %s', 'bbpress' ), bbp_get_topic_title() ) ); ?>" size="35" name="bbp_topic_split_destination_title" />
 							</div>
 

--- a/buddypress.org/public_html/wp-content/themes/bb-base/bbpress/form-topic-split.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/bbpress/form-topic-split.php
@@ -21,6 +21,7 @@
 
 				<fieldset class="bbp-form">
 
+					<?php /* translators: %s: Topic title. */ ?>
 					<legend><?php printf( esc_html__( 'Split topic "%s"', 'bbpress' ), bbp_get_topic_title() ); ?></legend>
 
 					<div>
@@ -38,6 +39,7 @@
 
 							<div>
 								<input name="bbp_topic_split_option" id="bbp_topic_split_option_reply" type="radio" checked="checked" value="reply" />
+								<?php /* translators: %s: Forum title. */ ?>
 								<label for="bbp_topic_split_option_reply"><?php printf( wp_kses_post( __( 'New topic in <strong>%s</strong> titled:', 'bbpress' ) ), bbp_get_forum_title( bbp_get_topic_forum_id( bbp_get_topic_id() ) ) ); ?></label>
 								<input type="text" id="bbp_topic_split_destination_title" value="<?php echo esc_attr( sprintf( __( 'Split: %s', 'bbpress' ), bbp_get_topic_title() ) ); ?>" size="35" name="bbp_topic_split_destination_title" />
 							</div>

--- a/buddypress.org/public_html/wp-content/themes/bb-base/bbpress/form-topic.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/bbpress/form-topic.php
@@ -21,9 +21,9 @@
 
 					<?php
 						if ( bbp_is_topic_edit() )
-							printf( __( 'Now Editing &ldquo;%s&rdquo;', 'bbpress' ), bbp_get_topic_title() );
+							printf( esc_html__( 'Now Editing &ldquo;%s&rdquo;', 'bbpress' ), bbp_get_topic_title() );
 						else
-							bbp_is_single_forum() ? printf( __( 'Create New Topic in &ldquo;%s&rdquo;', 'bbpress' ), bbp_get_forum_title() ) : _e( 'Create New Topic', 'bbpress' );
+							bbp_is_single_forum() ? printf( esc_html__( 'Create New Topic in &ldquo;%s&rdquo;', 'bbpress' ), bbp_get_forum_title() ) : esc_html_e( 'Create New Topic', 'bbpress' );
 					?>
 
 				</legend>
@@ -33,9 +33,9 @@
 				<?php if ( ! bbp_is_topic_edit() && ! bbp_is_forum_closed() ) : ?>
 
 					<div class="bbp-template-notice">
-						<p><?php _e( 'If asking for help, please include your WordPress version, bbPress version, and a link to your site.',                              'bbporg' ); ?></p>
-						<p><?php _e( 'If you have a problem while using a non-bundled theme, check if it happens with TwentyTen or TwentyEleven.',                        'bbporg' ); ?></p>
-						<p><?php _e( 'If you found a bug, please create a <a href="https://bbpress.trac.wordpress.org/">trac ticket</a> with detailed duplication steps.', 'bbporg' ); ?></p>
+						<p><?php esc_html_e( 'If asking for help, please include your WordPress version, bbPress version, and a link to your site.', 'bbporg' ); ?></p>
+						<p><?php esc_html_e( 'If you have a problem while using a non-bundled theme, check if it happens with TwentyTen or TwentyEleven.', 'bbporg' ); ?></p>
+						<p><?php echo wp_kses_post( __( 'If you found a bug, please create a <a href="https://bbpress.trac.wordpress.org/">trac ticket</a> with detailed duplication steps.', 'bbporg' ) ); ?></p>
 					</div>
 
 				<?php endif; ?>
@@ -43,7 +43,7 @@
 				<?php if ( !bbp_is_topic_edit() && bbp_is_forum_closed() ) : ?>
 
 					<div class="bbp-template-notice">
-						<p><?php _e( 'This forum is marked as closed to new topics, however your posting capabilities still allow you to do so.', 'bbpress' ); ?></p>
+						<p><?php esc_html_e( 'This forum is marked as closed to new topics, however your posting capabilities still allow you to do so.', 'bbpress' ); ?></p>
 					</div>
 
 				<?php endif; ?>
@@ -51,7 +51,7 @@
 				<?php if ( current_user_can( 'unfiltered_html' ) ) : ?>
 
 					<div class="bbp-template-notice">
-						<p><?php _e( 'Your account has the ability to post unrestricted HTML content.', 'bbpress' ); ?></p>
+						<p><?php esc_html_e( 'Your account has the ability to post unrestricted HTML content.', 'bbpress' ); ?></p>
 					</div>
 
 				<?php endif; ?>
@@ -65,7 +65,7 @@
 					<?php do_action( 'bbp_theme_before_topic_form_title' ); ?>
 
 					<p>
-						<label for="bbp_topic_title"><?php printf( __( 'Topic Title (Maximum Length: %d):', 'bbpress' ), bbp_get_title_max_length() ); ?></label><br />
+						<label for="bbp_topic_title"><?php printf( esc_html__( 'Topic Title (Maximum Length: %d):', 'bbpress' ), bbp_get_title_max_length() ); ?></label><br />
 						<input type="text" id="bbp_topic_title" value="<?php bbp_form_topic_title(); ?>" size="40" name="bbp_topic_title" maxlength="<?php bbp_title_max_length(); ?>" />
 					</p>
 
@@ -76,7 +76,7 @@
 					<?php if ( !function_exists( 'wp_editor' ) ) : ?>
 
 						<p>
-							<label for="bbp_reply_content"><?php _e( 'Reply:', 'bbpress' ); ?></label><br />
+							<label for="bbp_reply_content"><?php esc_html_e( 'Reply:', 'bbpress' ); ?></label><br />
 							<textarea id="bbp_topic_content" name="bbp_topic_content" cols="60" rows="6"><?php bbp_form_topic_content(); ?></textarea>
 						</p>
 
@@ -91,7 +91,7 @@
 					<?php if ( !current_user_can( 'unfiltered_html' ) ) : ?>
 
 						<p class="form-allowed-tags">
-							<label><?php _e( 'You may use these <abbr title="HyperText Markup Language">HTML</abbr> tags and attributes:','bbpress' ); ?></label><br />
+							<label><?php echo wp_kses_post( __( 'You may use these <abbr title="HyperText Markup Language">HTML</abbr> tags and attributes:', 'bbpress' ) ); ?></label><br />
 							<code><?php bbp_allowed_tags(); ?></code>
 						</p>
 
@@ -100,7 +100,7 @@
 					<?php do_action( 'bbp_theme_before_topic_form_tags' ); ?>
 
 					<p>
-						<label for="bbp_topic_tags"><?php _e( 'Topic Tags:', 'bbpress' ); ?></label><br />
+						<label for="bbp_topic_tags"><?php esc_html_e( 'Topic Tags:', 'bbpress' ); ?></label><br />
 						<input type="text" value="<?php bbp_form_topic_tags(); ?>" size="40" name="bbp_topic_tags" id="bbp_topic_tags" <?php disabled( bbp_is_topic_spam() ); ?> />
 					</p>
 
@@ -111,7 +111,7 @@
 						<?php do_action( 'bbp_theme_before_topic_form_forum' ); ?>
 
 						<p>
-							<label for="bbp_forum_id"><?php _e( 'Forum:', 'bbpress' ); ?></label><br />
+							<label for="bbp_forum_id"><?php esc_html_e( 'Forum:', 'bbpress' ); ?></label><br />
 							<?php bbp_dropdown( array( 'selected' => bbp_get_form_topic_forum() ) ); ?>
 						</p>
 
@@ -125,7 +125,7 @@
 
 						<p>
 
-							<label for="bbp_stick_topic"><?php _e( 'Topic Type:', 'bbpress' ); ?></label><br />
+							<label for="bbp_stick_topic"><?php esc_html_e( 'Topic Type:', 'bbpress' ); ?></label><br />
 
 							<?php bbp_topic_type_select(); ?>
 
@@ -144,11 +144,11 @@
 
 							<?php if ( bbp_is_topic_edit() && ( get_the_author_meta( 'ID' ) != bbp_get_current_user_id() ) ) : ?>
 
-								<label for="bbp_topic_subscription"><?php _e( 'Notify the author of follow-up replies via email', 'bbpress' ); ?></label>
+								<label for="bbp_topic_subscription"><?php esc_html_e( 'Notify the author of follow-up replies via email', 'bbpress' ); ?></label>
 
 							<?php else : ?>
 
-								<label for="bbp_topic_subscription"><?php _e( 'Notify me of follow-up replies via email', 'bbpress' ); ?></label>
+								<label for="bbp_topic_subscription"><?php esc_html_e( 'Notify me of follow-up replies via email', 'bbpress' ); ?></label>
 
 							<?php endif; ?>
 						</p>
@@ -164,11 +164,11 @@
 						<fieldset class="bbp-form">
 							<legend>
 								<input name="bbp_log_topic_edit" id="bbp_log_topic_edit" type="checkbox" value="1" <?php bbp_form_topic_log_edit(); ?> />
-								<label for="bbp_log_topic_edit"><?php _e( 'Keep a log of this edit:', 'bbpress' ); ?></label><br />
+								<label for="bbp_log_topic_edit"><?php esc_html_e( 'Keep a log of this edit:', 'bbpress' ); ?></label><br />
 							</legend>
 
 							<div>
-								<label for="bbp_topic_edit_reason"><?php printf( __( 'Optional reason for editing:', 'bbpress' ), bbp_get_current_user_name() ); ?></label><br />
+								<label for="bbp_topic_edit_reason"><?php printf( esc_html__( 'Optional reason for editing:', 'bbpress' ), bbp_get_current_user_name() ); ?></label><br />
 								<input type="text" value="<?php bbp_form_topic_edit_reason(); ?>" size="40" name="bbp_topic_edit_reason" id="bbp_topic_edit_reason" />
 							</div>
 						</fieldset>
@@ -183,7 +183,7 @@
 
 						<?php do_action( 'bbp_theme_before_topic_form_submit_button' ); ?>
 
-						<button type="submit" id="bbp_topic_submit" name="bbp_topic_submit" class="button submit"><?php _e( 'Submit', 'bbpress' ); ?></button>
+						<button type="submit" id="bbp_topic_submit" name="bbp_topic_submit" class="button submit"><?php esc_html_e( 'Submit', 'bbpress' ); ?></button>
 
 						<?php do_action( 'bbp_theme_after_topic_form_submit_button' ); ?>
 
@@ -206,7 +206,7 @@
 
 	<div id="no-topic-<?php bbp_topic_id(); ?>" class="bbp-no-topic">
 		<div class="bbp-template-notice">
-			<p><?php printf( __( 'The forum &#8216;%s&#8217; is closed to new topics and replies.', 'bbpress' ), bbp_get_forum_title() ); ?></p>
+			<p><?php printf( esc_html__( 'The forum &#8216;%s&#8217; is closed to new topics and replies.', 'bbpress' ), bbp_get_forum_title() ); ?></p>
 		</div>
 	</div>
 
@@ -214,7 +214,7 @@
 
 	<div id="no-topic-<?php bbp_topic_id(); ?>" class="bbp-no-topic">
 		<div class="bbp-template-notice">
-			<p><?php is_user_logged_in() ? _e( 'You cannot create new topics at this time.', 'bbpress' ) : _e( 'You must be logged in to create new topics.', 'bbpress' ); ?></p>
+			<p><?php is_user_logged_in() ? esc_html_e( 'You cannot create new topics at this time.', 'bbpress' ) : esc_html_e( 'You must be logged in to create new topics.', 'bbpress' ); ?></p>
 		</div>
 	</div>
 

--- a/buddypress.org/public_html/wp-content/themes/bb-base/bbpress/form-topic.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/bbpress/form-topic.php
@@ -22,10 +22,10 @@
 					<?php
 						if ( bbp_is_topic_edit() )
 							/* translators: %s: Topic title. */
-							printf( esc_html__( 'Now Editing &ldquo;%s&rdquo;', 'bbpress' ), bbp_get_topic_title() );
+							printf( esc_html__( 'Now Editing &ldquo;%s&rdquo;', 'bbpress' ), esc_html( bbp_get_topic_title() ) );
 						else
 							/* translators: %s: Forum title. */
-							bbp_is_single_forum() ? printf( esc_html__( 'Create New Topic in &ldquo;%s&rdquo;', 'bbpress' ), bbp_get_forum_title() ) : esc_html_e( 'Create New Topic', 'bbpress' );
+							bbp_is_single_forum() ? printf( esc_html__( 'Create New Topic in &ldquo;%s&rdquo;', 'bbpress' ), esc_html( bbp_get_forum_title() ) ) : esc_html_e( 'Create New Topic', 'bbpress' );
 					?>
 
 				</legend>
@@ -68,7 +68,7 @@
 
 					<p>
 						<?php /* translators: %d: Maximum title length. */ ?>
-						<label for="bbp_topic_title"><?php printf( esc_html__( 'Topic Title (Maximum Length: %d):', 'bbpress' ), bbp_get_title_max_length() ); ?></label><br />
+						<label for="bbp_topic_title"><?php printf( esc_html__( 'Topic Title (Maximum Length: %d):', 'bbpress' ), (int) bbp_get_title_max_length() ); ?></label><br />
 						<input type="text" id="bbp_topic_title" value="<?php bbp_form_topic_title(); ?>" size="40" name="bbp_topic_title" maxlength="<?php bbp_title_max_length(); ?>" />
 					</p>
 
@@ -171,7 +171,7 @@
 							</legend>
 
 							<div>
-								<label for="bbp_topic_edit_reason"><?php printf( esc_html__( 'Optional reason for editing:', 'bbpress' ), bbp_get_current_user_name() ); ?></label><br />
+								<label for="bbp_topic_edit_reason"><?php printf( esc_html__( 'Optional reason for editing:', 'bbpress' ), esc_html( bbp_get_current_user_name() ) ); ?></label><br />
 								<input type="text" value="<?php bbp_form_topic_edit_reason(); ?>" size="40" name="bbp_topic_edit_reason" id="bbp_topic_edit_reason" />
 							</div>
 						</fieldset>
@@ -210,7 +210,7 @@
 	<div id="no-topic-<?php bbp_topic_id(); ?>" class="bbp-no-topic">
 		<div class="bbp-template-notice">
 			<?php /* translators: %s: Forum title. */ ?>
-			<p><?php printf( esc_html__( 'The forum &#8216;%s&#8217; is closed to new topics and replies.', 'bbpress' ), bbp_get_forum_title() ); ?></p>
+			<p><?php printf( esc_html__( 'The forum &#8216;%s&#8217; is closed to new topics and replies.', 'bbpress' ), esc_html( bbp_get_forum_title() ) ); ?></p>
 		</div>
 	</div>
 

--- a/buddypress.org/public_html/wp-content/themes/bb-base/bbpress/form-topic.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/bbpress/form-topic.php
@@ -21,8 +21,10 @@
 
 					<?php
 						if ( bbp_is_topic_edit() )
+							/* translators: %s: Topic title. */
 							printf( esc_html__( 'Now Editing &ldquo;%s&rdquo;', 'bbpress' ), bbp_get_topic_title() );
 						else
+							/* translators: %s: Forum title. */
 							bbp_is_single_forum() ? printf( esc_html__( 'Create New Topic in &ldquo;%s&rdquo;', 'bbpress' ), bbp_get_forum_title() ) : esc_html_e( 'Create New Topic', 'bbpress' );
 					?>
 
@@ -65,6 +67,7 @@
 					<?php do_action( 'bbp_theme_before_topic_form_title' ); ?>
 
 					<p>
+						<?php /* translators: %d: Maximum title length. */ ?>
 						<label for="bbp_topic_title"><?php printf( esc_html__( 'Topic Title (Maximum Length: %d):', 'bbpress' ), bbp_get_title_max_length() ); ?></label><br />
 						<input type="text" id="bbp_topic_title" value="<?php bbp_form_topic_title(); ?>" size="40" name="bbp_topic_title" maxlength="<?php bbp_title_max_length(); ?>" />
 					</p>
@@ -206,6 +209,7 @@
 
 	<div id="no-topic-<?php bbp_topic_id(); ?>" class="bbp-no-topic">
 		<div class="bbp-template-notice">
+			<?php /* translators: %s: Forum title. */ ?>
 			<p><?php printf( esc_html__( 'The forum &#8216;%s&#8217; is closed to new topics and replies.', 'bbpress' ), bbp_get_forum_title() ); ?></p>
 		</div>
 	</div>

--- a/buddypress.org/public_html/wp-content/themes/bb-base/bbpress/loop-forums.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/bbpress/loop-forums.php
@@ -5,8 +5,8 @@
 	<li class="bbp-header">
 
 		<ul class="forum-titles">
-			<li class="bbp-forum-info"><?php _e( 'Forum', 'bbpress' ); ?></li>
-			<li class="bbp-forum-reply-count"><?php _e( 'Posts', 'bbpress' ); ?></li>
+			<li class="bbp-forum-info"><?php esc_html_e( 'Forum', 'bbpress' ); ?></li>
+			<li class="bbp-forum-reply-count"><?php esc_html_e( 'Posts', 'bbpress' ); ?></li>
 		</ul>
 
 	</li><!-- .bbp-header -->

--- a/buddypress.org/public_html/wp-content/themes/bb-base/bbpress/loop-single-topic.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/bbpress/loop-single-topic.php
@@ -46,6 +46,7 @@
 
 			<?php do_action( 'bbp_theme_before_topic_started_by' ); ?>
 
+			<?php /* translators: %1$s: Topic author link. */ ?>
 			<span class="bbp-topic-started-by"><?php printf( esc_html__( 'Started by: %1$s', 'bbpress' ), bbp_get_topic_author_link( array( 'size' => '14' ) ) ); ?></span>
 
 			<?php do_action( 'bbp_theme_after_topic_started_by' ); ?>

--- a/buddypress.org/public_html/wp-content/themes/bb-base/bbpress/loop-single-topic.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/bbpress/loop-single-topic.php
@@ -47,7 +47,7 @@
 			<?php do_action( 'bbp_theme_before_topic_started_by' ); ?>
 
 			<?php /* translators: %1$s: Topic author link. */ ?>
-			<span class="bbp-topic-started-by"><?php printf( esc_html__( 'Started by: %1$s', 'bbpress' ), bbp_get_topic_author_link( array( 'size' => '14' ) ) ); ?></span>
+			<span class="bbp-topic-started-by"><?php printf( esc_html__( 'Started by: %1$s', 'bbpress' ), wp_kses_post( bbp_get_topic_author_link( array( 'size' => '14' ) ) ) ); ?></span>
 
 			<?php do_action( 'bbp_theme_after_topic_started_by' ); ?>
 

--- a/buddypress.org/public_html/wp-content/themes/bb-base/bbpress/loop-single-topic.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/bbpress/loop-single-topic.php
@@ -46,7 +46,7 @@
 
 			<?php do_action( 'bbp_theme_before_topic_started_by' ); ?>
 
-			<span class="bbp-topic-started-by"><?php printf( __( 'Started by: %1$s', 'bbpress' ), bbp_get_topic_author_link( array( 'size' => '14' ) ) ); ?></span>
+			<span class="bbp-topic-started-by"><?php printf( esc_html__( 'Started by: %1$s', 'bbpress' ), bbp_get_topic_author_link( array( 'size' => '14' ) ) ); ?></span>
 
 			<?php do_action( 'bbp_theme_after_topic_started_by' ); ?>
 

--- a/buddypress.org/public_html/wp-content/themes/bb-base/bbpress/loop-single-topic.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/bbpress/loop-single-topic.php
@@ -47,7 +47,7 @@
 			<?php do_action( 'bbp_theme_before_topic_started_by' ); ?>
 
 			<?php /* translators: %1$s: Topic author link. */ ?>
-			<span class="bbp-topic-started-by"><?php printf( esc_html__( 'Started by: %1$s', 'bbpress' ), wp_kses_post( bbp_get_topic_author_link( array( 'size' => '14' ) ) ) ); ?></span>
+			<span class="bbp-topic-started-by"><?php printf( esc_html__( 'Started by: %1$s', 'bbpress' ), bbp_get_topic_author_link( array( 'size' => '14' ) ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- bbPress builds this markup; wp_kses_post() would strip the avatar's srcset and decoding attributes. ?></span>
 
 			<?php do_action( 'bbp_theme_after_topic_started_by' ); ?>
 

--- a/buddypress.org/public_html/wp-content/themes/bb-base/buddypress/activity/index.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/buddypress/activity/index.php
@@ -52,7 +52,7 @@
 				<?php if ( bp_get_total_favorite_count_for_user( bp_loggedin_user_id() ) ) : ?>
 
 					<?php /* translators: %s: Favorite count. */ ?>
-					<li id="activity-favorites"><a href="<?php echo esc_url( bp_loggedin_user_domain() . bp_get_activity_slug() . '/favorites/' ); ?>" title="<?php esc_attr_e( "The activity I've marked as a favorite.", 'buddypress' ); ?>"><?php printf( wp_kses_post( __( 'My Favorites <span>%s</span>', 'buddypress' ) ), (int) bp_get_total_favorite_count_for_user( bp_loggedin_user_id() ) ); ?></a></li>
+					<li id="activity-favorites"><a href="<?php echo esc_url( bp_loggedin_user_domain() . bp_get_activity_slug() . '/favorites/' ); ?>" title="<?php esc_attr_e( 'The activity I&#8217;ve marked as a favorite.', 'buddypress' ); ?>"><?php printf( wp_kses_post( __( 'My Favorites <span>%s</span>', 'buddypress' ) ), (int) bp_get_total_favorite_count_for_user( bp_loggedin_user_id() ) ); ?></a></li>
 
 				<?php endif; ?>
 

--- a/buddypress.org/public_html/wp-content/themes/bb-base/buddypress/activity/index.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/buddypress/activity/index.php
@@ -16,6 +16,7 @@
 		<ul>
 			<?php do_action( 'bp_before_activity_type_tab_all' ); ?>
 
+			<?php /* translators: %s: Member count. */ ?>
 			<li class="selected" id="activity-all"><a href="<?php bp_activity_directory_permalink(); ?>" title="<?php esc_attr_e( 'The public activity for everyone on this site.', 'buddypress' ); ?>"><?php printf( wp_kses_post( __( 'All Members <span>%s</span>', 'buddypress' ) ), 'ms' ); ?></a></li>
 
 			<?php if ( is_user_logged_in() ) : ?>
@@ -26,6 +27,7 @@
 
 					<?php if ( bp_get_total_friend_count( bp_loggedin_user_id() ) ) : ?>
 
+						<?php /* translators: %s: Friend count. */ ?>
 						<li id="activity-friends"><a href="<?php echo bp_loggedin_user_domain() . bp_get_activity_slug() . '/' . bp_get_friends_slug() . '/'; ?>" title="<?php esc_attr_e( 'The activity of my friends only.', 'buddypress' ); ?>"><?php printf( wp_kses_post( __( 'My Friends <span>%s</span>', 'buddypress' ) ), bp_get_total_friend_count( bp_loggedin_user_id() ) ); ?></a></li>
 
 					<?php endif; ?>
@@ -38,6 +40,7 @@
 
 					<?php if ( bp_get_total_group_count_for_user( bp_loggedin_user_id() ) ) : ?>
 
+						<?php /* translators: %s: Group count. */ ?>
 						<li id="activity-groups"><a href="<?php echo bp_loggedin_user_domain() . bp_get_activity_slug() . '/' . bp_get_groups_slug() . '/'; ?>" title="<?php esc_attr_e( 'The activity of groups I am a member of.', 'buddypress' ); ?>"><?php printf( wp_kses_post( __( 'My Groups <span>%s</span>', 'buddypress' ) ), bp_get_total_group_count_for_user( bp_loggedin_user_id() ) ); ?></a></li>
 
 					<?php endif; ?>
@@ -48,6 +51,7 @@
 
 				<?php if ( bp_get_total_favorite_count_for_user( bp_loggedin_user_id() ) ) : ?>
 
+					<?php /* translators: %s: Favorite count. */ ?>
 					<li id="activity-favorites"><a href="<?php echo bp_loggedin_user_domain() . bp_get_activity_slug() . '/favorites/'; ?>" title="<?php esc_attr_e( "The activity I've marked as a favorite.", 'buddypress' ); ?>"><?php printf( wp_kses_post( __( 'My Favorites <span>%s</span>', 'buddypress' ) ), bp_get_total_favorite_count_for_user( bp_loggedin_user_id() ) ); ?></a></li>
 
 				<?php endif; ?>
@@ -58,6 +62,7 @@
 				<?php
 				if ( bp_get_total_mention_count_for_user( bp_loggedin_user_id() ) ) :
 					?>
+					<?php /* translators: %s: Number of new mentions. */ ?>
 					<strong><?php printf( wp_kses_post( __( '<span>%s new</span>', 'buddypress' ) ), bp_get_total_mention_count_for_user( bp_loggedin_user_id() ) ); ?></strong><?php endif; ?></a></li>
 
 			<?php endif; ?>

--- a/buddypress.org/public_html/wp-content/themes/bb-base/buddypress/activity/index.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/buddypress/activity/index.php
@@ -16,7 +16,7 @@
 		<ul>
 			<?php do_action( 'bp_before_activity_type_tab_all' ); ?>
 
-			<li class="selected" id="activity-all"><a href="<?php bp_activity_directory_permalink(); ?>" title="<?php esc_attr_e( 'The public activity for everyone on this site.', 'buddypress' ); ?>"><?php printf( /* translators: %s: Member count. */ wp_kses_post( __( 'All Members <span>%s</span>', 'buddypress' ) ), (int) bp_get_total_member_count() ); ?></a></li>
+			<li class="selected" id="activity-all"><a href="<?php bp_activity_directory_permalink(); ?>" title="<?php esc_attr_e( 'The public activity for everyone on this site.', 'buddypress' ); ?>"><?php printf( /* translators: %s: Member count. */ wp_kses_post( __( 'All Members <span>%s</span>', 'buddypress' ) ), esc_html( bp_get_total_member_count() ) ); ?></a></li>
 
 			<?php if ( is_user_logged_in() ) : ?>
 
@@ -26,7 +26,7 @@
 
 					<?php if ( bp_get_total_friend_count( bp_loggedin_user_id() ) ) : ?>
 
-						<li id="activity-friends"><a href="<?php echo esc_url( bp_loggedin_user_domain() . bp_get_activity_slug() . '/' . bp_get_friends_slug() . '/' ); ?>" title="<?php esc_attr_e( 'The activity of my friends only.', 'buddypress' ); ?>"><?php printf( /* translators: %s: Friend count. */ wp_kses_post( __( 'My Friends <span>%s</span>', 'buddypress' ) ), (int) bp_get_total_friend_count( bp_loggedin_user_id() ) ); ?></a></li>
+						<li id="activity-friends"><a href="<?php echo esc_url( bp_loggedin_user_domain() . bp_get_activity_slug() . '/' . bp_get_friends_slug() . '/' ); ?>" title="<?php esc_attr_e( 'The activity of my friends only.', 'buddypress' ); ?>"><?php printf( /* translators: %s: Friend count. */ wp_kses_post( __( 'My Friends <span>%s</span>', 'buddypress' ) ), esc_html( bp_get_total_friend_count( bp_loggedin_user_id() ) ) ); ?></a></li>
 
 					<?php endif; ?>
 
@@ -38,7 +38,7 @@
 
 					<?php if ( bp_get_total_group_count_for_user( bp_loggedin_user_id() ) ) : ?>
 
-						<li id="activity-groups"><a href="<?php echo esc_url( bp_loggedin_user_domain() . bp_get_activity_slug() . '/' . bp_get_groups_slug() . '/' ); ?>" title="<?php esc_attr_e( 'The activity of groups I am a member of.', 'buddypress' ); ?>"><?php printf( /* translators: %s: Group count. */ wp_kses_post( __( 'My Groups <span>%s</span>', 'buddypress' ) ), (int) bp_get_total_group_count_for_user( bp_loggedin_user_id() ) ); ?></a></li>
+						<li id="activity-groups"><a href="<?php echo esc_url( bp_loggedin_user_domain() . bp_get_activity_slug() . '/' . bp_get_groups_slug() . '/' ); ?>" title="<?php esc_attr_e( 'The activity of groups I am a member of.', 'buddypress' ); ?>"><?php printf( /* translators: %s: Group count. */ wp_kses_post( __( 'My Groups <span>%s</span>', 'buddypress' ) ), esc_html( bp_get_total_group_count_for_user( bp_loggedin_user_id() ) ) ); ?></a></li>
 
 					<?php endif; ?>
 
@@ -48,7 +48,7 @@
 
 				<?php if ( bp_get_total_favorite_count_for_user( bp_loggedin_user_id() ) ) : ?>
 
-					<li id="activity-favorites"><a href="<?php echo esc_url( bp_loggedin_user_domain() . bp_get_activity_slug() . '/favorites/' ); ?>" title="<?php esc_attr_e( 'The activity I&#8217;ve marked as a favorite.', 'buddypress' ); ?>"><?php printf( /* translators: %s: Favorite count. */ wp_kses_post( __( 'My Favorites <span>%s</span>', 'buddypress' ) ), (int) bp_get_total_favorite_count_for_user( bp_loggedin_user_id() ) ); ?></a></li>
+					<li id="activity-favorites"><a href="<?php echo esc_url( bp_loggedin_user_domain() . bp_get_activity_slug() . '/favorites/' ); ?>" title="<?php esc_attr_e( "The activity I've marked as a favorite.", 'buddypress' ); ?>"><?php printf( /* translators: %s: Favorite count. */ wp_kses_post( __( 'My Favorites <span>%s</span>', 'buddypress' ) ), esc_html( bp_get_total_favorite_count_for_user( bp_loggedin_user_id() ) ) ); ?></a></li>
 
 				<?php endif; ?>
 
@@ -59,7 +59,7 @@
 				if ( bp_get_total_mention_count_for_user( bp_loggedin_user_id() ) ) :
 					?>
 					<?php /* translators: %s: Number of new mentions. */ ?>
-					<strong><?php printf( wp_kses_post( __( '<span>%s new</span>', 'buddypress' ) ), (int) bp_get_total_mention_count_for_user( bp_loggedin_user_id() ) ); ?></strong><?php endif; ?></a></li>
+					<strong><?php printf( wp_kses_post( __( '<span>%s new</span>', 'buddypress' ) ), esc_html( bp_get_total_mention_count_for_user( bp_loggedin_user_id() ) ) ); ?></strong><?php endif; ?></a></li>
 
 			<?php endif; ?>
 

--- a/buddypress.org/public_html/wp-content/themes/bb-base/buddypress/activity/index.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/buddypress/activity/index.php
@@ -16,7 +16,7 @@
 		<ul>
 			<?php do_action( 'bp_before_activity_type_tab_all' ); ?>
 
-			<li class="selected" id="activity-all"><a href="<?php bp_activity_directory_permalink(); ?>" title="<?php esc_attr_e( 'The public activity for everyone on this site.', 'buddypress' ); ?>"><?php printf( __( 'All Members <span5%s</span>', 'buddypress' ), 'ms' ); ?></a></li>
+			<li class="selected" id="activity-all"><a href="<?php bp_activity_directory_permalink(); ?>" title="<?php esc_attr_e( 'The public activity for everyone on this site.', 'buddypress' ); ?>"><?php printf( wp_kses_post( __( 'All Members <span>%s</span>', 'buddypress' ) ), 'ms' ); ?></a></li>
 
 			<?php if ( is_user_logged_in() ) : ?>
 
@@ -26,7 +26,7 @@
 
 					<?php if ( bp_get_total_friend_count( bp_loggedin_user_id() ) ) : ?>
 
-						<li id="activity-friends"><a href="<?php echo bp_loggedin_user_domain() . bp_get_activity_slug() . '/' . bp_get_friends_slug() . '/'; ?>" title="<?php esc_attr_e( 'The activity of my friends only.', 'buddypress' ); ?>"><?php printf( __( 'My Friends <span>%s</span>', 'buddypress' ), bp_get_total_friend_count( bp_loggedin_user_id() ) ); ?></a></li>
+						<li id="activity-friends"><a href="<?php echo bp_loggedin_user_domain() . bp_get_activity_slug() . '/' . bp_get_friends_slug() . '/'; ?>" title="<?php esc_attr_e( 'The activity of my friends only.', 'buddypress' ); ?>"><?php printf( wp_kses_post( __( 'My Friends <span>%s</span>', 'buddypress' ) ), bp_get_total_friend_count( bp_loggedin_user_id() ) ); ?></a></li>
 
 					<?php endif; ?>
 
@@ -38,7 +38,7 @@
 
 					<?php if ( bp_get_total_group_count_for_user( bp_loggedin_user_id() ) ) : ?>
 
-						<li id="activity-groups"><a href="<?php echo bp_loggedin_user_domain() . bp_get_activity_slug() . '/' . bp_get_groups_slug() . '/'; ?>" title="<?php esc_attr_e( 'The activity of groups I am a member of.', 'buddypress' ); ?>"><?php printf( __( 'My Groups <span>%s</span>', 'buddypress' ), bp_get_total_group_count_for_user( bp_loggedin_user_id() ) ); ?></a></li>
+						<li id="activity-groups"><a href="<?php echo bp_loggedin_user_domain() . bp_get_activity_slug() . '/' . bp_get_groups_slug() . '/'; ?>" title="<?php esc_attr_e( 'The activity of groups I am a member of.', 'buddypress' ); ?>"><?php printf( wp_kses_post( __( 'My Groups <span>%s</span>', 'buddypress' ) ), bp_get_total_group_count_for_user( bp_loggedin_user_id() ) ); ?></a></li>
 
 					<?php endif; ?>
 
@@ -48,13 +48,17 @@
 
 				<?php if ( bp_get_total_favorite_count_for_user( bp_loggedin_user_id() ) ) : ?>
 
-					<li id="activity-favorites"><a href="<?php echo bp_loggedin_user_domain() . bp_get_activity_slug() . '/favorites/'; ?>" title="<?php esc_attr_e( "The activity I've marked as a favorite.", 'buddypress' ); ?>"><?php printf( __( 'My Favorites <span>%s</span>', 'buddypress' ), bp_get_total_favorite_count_for_user( bp_loggedin_user_id() ) ); ?></a></li>
+					<li id="activity-favorites"><a href="<?php echo bp_loggedin_user_domain() . bp_get_activity_slug() . '/favorites/'; ?>" title="<?php esc_attr_e( "The activity I've marked as a favorite.", 'buddypress' ); ?>"><?php printf( wp_kses_post( __( 'My Favorites <span>%s</span>', 'buddypress' ) ), bp_get_total_favorite_count_for_user( bp_loggedin_user_id() ) ); ?></a></li>
 
 				<?php endif; ?>
 
 				<?php do_action( 'bp_before_activity_type_tab_mentions' ); ?>
 
-				<li id="activity-mentions"><a href="<?php echo bp_loggedin_user_domain() . bp_get_activity_slug() . '/mentions/'; ?>" title="<?php esc_attr_e( 'Activity that I have been mentioned in.', 'buddypress' ); ?>"><?php _e( 'Mentions', 'buddypress' ); ?><?php if ( bp_get_total_mention_count_for_user( bp_loggedin_user_id() ) ) : ?> <strong><?php printf( __( '<span>%s new</span>', 'buddypress' ), bp_get_total_mention_count_for_user( bp_loggedin_user_id() ) ); ?></strong><?php endif; ?></a></li>
+				<li id="activity-mentions"><a href="<?php echo bp_loggedin_user_domain() . bp_get_activity_slug() . '/mentions/'; ?>" title="<?php esc_attr_e( 'Activity that I have been mentioned in.', 'buddypress' ); ?>"><?php esc_html_e( 'Mentions', 'buddypress' ); ?>
+				<?php
+				if ( bp_get_total_mention_count_for_user( bp_loggedin_user_id() ) ) :
+					?>
+					<strong><?php printf( wp_kses_post( __( '<span>%s new</span>', 'buddypress' ) ), bp_get_total_mention_count_for_user( bp_loggedin_user_id() ) ); ?></strong><?php endif; ?></a></li>
 
 			<?php endif; ?>
 
@@ -64,44 +68,44 @@
 
 	<div class="item-list-tabs no-ajax" id="subnav" role="navigation">
 		<ul>
-			<li class="feed"><a href="<?php bp_sitewide_activity_feed_link(); ?>" title="<?php esc_attr_e( 'RSS Feed', 'buddypress' ); ?>"><?php _e( 'RSS', 'buddypress' ); ?></a></li>
+			<li class="feed"><a href="<?php bp_sitewide_activity_feed_link(); ?>" title="<?php esc_attr_e( 'RSS Feed', 'buddypress' ); ?>"><?php esc_html_e( 'RSS', 'buddypress' ); ?></a></li>
 
 			<?php do_action( 'bp_activity_syndication_options' ); ?>
 
 			<li id="activity-filter-select" class="last">
-				<label for="activity-filter-by"><?php _e( 'Show:', 'buddypress' ); ?></label>
+				<label for="activity-filter-by"><?php esc_html_e( 'Show:', 'buddypress' ); ?></label>
 				<select id="activity-filter-by">
-					<option value="-1"><?php _e( 'Everything', 'buddypress' ); ?></option>
-					<option value="activity_update"><?php _e( 'Updates', 'buddypress' ); ?></option>
+					<option value="-1"><?php esc_html_e( 'Everything', 'buddypress' ); ?></option>
+					<option value="activity_update"><?php esc_html_e( 'Updates', 'buddypress' ); ?></option>
 
 					<?php if ( bp_is_active( 'blogs' ) ) : ?>
 
-						<option value="new_blog_post"><?php _e( 'Posts', 'buddypress' ); ?></option>
-						<option value="new_blog_comment"><?php _e( 'Comments', 'buddypress' ); ?></option>
+						<option value="new_blog_post"><?php esc_html_e( 'Posts', 'buddypress' ); ?></option>
+						<option value="new_blog_comment"><?php esc_html_e( 'Comments', 'buddypress' ); ?></option>
 
 					<?php endif; ?>
 
 					<?php if ( bp_is_active( 'forums' ) ) : ?>
 
-						<option value="new_forum_topic"><?php _e( 'Forum Topics', 'buddypress' ); ?></option>
-						<option value="new_forum_post"><?php _e( 'Forum Replies', 'buddypress' ); ?></option>
+						<option value="new_forum_topic"><?php esc_html_e( 'Forum Topics', 'buddypress' ); ?></option>
+						<option value="new_forum_post"><?php esc_html_e( 'Forum Replies', 'buddypress' ); ?></option>
 
 					<?php endif; ?>
 
 					<?php if ( bp_is_active( 'groups' ) ) : ?>
 
-						<option value="created_group"><?php _e( 'New Groups', 'buddypress' ); ?></option>
-						<option value="joined_group"><?php _e( 'Group Memberships', 'buddypress' ); ?></option>
+						<option value="created_group"><?php esc_html_e( 'New Groups', 'buddypress' ); ?></option>
+						<option value="joined_group"><?php esc_html_e( 'Group Memberships', 'buddypress' ); ?></option>
 
 					<?php endif; ?>
 
 					<?php if ( bp_is_active( 'friends' ) ) : ?>
 
-						<option value="friendship_accepted,friendship_created"><?php _e( 'Friendships', 'buddypress' ); ?></option>
+						<option value="friendship_accepted,friendship_created"><?php esc_html_e( 'Friendships', 'buddypress' ); ?></option>
 
 					<?php endif; ?>
 
-					<option value="new_member"><?php _e( 'New Members', 'buddypress' ); ?></option>
+					<option value="new_member"><?php esc_html_e( 'New Members', 'buddypress' ); ?></option>
 
 					<?php do_action( 'bp_activity_filter_options' ); ?>
 

--- a/buddypress.org/public_html/wp-content/themes/bb-base/buddypress/activity/index.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/buddypress/activity/index.php
@@ -28,7 +28,7 @@
 					<?php if ( bp_get_total_friend_count( bp_loggedin_user_id() ) ) : ?>
 
 						<?php /* translators: %s: Friend count. */ ?>
-						<li id="activity-friends"><a href="<?php echo bp_loggedin_user_domain() . bp_get_activity_slug() . '/' . bp_get_friends_slug() . '/'; ?>" title="<?php esc_attr_e( 'The activity of my friends only.', 'buddypress' ); ?>"><?php printf( wp_kses_post( __( 'My Friends <span>%s</span>', 'buddypress' ) ), bp_get_total_friend_count( bp_loggedin_user_id() ) ); ?></a></li>
+						<li id="activity-friends"><a href="<?php echo esc_url( bp_loggedin_user_domain() . bp_get_activity_slug() . '/' . bp_get_friends_slug() . '/' ); ?>" title="<?php esc_attr_e( 'The activity of my friends only.', 'buddypress' ); ?>"><?php printf( wp_kses_post( __( 'My Friends <span>%s</span>', 'buddypress' ) ), (int) bp_get_total_friend_count( bp_loggedin_user_id() ) ); ?></a></li>
 
 					<?php endif; ?>
 
@@ -41,7 +41,7 @@
 					<?php if ( bp_get_total_group_count_for_user( bp_loggedin_user_id() ) ) : ?>
 
 						<?php /* translators: %s: Group count. */ ?>
-						<li id="activity-groups"><a href="<?php echo bp_loggedin_user_domain() . bp_get_activity_slug() . '/' . bp_get_groups_slug() . '/'; ?>" title="<?php esc_attr_e( 'The activity of groups I am a member of.', 'buddypress' ); ?>"><?php printf( wp_kses_post( __( 'My Groups <span>%s</span>', 'buddypress' ) ), bp_get_total_group_count_for_user( bp_loggedin_user_id() ) ); ?></a></li>
+						<li id="activity-groups"><a href="<?php echo esc_url( bp_loggedin_user_domain() . bp_get_activity_slug() . '/' . bp_get_groups_slug() . '/' ); ?>" title="<?php esc_attr_e( 'The activity of groups I am a member of.', 'buddypress' ); ?>"><?php printf( wp_kses_post( __( 'My Groups <span>%s</span>', 'buddypress' ) ), (int) bp_get_total_group_count_for_user( bp_loggedin_user_id() ) ); ?></a></li>
 
 					<?php endif; ?>
 
@@ -52,18 +52,18 @@
 				<?php if ( bp_get_total_favorite_count_for_user( bp_loggedin_user_id() ) ) : ?>
 
 					<?php /* translators: %s: Favorite count. */ ?>
-					<li id="activity-favorites"><a href="<?php echo bp_loggedin_user_domain() . bp_get_activity_slug() . '/favorites/'; ?>" title="<?php esc_attr_e( "The activity I've marked as a favorite.", 'buddypress' ); ?>"><?php printf( wp_kses_post( __( 'My Favorites <span>%s</span>', 'buddypress' ) ), bp_get_total_favorite_count_for_user( bp_loggedin_user_id() ) ); ?></a></li>
+					<li id="activity-favorites"><a href="<?php echo esc_url( bp_loggedin_user_domain() . bp_get_activity_slug() . '/favorites/' ); ?>" title="<?php esc_attr_e( "The activity I've marked as a favorite.", 'buddypress' ); ?>"><?php printf( wp_kses_post( __( 'My Favorites <span>%s</span>', 'buddypress' ) ), (int) bp_get_total_favorite_count_for_user( bp_loggedin_user_id() ) ); ?></a></li>
 
 				<?php endif; ?>
 
 				<?php do_action( 'bp_before_activity_type_tab_mentions' ); ?>
 
-				<li id="activity-mentions"><a href="<?php echo bp_loggedin_user_domain() . bp_get_activity_slug() . '/mentions/'; ?>" title="<?php esc_attr_e( 'Activity that I have been mentioned in.', 'buddypress' ); ?>"><?php esc_html_e( 'Mentions', 'buddypress' ); ?>
+				<li id="activity-mentions"><a href="<?php echo esc_url( bp_loggedin_user_domain() . bp_get_activity_slug() . '/mentions/' ); ?>" title="<?php esc_attr_e( 'Activity that I have been mentioned in.', 'buddypress' ); ?>"><?php esc_html_e( 'Mentions', 'buddypress' ); ?>
 				<?php
 				if ( bp_get_total_mention_count_for_user( bp_loggedin_user_id() ) ) :
 					?>
 					<?php /* translators: %s: Number of new mentions. */ ?>
-					<strong><?php printf( wp_kses_post( __( '<span>%s new</span>', 'buddypress' ) ), bp_get_total_mention_count_for_user( bp_loggedin_user_id() ) ); ?></strong><?php endif; ?></a></li>
+					<strong><?php printf( wp_kses_post( __( '<span>%s new</span>', 'buddypress' ) ), (int) bp_get_total_mention_count_for_user( bp_loggedin_user_id() ) ); ?></strong><?php endif; ?></a></li>
 
 			<?php endif; ?>
 

--- a/buddypress.org/public_html/wp-content/themes/bb-base/buddypress/activity/index.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/buddypress/activity/index.php
@@ -16,8 +16,7 @@
 		<ul>
 			<?php do_action( 'bp_before_activity_type_tab_all' ); ?>
 
-			<?php /* translators: %s: Member count. */ ?>
-			<li class="selected" id="activity-all"><a href="<?php bp_activity_directory_permalink(); ?>" title="<?php esc_attr_e( 'The public activity for everyone on this site.', 'buddypress' ); ?>"><?php printf( wp_kses_post( __( 'All Members <span>%s</span>', 'buddypress' ) ), 'ms' ); ?></a></li>
+			<li class="selected" id="activity-all"><a href="<?php bp_activity_directory_permalink(); ?>" title="<?php esc_attr_e( 'The public activity for everyone on this site.', 'buddypress' ); ?>"><?php printf( /* translators: %s: Member count. */ wp_kses_post( __( 'All Members <span>%s</span>', 'buddypress' ) ), (int) bp_get_total_member_count() ); ?></a></li>
 
 			<?php if ( is_user_logged_in() ) : ?>
 
@@ -27,8 +26,7 @@
 
 					<?php if ( bp_get_total_friend_count( bp_loggedin_user_id() ) ) : ?>
 
-						<?php /* translators: %s: Friend count. */ ?>
-						<li id="activity-friends"><a href="<?php echo esc_url( bp_loggedin_user_domain() . bp_get_activity_slug() . '/' . bp_get_friends_slug() . '/' ); ?>" title="<?php esc_attr_e( 'The activity of my friends only.', 'buddypress' ); ?>"><?php printf( wp_kses_post( __( 'My Friends <span>%s</span>', 'buddypress' ) ), (int) bp_get_total_friend_count( bp_loggedin_user_id() ) ); ?></a></li>
+						<li id="activity-friends"><a href="<?php echo esc_url( bp_loggedin_user_domain() . bp_get_activity_slug() . '/' . bp_get_friends_slug() . '/' ); ?>" title="<?php esc_attr_e( 'The activity of my friends only.', 'buddypress' ); ?>"><?php printf( /* translators: %s: Friend count. */ wp_kses_post( __( 'My Friends <span>%s</span>', 'buddypress' ) ), (int) bp_get_total_friend_count( bp_loggedin_user_id() ) ); ?></a></li>
 
 					<?php endif; ?>
 
@@ -40,8 +38,7 @@
 
 					<?php if ( bp_get_total_group_count_for_user( bp_loggedin_user_id() ) ) : ?>
 
-						<?php /* translators: %s: Group count. */ ?>
-						<li id="activity-groups"><a href="<?php echo esc_url( bp_loggedin_user_domain() . bp_get_activity_slug() . '/' . bp_get_groups_slug() . '/' ); ?>" title="<?php esc_attr_e( 'The activity of groups I am a member of.', 'buddypress' ); ?>"><?php printf( wp_kses_post( __( 'My Groups <span>%s</span>', 'buddypress' ) ), (int) bp_get_total_group_count_for_user( bp_loggedin_user_id() ) ); ?></a></li>
+						<li id="activity-groups"><a href="<?php echo esc_url( bp_loggedin_user_domain() . bp_get_activity_slug() . '/' . bp_get_groups_slug() . '/' ); ?>" title="<?php esc_attr_e( 'The activity of groups I am a member of.', 'buddypress' ); ?>"><?php printf( /* translators: %s: Group count. */ wp_kses_post( __( 'My Groups <span>%s</span>', 'buddypress' ) ), (int) bp_get_total_group_count_for_user( bp_loggedin_user_id() ) ); ?></a></li>
 
 					<?php endif; ?>
 
@@ -51,8 +48,7 @@
 
 				<?php if ( bp_get_total_favorite_count_for_user( bp_loggedin_user_id() ) ) : ?>
 
-					<?php /* translators: %s: Favorite count. */ ?>
-					<li id="activity-favorites"><a href="<?php echo esc_url( bp_loggedin_user_domain() . bp_get_activity_slug() . '/favorites/' ); ?>" title="<?php esc_attr_e( 'The activity I&#8217;ve marked as a favorite.', 'buddypress' ); ?>"><?php printf( wp_kses_post( __( 'My Favorites <span>%s</span>', 'buddypress' ) ), (int) bp_get_total_favorite_count_for_user( bp_loggedin_user_id() ) ); ?></a></li>
+					<li id="activity-favorites"><a href="<?php echo esc_url( bp_loggedin_user_domain() . bp_get_activity_slug() . '/favorites/' ); ?>" title="<?php esc_attr_e( 'The activity I&#8217;ve marked as a favorite.', 'buddypress' ); ?>"><?php printf( /* translators: %s: Favorite count. */ wp_kses_post( __( 'My Favorites <span>%s</span>', 'buddypress' ) ), (int) bp_get_total_favorite_count_for_user( bp_loggedin_user_id() ) ); ?></a></li>
 
 				<?php endif; ?>
 

--- a/buddypress.org/public_html/wp-content/themes/bb-base/buddypress/members/single/profile/edit.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/buddypress/members/single/profile/edit.php
@@ -7,7 +7,7 @@ if ( bp_has_profile( 'profile_group_id=' . bp_get_current_profile_group_id() ) )
 
 	<?php do_action( 'bp_before_profile_field_content' ); ?>
 
-		<h4><?php printf( __( "Editing '%s' Profile Group", "buddypress" ), bp_get_the_profile_group_name() ); ?></h4>
+		<h4><?php printf( esc_html__( "Editing '%s' Profile Group", 'buddypress' ), bp_get_the_profile_group_name() ); ?></h4>
 
 		<ul class="button-nav">
 
@@ -23,21 +23,21 @@ if ( bp_has_profile( 'profile_group_id=' . bp_get_current_profile_group_id() ) )
 
 				<?php if ( 'textbox' == bp_get_the_profile_field_type() ) : ?>
 
-					<label for="<?php bp_the_profile_field_input_name(); ?>"><?php bp_the_profile_field_name(); ?> <?php if ( bp_get_the_profile_field_is_required() ) : ?><?php _e( '(required)', 'buddypress' ); ?><?php endif; ?></label>
+					<label for="<?php bp_the_profile_field_input_name(); ?>"><?php bp_the_profile_field_name(); ?> <?php if ( bp_get_the_profile_field_is_required() ) : ?><?php esc_html_e( '(required)', 'buddypress' ); ?><?php endif; ?></label>
 					<input type="text" name="<?php bp_the_profile_field_input_name(); ?>" id="<?php bp_the_profile_field_input_name(); ?>" value="<?php bp_the_profile_field_edit_value(); ?>" <?php if ( bp_get_the_profile_field_is_required() ) : ?>aria-required="true"<?php endif; ?>/>
 
 				<?php endif; ?>
 
 				<?php if ( 'textarea' == bp_get_the_profile_field_type() ) : ?>
 
-					<label for="<?php bp_the_profile_field_input_name(); ?>"><?php bp_the_profile_field_name(); ?> <?php if ( bp_get_the_profile_field_is_required() ) : ?><?php _e( '(required)', 'buddypress' ); ?><?php endif; ?></label>
+					<label for="<?php bp_the_profile_field_input_name(); ?>"><?php bp_the_profile_field_name(); ?> <?php if ( bp_get_the_profile_field_is_required() ) : ?><?php esc_html_e( '(required)', 'buddypress' ); ?><?php endif; ?></label>
 					<textarea rows="5" cols="40" name="<?php bp_the_profile_field_input_name(); ?>" id="<?php bp_the_profile_field_input_name(); ?>" <?php if ( bp_get_the_profile_field_is_required() ) : ?>aria-required="true"<?php endif; ?>><?php bp_the_profile_field_edit_value(); ?></textarea>
 
 				<?php endif; ?>
 
 				<?php if ( 'selectbox' == bp_get_the_profile_field_type() ) : ?>
 
-					<label for="<?php bp_the_profile_field_input_name(); ?>"><?php bp_the_profile_field_name(); ?> <?php if ( bp_get_the_profile_field_is_required() ) : ?><?php _e( '(required)', 'buddypress' ); ?><?php endif; ?></label>
+					<label for="<?php bp_the_profile_field_input_name(); ?>"><?php bp_the_profile_field_name(); ?> <?php if ( bp_get_the_profile_field_is_required() ) : ?><?php esc_html_e( '(required)', 'buddypress' ); ?><?php endif; ?></label>
 					<select name="<?php bp_the_profile_field_input_name(); ?>" id="<?php bp_the_profile_field_input_name(); ?>" <?php if ( bp_get_the_profile_field_is_required() ) : ?>aria-required="true"<?php endif; ?>>
 						<?php bp_the_profile_field_options(); ?>
 					</select>
@@ -46,7 +46,7 @@ if ( bp_has_profile( 'profile_group_id=' . bp_get_current_profile_group_id() ) )
 
 				<?php if ( 'multiselectbox' == bp_get_the_profile_field_type() ) : ?>
 
-					<label for="<?php bp_the_profile_field_input_name(); ?>"><?php bp_the_profile_field_name(); ?> <?php if ( bp_get_the_profile_field_is_required() ) : ?><?php _e( '(required)', 'buddypress' ); ?><?php endif; ?></label>
+					<label for="<?php bp_the_profile_field_input_name(); ?>"><?php bp_the_profile_field_name(); ?> <?php if ( bp_get_the_profile_field_is_required() ) : ?><?php esc_html_e( '(required)', 'buddypress' ); ?><?php endif; ?></label>
 					<select name="<?php bp_the_profile_field_input_name(); ?>" id="<?php bp_the_profile_field_input_name(); ?>" multiple="multiple" <?php if ( bp_get_the_profile_field_is_required() ) : ?>aria-required="true"<?php endif; ?>>
 
 						<?php bp_the_profile_field_options(); ?>
@@ -55,7 +55,7 @@ if ( bp_has_profile( 'profile_group_id=' . bp_get_current_profile_group_id() ) )
 
 					<?php if ( !bp_get_the_profile_field_is_required() ) : ?>
 
-						<a class="clear-value" href="javascript:clear( '<?php bp_the_profile_field_input_name(); ?>' );"><?php _e( 'Clear', 'buddypress' ); ?></a>
+						<a class="clear-value" href="javascript:clear( '<?php bp_the_profile_field_input_name(); ?>' );"><?php esc_html_e( 'Clear', 'buddypress' ); ?></a>
 
 					<?php endif; ?>
 
@@ -64,13 +64,17 @@ if ( bp_has_profile( 'profile_group_id=' . bp_get_current_profile_group_id() ) )
 				<?php if ( 'radio' == bp_get_the_profile_field_type() ) : ?>
 
 					<div class="radio">
-						<span class="label"><?php bp_the_profile_field_name(); ?> <?php if ( bp_get_the_profile_field_is_required() ) : ?><?php _e( '(required)', 'buddypress' ); ?><?php endif; ?></span>
+						<span class="label"><?php bp_the_profile_field_name(); ?>
+						<?php
+						if ( bp_get_the_profile_field_is_required() ) :
+							?>
+							<?php esc_html_e( '(required)', 'buddypress' ); ?><?php endif; ?></span>
 
 						<?php bp_the_profile_field_options(); ?>
 
 						<?php if ( !bp_get_the_profile_field_is_required() ) : ?>
 
-							<a class="clear-value" href="javascript:clear( '<?php bp_the_profile_field_input_name(); ?>' );"><?php _e( 'Clear', 'buddypress' ); ?></a>
+							<a class="clear-value" href="javascript:clear( '<?php bp_the_profile_field_input_name(); ?>' );"><?php esc_html_e( 'Clear', 'buddypress' ); ?></a>
 
 						<?php endif; ?>
 					</div>
@@ -80,7 +84,11 @@ if ( bp_has_profile( 'profile_group_id=' . bp_get_current_profile_group_id() ) )
 				<?php if ( 'checkbox' == bp_get_the_profile_field_type() ) : ?>
 
 					<div class="checkbox">
-						<span class="label"><?php bp_the_profile_field_name(); ?> <?php if ( bp_get_the_profile_field_is_required() ) : ?><?php _e( '(required)', 'buddypress' ); ?><?php endif; ?></span>
+						<span class="label"><?php bp_the_profile_field_name(); ?>
+						<?php
+						if ( bp_get_the_profile_field_is_required() ) :
+							?>
+							<?php esc_html_e( '(required)', 'buddypress' ); ?><?php endif; ?></span>
 
 						<?php bp_the_profile_field_options(); ?>
 					</div>
@@ -90,7 +98,11 @@ if ( bp_has_profile( 'profile_group_id=' . bp_get_current_profile_group_id() ) )
 				<?php if ( 'datebox' == bp_get_the_profile_field_type() ) : ?>
 
 					<div class="datebox">
-						<label for="<?php bp_the_profile_field_input_name(); ?>_day"><?php bp_the_profile_field_name(); ?> <?php if ( bp_get_the_profile_field_is_required() ) : ?><?php _e( '(required)', 'buddypress' ); ?><?php endif; ?></label>
+						<label for="<?php bp_the_profile_field_input_name(); ?>_day"><?php bp_the_profile_field_name(); ?>
+						<?php
+						if ( bp_get_the_profile_field_is_required() ) :
+							?>
+							<?php esc_html_e( '(required)', 'buddypress' ); ?><?php endif; ?></label>
 
 						<select name="<?php bp_the_profile_field_input_name(); ?>_day" id="<?php bp_the_profile_field_input_name(); ?>_day" <?php if ( bp_get_the_profile_field_is_required() ) : ?>aria-required="true"<?php endif; ?>>
 
@@ -123,7 +135,7 @@ if ( bp_has_profile( 'profile_group_id=' . bp_get_current_profile_group_id() ) )
 	<?php do_action( 'bp_after_profile_field_content' ); ?>
 
 	<div class="submit">
-		<input type="submit" name="profile-group-edit-submit" id="profile-group-edit-submit" value="<?php _e( 'Save Changes', 'buddypress' ); ?> " />
+		<input type="submit" name="profile-group-edit-submit" id="profile-group-edit-submit" value="<?php esc_attr_e( 'Save Changes', 'buddypress' ); ?> " />
 	</div>
 
 	<input type="hidden" name="field_ids" id="field_ids" value="<?php bp_the_profile_group_field_ids(); ?>" />

--- a/buddypress.org/public_html/wp-content/themes/bb-base/buddypress/members/single/profile/edit.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/buddypress/members/single/profile/edit.php
@@ -8,7 +8,7 @@ if ( bp_has_profile( 'profile_group_id=' . bp_get_current_profile_group_id() ) )
 	<?php do_action( 'bp_before_profile_field_content' ); ?>
 
 		<?php /* translators: %s: Profile group name. */ ?>
-		<h4><?php printf( esc_html__( "Editing '%s' Profile Group", 'buddypress' ), bp_get_the_profile_group_name() ); ?></h4>
+		<h4><?php printf( esc_html__( "Editing '%s' Profile Group", 'buddypress' ), esc_html( bp_get_the_profile_group_name() ) ); ?></h4>
 
 		<ul class="button-nav">
 
@@ -24,21 +24,21 @@ if ( bp_has_profile( 'profile_group_id=' . bp_get_current_profile_group_id() ) )
 
 				<?php if ( 'textbox' == bp_get_the_profile_field_type() ) : ?>
 
-					<label for="<?php bp_the_profile_field_input_name(); ?>"><?php bp_the_profile_field_name(); ?> <?php if ( bp_get_the_profile_field_is_required() ) : ?><?php esc_html_e( '(required)', 'buddypress' ); ?><?php endif; ?></label>
+					<label for="<?php bp_the_profile_field_input_name(); ?>"><?php bp_the_profile_field_name(); ?> <?php echo bp_get_the_profile_field_is_required() ? esc_html__( '(required)', 'buddypress' ) : ''; ?></label>
 					<input type="text" name="<?php bp_the_profile_field_input_name(); ?>" id="<?php bp_the_profile_field_input_name(); ?>" value="<?php bp_the_profile_field_edit_value(); ?>" <?php if ( bp_get_the_profile_field_is_required() ) : ?>aria-required="true"<?php endif; ?>/>
 
 				<?php endif; ?>
 
 				<?php if ( 'textarea' == bp_get_the_profile_field_type() ) : ?>
 
-					<label for="<?php bp_the_profile_field_input_name(); ?>"><?php bp_the_profile_field_name(); ?> <?php if ( bp_get_the_profile_field_is_required() ) : ?><?php esc_html_e( '(required)', 'buddypress' ); ?><?php endif; ?></label>
+					<label for="<?php bp_the_profile_field_input_name(); ?>"><?php bp_the_profile_field_name(); ?> <?php echo bp_get_the_profile_field_is_required() ? esc_html__( '(required)', 'buddypress' ) : ''; ?></label>
 					<textarea rows="5" cols="40" name="<?php bp_the_profile_field_input_name(); ?>" id="<?php bp_the_profile_field_input_name(); ?>" <?php if ( bp_get_the_profile_field_is_required() ) : ?>aria-required="true"<?php endif; ?>><?php bp_the_profile_field_edit_value(); ?></textarea>
 
 				<?php endif; ?>
 
 				<?php if ( 'selectbox' == bp_get_the_profile_field_type() ) : ?>
 
-					<label for="<?php bp_the_profile_field_input_name(); ?>"><?php bp_the_profile_field_name(); ?> <?php if ( bp_get_the_profile_field_is_required() ) : ?><?php esc_html_e( '(required)', 'buddypress' ); ?><?php endif; ?></label>
+					<label for="<?php bp_the_profile_field_input_name(); ?>"><?php bp_the_profile_field_name(); ?> <?php echo bp_get_the_profile_field_is_required() ? esc_html__( '(required)', 'buddypress' ) : ''; ?></label>
 					<select name="<?php bp_the_profile_field_input_name(); ?>" id="<?php bp_the_profile_field_input_name(); ?>" <?php if ( bp_get_the_profile_field_is_required() ) : ?>aria-required="true"<?php endif; ?>>
 						<?php bp_the_profile_field_options(); ?>
 					</select>
@@ -47,7 +47,7 @@ if ( bp_has_profile( 'profile_group_id=' . bp_get_current_profile_group_id() ) )
 
 				<?php if ( 'multiselectbox' == bp_get_the_profile_field_type() ) : ?>
 
-					<label for="<?php bp_the_profile_field_input_name(); ?>"><?php bp_the_profile_field_name(); ?> <?php if ( bp_get_the_profile_field_is_required() ) : ?><?php esc_html_e( '(required)', 'buddypress' ); ?><?php endif; ?></label>
+					<label for="<?php bp_the_profile_field_input_name(); ?>"><?php bp_the_profile_field_name(); ?> <?php echo bp_get_the_profile_field_is_required() ? esc_html__( '(required)', 'buddypress' ) : ''; ?></label>
 					<select name="<?php bp_the_profile_field_input_name(); ?>" id="<?php bp_the_profile_field_input_name(); ?>" multiple="multiple" <?php if ( bp_get_the_profile_field_is_required() ) : ?>aria-required="true"<?php endif; ?>>
 
 						<?php bp_the_profile_field_options(); ?>

--- a/buddypress.org/public_html/wp-content/themes/bb-base/buddypress/members/single/profile/edit.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/buddypress/members/single/profile/edit.php
@@ -7,6 +7,7 @@ if ( bp_has_profile( 'profile_group_id=' . bp_get_current_profile_group_id() ) )
 
 	<?php do_action( 'bp_before_profile_field_content' ); ?>
 
+		<?php /* translators: %s: Profile group name. */ ?>
 		<h4><?php printf( esc_html__( "Editing '%s' Profile Group", 'buddypress' ), bp_get_the_profile_group_name() ); ?></h4>
 
 		<ul class="button-nav">

--- a/buddypress.org/public_html/wp-content/themes/bb-base/footer.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/footer.php
@@ -2,7 +2,7 @@
 /**
  * The template for displaying the footer.
  *
- * @package bb-base
+ * @package bbPress
  */
 
 ?>

--- a/buddypress.org/public_html/wp-content/themes/bb-base/footer.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/footer.php
@@ -5,20 +5,20 @@
 		<div id="footer"><div id="footer-inner">
 			<div class="links">
 				<p>
-					<a href="https://wordpress.org"><?php _e( 'WordPress.org', 'bbporg'); ?></a>
-					<a href="https://bbpress.org"><?php _e( 'bbPress.org', 'bbporg'); ?></a>
-					<a href="https://buddypress.org"><?php _e( 'BuddyPress.org', 'bbporg'); ?></a>
-					<a href="https://ma.tt"><?php _e( 'Matt', 'bbporg' ); ?></a>
-					<a href="<?php bloginfo( 'rss2_url' ); ?>" title="<?php esc_attr_e( 'RSS Feed for Articles', 'bbporg' ); ?>"><?php _e( 'Blog RSS', 'bbporg' ); ?></a>
+					<a href="https://wordpress.org"><?php esc_html_e( 'WordPress.org', 'bbporg' ); ?></a>
+					<a href="https://bbpress.org"><?php esc_html_e( 'bbPress.org', 'bbporg' ); ?></a>
+					<a href="https://buddypress.org"><?php esc_html_e( 'BuddyPress.org', 'bbporg' ); ?></a>
+					<a href="https://ma.tt"><?php esc_html_e( 'Matt', 'bbporg' ); ?></a>
+					<a href="<?php bloginfo( 'rss2_url' ); ?>" title="<?php esc_attr_e( 'RSS Feed for Articles', 'bbporg' ); ?>"><?php esc_html_e( 'Blog RSS', 'bbporg' ); ?></a>
 				</p>
 			</div>
 			<div class="details">
 				<p>
-					<a href="https://bbpress.org/about/gpl/"><?php _e('GPL', 'bbporg'); ?></a>
-					<a href="https://bbpress.org/contact/"><?php _e('Contact Us', 'bbporg'); ?></a>
-					<a href="https://wordpress.org/about/privacy/"><?php _e('Privacy', 'bbporg'); ?></a>
-					<a href="https://bbpress.org/terms/"><?php _e('Terms of Service', 'bbporg'); ?></a>
-					<a href="https://x.com/bbpress"><?php _e( 'X', 'bbporg'); ?></a>
+					<a href="https://bbpress.org/about/gpl/"><?php esc_html_e( 'GPL', 'bbporg' ); ?></a>
+					<a href="https://bbpress.org/contact/"><?php esc_html_e( 'Contact Us', 'bbporg' ); ?></a>
+					<a href="https://wordpress.org/about/privacy/"><?php esc_html_e( 'Privacy', 'bbporg' ); ?></a>
+					<a href="https://bbpress.org/terms/"><?php esc_html_e( 'Terms of Service', 'bbporg' ); ?></a>
+					<a href="https://x.com/bbpress"><?php esc_html_e( 'X', 'bbporg' ); ?></a>
 				</p>
 			</div>
 		</div></div>

--- a/buddypress.org/public_html/wp-content/themes/bb-base/footer.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/footer.php
@@ -2,7 +2,7 @@
 /**
  * The template for displaying the footer.
  *
- * @package bbPress
+ * @package bb-base
  */
 
 ?>

--- a/buddypress.org/public_html/wp-content/themes/bb-base/footer.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/footer.php
@@ -1,3 +1,11 @@
+<?php
+/**
+ * The template for displaying the footer.
+ *
+ * @package bb-base
+ */
+
+?>
 			</div>
 		</div>
 		<hr class="hidden" />

--- a/buddypress.org/public_html/wp-content/themes/bb-base/functions.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/functions.php
@@ -212,7 +212,7 @@ function bb_base_single_topic_description() {
 	<?php if ( !empty( $time_since  ) ) : ?>
 		<li class="topic-freshness-time"><?php
 			/* translators: %s: date/time link to the latest post */
-			printf( esc_html__( 'About %s', 'bborg' ), esc_html( $time_since ) );
+			printf( esc_html__( 'About %s', 'bborg' ), wp_kses_post( $time_since ) );
 		?></li>
 	<?php endif; ?>
 	<?php if ( is_user_logged_in() ) : ?>
@@ -289,7 +289,7 @@ function bb_base_single_forum_description() {
 	<?php if ( !empty( $time_since  ) ) : ?>
 		<li class="forum-freshness-time"><?php
 			/* translators: %s: date/time link to the latest post */
-			printf( esc_html__( 'About %s', 'bborg' ), esc_html( $time_since ) );
+			printf( esc_html__( 'About %s', 'bborg' ), wp_kses_post( $time_since ) );
 		?></li>
 	<?php endif; ?>
 	<?php if ( is_user_logged_in() ) : ?>

--- a/buddypress.org/public_html/wp-content/themes/bb-base/functions.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/functions.php
@@ -176,11 +176,13 @@ function bb_base_single_topic_description() {
 	?>
 
 	<li class="topic-forum"><?php
-		/* translators: %s: forum title */
-		printf( esc_html__( 'In: %s', 'bborg' ),
-			sprintf( '<a href="%s">%s</a>',
+		printf(
+			/* translators: %s: forum title */
+			esc_html__( 'In: %s', 'bborg' ),
+			sprintf(
+				'<a href="%s">%s</a>',
 				esc_url( bbp_get_forum_permalink( bbp_get_topic_forum_id() ) ),
-				bbp_get_topic_forum_title()
+				esc_html( bbp_get_topic_forum_title() )
 			)
 		);
 	?></li>
@@ -192,16 +194,25 @@ function bb_base_single_topic_description() {
 	<?php endif; ?>
 	<?php if ( !empty( $last_reply  ) ) : ?>
 		<li class="topic-freshness-author"><?php
-			/* translators: %s: reply author link */
-			printf( esc_html__( 'Last voice: %s', 'bborg' ),
-				bbp_get_author_link( array( 'type' => 'name', 'post_id' => $last_reply, 'size' => '15' ) )
+			printf(
+				/* translators: %s: reply author link */
+				esc_html__( 'Last voice: %s', 'bborg' ),
+				wp_kses_post(
+					bbp_get_author_link(
+						array(
+							'type'    => 'name',
+							'post_id' => $last_reply,
+							'size'    => '15',
+						)
+					)
+				)
 			);
 		?></li>
 	<?php endif; ?>
 	<?php if ( !empty( $time_since  ) ) : ?>
 		<li class="topic-freshness-time"><?php
 			/* translators: %s: date/time link to the latest post */
-			printf( esc_html__( 'About %s', 'bborg' ), $time_since );
+			printf( esc_html__( 'About %s', 'bborg' ), esc_html( $time_since ) );
 		?></li>
 	<?php endif; ?>
 	<?php if ( is_user_logged_in() ) : ?>
@@ -242,11 +253,13 @@ function bb_base_single_forum_description() {
 
 	<?php if ( bbp_get_forum_parent_id() ) : ?>
 		<li class="topic-parent"><?php
-			/* translators: %s: forum title */
-			printf( esc_html__( 'In: %s', 'bborg' ),
-				sprintf( '<a href="%s">%s</a>',
+			printf(
+				/* translators: %s: forum title */
+				esc_html__( 'In: %s', 'bborg' ),
+				sprintf(
+					'<a href="%s">%s</a>',
 					esc_url( bbp_get_forum_permalink( bbp_get_forum_parent_id() ) ),
-					bbp_get_forum_title( bbp_get_forum_parent_id() )
+					esc_html( bbp_get_forum_title( bbp_get_forum_parent_id() ) )
 				)
 			);
 		?></li>
@@ -259,16 +272,24 @@ function bb_base_single_forum_description() {
 	<?php endif; ?>
 	<?php if ( !empty( $last_active  ) ) : ?>
 		<li class="forum-freshness-author"><?php
-			/* translators: %s: post author link */
-			printf( esc_html__( 'Last voice: %s', 'bborg' ),
-				bbp_get_author_link( array( 'type' => 'name', 'post_id' => $last_active ) )
+			printf(
+				/* translators: %s: post author link */
+				esc_html__( 'Last voice: %s', 'bborg' ),
+				wp_kses_post(
+					bbp_get_author_link(
+						array(
+							'type'    => 'name',
+							'post_id' => $last_active,
+						)
+					)
+				)
 			);
 		?></li>
 	<?php endif; ?>
 	<?php if ( !empty( $time_since  ) ) : ?>
 		<li class="forum-freshness-time"><?php
 			/* translators: %s: date/time link to the latest post */
-			printf( esc_html__( 'About %s', 'bborg' ), $time_since );
+			printf( esc_html__( 'About %s', 'bborg' ), esc_html( $time_since ) );
 		?></li>
 	<?php endif; ?>
 	<?php if ( is_user_logged_in() ) : ?>

--- a/buddypress.org/public_html/wp-content/themes/bb-base/functions.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/functions.php
@@ -177,7 +177,7 @@ function bb_base_single_topic_description() {
 
 	<li class="topic-forum"><?php
 		printf(
-			/* translators: %s: forum title */
+			/* translators: %s: Forum title. */
 			esc_html__( 'In: %s', 'bborg' ),
 			sprintf(
 				'<a href="%s">%s</a>',
@@ -195,7 +195,7 @@ function bb_base_single_topic_description() {
 	<?php if ( !empty( $last_reply  ) ) : ?>
 		<li class="topic-freshness-author"><?php
 			printf(
-				/* translators: %s: reply author link */
+				/* translators: %s: Reply author link. */
 				esc_html__( 'Last voice: %s', 'bborg' ),
 				wp_kses_post(
 					bbp_get_author_link(
@@ -254,7 +254,7 @@ function bb_base_single_forum_description() {
 	<?php if ( bbp_get_forum_parent_id() ) : ?>
 		<li class="topic-parent"><?php
 			printf(
-				/* translators: %s: forum title */
+				/* translators: %s: Forum title. */
 				esc_html__( 'In: %s', 'bborg' ),
 				sprintf(
 					'<a href="%s">%s</a>',
@@ -273,7 +273,7 @@ function bb_base_single_forum_description() {
 	<?php if ( !empty( $last_active  ) ) : ?>
 		<li class="forum-freshness-author"><?php
 			printf(
-				/* translators: %s: post author link */
+				/* translators: %s: Post author link. */
 				esc_html__( 'Last voice: %s', 'bborg' ),
 				wp_kses_post(
 					bbp_get_author_link(

--- a/buddypress.org/public_html/wp-content/themes/bb-base/functions.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/functions.php
@@ -77,8 +77,8 @@ function bb_base_topic_search_form() {
 
 	<form role="search" method="get" id="searchform" action="">
 		<div>
-			<h2><?php _e( 'Forum Search', 'bborg'); ?></h2>
-			<label class="screen-reader-text hidden" for="ts"><?php _e( 'Search for:', 'bborg' ); ?></label>
+			<h2><?php esc_html_e( 'Forum Search', 'bborg' ); ?></h2>
+			<label class="screen-reader-text hidden" for="ts"><?php esc_html_e( 'Search for:', 'bborg' ); ?></label>
 			<input type="text" value="<?php echo bb_base_topic_search_query(); ?>" name="ts" id="ts" placeholder="<?php esc_attr_e( 'Search', 'bborg' ); ?>" />
 		</div>
 	</form>
@@ -91,8 +91,8 @@ function bb_base_reply_search_form() {
 
 	<form role="search" method="get" id="searchform" action="">
 		<div>
-			<h2><?php _e( 'Reply Search', 'bborg'); ?></h2>
-			<label class="screen-reader-text hidden" for="rs"><?php _e( 'Search for:', 'bborg' ); ?></label>
+			<h2><?php esc_html_e( 'Reply Search', 'bborg' ); ?></h2>
+			<label class="screen-reader-text hidden" for="rs"><?php esc_html_e( 'Search for:', 'bborg' ); ?></label>
 			<input type="text" value="<?php echo bb_base_reply_search_query(); ?>" name="rs" id="rs" placeholder="<?php esc_attr_e( 'Search', 'bborg' ); ?>" />
 		</div>
 	</form>
@@ -105,8 +105,8 @@ function bb_base_plugin_search_form() {
 
 	<form role="search" method="get" id="searchform" action="">
 		<div>
-			<h2><?php _e( 'Plugin Search', 'bborg'); ?></h2>
-			<label class="screen-reader-text hidden" for="ps"><?php _e( 'Search for:', 'bborg' ); ?></label>
+			<h2><?php esc_html_e( 'Plugin Search', 'bborg' ); ?></h2>
+			<label class="screen-reader-text hidden" for="ps"><?php esc_html_e( 'Search for:', 'bborg' ); ?></label>
 			<input type="text" value="<?php echo bb_base_plugin_search_query(); ?>" name="ps" id="ts" placeholder="<?php esc_attr_e( 'Search', 'bborg' ); ?>" />
 		</div>
 	</form>
@@ -177,7 +177,7 @@ function bb_base_single_topic_description() {
 
 	<li class="topic-forum"><?php
 		/* translators: %s: forum title */
-		printf( __( 'In: %s', 'bborg' ),
+		printf( esc_html__( 'In: %s', 'bborg' ),
 			sprintf( '<a href="%s">%s</a>',
 				esc_url( bbp_get_forum_permalink( bbp_get_topic_forum_id() ) ),
 				bbp_get_topic_forum_title()
@@ -193,7 +193,7 @@ function bb_base_single_topic_description() {
 	<?php if ( !empty( $last_reply  ) ) : ?>
 		<li class="topic-freshness-author"><?php
 			/* translators: %s: reply author link */
-			printf( __( 'Last voice: %s', 'bborg' ),
+			printf( esc_html__( 'Last voice: %s', 'bborg' ),
 				bbp_get_author_link( array( 'type' => 'name', 'post_id' => $last_reply, 'size' => '15' ) )
 			);
 		?></li>
@@ -201,7 +201,7 @@ function bb_base_single_topic_description() {
 	<?php if ( !empty( $time_since  ) ) : ?>
 		<li class="topic-freshness-time"><?php
 			/* translators: %s: date/time link to the latest post */
-			printf( __( 'About %s', 'bborg' ), $time_since );
+			printf( esc_html__( 'About %s', 'bborg' ), $time_since );
 		?></li>
 	<?php endif; ?>
 	<?php if ( is_user_logged_in() ) : ?>
@@ -243,7 +243,7 @@ function bb_base_single_forum_description() {
 	<?php if ( bbp_get_forum_parent_id() ) : ?>
 		<li class="topic-parent"><?php
 			/* translators: %s: forum title */
-			printf( __( 'In: %s', 'bborg' ),
+			printf( esc_html__( 'In: %s', 'bborg' ),
 				sprintf( '<a href="%s">%s</a>',
 					esc_url( bbp_get_forum_permalink( bbp_get_forum_parent_id() ) ),
 					bbp_get_forum_title( bbp_get_forum_parent_id() )
@@ -260,7 +260,7 @@ function bb_base_single_forum_description() {
 	<?php if ( !empty( $last_active  ) ) : ?>
 		<li class="forum-freshness-author"><?php
 			/* translators: %s: post author link */
-			printf( __( 'Last voice: %s', 'bborg' ),
+			printf( esc_html__( 'Last voice: %s', 'bborg' ),
 				bbp_get_author_link( array( 'type' => 'name', 'post_id' => $last_active ) )
 			);
 		?></li>
@@ -268,7 +268,7 @@ function bb_base_single_forum_description() {
 	<?php if ( !empty( $time_since  ) ) : ?>
 		<li class="forum-freshness-time"><?php
 			/* translators: %s: date/time link to the latest post */
-			printf( __( 'About %s', 'bborg' ), $time_since );
+			printf( esc_html__( 'About %s', 'bborg' ), $time_since );
 		?></li>
 	<?php endif; ?>
 	<?php if ( is_user_logged_in() ) : ?>

--- a/buddypress.org/public_html/wp-content/themes/bb-base/header-accessibility.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/header-accessibility.php
@@ -2,7 +2,7 @@
 /**
  * Skip links shown at the top of every page.
  *
- * @package bbPress
+ * @package bb-base
  */
 
 ?>

--- a/buddypress.org/public_html/wp-content/themes/bb-base/header-accessibility.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/header-accessibility.php
@@ -1,18 +1,18 @@
 	<dl id="accessibility">
 		<dt>Skip to:</dt>
-		<dd><a href="#content" title="Skip to content"><?php _e( 'Content', 'bborg' ); ?></a></dd>
-		<dd><a href="#pages" title="Skip to pages"><?php _e( 'Pages', 'bborg' ); ?></a></dd>
-		<dd><a href="#categories" title="Skip to categories"><?php _e( 'Categories', 'bborg' ); ?></a></dd>
-		<dd><a href="#search" title="Skip to search"><?php _e( 'Search', 'bborg' ); ?></a></dd>
+		<dd><a href="#content" title="Skip to content"><?php esc_html_e( 'Content', 'bborg' ); ?></a></dd>
+		<dd><a href="#pages" title="Skip to pages"><?php esc_html_e( 'Pages', 'bborg' ); ?></a></dd>
+		<dd><a href="#categories" title="Skip to categories"><?php esc_html_e( 'Categories', 'bborg' ); ?></a></dd>
+		<dd><a href="#search" title="Skip to search"><?php esc_html_e( 'Search', 'bborg' ); ?></a></dd>
 <?php if ( ( is_page() || is_single() || is_attachment() ) && comments_open() ) : ?>
-		<dd class="separator"><a href="#comments" title="Skip to comments"><?php _e( 'Comments', 'bborg' ); ?></a></dd>
-		<dd><a href="#commentform" title="Skip to comment form"><?php _e( 'Respond', 'bborg' ); ?></a></dd>
+		<dd class="separator"><a href="#comments" title="Skip to comments"><?php esc_html_e( 'Comments', 'bborg' ); ?></a></dd>
+		<dd><a href="#commentform" title="Skip to comment form"><?php esc_html_e( 'Respond', 'bborg' ); ?></a></dd>
 <?php endif; ?>
-		<dd class="separator"><a href="#top" title="Skip to top"><?php _e( 'Top', 'bborg' ); ?></a></dd>
+		<dd class="separator"><a href="#top" title="Skip to top"><?php esc_html_e( 'Top', 'bborg' ); ?></a></dd>
 <?php if ( is_category() || is_post_type_archive( 'post' ) || is_singular( 'post' ) ) : ?>
 		<?php previous_post_link( "\t\t\t\t<dd>%link</dd>\n", __( 'Previous Post', 'bbporg' ) ); ?>
 		<?php next_post_link( "\t\t\t\t<dd>%link</dd>\n", __( 'Next Post', 'bbporg' ) ); ?>
 <?php endif; ?>
-		<dd><a href="#bottom" title="Skip to bottom"><?php _e( 'Bottom', 'bborg' ); ?></a></dd>
+		<dd><a href="#bottom" title="Skip to bottom"><?php esc_html_e( 'Bottom', 'bborg' ); ?></a></dd>
 	</dl>
 	<hr class="hidden" />

--- a/buddypress.org/public_html/wp-content/themes/bb-base/header-accessibility.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/header-accessibility.php
@@ -1,3 +1,11 @@
+<?php
+/**
+ * Skip links shown at the top of every page.
+ *
+ * @package bb-base
+ */
+
+?>
 	<dl id="accessibility">
 		<dt>Skip to:</dt>
 		<dd><a href="#content" title="Skip to content"><?php esc_html_e( 'Content', 'bborg' ); ?></a></dd>

--- a/buddypress.org/public_html/wp-content/themes/bb-base/header-accessibility.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/header-accessibility.php
@@ -2,7 +2,7 @@
 /**
  * Skip links shown at the top of every page.
  *
- * @package bb-base
+ * @package bbPress
  */
 
 ?>

--- a/buddypress.org/public_html/wp-content/themes/bb-base/image.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/image.php
@@ -14,13 +14,13 @@ if ( have_posts() ) :
 			<dd>
 				<?php
 				/* translators: 1: Date; 2: time. */
-				printf( esc_html__( '%1$s at %2$s' ), get_the_time( 'l, F jS, Y' ), get_the_time() );
+				printf( esc_html__( '%1$s at %2$s' ), esc_html( get_the_time( 'l, F jS, Y' ) ), esc_html( get_the_time() ) );
 				?>
 			</dd>
 			<dd>
 				<?php
 				/* translators: author posts link */
-				printf( wp_kses_post( __( 'by <cite>%s</cite>', 'bborg' ) ), get_the_author_posts_link() );
+				printf( wp_kses_post( __( 'by <cite>%s</cite>', 'bborg' ) ), wp_kses_post( get_the_author_posts_link() ) );
 				?>
 			</dd>
 			<?php the_tags( "\t\t\t\t\t<dt>" . esc_html__( 'Tagged as', 'bborg' ) . "</dt>\n\t\t\t\t\t<dd>", "</dd>\t\t\t\t\t<dd>", "</dd>\n" ); ?>

--- a/buddypress.org/public_html/wp-content/themes/bb-base/image.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/image.php
@@ -14,13 +14,13 @@ if ( have_posts() ) :
 			<dd>
 				<?php
 				/* translators: 1: Date; 2: time. */
-				printf( __( '%1$s at %2$s' ), get_the_time( 'l, F jS, Y' ), get_the_time() );
+				printf( esc_html__( '%1$s at %2$s' ), get_the_time( 'l, F jS, Y' ), get_the_time() );
 				?>
 			</dd>
 			<dd>
 				<?php
 				/* translators: author posts link */
-				printf( __( 'by <cite>%s</cite>', 'bborg' ), get_the_author_posts_link() );
+				printf( wp_kses_post( __( 'by <cite>%s</cite>', 'bborg' ) ), get_the_author_posts_link() );
 				?>
 			</dd>
 			<?php the_tags( "\t\t\t\t\t<dt>" . esc_html__( 'Tagged as', 'bborg' ) . "</dt>\n\t\t\t\t\t<dd>", "</dd>\t\t\t\t\t<dd>", "</dd>\n" ); ?>
@@ -34,7 +34,7 @@ if ( have_posts() ) :
 			<dd><a href="<?php trackback_url(); ?>" rel="trackback"><?php esc_html_e( 'your own site', 'bbporg' ); ?></a></dd>
 			<?php endif;
 				if ( 'open' == $post->comment_status ) :
-					_e( '<dt>Respond if</dt><dd><a href="#respond">you&#8217;d like to leave feedback</a></dd>', 'bbporg' );
+					echo wp_kses_post( __( '<dt>Respond if</dt><dd><a href="#respond">you&#8217;d like to leave feedback</a></dd>', 'bbporg' ) );
 				endif;
 				edit_post_link( esc_html__( 'Edit', 'bbporg' ), "\t\t\t\t\t<dt>" . esc_html__( 'You can', 'bborg' ) . "</dt>\n\t\t\t\t\t<dd>", "</dd>\n");
 			?>

--- a/buddypress.org/public_html/wp-content/themes/bb-base/index.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/index.php
@@ -7,12 +7,11 @@ if ( have_posts() ) :
 		<h2 id="post-<?php the_ID(); ?>"><a href="<?php the_permalink() ?>" rel="bookmark"><?php the_title(); ?></a></h2>
 		<cite>
 			<?php
-			/* translators: 1: post date, 2: post author */
 			printf(
 				/* translators: 1: Publication date, 2: Author link. */
 				esc_html__( 'Published on %1$s by %2$s', 'bborg' ),
-				get_the_time( 'F jS, Y' ),
-				get_the_author_link()
+				esc_html( get_the_time( 'F jS, Y' ) ),
+				wp_kses_post( get_the_author_link() )
 			);
 			?>
 		</cite>

--- a/buddypress.org/public_html/wp-content/themes/bb-base/index.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/index.php
@@ -8,7 +8,8 @@ if ( have_posts() ) :
 		<cite>
 			<?php
 			/* translators: 1: post date, 2: post author */
-			printf( __( 'Published on %1$s by %2$s', 'bborg' ),
+			printf(
+				esc_html__( 'Published on %1$s by %2$s', 'bborg' ),
 				get_the_time( 'F jS, Y' ),
 				get_the_author_link()
 			);
@@ -31,7 +32,7 @@ if ( have_posts() ) :
 	endif;
 else :
 	?>
-	<p><em><?php _e( 'Sorry, no posts matched your criteria.', 'bborg' ); ?></em></p>
+	<p><em><?php esc_html_e( 'Sorry, no posts matched your criteria.', 'bborg' ); ?></em></p>
 	<?php
 endif;
 ?>

--- a/buddypress.org/public_html/wp-content/themes/bb-base/index.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/index.php
@@ -9,6 +9,7 @@ if ( have_posts() ) :
 			<?php
 			/* translators: 1: post date, 2: post author */
 			printf(
+				/* translators: 1: Publication date, 2: Author link. */
 				esc_html__( 'Published on %1$s by %2$s', 'bborg' ),
 				get_the_time( 'F jS, Y' ),
 				get_the_author_link()

--- a/buddypress.org/public_html/wp-content/themes/bb-base/page-homepage.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/page-homepage.php
@@ -4,7 +4,7 @@ Template Name: Homepage
 */
 get_header(); ?>
 
-<h2 id="post-home"><?php _e( 'Recent Topics', 'bbporg' ); ?></h2>
+<h2 id="post-home"><?php esc_html_e( 'Recent Topics', 'bbporg' ); ?></h2>
 
 <?php if ( function_exists( 'is_bbpress' )  ) : ?>
 <div id="bbpress-forums">

--- a/buddypress.org/public_html/wp-content/themes/bb-base/sidebar.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/sidebar.php
@@ -6,7 +6,7 @@
 		<?php if ( bbp_is_single_forum() || bb_base_topic_search_query( false ) ) : ?>
 
 			<div>
-				<h2><?php _e( 'Forum Info', 'bbporg'); ?></h2>
+				<h2><?php esc_html_e( 'Forum Info', 'bbporg' ); ?></h2>
 				<ul class="forum-info">
 					<?php bb_base_single_forum_description(); ?>
 				</ul>
@@ -15,7 +15,7 @@
 			<?php bb_base_topic_search_form(); ?>
 
 			<div>
-				<h2><?php _e( 'Forum Feeds', 'bbporg'); ?></h2>
+				<h2><?php esc_html_e( 'Forum Feeds', 'bbporg' ); ?></h2>
 				<ul>
 					<li><a class="feed" href="<?php bbp_forum_permalink(); ?>feed/" title="<?php esc_attr_e( 'Forum Posts', 'bborg' ); ?>"><?php esc_html_e( 'Recent Posts', 'bborg' ); ?></a></li>
 					<li><a class="feed" href="<?php bbp_forum_permalink(); ?>feed/?type=topic" title="<?php esc_attr_e( 'Forum Topics', 'bborg' ); ?>"><?php esc_html_e( 'Recent Topics', 'bborg' ); ?></a></li>
@@ -25,7 +25,7 @@
 		<?php elseif ( bbp_is_single_topic() || bbp_is_topic_edit() || bbp_is_reply_edit() ) : ?>
 
 			<div>
-				<h2><?php _e( 'Topic Info', 'bbporg'); ?></h2>
+				<h2><?php esc_html_e( 'Topic Info', 'bbporg' ); ?></h2>
 				<ul class="topic-info">
 					<?php bb_base_single_topic_description(); ?>
 				</ul>
@@ -58,13 +58,13 @@
 		<?php else : ?>
 
 			<div>
-				<h2><?php _e( 'Forums', 'bbporg'); ?></h2>
+				<h2><?php esc_html_e( 'Forums', 'bbporg' ); ?></h2>
 				<?php echo do_shortcode( '[bbp-forum-index]' ); ?>
 			</div>
 			<hr class="hidden" />
 
 			<div>
-				<h2><?php _e( 'Views', 'bbporg'); ?></h2>
+				<h2><?php esc_html_e( 'Views', 'bbporg' ); ?></h2>
 				<ul>
 
 					<?php foreach ( bbp_get_views() as $view => $args ) : ?>
@@ -77,7 +77,7 @@
 			</div>
 
 			<div>
-				<h2><?php _e( 'Feeds', 'bbporg'); ?></h2>
+				<h2><?php esc_html_e( 'Feeds', 'bbporg' ); ?></h2>
 				<ul>
 					<li><a class="feed" href="<?php bbp_forums_url(); ?>feed/" title="<?php esc_attr_e( 'All Recent Posts', 'bborg' ); ?>"><?php esc_html_e( 'All Recent Posts', 'bborg' ); ?></a></li>
 					<li><a class="feed" href="<?php bbp_topics_url(); ?>feed/" title="<?php esc_attr_e( 'All Recent Topics', 'bborg' ); ?>"><?php esc_html_e( 'All Recent Topics', 'bborg' ); ?></a></li>
@@ -85,7 +85,7 @@
 			</div>
 
 			<div class="bbp-topic-tag-cloud">
-				<h2><?php _e( 'Tags', 'bbporg'); ?></h2>
+				<h2><?php esc_html_e( 'Tags', 'bbporg' ); ?></h2>
 				<?php echo do_shortcode( '[bbp-topic-tags]' ); ?>
 			</div>
 
@@ -94,29 +94,29 @@
 	<?php elseif ( is_front_page() || is_404() ) : ?>
 
 		<div class="feature">
-			<h2><?php _e('WordPress', 'bbporg'); ?></h2>
+			<h2><?php esc_html_e( 'WordPress', 'bbporg' ); ?></h2>
 			<p><a href="https://wordpress.org"><img width="78" height="58" alt="" src="<?php echo esc_url( get_template_directory_uri() . '/images/wordpress.gif' ); ?>"/></a><?php esc_html_e( 'The world&#8217;s most powerful web publishing software.', 'bborg' ); ?></p>
 		</div>
 		<div class="feature">
-			<h2><?php _e('bbPress', 'bbporg'); ?></h2>
+			<h2><?php esc_html_e( 'bbPress', 'bbporg' ); ?></h2>
 			<p><a href="https://bbpress.org"><img width="78" height="58" alt="" src="<?php echo esc_url( get_template_directory_uri() . '/images/bbpress.gif' ); ?>"/></a><?php esc_html_e( 'Simple and elegant forum software from the creators of WordPress.', 'bborg' ); ?></p>
 		</div>
 		<div style="margin-right: 0pt;" class="feature">
-			<h2><?php _e('BuddyPress', 'bbporg'); ?></h2>
+			<h2><?php esc_html_e( 'BuddyPress', 'bbporg' ); ?></h2>
 			<p><a href="https://buddypress.org"><img width="78" height="58" alt="" src="<?php echo esc_url( get_template_directory_uri() . '/images/buddypress.gif' ); ?>"/></a><?php esc_html_e( 'Create a fully featured niche social-network with a few easy clicks.', 'bborg' ); ?></p>
 		</div>
 
 	<?php elseif ( ( ! is_page( 'login' ) && ! is_page( 'register' ) && ! is_page( 'lost-password' ) ) || is_home() || is_singular( 'post' ) || is_archive() ) : ?>
 
 		<div>
-			<h2><?php _e( 'Categories', 'bbporg'); ?></h2>
+			<h2><?php esc_html_e( 'Categories', 'bbporg' ); ?></h2>
 			<ul>
 				<?php wp_list_categories( array( 'title_li' => false ) ); ?>
 			</ul>
 		</div>
 
 		<div>
-			<h2><?php _e( 'Tags', 'bbporg'); ?></h2>
+			<h2><?php esc_html_e( 'Tags', 'bbporg' ); ?></h2>
 			<?php wp_tag_cloud(); ?>
 		</div>
 

--- a/buddypress.org/public_html/wp-content/themes/bb-base/single.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/single.php
@@ -4,6 +4,7 @@
 	<cite><?php
 		/* translators: 1: post date, 2: post author */
 		printf(
+			/* translators: 1: Publication date, 2: Author link. */
 			esc_html__( 'Published on %1$s by %2$s', 'bborg' ),
 			get_the_time( 'F jS, Y' ),
 			get_the_author_link()

--- a/buddypress.org/public_html/wp-content/themes/bb-base/single.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/single.php
@@ -3,7 +3,8 @@
 	<h2 id="post-<?php the_ID(); ?>"><?php the_title(); ?></h2>
 	<cite><?php
 		/* translators: 1: post date, 2: post author */
-		printf( __( 'Published on %1$s by %2$s', 'bborg' ),
+		printf(
+			esc_html__( 'Published on %1$s by %2$s', 'bborg' ),
 			get_the_time( 'F jS, Y' ),
 			get_the_author_link()
 		);
@@ -16,7 +17,7 @@
 
 <?php endwhile; else : ?>
 
-	<p><em><?php _e( 'Sorry, no posts matched your criteria.', 'bborg' ); ?></em></p>
+	<p><em><?php esc_html_e( 'Sorry, no posts matched your criteria.', 'bborg' ); ?></em></p>
 
 <?php endif; ?>
 <?php get_sidebar(); get_footer(); ?>

--- a/buddypress.org/public_html/wp-content/themes/bb-base/single.php
+++ b/buddypress.org/public_html/wp-content/themes/bb-base/single.php
@@ -2,12 +2,11 @@
 <?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
 	<h2 id="post-<?php the_ID(); ?>"><?php the_title(); ?></h2>
 	<cite><?php
-		/* translators: 1: post date, 2: post author */
 		printf(
 			/* translators: 1: Publication date, 2: Author link. */
 			esc_html__( 'Published on %1$s by %2$s', 'bborg' ),
-			get_the_time( 'F jS, Y' ),
-			get_the_author_link()
+			esc_html( get_the_time( 'F jS, Y' ) ),
+			wp_kses_post( get_the_author_link() )
 		);
 	?></cite>
 	<div class="single-post" id="post-<?php the_ID(); ?>"><?php the_content( __( 'Read more &rarr;', 'bborg' ) ); ?></div>

--- a/buddypress.org/public_html/wp-content/themes/bbpress-org/bbpress/form-topic.php
+++ b/buddypress.org/public_html/wp-content/themes/bbpress-org/bbpress/form-topic.php
@@ -22,10 +22,10 @@
 					<?php
 						if ( bbp_is_topic_edit() )
 							/* translators: %s: Topic title. */
-							printf( esc_html__( 'Now Editing &ldquo;%s&rdquo;', 'bbpress' ), bbp_get_topic_title() );
+							printf( esc_html__( 'Now Editing &ldquo;%s&rdquo;', 'bbpress' ), esc_html( bbp_get_topic_title() ) );
 						else
 							/* translators: %s: Forum title. */
-							bbp_is_single_forum() ? printf( esc_html__( 'Create New Topic in &ldquo;%s&rdquo;', 'bbpress' ), bbp_get_forum_title() ) : esc_html_e( 'Create New Topic', 'bbpress' );
+							bbp_is_single_forum() ? printf( esc_html__( 'Create New Topic in &ldquo;%s&rdquo;', 'bbpress' ), esc_html( bbp_get_forum_title() ) ) : esc_html_e( 'Create New Topic', 'bbpress' );
 					?>
 
 				</legend>
@@ -69,7 +69,7 @@
 
 					<p>
 						<?php /* translators: %d: Maximum title length. */ ?>
-						<label for="bbp_topic_title"><?php printf( esc_html__( 'Topic Title (Maximum Length: %d):', 'bbpress' ), bbp_get_title_max_length() ); ?></label><br />
+						<label for="bbp_topic_title"><?php printf( esc_html__( 'Topic Title (Maximum Length: %d):', 'bbpress' ), (int) bbp_get_title_max_length() ); ?></label><br />
 						<input type="text" id="bbp_topic_title" value="<?php bbp_form_topic_title(); ?>" size="40" name="bbp_topic_title" maxlength="<?php bbp_title_max_length(); ?>" />
 					</p>
 
@@ -172,7 +172,7 @@
 							</legend>
 
 							<div>
-								<label for="bbp_topic_edit_reason"><?php printf( esc_html__( 'Optional reason for editing:', 'bbpress' ), bbp_get_current_user_name() ); ?></label><br />
+								<label for="bbp_topic_edit_reason"><?php printf( esc_html__( 'Optional reason for editing:', 'bbpress' ), esc_html( bbp_get_current_user_name() ) ); ?></label><br />
 								<input type="text" value="<?php bbp_form_topic_edit_reason(); ?>" size="40" name="bbp_topic_edit_reason" id="bbp_topic_edit_reason" />
 							</div>
 						</fieldset>
@@ -211,7 +211,7 @@
 	<div id="no-topic-<?php bbp_topic_id(); ?>" class="bbp-no-topic">
 		<div class="bbp-template-notice">
 			<?php /* translators: %s: Forum title. */ ?>
-			<p><?php printf( esc_html__( 'The forum &#8216;%s&#8217; is closed to new topics and replies.', 'bbpress' ), bbp_get_forum_title() ); ?></p>
+			<p><?php printf( esc_html__( 'The forum &#8216;%s&#8217; is closed to new topics and replies.', 'bbpress' ), esc_html( bbp_get_forum_title() ) ); ?></p>
 		</div>
 	</div>
 

--- a/buddypress.org/public_html/wp-content/themes/bbpress-org/bbpress/form-topic.php
+++ b/buddypress.org/public_html/wp-content/themes/bbpress-org/bbpress/form-topic.php
@@ -21,8 +21,10 @@
 
 					<?php
 						if ( bbp_is_topic_edit() )
+							/* translators: %s: Topic title. */
 							printf( esc_html__( 'Now Editing &ldquo;%s&rdquo;', 'bbpress' ), bbp_get_topic_title() );
 						else
+							/* translators: %s: Forum title. */
 							bbp_is_single_forum() ? printf( esc_html__( 'Create New Topic in &ldquo;%s&rdquo;', 'bbpress' ), bbp_get_forum_title() ) : esc_html_e( 'Create New Topic', 'bbpress' );
 					?>
 
@@ -66,6 +68,7 @@
 					<?php do_action( 'bbp_theme_before_topic_form_title' ); ?>
 
 					<p>
+						<?php /* translators: %d: Maximum title length. */ ?>
 						<label for="bbp_topic_title"><?php printf( esc_html__( 'Topic Title (Maximum Length: %d):', 'bbpress' ), bbp_get_title_max_length() ); ?></label><br />
 						<input type="text" id="bbp_topic_title" value="<?php bbp_form_topic_title(); ?>" size="40" name="bbp_topic_title" maxlength="<?php bbp_title_max_length(); ?>" />
 					</p>
@@ -207,6 +210,7 @@
 
 	<div id="no-topic-<?php bbp_topic_id(); ?>" class="bbp-no-topic">
 		<div class="bbp-template-notice">
+			<?php /* translators: %s: Forum title. */ ?>
 			<p><?php printf( esc_html__( 'The forum &#8216;%s&#8217; is closed to new topics and replies.', 'bbpress' ), bbp_get_forum_title() ); ?></p>
 		</div>
 	</div>

--- a/buddypress.org/public_html/wp-content/themes/bbpress-org/bbpress/form-topic.php
+++ b/buddypress.org/public_html/wp-content/themes/bbpress-org/bbpress/form-topic.php
@@ -21,9 +21,9 @@
 
 					<?php
 						if ( bbp_is_topic_edit() )
-							printf( __( 'Now Editing &ldquo;%s&rdquo;', 'bbpress' ), bbp_get_topic_title() );
+							printf( esc_html__( 'Now Editing &ldquo;%s&rdquo;', 'bbpress' ), bbp_get_topic_title() );
 						else
-							bbp_is_single_forum() ? printf( __( 'Create New Topic in &ldquo;%s&rdquo;', 'bbpress' ), bbp_get_forum_title() ) : _e( 'Create New Topic', 'bbpress' );
+							bbp_is_single_forum() ? printf( esc_html__( 'Create New Topic in &ldquo;%s&rdquo;', 'bbpress' ), bbp_get_forum_title() ) : esc_html_e( 'Create New Topic', 'bbpress' );
 					?>
 
 				</legend>
@@ -33,10 +33,10 @@
 				<?php if ( ! bbp_is_topic_edit() && ! bbp_is_forum_closed() ) : ?>
 
 					<div class="bbp-template-notice">
-						<p><?php _e( 'If asking for help, please include your WordPress version, bbPress version, and a link to your site.',                               'bbporg' ); ?></p>
-						<p><?php _e( 'If you are using a non-bundled theme, confirm your issue still happens with Twenty Twelve, Twenty Thirteen, etc...',                 'bbporg' ); ?></p>
-						<p><?php _e( 'If you found a bug, please create a <a href="https://bbpress.trac.wordpress.org/">trac ticket</a> with detailed duplication steps.', 'bbporg' ); ?></p>
-						<p><?php _e( 'Posts with 3 or more links will be manually approved by our forum moderators.',                                                      'bbporg' ); ?></p>
+						<p><?php esc_html_e( 'If asking for help, please include your WordPress version, bbPress version, and a link to your site.', 'bbporg' ); ?></p>
+						<p><?php esc_html_e( 'If you are using a non-bundled theme, confirm your issue still happens with Twenty Twelve, Twenty Thirteen, etc...', 'bbporg' ); ?></p>
+						<p><?php echo wp_kses_post( __( 'If you found a bug, please create a <a href="https://bbpress.trac.wordpress.org/">trac ticket</a> with detailed duplication steps.', 'bbporg' ) ); ?></p>
+						<p><?php esc_html_e( 'Posts with 3 or more links will be manually approved by our forum moderators.', 'bbporg' ); ?></p>
 					</div>
 
 				<?php endif; ?>
@@ -44,7 +44,7 @@
 				<?php if ( !bbp_is_topic_edit() && bbp_is_forum_closed() ) : ?>
 
 					<div class="bbp-template-notice">
-						<p><?php _e( 'This forum is marked as closed to new topics, however your posting capabilities still allow you to do so.', 'bbpress' ); ?></p>
+						<p><?php esc_html_e( 'This forum is marked as closed to new topics, however your posting capabilities still allow you to do so.', 'bbpress' ); ?></p>
 					</div>
 
 				<?php endif; ?>
@@ -52,7 +52,7 @@
 				<?php if ( current_user_can( 'unfiltered_html' ) ) : ?>
 
 					<div class="bbp-template-notice">
-						<p><?php _e( 'Your account has the ability to post unrestricted HTML content.', 'bbpress' ); ?></p>
+						<p><?php esc_html_e( 'Your account has the ability to post unrestricted HTML content.', 'bbpress' ); ?></p>
 					</div>
 
 				<?php endif; ?>
@@ -66,7 +66,7 @@
 					<?php do_action( 'bbp_theme_before_topic_form_title' ); ?>
 
 					<p>
-						<label for="bbp_topic_title"><?php printf( __( 'Topic Title (Maximum Length: %d):', 'bbpress' ), bbp_get_title_max_length() ); ?></label><br />
+						<label for="bbp_topic_title"><?php printf( esc_html__( 'Topic Title (Maximum Length: %d):', 'bbpress' ), bbp_get_title_max_length() ); ?></label><br />
 						<input type="text" id="bbp_topic_title" value="<?php bbp_form_topic_title(); ?>" size="40" name="bbp_topic_title" maxlength="<?php bbp_title_max_length(); ?>" />
 					</p>
 
@@ -77,7 +77,7 @@
 					<?php if ( !function_exists( 'wp_editor' ) ) : ?>
 
 						<p>
-							<label for="bbp_reply_content"><?php _e( 'Reply:', 'bbpress' ); ?></label><br />
+							<label for="bbp_reply_content"><?php esc_html_e( 'Reply:', 'bbpress' ); ?></label><br />
 							<textarea id="bbp_topic_content" name="bbp_topic_content" cols="60" rows="6"><?php bbp_form_topic_content(); ?></textarea>
 						</p>
 
@@ -92,7 +92,7 @@
 					<?php if ( !current_user_can( 'unfiltered_html' ) ) : ?>
 
 						<p class="form-allowed-tags">
-							<label><?php _e( 'You may use these <abbr title="HyperText Markup Language">HTML</abbr> tags and attributes:','bbpress' ); ?></label><br />
+							<label><?php echo wp_kses_post( __( 'You may use these <abbr title="HyperText Markup Language">HTML</abbr> tags and attributes:', 'bbpress' ) ); ?></label><br />
 							<code><?php bbp_allowed_tags(); ?></code>
 						</p>
 
@@ -101,7 +101,7 @@
 					<?php do_action( 'bbp_theme_before_topic_form_tags' ); ?>
 
 					<p>
-						<label for="bbp_topic_tags"><?php _e( 'Topic Tags:', 'bbpress' ); ?></label><br />
+						<label for="bbp_topic_tags"><?php esc_html_e( 'Topic Tags:', 'bbpress' ); ?></label><br />
 						<input type="text" value="<?php bbp_form_topic_tags(); ?>" size="40" name="bbp_topic_tags" id="bbp_topic_tags" <?php disabled( bbp_is_topic_spam() ); ?> />
 					</p>
 
@@ -112,7 +112,7 @@
 						<?php do_action( 'bbp_theme_before_topic_form_forum' ); ?>
 
 						<p>
-							<label for="bbp_forum_id"><?php _e( 'Forum:', 'bbpress' ); ?></label><br />
+							<label for="bbp_forum_id"><?php esc_html_e( 'Forum:', 'bbpress' ); ?></label><br />
 							<?php bbp_dropdown( array( 'selected' => bbp_get_form_topic_forum() ) ); ?>
 						</p>
 
@@ -126,7 +126,7 @@
 
 						<p>
 
-							<label for="bbp_stick_topic"><?php _e( 'Topic Type:', 'bbpress' ); ?></label><br />
+							<label for="bbp_stick_topic"><?php esc_html_e( 'Topic Type:', 'bbpress' ); ?></label><br />
 
 							<?php bbp_topic_type_select(); ?>
 
@@ -145,11 +145,11 @@
 
 							<?php if ( bbp_is_topic_edit() && ( get_the_author_meta( 'ID' ) != bbp_get_current_user_id() ) ) : ?>
 
-								<label for="bbp_topic_subscription"><?php _e( 'Notify the author of follow-up replies via email', 'bbpress' ); ?></label>
+								<label for="bbp_topic_subscription"><?php esc_html_e( 'Notify the author of follow-up replies via email', 'bbpress' ); ?></label>
 
 							<?php else : ?>
 
-								<label for="bbp_topic_subscription"><?php _e( 'Notify me of follow-up replies via email', 'bbpress' ); ?></label>
+								<label for="bbp_topic_subscription"><?php esc_html_e( 'Notify me of follow-up replies via email', 'bbpress' ); ?></label>
 
 							<?php endif; ?>
 						</p>
@@ -165,11 +165,11 @@
 						<fieldset class="bbp-form">
 							<legend>
 								<input name="bbp_log_topic_edit" id="bbp_log_topic_edit" type="checkbox" value="1" <?php bbp_form_topic_log_edit(); ?> />
-								<label for="bbp_log_topic_edit"><?php _e( 'Keep a log of this edit:', 'bbpress' ); ?></label><br />
+								<label for="bbp_log_topic_edit"><?php esc_html_e( 'Keep a log of this edit:', 'bbpress' ); ?></label><br />
 							</legend>
 
 							<div>
-								<label for="bbp_topic_edit_reason"><?php printf( __( 'Optional reason for editing:', 'bbpress' ), bbp_get_current_user_name() ); ?></label><br />
+								<label for="bbp_topic_edit_reason"><?php printf( esc_html__( 'Optional reason for editing:', 'bbpress' ), bbp_get_current_user_name() ); ?></label><br />
 								<input type="text" value="<?php bbp_form_topic_edit_reason(); ?>" size="40" name="bbp_topic_edit_reason" id="bbp_topic_edit_reason" />
 							</div>
 						</fieldset>
@@ -184,7 +184,7 @@
 
 						<?php do_action( 'bbp_theme_before_topic_form_submit_button' ); ?>
 
-						<button type="submit" id="bbp_topic_submit" name="bbp_topic_submit" class="button submit"><?php _e( 'Submit', 'bbpress' ); ?></button>
+						<button type="submit" id="bbp_topic_submit" name="bbp_topic_submit" class="button submit"><?php esc_html_e( 'Submit', 'bbpress' ); ?></button>
 
 						<?php do_action( 'bbp_theme_after_topic_form_submit_button' ); ?>
 
@@ -207,7 +207,7 @@
 
 	<div id="no-topic-<?php bbp_topic_id(); ?>" class="bbp-no-topic">
 		<div class="bbp-template-notice">
-			<p><?php printf( __( 'The forum &#8216;%s&#8217; is closed to new topics and replies.', 'bbpress' ), bbp_get_forum_title() ); ?></p>
+			<p><?php printf( esc_html__( 'The forum &#8216;%s&#8217; is closed to new topics and replies.', 'bbpress' ), bbp_get_forum_title() ); ?></p>
 		</div>
 	</div>
 
@@ -215,7 +215,7 @@
 
 	<div id="no-topic-<?php bbp_topic_id(); ?>" class="bbp-no-topic">
 		<div class="bbp-template-notice">
-			<p><?php is_user_logged_in() ? _e( 'You cannot create new topics at this time.', 'bbpress' ) : _e( 'You must be logged in to create new topics.', 'bbpress' ); ?></p>
+			<p><?php is_user_logged_in() ? esc_html_e( 'You cannot create new topics at this time.', 'bbpress' ) : esc_html_e( 'You must be logged in to create new topics.', 'bbpress' ); ?></p>
 		</div>
 	</div>
 

--- a/buddypress.org/public_html/wp-content/themes/bbpress-org/header-front.php
+++ b/buddypress.org/public_html/wp-content/themes/bbpress-org/header-front.php
@@ -1,9 +1,9 @@
 <?php if ( is_front_page() ) : ?>
 	<div id="headline"><div id="headline-inner">
-		<h2 class="graphic home"><?php _e( 'Meet bbPress', 'bbporg' ); ?></h2>
-		<p><?php _e( 'Forum software from the creators of WordPress. Asyncronous discussion, user profiles, subscriptions, and more!', 'bbporg' ); ?></p>
+		<h2 class="graphic home"><?php esc_html_e( 'Meet bbPress', 'bbporg' ); ?></h2>
+		<p><?php esc_html_e( 'Forum software from the creators of WordPress. Asyncronous discussion, user profiles, subscriptions, and more!', 'bbporg' ); ?></p>
 		<div>
-			<a href="//bbpress.org/download/" id="big-demo-button" class="button"><?php _e( 'Download &rarr;', 'bbporg' ); ?></a>
+			<a href="//bbpress.org/download/" id="big-demo-button" class="button"><?php esc_html_e( 'Download &rarr;', 'bbporg' ); ?></a>
 			<img src="<?php echo esc_url( get_theme_file_uri( 'images/screenshots.png' ) . '?v=6' ); ?>" srcset="<?php echo esc_url( get_theme_file_uri( 'images/screenshots.png' ) . '?v=6' ); ?> 1x, <?php echo esc_url( get_theme_file_uri( 'images/screenshots-2x.png' ) . '?v=6' ); ?> 2x" alt="">
 		</div>
 	</div></div>
@@ -11,31 +11,31 @@
 
 	<div id="showcase"><div id="showcase-inner">
 		<div class="feature">
-			<h2><?php _e( 'Simple Setup', 'bbporg' ); ?></h2>
+			<h2><?php esc_html_e( 'Simple Setup', 'bbporg' ); ?></h2>
 			<p>
 				<a href="//bbpress.org/about/simple/"><img src="<?php echo esc_url( get_theme_file_uri( 'images/feature_forums.gif' ) ); ?>" alt="<?php esc_attr_e( 'Simple Setup', 'bbporg' ); ?>" width="156" height="58"></a>
-				<span><?php _e( 'Easy to setup. <br>Easy to moderate. <br>Fast, and clean.', 'bbporg' ); ?></span>
+				<span><?php echo wp_kses_post( __( 'Easy to setup. <br>Easy to moderate. <br>Fast, and clean.', 'bbporg' ) ); ?></span>
 			</p>
 		</div>
 		<div class="feature">
-			<h2><?php _e( 'Fully Integrated', 'bbporg' ); ?></h2>
+			<h2><?php esc_html_e( 'Fully Integrated', 'bbporg' ); ?></h2>
 			<p>
 				<a href="//bbpress.org/about/integration/"><img src="<?php echo esc_url( get_theme_file_uri( 'images/feature_integration.gif' ) ); ?>" alt="<?php esc_attr_e( 'Fully Integrated', 'bbporg' ); ?>" width="156" height="116"></a>
-				<span><?php _e( 'One central account. <br>One unified admin area. <br>One click install.', 'bbporg' ); ?></span>
+				<span><?php echo wp_kses_post( __( 'One central account. <br>One unified admin area. <br>One click install.', 'bbporg' ) ); ?></span>
 			</p>
 		</div>
 		<div class="feature" style="margin:0;">
-			<h2><?php _e( 'Single Installation', 'bbporg' ); ?></h2>
+			<h2><?php esc_html_e( 'Single Installation', 'bbporg' ); ?></h2>
 			<p>
 				<a href="//bbpress.org/about/installation/"><img src="<?php echo esc_url( get_theme_file_uri( 'images/feature_installation.gif' ) ); ?>" alt="<?php esc_attr_e( 'Single Installation', 'bbporg' ); ?>" width="156" height="116"></a>
-				<span><?php _e( 'Simple step-by-step <br>installation walks you <br>through your options.', 'bbporg' ); ?></span>
+				<span><?php echo wp_kses_post( __( 'Simple step-by-step <br>installation walks you <br>through your options.', 'bbporg' ) ); ?></span>
 			</p>
 		</div>
 		<div class="feature">
-			<h2><?php _e( 'Multisite Forums', 'bbporg' ); ?></h2>
+			<h2><?php esc_html_e( 'Multisite Forums', 'bbporg' ); ?></h2>
 			<p>
 				<a href="//bbpress.org/about/multisite/"><img src="<?php echo esc_url( get_theme_file_uri( 'images/feature_blogs.gif' ) ); ?>" alt="<?php esc_attr_e( 'Multisite Forums', 'bbporg' ); ?>" width="156" height="116"></a>
-				<span><?php _e( 'Divide your site<br> into sections. Allow your <br>users to create content.', 'bbporg' ); ?></span>
+				<span><?php echo wp_kses_post( __( 'Divide your site<br> into sections. Allow your <br>users to create content.', 'bbporg' ) ); ?></span>
 			</p>
 		</div>
 	</div></div>

--- a/buddypress.org/public_html/wp-content/themes/bbpress-org/page-plugins.php
+++ b/buddypress.org/public_html/wp-content/themes/bbpress-org/page-plugins.php
@@ -64,7 +64,7 @@
 							<div><?php printf( esc_html__( 'Compatible up to: %s', 'bbporg' ), esc_html( $plugin->tested ) ); ?></div>
 						<?php endif; ?>
 						<?php /* translators: %s: Star rating markup. */ ?>
-						<div><?php printf( esc_html__( 'Rating: %s', 'bbporg' ), $plugin->rating_html ); // raw html - do not escape ?></div>
+						<div><?php printf( esc_html__( 'Rating: %s', 'bbporg' ), wp_kses_post( $plugin->rating_html ) ); ?></div>
 					</div>
 
 					<p class="plugin-description" style="font-size: 12px">

--- a/buddypress.org/public_html/wp-content/themes/bbpress-org/page-plugins.php
+++ b/buddypress.org/public_html/wp-content/themes/bbpress-org/page-plugins.php
@@ -16,6 +16,7 @@
 						<?php
 							/* translators: 1: starting number of plugins, 2: ending number, 3: total number */
 							printf(
+								/* translators: 1: First plugin number, 2: Last plugin number, 3: Total number of plugins. */
 								esc_html__( 'Viewing %1$s to %2$s (%3$s)', 'bbporg' ),
 								number_format_i18n( $from_num ),
 								number_format_i18n( $to_num ),
@@ -51,14 +52,18 @@
 
 					<div class="plugin-meta">
 						<?php if ( ! empty( $plugin->version ) ) : ?>
+							<?php /* translators: %s: Plugin version. */ ?>
 							<div><?php printf( esc_html__( 'Version: %s', 'bbporg' ), esc_html( $plugin->version ) ); ?></div>
 						<?php endif; ?>
 						<?php if ( ! empty( $plugin->requires ) ) : ?>
+							<?php /* translators: %s: Minimum WordPress version. */ ?>
 							<div><?php printf( esc_html__( 'Requires: %s', 'bbporg' ), esc_html( $plugin->requires ) ); ?></div>
 						<?php endif; ?>
 						<?php if ( ! empty( $plugin->tested ) ) : ?>
+							<?php /* translators: %s: Highest tested WordPress version. */ ?>
 							<div><?php printf( esc_html__( 'Compatible up to: %s', 'bbporg' ), esc_html( $plugin->tested ) ); ?></div>
 						<?php endif; ?>
+						<?php /* translators: %s: Star rating markup. */ ?>
 						<div><?php printf( esc_html__( 'Rating: %s', 'bbporg' ), $plugin->rating_html ); // raw html - do not escape ?></div>
 					</div>
 
@@ -76,6 +81,7 @@
 						<?php
 							/* translators: 1: starting number of plugins, 2: ending number, 3: total number */
 							printf(
+								/* translators: 1: First plugin number, 2: Last plugin number, 3: Total number of plugins. */
 								esc_html__( 'Viewing %1$s to %2$s (%3$s)', 'bbporg' ),
 								number_format_i18n( $from_num ),
 								number_format_i18n( $to_num ),

--- a/buddypress.org/public_html/wp-content/themes/bbpress-org/page-plugins.php
+++ b/buddypress.org/public_html/wp-content/themes/bbpress-org/page-plugins.php
@@ -15,7 +15,8 @@
 
 						<?php
 							/* translators: 1: starting number of plugins, 2: ending number, 3: total number */
-							printf( __( 'Viewing %1$s to %2$s (%3$s)', 'bbporg' ),
+							printf(
+								esc_html__( 'Viewing %1$s to %2$s (%3$s)', 'bbporg' ),
 								number_format_i18n( $from_num ),
 								number_format_i18n( $to_num ),
 								number_format_i18n( $plugins->info['results'] )
@@ -50,15 +51,15 @@
 
 					<div class="plugin-meta">
 						<?php if ( ! empty( $plugin->version ) ) : ?>
-							<div><?php printf( __( 'Version: %s', 'bbporg' ), esc_html( $plugin->version ) ); ?></div>
+							<div><?php printf( esc_html__( 'Version: %s', 'bbporg' ), esc_html( $plugin->version ) ); ?></div>
 						<?php endif; ?>
 						<?php if ( ! empty( $plugin->requires ) ) : ?>
-							<div><?php printf( __( 'Requires: %s', 'bbporg' ), esc_html( $plugin->requires ) ); ?></div>
+							<div><?php printf( esc_html__( 'Requires: %s', 'bbporg' ), esc_html( $plugin->requires ) ); ?></div>
 						<?php endif; ?>
 						<?php if ( ! empty( $plugin->tested ) ) : ?>
-							<div><?php printf( __( 'Compatible up to: %s', 'bbporg' ), esc_html( $plugin->tested ) ); ?></div>
+							<div><?php printf( esc_html__( 'Compatible up to: %s', 'bbporg' ), esc_html( $plugin->tested ) ); ?></div>
 						<?php endif; ?>
-						<div><?php printf( __( 'Rating: %s', 'bbporg' ), $plugin->rating_html ); // raw html - do not escape ?></div>
+						<div><?php printf( esc_html__( 'Rating: %s', 'bbporg' ), $plugin->rating_html ); // raw html - do not escape ?></div>
 					</div>
 
 					<p class="plugin-description" style="font-size: 12px">
@@ -74,7 +75,8 @@
 
 						<?php
 							/* translators: 1: starting number of plugins, 2: ending number, 3: total number */
-							printf( __( 'Viewing %1$s to %2$s (%3$s)', 'bbporg' ),
+							printf(
+								esc_html__( 'Viewing %1$s to %2$s (%3$s)', 'bbporg' ),
 								number_format_i18n( $from_num ),
 								number_format_i18n( $to_num ),
 								number_format_i18n( $plugins->info['results'] )

--- a/buddypress.org/public_html/wp-content/themes/bbpress-org/sidebar.php
+++ b/buddypress.org/public_html/wp-content/themes/bbpress-org/sidebar.php
@@ -16,7 +16,7 @@ endif;
 		<?php if ( bbp_is_single_forum() || bb_base_topic_search_query( false ) ) : ?>
 
 			<div>
-				<h2><?php _e( 'Forum Info', 'bbporg' ); ?></h2>
+				<h2><?php esc_html_e( 'Forum Info', 'bbporg' ); ?></h2>
 				<ul class="forum-info">
 					<?php bb_base_single_forum_description(); ?>
 				</ul>
@@ -25,17 +25,17 @@ endif;
 			<?php bb_base_topic_search_form(); ?>
 
 			<div>
-				<h2><?php _e( 'Forum Feeds', 'bbporg' ); ?></h2>
+				<h2><?php esc_html_e( 'Forum Feeds', 'bbporg' ); ?></h2>
 				<ul>
-					<li><a class="feed" href="<?php bbp_forum_permalink(); ?>feed/"><?php _e( 'Recent Posts', 'bbporg' ); ?></a></li>
-					<li><a class="feed" href="<?php bbp_forum_permalink(); ?>feed/?type=topic"><?php _e( 'Recent Topics', 'bbporg' ); ?></a></li>
+					<li><a class="feed" href="<?php bbp_forum_permalink(); ?>feed/"><?php esc_html_e( 'Recent Posts', 'bbporg' ); ?></a></li>
+					<li><a class="feed" href="<?php bbp_forum_permalink(); ?>feed/?type=topic"><?php esc_html_e( 'Recent Topics', 'bbporg' ); ?></a></li>
 				</ul>
 			</div>
 
 		<?php elseif ( bbp_is_single_topic() || bbp_is_topic_edit() || bbp_is_reply_edit() ) : ?>
 
 			<div>
-				<h2><?php _e( 'Topic Info', 'bbporg' ); ?></h2>
+				<h2><?php esc_html_e( 'Topic Info', 'bbporg' ); ?></h2>
 				<ul class="topic-info">
 					<?php bb_base_single_topic_description(); ?>
 				</ul>
@@ -68,13 +68,13 @@ endif;
 		<?php else : ?>
 
 			<div>
-				<h2><?php _e( 'Forums', 'bbporg' ); ?></h2>
+				<h2><?php esc_html_e( 'Forums', 'bbporg' ); ?></h2>
 				<?php echo do_shortcode( '[bbp-forum-index]' ); ?>
 			</div>
 			<hr class="hidden" />
 
 			<div>
-				<h2><?php _e( 'Views', 'bbporg' ); ?></h2>
+				<h2><?php esc_html_e( 'Views', 'bbporg' ); ?></h2>
 				<ul>
 
 					<?php foreach ( bbp_get_views() as $view => $args ) : ?>
@@ -87,15 +87,15 @@ endif;
 			</div>
 
 			<div>
-				<h2><?php _e( 'Feeds', 'bbporg' ); ?></h2>
+				<h2><?php esc_html_e( 'Feeds', 'bbporg' ); ?></h2>
 				<ul>
-					<li><a class="feed" href="<?php bbp_forums_url(); ?>feed/"><?php _e( 'All Recent Posts', 'bbporg' ); ?></a></li>
-					<li><a class="feed" href="<?php bbp_topics_url(); ?>feed/"><?php _e( 'All Recent Topics', 'bbporg' ); ?></a></li>
+					<li><a class="feed" href="<?php bbp_forums_url(); ?>feed/"><?php esc_html_e( 'All Recent Posts', 'bbporg' ); ?></a></li>
+					<li><a class="feed" href="<?php bbp_topics_url(); ?>feed/"><?php esc_html_e( 'All Recent Topics', 'bbporg' ); ?></a></li>
 				</ul>
 			</div>
 
 			<div class="bbp-topic-tag-cloud">
-				<h2><?php _e( 'Tags', 'bbporg' ); ?></h2>
+				<h2><?php esc_html_e( 'Tags', 'bbporg' ); ?></h2>
 				<?php echo do_shortcode( '[bbp-topic-tags]' ); ?>
 			</div>
 
@@ -106,7 +106,7 @@ endif;
 		<?php bb_base_plugin_search_form(); ?>
 
 		<div>
-			<h2><?php _e( 'Legacy', 'bbporg' ); ?></h2>
+			<h2><?php esc_html_e( 'Legacy', 'bbporg' ); ?></h2>
 			<ul>
 				<li><a href="<?php echo esc_url( get_permalink( 116247 ) ); ?>"><?php esc_html_e( 'Plugins for bbPress 1.1', 'bbporg' ); ?></a></li>
 			</ul>
@@ -115,14 +115,14 @@ endif;
 	<?php elseif ( ( ! is_page( 'login' ) && ! is_page( 'register' ) && ! is_page( 'lost-password' ) ) || is_home() || is_singular( 'post' ) || is_archive() ) : ?>
 
 		<div>
-			<h2><?php _e( 'Categories', 'bbporg' ); ?></h2>
+			<h2><?php esc_html_e( 'Categories', 'bbporg' ); ?></h2>
 			<ul>
 				<?php wp_list_categories( array( 'title_li' => false ) ); ?>
 			</ul>
 		</div>
 
 		<div>
-			<h2><?php _e( 'Tags', 'bbporg' ); ?></h2>
+			<h2><?php esc_html_e( 'Tags', 'bbporg' ); ?></h2>
 			<?php wp_tag_cloud(); ?>
 		</div>
 

--- a/buddypress.org/public_html/wp-content/themes/bporg-developer/header.php
+++ b/buddypress.org/public_html/wp-content/themes/bporg-developer/header.php
@@ -32,7 +32,7 @@
 
 <header id="masthead" class="site-header<?php if ( is_front_page() ) { echo ' home'; } ?>" role="banner">
 	<?php if ( get_query_var( 'is_handbook' ) ) : ?>
-	<a href="#" id="secondary-toggle" onclick="return false;"><strong><?php _e( 'Menu', 'bporg-developer' ); ?></strong></a>
+	<a href="#" id="secondary-toggle" onclick="return false;"><strong><?php esc_html_e( 'Menu', 'bporg-developer' ); ?></strong></a>
 	<?php endif; ?>
 	<div class="site-branding">
 		<h1 class="site-title">
@@ -68,7 +68,7 @@
 			<?php get_search_form(); ?>
 			<div id="inner-search-icon-container">
 				<div id="inner-search-icon">
-					<div class="dashicons dashicons-search"><span class="screen-reader-text"><?php _e( 'Search', 'bporg-developer' ); ?></span></div>
+					<div class="dashicons dashicons-search"><span class="screen-reader-text"><?php esc_html_e( 'Search', 'bporg-developer' ); ?></span></div>
 				</div>
 			</div>
 		</div>

--- a/buddypress.org/public_html/wp-content/themes/bporg-developer/page-reference-landing.php
+++ b/buddypress.org/public_html/wp-content/themes/bporg-developer/page-reference-landing.php
@@ -65,7 +65,7 @@ get_header(); ?>
                                         </li>
 
                                     <?php endwhile; ?>
-									<li class="view-all-new-in"><a href="<?php echo esc_attr( get_term_link( $version, 'wp-parser-since' ) ); ?>"><?php esc_html_e( 'View all&hellip;', 'bporg-developer' ); ?></a></li>
+									<li class="view-all-new-in"><a href="<?php echo esc_url( get_term_link( $version, 'wp-parser-since' ) ); ?>"><?php esc_html_e( 'View all&hellip;', 'bporg-developer' ); ?></a></li>
                                 </ul>
                             </div>
                         </div>

--- a/buddypress.org/public_html/wp-content/themes/bporg-developer/page-reference-landing.php
+++ b/buddypress.org/public_html/wp-content/themes/bporg-developer/page-reference-landing.php
@@ -19,13 +19,13 @@ get_header(); ?>
 		<main id="main" class="site-main" role="main">
 			<div class="reference-landing">
 				<div class="search-guide section clear">
-					<h4 class="ref-intro"><?php _e( 'Want to know what&#39;s going on inside BuddyPress? Search the Code Reference for more information about BuddyPress&#39; functions, classes, methods, and hooks.', 'bporg-developer' ); ?></h4>
-					<h3 class="search-intro"><?php _e( 'Try it out:', 'bporg-developer' ); ?></h3>
+					<h4 class="ref-intro"><?php esc_html_e( 'Want to know what&#39;s going on inside BuddyPress? Search the Code Reference for more information about BuddyPress&#39; functions, classes, methods, and hooks.', 'bporg-developer' ); ?></h4>
+					<h3 class="search-intro"><?php esc_html_e( 'Try it out:', 'bporg-developer' ); ?></h3>
 					<?php get_search_form(); ?>
 				</div><!-- /search-guide -->
 
 				<div class="topic-guide section">
-					<h4><?php _e( 'Or browse through topics:', 'bporg-developer' ); ?></h4>
+					<h4><?php esc_html_e( 'Or browse through topics:', 'bporg-developer' ); ?></h4>
 					<ul class="unordered-list horizontal-list no-bullets">
 						<li><a href="<?php echo esc_url( get_post_type_archive_link( 'wp-parser-function' ) ); ?>"><?php esc_html_e( 'Functions', 'bporg-developer' ); ?></a></li>
 						<li><a href="<?php echo esc_url( get_post_type_archive_link( 'wp-parser-hook' ) ); ?>"><?php esc_html_e( 'Hooks', 'bporg-developer' ); ?></a></li>
@@ -38,7 +38,7 @@ get_header(); ?>
                     <?php $version = DevHub\bporg_developer_get_current_version_term(); ?>
 					<?php if ( $version && ! is_wp_error( $version ) ) : ?>
                         <div class="widget box gray">
-                            <h3 class="widget-title"><?php printf( __( 'New &amp; Updated in BuddyPress %s:', 'bporg-developer' ), substr( $version->name, 0, -2 ) ); ?></h3>
+                            <h3 class="widget-title"><?php printf( esc_html__( 'New &amp; Updated in BuddyPress %s:', 'bporg-developer' ), substr( $version->name, 0, -2 ) ); ?></h3>
                             <div class="widget-content">
                                 <ul class="unordered-list no-bullets">
                                     <?php
@@ -64,14 +64,14 @@ get_header(); ?>
                                         </li>
 
                                     <?php endwhile; ?>
-                                    <li class="view-all-new-in"><a href="<?php echo esc_attr( get_term_link( $version, 'wp-parser-since' ) ); ?>"><?php _e( 'View all&hellip;', 'bporg-developer' ); ?></a></li>
+                                    <li class="view-all-new-in"><a href="<?php echo esc_attr( get_term_link( $version, 'wp-parser-since' ) ); ?>"><?php esc_html_e( 'View all&hellip;', 'bporg-developer' ); ?></a></li>
                                 </ul>
                             </div>
                         </div>
                     <?php endif; ?>
                     <?php if ( has_nav_menu( 'reference-home-api' ) ) : ?>
                         <div class="widget box gray">
-                            <h3 class="widget-title"><?php _e( 'API', 'bporg-developer' ); ?></h3>
+                            <h3 class="widget-title"><?php esc_html_e( 'API', 'bporg-developer' ); ?></h3>
                             <div class="widget-content">
                                 <?php wp_nav_menu(
                                         [

--- a/buddypress.org/public_html/wp-content/themes/bporg-developer/page-reference-landing.php
+++ b/buddypress.org/public_html/wp-content/themes/bporg-developer/page-reference-landing.php
@@ -38,8 +38,8 @@ get_header(); ?>
                     <?php $version = DevHub\bporg_developer_get_current_version_term(); ?>
 					<?php if ( $version && ! is_wp_error( $version ) ) : ?>
                         <div class="widget box gray">
-                            <?php /* translators: %s: BuddyPress version. */ ?>
-                            <h3 class="widget-title"><?php printf( esc_html__( 'New &amp; Updated in BuddyPress %s:', 'bporg-developer' ), substr( $version->name, 0, -2 ) ); ?></h3>
+							<?php /* translators: %s: BuddyPress version. */ ?>
+							<h3 class="widget-title"><?php printf( esc_html__( 'New &amp; Updated in BuddyPress %s:', 'bporg-developer' ), esc_html( substr( $version->name, 0, -2 ) ) ); ?></h3>
                             <div class="widget-content">
                                 <ul class="unordered-list no-bullets">
                                     <?php
@@ -65,14 +65,14 @@ get_header(); ?>
                                         </li>
 
                                     <?php endwhile; ?>
-                                    <li class="view-all-new-in"><a href="<?php echo esc_attr( get_term_link( $version, 'wp-parser-since' ) ); ?>"><?php esc_html_e( 'View all&hellip;', 'bporg-developer' ); ?></a></li>
+									<li class="view-all-new-in"><a href="<?php echo esc_attr( get_term_link( $version, 'wp-parser-since' ) ); ?>"><?php esc_html_e( 'View all&hellip;', 'bporg-developer' ); ?></a></li>
                                 </ul>
                             </div>
                         </div>
                     <?php endif; ?>
                     <?php if ( has_nav_menu( 'reference-home-api' ) ) : ?>
                         <div class="widget box gray">
-                            <h3 class="widget-title"><?php esc_html_e( 'API', 'bporg-developer' ); ?></h3>
+							<h3 class="widget-title"><?php esc_html_e( 'API', 'bporg-developer' ); ?></h3>
                             <div class="widget-content">
                                 <?php wp_nav_menu(
                                         [

--- a/buddypress.org/public_html/wp-content/themes/bporg-developer/page-reference-landing.php
+++ b/buddypress.org/public_html/wp-content/themes/bporg-developer/page-reference-landing.php
@@ -38,6 +38,7 @@ get_header(); ?>
                     <?php $version = DevHub\bporg_developer_get_current_version_term(); ?>
 					<?php if ( $version && ! is_wp_error( $version ) ) : ?>
                         <div class="widget box gray">
+                            <?php /* translators: %s: BuddyPress version. */ ?>
                             <h3 class="widget-title"><?php printf( esc_html__( 'New &amp; Updated in BuddyPress %s:', 'bporg-developer' ), substr( $version->name, 0, -2 ) ); ?></h3>
                             <div class="widget-content">
                                 <ul class="unordered-list no-bullets">

--- a/buddypress.org/public_html/wp-content/themes/bporg-developer/reference/template-source.php
+++ b/buddypress.org/public_html/wp-content/themes/bporg-developer/reference/template-source.php
@@ -16,6 +16,7 @@ if ( ! empty( $source_file ) ) :
 		<p>
 			<?php
 			printf(
+				/* translators: %s: Source file link. */
 				esc_html__( 'File: %s', 'bporg-developer' ),
 				'<a href="' . esc_url( get_source_file_archive_link( $source_file ) ) . '">' . esc_html( $source_file ) . '</a>'
 			); ?>

--- a/buddypress.org/public_html/wp-content/themes/bporg-developer/reference/template-source.php
+++ b/buddypress.org/public_html/wp-content/themes/bporg-developer/reference/template-source.php
@@ -12,9 +12,11 @@ if ( ! empty( $source_file ) ) :
 	?>
 	<hr />
 	<section class="source-content">
-		<h3><?php _e( 'Source', 'bporg-developer' ); ?></h3>
+		<h3><?php esc_html_e( 'Source', 'bporg-developer' ); ?></h3>
 		<p>
-			<?php printf( __( 'File: %s', 'bporg-developer' ),
+			<?php
+			printf(
+				esc_html__( 'File: %s', 'bporg-developer' ),
 				'<a href="' . esc_url( get_source_file_archive_link( $source_file ) ) . '">' . esc_html( $source_file ) . '</a>'
 			); ?>
 		</p>
@@ -25,14 +27,14 @@ if ( ! empty( $source_file ) ) :
 			</div>
 			<p class="source-code-links">
 				<span>
-					<a href="#" class="show-complete-source"><?php _e( 'Expand full source code', 'bporg-developer' ); ?></a>
-					<a href="#" class="less-complete-source"><?php _e( 'Collapse full source code', 'bporg-developer' ); ?></a>
+					<a href="#" class="show-complete-source"><?php esc_html_e( 'Expand full source code', 'bporg-developer' ); ?></a>
+					<a href="#" class="less-complete-source"><?php esc_html_e( 'Collapse full source code', 'bporg-developer' ); ?></a>
 				</span>
-				<span><a href="<?php bporg_developer_source_file_link(); ?>"><?php _e( 'View on Trac', 'bporg-developer' ); ?></a></span>
+				<span><a href="<?php bporg_developer_source_file_link(); ?>"><?php esc_html_e( 'View on Trac', 'bporg-developer' ); ?></a></span>
 			</p>
 		<?php else : ?>
 			<p>
-				<a href="<?php bporg_developer_source_file_link(); ?>"><?php _e( 'View on Trac', 'bporg-developer' ); ?></a>
+				<a href="<?php bporg_developer_source_file_link(); ?>"><?php esc_html_e( 'View on Trac', 'bporg-developer' ); ?></a>
 			</p>
 		<?php endif; ?>
 	</section>

--- a/buddypress.org/public_html/wp-content/themes/buddypress-org/bbpress/form-topic.php
+++ b/buddypress.org/public_html/wp-content/themes/buddypress-org/bbpress/form-topic.php
@@ -22,10 +22,10 @@
 					<?php
 						if ( bbp_is_topic_edit() )
 							/* translators: %s: Topic title. */
-							printf( esc_html__( 'Now Editing &ldquo;%s&rdquo;', 'bbpress' ), bbp_get_topic_title() );
+							printf( esc_html__( 'Now Editing &ldquo;%s&rdquo;', 'bbpress' ), esc_html( bbp_get_topic_title() ) );
 						else
 							/* translators: %s: Forum title. */
-							bbp_is_single_forum() ? printf( esc_html__( 'Create New Topic in &ldquo;%s&rdquo;', 'bbpress' ), bbp_get_forum_title() ) : esc_html_e( 'Create New Topic', 'bbpress' );
+							bbp_is_single_forum() ? printf( esc_html__( 'Create New Topic in &ldquo;%s&rdquo;', 'bbpress' ), esc_html( bbp_get_forum_title() ) ) : esc_html_e( 'Create New Topic', 'bbpress' );
 					?>
 
 				</legend>
@@ -69,7 +69,7 @@
 
 					<p>
 						<?php /* translators: %d: Maximum title length. */ ?>
-						<label for="bbp_topic_title"><?php printf( esc_html__( 'Topic Title (Maximum Length: %d):', 'bbpress' ), bbp_get_title_max_length() ); ?></label><br />
+						<label for="bbp_topic_title"><?php printf( esc_html__( 'Topic Title (Maximum Length: %d):', 'bbpress' ), (int) bbp_get_title_max_length() ); ?></label><br />
 						<input type="text" id="bbp_topic_title" value="<?php bbp_form_topic_title(); ?>" size="40" name="bbp_topic_title" maxlength="<?php bbp_title_max_length(); ?>" />
 					</p>
 
@@ -172,7 +172,7 @@
 							</legend>
 
 							<div>
-								<label for="bbp_topic_edit_reason"><?php printf( esc_html__( 'Optional reason for editing:', 'bbpress' ), bbp_get_current_user_name() ); ?></label><br />
+								<label for="bbp_topic_edit_reason"><?php printf( esc_html__( 'Optional reason for editing:', 'bbpress' ), esc_html( bbp_get_current_user_name() ) ); ?></label><br />
 								<input type="text" value="<?php bbp_form_topic_edit_reason(); ?>" size="40" name="bbp_topic_edit_reason" id="bbp_topic_edit_reason" />
 							</div>
 						</fieldset>
@@ -211,7 +211,7 @@
 	<div id="no-topic-<?php bbp_topic_id(); ?>" class="bbp-no-topic">
 		<div class="bbp-template-notice">
 			<?php /* translators: %s: Forum title. */ ?>
-			<p><?php printf( esc_html__( 'The forum &#8216;%s&#8217; is closed to new topics and replies.', 'bbpress' ), bbp_get_forum_title() ); ?></p>
+			<p><?php printf( esc_html__( 'The forum &#8216;%s&#8217; is closed to new topics and replies.', 'bbpress' ), esc_html( bbp_get_forum_title() ) ); ?></p>
 		</div>
 	</div>
 

--- a/buddypress.org/public_html/wp-content/themes/buddypress-org/bbpress/form-topic.php
+++ b/buddypress.org/public_html/wp-content/themes/buddypress-org/bbpress/form-topic.php
@@ -21,9 +21,9 @@
 
 					<?php
 						if ( bbp_is_topic_edit() )
-							printf( __( 'Now Editing &ldquo;%s&rdquo;', 'bbpress' ), bbp_get_topic_title() );
+							printf( esc_html__( 'Now Editing &ldquo;%s&rdquo;', 'bbpress' ), bbp_get_topic_title() );
 						else
-							bbp_is_single_forum() ? printf( __( 'Create New Topic in &ldquo;%s&rdquo;', 'bbpress' ), bbp_get_forum_title() ) : _e( 'Create New Topic', 'bbpress' );
+							bbp_is_single_forum() ? printf( esc_html__( 'Create New Topic in &ldquo;%s&rdquo;', 'bbpress' ), bbp_get_forum_title() ) : esc_html_e( 'Create New Topic', 'bbpress' );
 					?>
 
 				</legend>
@@ -33,10 +33,10 @@
 				<?php if ( ! bbp_is_topic_edit() && ! bbp_is_forum_closed() ) : ?>
 
 					<div class="bbp-template-notice">
-						<p><?php _e( 'If asking for help, please include your WordPress version, BuddyPress version, and a link to your site.',                               'bporg' ); ?></p>
-						<p><?php _e( 'If you are using a non-bundled theme, confirm your issue still happens with Twenty Twelve, Twenty Thirteen, etc...',                    'bporg' ); ?></p>
-						<p><?php _e( 'If you found a bug, please create a <a href="https://buddypress.trac.wordpress.org/">trac ticket</a> with detailed duplication steps.', 'bporg' ); ?></p>
-						<p><?php _e( 'Posts with 3 or more links will be manually approved by our forum moderators.',                                                         'bporg' ); ?></p>
+						<p><?php esc_html_e( 'If asking for help, please include your WordPress version, BuddyPress version, and a link to your site.', 'bporg' ); ?></p>
+						<p><?php esc_html_e( 'If you are using a non-bundled theme, confirm your issue still happens with Twenty Twelve, Twenty Thirteen, etc...', 'bporg' ); ?></p>
+						<p><?php echo wp_kses_post( __( 'If you found a bug, please create a <a href="https://buddypress.trac.wordpress.org/">trac ticket</a> with detailed duplication steps.', 'bporg' ) ); ?></p>
+						<p><?php esc_html_e( 'Posts with 3 or more links will be manually approved by our forum moderators.', 'bporg' ); ?></p>
 					</div>
 
 				<?php endif; ?>
@@ -44,7 +44,7 @@
 				<?php if ( !bbp_is_topic_edit() && bbp_is_forum_closed() ) : ?>
 
 					<div class="bbp-template-notice">
-						<p><?php _e( 'This forum is marked as closed to new topics, however your posting capabilities still allow you to do so.', 'bbpress' ); ?></p>
+						<p><?php esc_html_e( 'This forum is marked as closed to new topics, however your posting capabilities still allow you to do so.', 'bbpress' ); ?></p>
 					</div>
 
 				<?php endif; ?>
@@ -52,7 +52,7 @@
 				<?php if ( current_user_can( 'unfiltered_html' ) ) : ?>
 
 					<div class="bbp-template-notice">
-						<p><?php _e( 'Your account has the ability to post unrestricted HTML content.', 'bbpress' ); ?></p>
+						<p><?php esc_html_e( 'Your account has the ability to post unrestricted HTML content.', 'bbpress' ); ?></p>
 					</div>
 
 				<?php endif; ?>
@@ -66,7 +66,7 @@
 					<?php do_action( 'bbp_theme_before_topic_form_title' ); ?>
 
 					<p>
-						<label for="bbp_topic_title"><?php printf( __( 'Topic Title (Maximum Length: %d):', 'bbpress' ), bbp_get_title_max_length() ); ?></label><br />
+						<label for="bbp_topic_title"><?php printf( esc_html__( 'Topic Title (Maximum Length: %d):', 'bbpress' ), bbp_get_title_max_length() ); ?></label><br />
 						<input type="text" id="bbp_topic_title" value="<?php bbp_form_topic_title(); ?>" size="40" name="bbp_topic_title" maxlength="<?php bbp_title_max_length(); ?>" />
 					</p>
 
@@ -77,7 +77,7 @@
 					<?php if ( !function_exists( 'wp_editor' ) ) : ?>
 
 						<p>
-							<label for="bbp_reply_content"><?php _e( 'Reply:', 'bbpress' ); ?></label><br />
+							<label for="bbp_reply_content"><?php esc_html_e( 'Reply:', 'bbpress' ); ?></label><br />
 							<textarea id="bbp_topic_content" name="bbp_topic_content" cols="60" rows="6"><?php bbp_form_topic_content(); ?></textarea>
 						</p>
 
@@ -92,7 +92,7 @@
 					<?php if ( !current_user_can( 'unfiltered_html' ) ) : ?>
 
 						<p class="form-allowed-tags">
-							<label><?php _e( 'You may use these <abbr title="HyperText Markup Language">HTML</abbr> tags and attributes:','bbpress' ); ?></label><br />
+							<label><?php echo wp_kses_post( __( 'You may use these <abbr title="HyperText Markup Language">HTML</abbr> tags and attributes:', 'bbpress' ) ); ?></label><br />
 							<code><?php bbp_allowed_tags(); ?></code>
 						</p>
 
@@ -101,7 +101,7 @@
 					<?php do_action( 'bbp_theme_before_topic_form_tags' ); ?>
 
 					<p>
-						<label for="bbp_topic_tags"><?php _e( 'Topic Tags:', 'bbpress' ); ?></label><br />
+						<label for="bbp_topic_tags"><?php esc_html_e( 'Topic Tags:', 'bbpress' ); ?></label><br />
 						<input type="text" value="<?php bbp_form_topic_tags(); ?>" size="40" name="bbp_topic_tags" id="bbp_topic_tags" <?php disabled( bbp_is_topic_spam() ); ?> />
 					</p>
 
@@ -112,7 +112,7 @@
 						<?php do_action( 'bbp_theme_before_topic_form_forum' ); ?>
 
 						<p>
-							<label for="bbp_forum_id"><?php _e( 'Forum:', 'bbpress' ); ?></label><br />
+							<label for="bbp_forum_id"><?php esc_html_e( 'Forum:', 'bbpress' ); ?></label><br />
 							<?php bbp_dropdown( array( 'selected' => bbp_get_form_topic_forum() ) ); ?>
 						</p>
 
@@ -126,7 +126,7 @@
 
 						<p>
 
-							<label for="bbp_stick_topic"><?php _e( 'Topic Type:', 'bbpress' ); ?></label><br />
+							<label for="bbp_stick_topic"><?php esc_html_e( 'Topic Type:', 'bbpress' ); ?></label><br />
 
 							<?php bbp_topic_type_select(); ?>
 
@@ -145,11 +145,11 @@
 
 							<?php if ( bbp_is_topic_edit() && ( get_the_author_meta( 'ID' ) != bbp_get_current_user_id() ) ) : ?>
 
-								<label for="bbp_topic_subscription"><?php _e( 'Notify the author of follow-up replies via email', 'bbpress' ); ?></label>
+								<label for="bbp_topic_subscription"><?php esc_html_e( 'Notify the author of follow-up replies via email', 'bbpress' ); ?></label>
 
 							<?php else : ?>
 
-								<label for="bbp_topic_subscription"><?php _e( 'Notify me of follow-up replies via email', 'bbpress' ); ?></label>
+								<label for="bbp_topic_subscription"><?php esc_html_e( 'Notify me of follow-up replies via email', 'bbpress' ); ?></label>
 
 							<?php endif; ?>
 						</p>
@@ -165,11 +165,11 @@
 						<fieldset class="bbp-form">
 							<legend>
 								<input name="bbp_log_topic_edit" id="bbp_log_topic_edit" type="checkbox" value="1" <?php bbp_form_topic_log_edit(); ?> />
-								<label for="bbp_log_topic_edit"><?php _e( 'Keep a log of this edit:', 'bbpress' ); ?></label><br />
+								<label for="bbp_log_topic_edit"><?php esc_html_e( 'Keep a log of this edit:', 'bbpress' ); ?></label><br />
 							</legend>
 
 							<div>
-								<label for="bbp_topic_edit_reason"><?php printf( __( 'Optional reason for editing:', 'bbpress' ), bbp_get_current_user_name() ); ?></label><br />
+								<label for="bbp_topic_edit_reason"><?php printf( esc_html__( 'Optional reason for editing:', 'bbpress' ), bbp_get_current_user_name() ); ?></label><br />
 								<input type="text" value="<?php bbp_form_topic_edit_reason(); ?>" size="40" name="bbp_topic_edit_reason" id="bbp_topic_edit_reason" />
 							</div>
 						</fieldset>
@@ -184,7 +184,7 @@
 
 						<?php do_action( 'bbp_theme_before_topic_form_submit_button' ); ?>
 
-						<button type="submit" id="bbp_topic_submit" name="bbp_topic_submit" class="button submit"><?php _e( 'Submit', 'bbpress' ); ?></button>
+						<button type="submit" id="bbp_topic_submit" name="bbp_topic_submit" class="button submit"><?php esc_html_e( 'Submit', 'bbpress' ); ?></button>
 
 						<?php do_action( 'bbp_theme_after_topic_form_submit_button' ); ?>
 
@@ -207,7 +207,7 @@
 
 	<div id="no-topic-<?php bbp_topic_id(); ?>" class="bbp-no-topic">
 		<div class="bbp-template-notice">
-			<p><?php printf( __( 'The forum &#8216;%s&#8217; is closed to new topics and replies.', 'bbpress' ), bbp_get_forum_title() ); ?></p>
+			<p><?php printf( esc_html__( 'The forum &#8216;%s&#8217; is closed to new topics and replies.', 'bbpress' ), bbp_get_forum_title() ); ?></p>
 		</div>
 	</div>
 
@@ -215,7 +215,7 @@
 
 	<div id="no-topic-<?php bbp_topic_id(); ?>" class="bbp-no-topic">
 		<div class="bbp-template-notice">
-			<p><?php is_user_logged_in() ? _e( 'You cannot create new topics at this time.', 'bbpress' ) : _e( 'You must be logged in to create new topics.', 'bbpress' ); ?></p>
+			<p><?php is_user_logged_in() ? esc_html_e( 'You cannot create new topics at this time.', 'bbpress' ) : esc_html_e( 'You must be logged in to create new topics.', 'bbpress' ); ?></p>
 		</div>
 	</div>
 

--- a/buddypress.org/public_html/wp-content/themes/buddypress-org/bbpress/form-topic.php
+++ b/buddypress.org/public_html/wp-content/themes/buddypress-org/bbpress/form-topic.php
@@ -21,8 +21,10 @@
 
 					<?php
 						if ( bbp_is_topic_edit() )
+							/* translators: %s: Topic title. */
 							printf( esc_html__( 'Now Editing &ldquo;%s&rdquo;', 'bbpress' ), bbp_get_topic_title() );
 						else
+							/* translators: %s: Forum title. */
 							bbp_is_single_forum() ? printf( esc_html__( 'Create New Topic in &ldquo;%s&rdquo;', 'bbpress' ), bbp_get_forum_title() ) : esc_html_e( 'Create New Topic', 'bbpress' );
 					?>
 
@@ -66,6 +68,7 @@
 					<?php do_action( 'bbp_theme_before_topic_form_title' ); ?>
 
 					<p>
+						<?php /* translators: %d: Maximum title length. */ ?>
 						<label for="bbp_topic_title"><?php printf( esc_html__( 'Topic Title (Maximum Length: %d):', 'bbpress' ), bbp_get_title_max_length() ); ?></label><br />
 						<input type="text" id="bbp_topic_title" value="<?php bbp_form_topic_title(); ?>" size="40" name="bbp_topic_title" maxlength="<?php bbp_title_max_length(); ?>" />
 					</p>
@@ -207,6 +210,7 @@
 
 	<div id="no-topic-<?php bbp_topic_id(); ?>" class="bbp-no-topic">
 		<div class="bbp-template-notice">
+			<?php /* translators: %s: Forum title. */ ?>
 			<p><?php printf( esc_html__( 'The forum &#8216;%s&#8217; is closed to new topics and replies.', 'bbpress' ), bbp_get_forum_title() ); ?></p>
 		</div>
 	</div>

--- a/buddypress.org/public_html/wp-content/themes/buddypress-org/footer.php
+++ b/buddypress.org/public_html/wp-content/themes/buddypress-org/footer.php
@@ -5,20 +5,20 @@
 		<div id="footer"><div id="footer-inner">
 			<div class="links">
 				<p>
-					<a href="https://wordpress.org"><?php _e( 'WordPress.org', 'bporg' ); ?></a>
-					<a href="https://bbpress.org"><?php _e( 'bbPress.org', 'bporg' ); ?></a>
-					<a href="https://buddypress.org"><?php _e( 'BuddyPress.org', 'bporg' ); ?></a>
-					<a href="https://ma.tt"><?php _e( 'Matt', 'bporg' ); ?></a>
-					<a href="<?php bloginfo( 'rss2_url' ); ?>"><?php _e( 'Blog RSS', 'bporg' ); ?></a>
+					<a href="https://wordpress.org"><?php esc_html_e( 'WordPress.org', 'bporg' ); ?></a>
+					<a href="https://bbpress.org"><?php esc_html_e( 'bbPress.org', 'bporg' ); ?></a>
+					<a href="https://buddypress.org"><?php esc_html_e( 'BuddyPress.org', 'bporg' ); ?></a>
+					<a href="https://ma.tt"><?php esc_html_e( 'Matt', 'bporg' ); ?></a>
+					<a href="<?php bloginfo( 'rss2_url' ); ?>"><?php esc_html_e( 'Blog RSS', 'bporg' ); ?></a>
 				</p>
 			</div>
 			<div class="details">
 				<p>
-					<a href="https://buddypress.org/about/gpl/"><?php _e( 'GPL', 'bporg' ); ?></a>
-					<a href="https://buddypress.org/contact/"><?php _e( 'Contact Us', 'bporg' ); ?></a>
-					<a href="https://wordpress.org/about/privacy/"><?php _e('Privacy', 'bbporg'); ?></a>
-					<a href="https://buddypress.org/terms/"><?php _e( 'Terms of Service', 'bporg' ); ?></a>
-					<a href="https://x.com/buddypressdev"><?php _e( 'X', 'bporg' ); ?></a>
+					<a href="https://buddypress.org/about/gpl/"><?php esc_html_e( 'GPL', 'bporg' ); ?></a>
+					<a href="https://buddypress.org/contact/"><?php esc_html_e( 'Contact Us', 'bporg' ); ?></a>
+					<a href="https://wordpress.org/about/privacy/"><?php esc_html_e( 'Privacy', 'bbporg' ); ?></a>
+					<a href="https://buddypress.org/terms/"><?php esc_html_e( 'Terms of Service', 'bporg' ); ?></a>
+					<a href="https://x.com/buddypressdev"><?php esc_html_e( 'X', 'bporg' ); ?></a>
 				</p>
 			</div>
 		</div></div>

--- a/buddypress.org/public_html/wp-content/themes/buddypress-org/footer.php
+++ b/buddypress.org/public_html/wp-content/themes/buddypress-org/footer.php
@@ -1,3 +1,11 @@
+<?php
+/**
+ * The template for displaying the footer.
+ *
+ * @package buddypress-org
+ */
+
+?>
 			</div>
 		</div>
 		<hr class="hidden" />

--- a/buddypress.org/public_html/wp-content/themes/buddypress-org/footer.php
+++ b/buddypress.org/public_html/wp-content/themes/buddypress-org/footer.php
@@ -2,7 +2,7 @@
 /**
  * The template for displaying the footer.
  *
- * @package buddypress-org
+ * @package bbPress
  */
 
 ?>

--- a/buddypress.org/public_html/wp-content/themes/buddypress-org/footer.php
+++ b/buddypress.org/public_html/wp-content/themes/buddypress-org/footer.php
@@ -2,7 +2,7 @@
 /**
  * The template for displaying the footer.
  *
- * @package bbPress
+ * @package buddypress-org
  */
 
 ?>

--- a/buddypress.org/public_html/wp-content/themes/buddypress-org/header-front.php
+++ b/buddypress.org/public_html/wp-content/themes/buddypress-org/header-front.php
@@ -50,7 +50,7 @@
 			<h2><?php esc_html_e( 'Friendships', 'bporg' ); ?></h2>
 			<p>
 				<a href="//buddypress.org/about/friends/"><img src="<?php echo esc_url( get_theme_file_uri( 'images/feature_friends.gif' ) ); ?>" alt="" width="156" height="116"></a>
-				<span><?php echo wp_kses_post( __( "Friendship connections. <br>It's always about <br>who you know!", 'bporg' ) ); ?></span>
+				<span><?php echo wp_kses_post( __( 'Friendship connections. <br>It&#8217;s always about <br>who you know!', 'bporg' ) ); ?></span>
 			</p>
 		</div>
 		<div class="feature">

--- a/buddypress.org/public_html/wp-content/themes/buddypress-org/header-front.php
+++ b/buddypress.org/public_html/wp-content/themes/buddypress-org/header-front.php
@@ -1,10 +1,10 @@
 <?php if ( bb_base_is_buddypress() && is_front_page() ) : ?>
 
 	<div id="headline"><div id="headline-inner">
-		<h2 class="graphic home"><?php _e( 'Meet BuddyPress', 'bporg' ); ?></h2>
-		<p><?php _e( 'The open source community platform of choice worldwide — from creators & small businesses to enterprises & governments.', 'bporg' ); ?></p>
+		<h2 class="graphic home"><?php esc_html_e( 'Meet BuddyPress', 'bporg' ); ?></h2>
+		<p><?php esc_html_e( 'The open source community platform of choice worldwide — from creators & small businesses to enterprises & governments.', 'bporg' ); ?></p>
 		<div>
-			<a href="<?php bloginfo( 'url' ); ?>/download/" id="big-demo-button" class="button"><?php _e( 'Download &rarr;', 'bporg' ); ?></a>
+			<a href="<?php bloginfo( 'url' ); ?>/download/" id="big-demo-button" class="button"><?php esc_html_e( 'Download &rarr;', 'bporg' ); ?></a>
 			<img src="<?php echo esc_url( get_theme_file_uri( 'images/screenshots.png' ) . '?v=6' ); ?>" srcset="<?php echo esc_url( get_theme_file_uri( 'images/screenshots.png' ) . '?v=6' ); ?> 1x, <?php echo esc_url( get_theme_file_uri( 'images/screenshots-2x.png' ) . '?v=6' ); ?> 2x" alt="">
 		</div>
 	</div></div>
@@ -12,59 +12,59 @@
 
 	<div id="showcase"><div id="showcase-inner">
 		<div class="feature">
-			<h2><?php _e( 'Profiles', 'bporg' ); ?></h2>
+			<h2><?php esc_html_e( 'Profiles', 'bporg' ); ?></h2>
 			<p>
 				<a href="//buddypress.org/about/profiles/"><img src="<?php echo esc_url( get_theme_file_uri( 'images/feature_profiles.gif' ) ); ?>" alt="" width="156" height="116"></a>
-				<span><?php _e( 'Custom profile fields.<br> Visibility levels.<br>Common field types.', 'bporg' ); ?></span>
+				<span><?php echo wp_kses_post( __( 'Custom profile fields.<br> Visibility levels.<br>Common field types.', 'bporg' ) ); ?></span>
 			</p>
 		</div>
 		<div class="feature">
-			<h2><?php _e( 'Settings', 'bporg' ); ?></h2>
+			<h2><?php esc_html_e( 'Settings', 'bporg' ); ?></h2>
 			<p>
 				<a href="//buddypress.org/about/settings/"><img src="<?php echo esc_url( get_theme_file_uri( 'images/feature_settings.gif' ) ); ?>" alt="" width="156" height="116"></a>
-				<span><?php _e( 'Manage account settings. <br>Email notifications. <br>Email and Password.', 'bporg' ); ?></span>
+				<span><?php echo wp_kses_post( __( 'Manage account settings. <br>Email notifications. <br>Email and Password.', 'bporg' ) ); ?></span>
 			</p>
 		</div>
 		<div class="feature">
-			<h2><?php _e( 'Groups', 'bporg' ); ?></h2>
+			<h2><?php esc_html_e( 'Groups', 'bporg' ); ?></h2>
 			<p>
 				<a href="//buddypress.org/about/groups/"><img src="<?php echo esc_url( get_theme_file_uri( 'images/feature_groups.gif' ) ); ?>" alt="" width="156" height="116"></a>
-				<span><?php _e( 'Extensible user groups. <br>Allow your users to <br>create micro-communities.', 'bporg' ); ?></span>
+				<span><?php echo wp_kses_post( __( 'Extensible user groups. <br>Allow your users to <br>create micro-communities.', 'bporg' ) ); ?></span>
 			</p>
 		</div>
 		<div class="feature">
-			<h2><?php _e( 'Activity Streams', 'bporg' ); ?></h2>
+			<h2><?php esc_html_e( 'Activity Streams', 'bporg' ); ?></h2>
 			<p>
 				<a href="//buddypress.org/about/activity/"><img src="<?php echo esc_url( get_theme_file_uri( 'images/feature_activity.gif' ) ); ?>" alt="" width="156" height="116"></a>
-				<span><?php _e( 'For members and groups. <br>Sitewide directory <br>and single threads.', 'bporg' ); ?></span>
+				<span><?php echo wp_kses_post( __( 'For members and groups. <br>Sitewide directory <br>and single threads.', 'bporg' ) ); ?></span>
 			</p>
 		</div>
 		<div class="feature">
-			<h2><?php _e( 'Notifications', 'bporg' ); ?></h2>
+			<h2><?php esc_html_e( 'Notifications', 'bporg' ); ?></h2>
 			<p>
 				<a href="//buddypress.org/about/notifications/"><img src="<?php echo esc_url( get_theme_file_uri( 'images/feature_notifications.gif' ) ); ?>" alt="" width="156" height="116"></a>
-				<span><?php _e( 'Get notified.<br> Smart read/unread. <br>Fully integrated.', 'bporg' ); ?></span>
+				<span><?php echo wp_kses_post( __( 'Get notified.<br> Smart read/unread. <br>Fully integrated.', 'bporg' ) ); ?></span>
 			</p>
 		</div>
 		<div class="feature">
-			<h2><?php _e( 'Friendships', 'bporg' ); ?></h2>
+			<h2><?php esc_html_e( 'Friendships', 'bporg' ); ?></h2>
 			<p>
 				<a href="//buddypress.org/about/friends/"><img src="<?php echo esc_url( get_theme_file_uri( 'images/feature_friends.gif' ) ); ?>" alt="" width="156" height="116"></a>
-				<span><?php _e( "Friendship connections. <br>It's always about <br>who you know!", 'bporg' ); ?></span>
+				<span><?php echo wp_kses_post( __( "Friendship connections. <br>It's always about <br>who you know!", 'bporg' ) ); ?></span>
 			</p>
 		</div>
 		<div class="feature">
-			<h2><?php _e( 'Private Messaging', 'bporg' ); ?></h2>
+			<h2><?php esc_html_e( 'Private Messaging', 'bporg' ); ?></h2>
 			<p>
 				<a href="//buddypress.org/about/private-messaging/"><img src="<?php echo esc_url( get_theme_file_uri( 'images/feature_pms.gif' ) ); ?>" alt="" width="156" height="116"></a>
-				<span><?php _e( 'Private conversations <br>with several members <br>at one time.', 'bporg' ); ?></span>
+				<span><?php echo wp_kses_post( __( 'Private conversations <br>with several members <br>at one time.', 'bporg' ) ); ?></span>
 			</p>
 		</div>
 		<div class="feature">
-			<h2><?php _e( '...and more!', 'bporg' ); ?></h2>
+			<h2><?php esc_html_e( '...and more!', 'bporg' ); ?></h2>
 			<p>
 				<a href="//buddypress.org/about/more/"><img src="<?php echo esc_url( get_theme_file_uri( 'images/feature_more.gif' ) ); ?>" alt="" width="156" height="116"></a>
-				<span><?php _e( 'Extend BuddyPress <br>with hundreds of <br>third party components.', 'bporg' ); ?></span>
+				<span><?php echo wp_kses_post( __( 'Extend BuddyPress <br>with hundreds of <br>third party components.', 'bporg' ) ); ?></span>
 			</p>
 		</div>
 	</div></div>

--- a/buddypress.org/public_html/wp-content/themes/buddypress-org/header-nav.php
+++ b/buddypress.org/public_html/wp-content/themes/buddypress-org/header-nav.php
@@ -13,37 +13,37 @@ $_is_download = is_page( 'download' );
 	<ul id="bb-nav" class="menu">
 		<li class="menu-item<?php if ( true === $_is_about ) : ?> current <?php endif; ?>">
 			<a href="https://buddypress.org/about/">
-				<?php _e( 'About', 'bborg' ); ?>
+				<?php esc_html_e( 'About', 'bborg' ); ?>
 			</a>
 		</li>
 		<li class="menu-item<?php if ( true === $_is_news ) : ?> current <?php endif; ?>">
 			<a href="https://buddypress.org/blog/">
-				<?php _e( 'News', 'bborg' ); ?>
+				<?php esc_html_e( 'News', 'bborg' ); ?>
 			</a>
 		</li>
 		<li class="menu-item<?php if ( true === $_is_codex ) : ?> current <?php endif; ?>">
 			<a href="https://codex.buddypress.org/">
-				<?php _e( 'Codex', 'bborg' ); ?>
+				<?php esc_html_e( 'Codex', 'bborg' ); ?>
 			</a>
 		</li>
 		<li class="menu-item">
 			<a href="https://developer.buddypress.org">
-				<?php _e( 'Develop', 'bborg' ); ?>
+				<?php esc_html_e( 'Develop', 'bborg' ); ?>
 			</a>
 		</li>
 		<li class="menu-item">
 			<a href="https://buddypress.trac.wordpress.org">
-				<?php _e( 'Make', 'bborg' ); ?>
+				<?php esc_html_e( 'Make', 'bborg' ); ?>
 			</a>
 		</li>
 		<li class="menu-item<?php if ( true === $_is_bbpress ) : ?> current <?php endif; ?>">
 			<a href="https://buddypress.org/support/">
-				<?php _e( 'Forums', 'bborg' ); ?>
+				<?php esc_html_e( 'Forums', 'bborg' ); ?>
 			</a>
 		</li>
 		<li class="menu-item <?php if ( true === $_is_download ) : ?> current <?php endif; ?>">
 			<a href="https://buddypress.org/download/">
-				<?php _e( 'Download', 'bborg' ); ?>
+				<?php esc_html_e( 'Download', 'bborg' ); ?>
 			</a>
 		</li>
 	</ul>

--- a/buddypress.org/public_html/wp-content/themes/buddypress-org/sidebar.php
+++ b/buddypress.org/public_html/wp-content/themes/buddypress-org/sidebar.php
@@ -23,7 +23,7 @@
 		<?php if ( bbp_is_single_forum() || bb_base_topic_search_query( false ) ) : ?>
 
 			<div>
-				<h2><?php _e( 'Forum Info', 'bporg' ); ?></h2>
+				<h2><?php esc_html_e( 'Forum Info', 'bporg' ); ?></h2>
 				<ul class="forum-info">
 					<?php bb_base_single_forum_description(); ?>
 				</ul>
@@ -32,17 +32,17 @@
 			<?php bb_base_topic_search_form(); ?>
 
 			<div>
-				<h2><?php _e( 'Forum Feeds', 'bporg' ); ?></h2>
+				<h2><?php esc_html_e( 'Forum Feeds', 'bporg' ); ?></h2>
 				<ul>
-					<li><a class="feed" href="<?php bbp_forum_permalink(); ?>feed/"><?php _e( 'Recent Posts', 'bporg' ); ?></a></li>
-					<li><a class="feed" href="<?php bbp_forum_permalink(); ?>feed/?type=topic"><?php _e( 'Recent Topics', 'bporg' ); ?></a></li>
+					<li><a class="feed" href="<?php bbp_forum_permalink(); ?>feed/"><?php esc_html_e( 'Recent Posts', 'bporg' ); ?></a></li>
+					<li><a class="feed" href="<?php bbp_forum_permalink(); ?>feed/?type=topic"><?php esc_html_e( 'Recent Topics', 'bporg' ); ?></a></li>
 				</ul>
 			</div>
 
 		<?php elseif ( bbp_is_single_topic() || bbp_is_topic_edit() || bbp_is_reply_edit() ) : ?>
 
 			<div>
-				<h2><?php _e( 'Topic Info', 'bporg' ); ?></h2>
+				<h2><?php esc_html_e( 'Topic Info', 'bporg' ); ?></h2>
 				<ul class="topic-info">
 					<?php bb_base_single_topic_description(); ?>
 				</ul>
@@ -75,13 +75,13 @@
 		<?php else : ?>
 
 			<div>
-				<h2><?php _e( 'Forums', 'bporg' ); ?></h2>
+				<h2><?php esc_html_e( 'Forums', 'bporg' ); ?></h2>
 				<?php echo do_shortcode( '[bbp-forum-index]' ); ?>
 			</div>
 			<hr class="hidden" />
 
 			<div>
-				<h2><?php _e( 'Views', 'bporg' ); ?></h2>
+				<h2><?php esc_html_e( 'Views', 'bporg' ); ?></h2>
 				<ul>
 
 					<?php foreach ( bbp_get_views() as $view => $args ) : ?>
@@ -94,15 +94,15 @@
 			</div>
 
 			<div>
-				<h2><?php _e( 'Feeds', 'bporg' ); ?></h2>
+				<h2><?php esc_html_e( 'Feeds', 'bporg' ); ?></h2>
 				<ul>
-					<li><a class="feed" href="<?php bbp_forums_url(); ?>feed/"><?php _e( 'All Recent Posts', 'bporg' ); ?></a></li>
-					<li><a class="feed" href="<?php bbp_topics_url(); ?>feed/"><?php _e( 'All Recent Topics', 'bporg' ); ?></a></li>
+					<li><a class="feed" href="<?php bbp_forums_url(); ?>feed/"><?php esc_html_e( 'All Recent Posts', 'bporg' ); ?></a></li>
+					<li><a class="feed" href="<?php bbp_topics_url(); ?>feed/"><?php esc_html_e( 'All Recent Topics', 'bporg' ); ?></a></li>
 				</ul>
 			</div>
 
 			<div class="bbp-topic-tag-cloud">
-				<h2><?php _e( 'Tags', 'bporg' ); ?></h2>
+				<h2><?php esc_html_e( 'Tags', 'bporg' ); ?></h2>
 				<?php echo do_shortcode( '[bbp-topic-tags]' ); ?>
 			</div>
 
@@ -113,23 +113,23 @@
 		<?php bb_base_plugin_search_form(); ?>
 
 		<div>
-			<h2><?php _e( 'Legacy', 'bporg' ); ?></h2>
+			<h2><?php esc_html_e( 'Legacy', 'bporg' ); ?></h2>
 			<ul>
-				<li><a href="https://buddypress.org/support/forum/plugin-forums/"><?php _e( 'Legacy Plugin Forums', 'bporg' ); ?></a></li>
+				<li><a href="https://buddypress.org/support/forum/plugin-forums/"><?php esc_html_e( 'Legacy Plugin Forums', 'bporg' ); ?></a></li>
 			</ul>
 		</div>
 
 	<?php elseif ( ( ! is_page( 'login' ) && ! is_page( 'register' ) && ! is_page( 'lost-password' ) ) || is_home() || is_singular( 'post' ) || is_archive() ) : ?>
 
 		<div>
-			<h2><?php _e( 'Categories', 'bporg' ); ?></h2>
+			<h2><?php esc_html_e( 'Categories', 'bporg' ); ?></h2>
 			<ul>
 				<?php wp_list_categories( array( 'title_li' => false ) ); ?>
 			</ul>
 		</div>
 
 		<div>
-			<h2><?php _e( 'Tags', 'bporg' ); ?></h2>
+			<h2><?php esc_html_e( 'Tags', 'bporg' ); ?></h2>
 			<?php wp_tag_cloud(); ?>
 		</div>
 

--- a/buddypress.org/public_html/wp-content/themes/codex-bbpress-org/footer.php
+++ b/buddypress.org/public_html/wp-content/themes/codex-bbpress-org/footer.php
@@ -7,20 +7,20 @@
 		<div id="footer"><div id="footer-inner">
 			<div class="links">
 				<p>
-					<a href="https://wordpress.org"><?php _e( 'WordPress.org', 'bbporg'); ?></a>
-					<a href="https://bbpress.org"><?php _e( 'bbPress.org', 'bbporg'); ?></a>
-					<a href="https://buddypress.org"><?php _e( 'BuddyPress.org', 'bbporg'); ?></a>
-					<a href="https://ma.tt"><?php _e( 'Matt', 'bbporg' ); ?></a>
-					<a href="<?php bloginfo( 'rss2_url' ); ?>" title="<?php esc_attr_e( 'RSS Feed for Articles', 'bbporg' ); ?>"><?php _e( 'Blog RSS', 'bbporg' ); ?></a>
+					<a href="https://wordpress.org"><?php esc_html_e( 'WordPress.org', 'bbporg' ); ?></a>
+					<a href="https://bbpress.org"><?php esc_html_e( 'bbPress.org', 'bbporg' ); ?></a>
+					<a href="https://buddypress.org"><?php esc_html_e( 'BuddyPress.org', 'bbporg' ); ?></a>
+					<a href="https://ma.tt"><?php esc_html_e( 'Matt', 'bbporg' ); ?></a>
+					<a href="<?php bloginfo( 'rss2_url' ); ?>" title="<?php esc_attr_e( 'RSS Feed for Articles', 'bbporg' ); ?>"><?php esc_html_e( 'Blog RSS', 'bbporg' ); ?></a>
 				</p>
 			</div>
 			<div class="details">
 				<p>
-					<a href="https://bbpress.org/about/gpl/"><?php _e('GPL', 'bbporg'); ?></a>
-					<a href="https://bbpress.org/contact/"><?php _e('Contact Us', 'bbporg'); ?></a>
-					<a href="https://wordpress.org/about/privacy/"><?php _e('Privacy', 'bbporg'); ?></a>
-					<a href="https://bbpress.org/terms/"><?php _e('Terms of Service', 'bbporg'); ?></a>
-					<a href="https://x.com/bbpress"><?php _e( 'X', 'bbporg'); ?></a>
+					<a href="https://bbpress.org/about/gpl/"><?php esc_html_e( 'GPL', 'bbporg' ); ?></a>
+					<a href="https://bbpress.org/contact/"><?php esc_html_e( 'Contact Us', 'bbporg' ); ?></a>
+					<a href="https://wordpress.org/about/privacy/"><?php esc_html_e( 'Privacy', 'bbporg' ); ?></a>
+					<a href="https://bbpress.org/terms/"><?php esc_html_e( 'Terms of Service', 'bbporg' ); ?></a>
+					<a href="https://x.com/bbpress"><?php esc_html_e( 'X', 'bbporg' ); ?></a>
 				</p>
 			</div>
 		</div></div>

--- a/buddypress.org/public_html/wp-content/themes/codex-bbpress-org/index.php
+++ b/buddypress.org/public_html/wp-content/themes/codex-bbpress-org/index.php
@@ -2,12 +2,11 @@
 <?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
 			<h2 id="post-<?php the_ID(); ?>"><a href="<?php the_permalink() ?>" rel="bookmark"><?php the_title(); ?></a></h2>
 			<cite><?php
-				/* translators: 1: post date, 2: post author */
 				printf(
 					/* translators: 1: Publication date, 2: Author link. */
 					esc_html__( 'Published on %1$s by %2$s', 'bbporg' ),
-					get_the_time( 'F jS, Y' ),
-					get_the_author_link()
+					esc_html( get_the_time( 'F jS, Y' ) ),
+					wp_kses_post( get_the_author_link() )
 				);
 			?></cite>
 			<div class="single-post" id="post-<?php the_ID(); ?>"><?php the_excerpt(); ?></div>

--- a/buddypress.org/public_html/wp-content/themes/codex-bbpress-org/index.php
+++ b/buddypress.org/public_html/wp-content/themes/codex-bbpress-org/index.php
@@ -3,7 +3,8 @@
 			<h2 id="post-<?php the_ID(); ?>"><a href="<?php the_permalink() ?>" rel="bookmark"><?php the_title(); ?></a></h2>
 			<cite><?php
 				/* translators: 1: post date, 2: post author */
-				printf( __( 'Published on %1$s by %2$s', 'bbporg' ),
+				printf(
+					esc_html__( 'Published on %1$s by %2$s', 'bbporg' ),
 					get_the_time( 'F jS, Y' ),
 					get_the_author_link()
 				);
@@ -12,7 +13,7 @@
 <?php endwhile;  ?>
 
 <?php else : ?>
-			<p><em><?php _e( 'Sorry, no posts matched your criteria.' ); ?></em></p>
+			<p><em><?php esc_html_e( 'Sorry, no posts matched your criteria.' ); ?></em></p>
 <?php endif; ?>
 			<?php posts_nav_link(' &#8212; ', __('Newer &rarr;'), __('&larr; Older') ); ?>
 			<hr class="hidden" />

--- a/buddypress.org/public_html/wp-content/themes/codex-bbpress-org/index.php
+++ b/buddypress.org/public_html/wp-content/themes/codex-bbpress-org/index.php
@@ -4,6 +4,7 @@
 			<cite><?php
 				/* translators: 1: post date, 2: post author */
 				printf(
+					/* translators: 1: Publication date, 2: Author link. */
 					esc_html__( 'Published on %1$s by %2$s', 'bbporg' ),
 					get_the_time( 'F jS, Y' ),
 					get_the_author_link()

--- a/buddypress.org/public_html/wp-content/themes/codex-buddypress-org/activity-entry.php
+++ b/buddypress.org/public_html/wp-content/themes/codex-buddypress-org/activity-entry.php
@@ -87,7 +87,7 @@
 					<div class="ac-textarea">
 						<textarea id="ac-input-<?php bp_activity_id() ?>" class="ac-input" name="ac_input_<?php bp_activity_id() ?>"></textarea>
 					</div>
-					<input type="submit" name="ac_form_submit" value="<?php esc_attr_e( 'Post', 'buddypress' ) ?> &rarr;" /> &nbsp; <?php esc_html_e( 'or press esc to cancel.', 'buddypress' ) ?>
+					<input type="submit" name="ac_form_submit" value="<?php esc_attr_e( 'Post', 'buddypress' ); ?> &rarr;" /> &nbsp; <?php esc_html_e( 'or press esc to cancel.', 'buddypress' ); ?>
 					<input type="hidden" name="comment_form_id" value="<?php bp_activity_id() ?>" />
 				</div>
 				<?php wp_nonce_field( 'new_activity_comment', '_wpnonce_new_activity_comment' ) ?>

--- a/buddypress.org/public_html/wp-content/themes/codex-buddypress-org/activity-entry.php
+++ b/buddypress.org/public_html/wp-content/themes/codex-buddypress-org/activity-entry.php
@@ -28,8 +28,8 @@
 		<?php if ( 'activity_comment' == bp_get_activity_type() ) : ?>
 
 			<div class="activity-inreplyto">
-				<strong><?php _e( 'In reply to', 'buddypress' ) ?></strong> - <?php bp_activity_parent_content() ?> &middot;
-				<a href="<?php bp_activity_thread_permalink() ?>" class="view" title="<?php esc_attr_e( 'Permalink', 'buddypress' ) ?>"><?php _e( 'View', 'buddypress' ) ?></a>
+				<strong><?php esc_html_e( 'In reply to', 'buddypress' ); ?></strong> - <?php bp_activity_parent_content(); ?> &middot;
+				<a href="<?php bp_activity_thread_permalink(); ?>" class="view" title="<?php esc_attr_e( 'Permalink', 'buddypress' ); ?>"><?php esc_html_e( 'View', 'buddypress' ); ?></a>
 			</div>
 
 		<?php endif; ?>
@@ -39,24 +39,24 @@
 			<?php if ( is_user_logged_in() ) : ?>
 				<?php if ( !bp_get_activity_is_favorite() ) : ?>
 
-					<a href="<?php bp_activity_favorite_link() ?>" class="button fav" title="<?php esc_attr_e( 'Mark as Favorite', 'buddypress' ) ?>"><?php _e( 'Favorite', 'buddypress' ) ?></a>
+					<a href="<?php bp_activity_favorite_link(); ?>" class="button fav" title="<?php esc_attr_e( 'Mark as Favorite', 'buddypress' ); ?>"><?php esc_html_e( 'Favorite', 'buddypress' ); ?></a>
 
 				<?php else : ?>
 
-					<a href="<?php bp_activity_unfavorite_link() ?>" class="button unfav" title="<?php esc_attr_e( 'Remove Favorite', 'buddypress' ) ?>"><?php _e( 'Remove Favorite', 'buddypress' ) ?></a>
+					<a href="<?php bp_activity_unfavorite_link(); ?>" class="button unfav" title="<?php esc_attr_e( 'Remove Favorite', 'buddypress' ); ?>"><?php esc_html_e( 'Remove Favorite', 'buddypress' ); ?></a>
 
 				<?php endif; ?>
 			<?php endif;?>
 
 			<?php if ( bp_get_activity_type() == 'new_forum_topic' || bp_get_activity_type() == 'new_forum_reply' ) : ?>
 
-				<a href="<?php bp_activity_thread_permalink() ?>" class="button view-thread"><?php _e( 'View Topic' ); ?></a>
+				<a href="<?php bp_activity_thread_permalink(); ?>" class="button view-thread"><?php esc_html_e( 'View Topic' ); ?></a>
 
 			<?php else : ?>
 
 				<?php if ( is_user_logged_in() && bp_activity_can_comment() ) : ?>
 
-					<a href="<?php bp_activity_comment_link() ?>" class="button acomment-reply" id="acomment-comment-<?php bp_activity_id() ?>"><?php _e( 'Comment', 'buddypress' ) ?> (<span><?php bp_activity_comment_count() ?></span>)</a>
+					<a href="<?php bp_activity_comment_link(); ?>" class="button acomment-reply" id="acomment-comment-<?php bp_activity_id(); ?>"><?php esc_html_e( 'Comment', 'buddypress' ); ?> (<span><?php bp_activity_comment_count(); ?></span>)</a>
 
 				<?php endif; ?>
 
@@ -87,7 +87,7 @@
 					<div class="ac-textarea">
 						<textarea id="ac-input-<?php bp_activity_id() ?>" class="ac-input" name="ac_input_<?php bp_activity_id() ?>"></textarea>
 					</div>
-					<input type="submit" name="ac_form_submit" value="<?php esc_attr_e( 'Post', 'buddypress' ) ?> &rarr;" /> &nbsp; <?php _e( 'or press esc to cancel.', 'buddypress' ) ?>
+					<input type="submit" name="ac_form_submit" value="<?php esc_attr_e( 'Post', 'buddypress' ) ?> &rarr;" /> &nbsp; <?php esc_html_e( 'or press esc to cancel.', 'buddypress' ) ?>
 					<input type="hidden" name="comment_form_id" value="<?php bp_activity_id() ?>" />
 				</div>
 				<?php wp_nonce_field( 'new_activity_comment', '_wpnonce_new_activity_comment' ) ?>

--- a/buddypress.org/public_html/wp-content/themes/codex-buddypress-org/footer.php
+++ b/buddypress.org/public_html/wp-content/themes/codex-buddypress-org/footer.php
@@ -10,20 +10,20 @@
 		<div id="footer"><div id="footer-inner">
 			<div class="links">
 				<p>
-					<a href="https://wordpress.org"><?php _e( 'WordPress.org', 'bporg' ); ?></a>
-					<a href="https://bbpress.org"><?php _e( 'bbPress.org', 'bporg' ); ?></a>
-					<a href="https://buddypress.org"><?php _e( 'BuddyPress.org', 'bporg' ); ?></a>
-					<a href="https://ma.tt"><?php _e( 'Matt', 'bporg' ); ?></a>
-					<a href="<?php bloginfo( 'rss2_url' ); ?>"><?php _e( 'Blog RSS', 'bporg' ); ?></a>
+					<a href="https://wordpress.org"><?php esc_html_e( 'WordPress.org', 'bporg' ); ?></a>
+					<a href="https://bbpress.org"><?php esc_html_e( 'bbPress.org', 'bporg' ); ?></a>
+					<a href="https://buddypress.org"><?php esc_html_e( 'BuddyPress.org', 'bporg' ); ?></a>
+					<a href="https://ma.tt"><?php esc_html_e( 'Matt', 'bporg' ); ?></a>
+					<a href="<?php bloginfo( 'rss2_url' ); ?>"><?php esc_html_e( 'Blog RSS', 'bporg' ); ?></a>
 				</p>
 			</div>
 			<div class="details">
 				<p>
-					<a href="https://buddypress.org/about/gpl/"><?php _e( 'GPL', 'bporg' ); ?></a>
-					<a href="https://buddypress.org/contact/"><?php _e( 'Contact Us', 'bporg' ); ?></a>
-					<a href="https://wordpress.org/about/privacy/"><?php _e('Privacy', 'bbporg'); ?></a>
-					<a href="https://buddypress.org/terms/"><?php _e( 'Terms of Service', 'bporg' ); ?></a>
-					<a href="https://x.com/buddypressdev"><?php _e( 'X', 'bporg' ); ?></a>
+					<a href="https://buddypress.org/about/gpl/"><?php esc_html_e( 'GPL', 'bporg' ); ?></a>
+					<a href="https://buddypress.org/contact/"><?php esc_html_e( 'Contact Us', 'bporg' ); ?></a>
+					<a href="https://wordpress.org/about/privacy/"><?php esc_html_e( 'Privacy', 'bbporg' ); ?></a>
+					<a href="https://buddypress.org/terms/"><?php esc_html_e( 'Terms of Service', 'bporg' ); ?></a>
+					<a href="https://x.com/buddypressdev"><?php esc_html_e( 'X', 'bporg' ); ?></a>
 				</p>
 			</div>
 		</div></div>

--- a/buddypress.org/public_html/wp-content/themes/codex-buddypress-org/header-nav.php
+++ b/buddypress.org/public_html/wp-content/themes/codex-buddypress-org/header-nav.php
@@ -13,37 +13,37 @@ $_is_download = false;
 	<ul id="bb-nav" class="menu">
 		<li class="menu-item<?php if ( true === $_is_about ) : ?> current <?php endif; ?>">
 			<a href="https://buddypress.org/about/">
-				<?php _e( 'About', 'bborg' ); ?>
+				<?php esc_html_e( 'About', 'bborg' ); ?>
 			</a>
 		</li>
 		<li class="menu-item<?php if ( true === $_is_news ) : ?> current <?php endif; ?>">
 			<a href="https://buddypress.org/blog/">
-				<?php _e( 'News', 'bborg' ); ?>
+				<?php esc_html_e( 'News', 'bborg' ); ?>
 			</a>
 		</li>
 		<li class="menu-item<?php if ( true === $_is_codex ) : ?> current <?php endif; ?>">
 			<a href="https://codex.buddypress.org/">
-				<?php _e( 'Codex', 'bborg' ); ?>
+				<?php esc_html_e( 'Codex', 'bborg' ); ?>
 			</a>
 		</li>
 		<li class="menu-item">
 			<a href="https://developer.buddypress.org">
-				<?php _e( 'Develop', 'bborg' ); ?>
+				<?php esc_html_e( 'Develop', 'bborg' ); ?>
 			</a>
 		</li>
 		<li class="menu-item">
 			<a href="https://buddypress.trac.wordpress.org">
-				<?php _e( 'Make', 'bborg' ); ?>
+				<?php esc_html_e( 'Make', 'bborg' ); ?>
 			</a>
 		</li>
 		<li class="menu-item<?php if ( true === $_is_bbpress ) : ?> current <?php endif; ?>">
 			<a href="https://buddypress.org/support/">
-				<?php _e( 'Forums', 'bborg' ); ?>
+				<?php esc_html_e( 'Forums', 'bborg' ); ?>
 			</a>
 		</li>
 		<li class="menu-item <?php if ( true === $_is_download ) : ?> current <?php endif; ?>">
 			<a href="https://buddypress.org/download/">
-				<?php _e( 'Download', 'bborg' ); ?>
+				<?php esc_html_e( 'Download', 'bborg' ); ?>
 			</a>
 		</li>
 	</ul>

--- a/buddypress.org/public_html/wp-content/themes/codex-buddypress-org/index.php
+++ b/buddypress.org/public_html/wp-content/themes/codex-buddypress-org/index.php
@@ -4,6 +4,7 @@
 			<cite><?php
 				/* translators: 1: post date, 2: post author */
 				printf(
+					/* translators: 1: Publication date, 2: Author link. */
 					esc_html__( 'Published on %1$s by %2$s', 'bporg' ),
 					get_the_time( 'F jS, Y' ),
 					get_the_author_link()

--- a/buddypress.org/public_html/wp-content/themes/codex-buddypress-org/index.php
+++ b/buddypress.org/public_html/wp-content/themes/codex-buddypress-org/index.php
@@ -3,7 +3,8 @@
 			<h2 id="post-<?php the_ID(); ?>"><a href="<?php the_permalink() ?>" rel="bookmark"><?php the_title(); ?></a></h2>
 			<cite><?php
 				/* translators: 1: post date, 2: post author */
-				printf( __( 'Published on %1$s by %2$s', 'bporg' ),
+				printf(
+					esc_html__( 'Published on %1$s by %2$s', 'bporg' ),
 					get_the_time( 'F jS, Y' ),
 					get_the_author_link()
 				);
@@ -12,7 +13,7 @@
 <?php endwhile;  ?>
 
 <?php else : ?>
-			<p><em><?php _e( 'Sorry, no posts matched your criteria.' ); ?></em></p>
+			<p><em><?php esc_html_e( 'Sorry, no posts matched your criteria.' ); ?></em></p>
 <?php endif; ?>
 			<?php posts_nav_link(' &#8212; ', __('Newer &rarr;'), __('&larr; Older') ); ?>
 			<hr class="hidden" />

--- a/buddypress.org/public_html/wp-content/themes/codex-buddypress-org/index.php
+++ b/buddypress.org/public_html/wp-content/themes/codex-buddypress-org/index.php
@@ -2,12 +2,11 @@
 <?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
 			<h2 id="post-<?php the_ID(); ?>"><a href="<?php the_permalink() ?>" rel="bookmark"><?php the_title(); ?></a></h2>
 			<cite><?php
-				/* translators: 1: post date, 2: post author */
 				printf(
 					/* translators: 1: Publication date, 2: Author link. */
 					esc_html__( 'Published on %1$s by %2$s', 'bporg' ),
-					get_the_time( 'F jS, Y' ),
-					get_the_author_link()
+					esc_html( get_the_time( 'F jS, Y' ) ),
+					wp_kses_post( get_the_author_link() )
 				);
 			?></cite>
 			<div class="single-post" id="post-<?php the_ID(); ?>"><?php the_excerpt(); ?></div>

--- a/buddypress.org/public_html/wp-content/themes/codex-buddypress-org/widgets/inbox.php
+++ b/buddypress.org/public_html/wp-content/themes/codex-buddypress-org/widgets/inbox.php
@@ -9,7 +9,7 @@ class BPOrg_Inbox_Widget extends WP_Widget {
 
 	    extract( $args );
 		echo $before_widget;
-		echo $before_title . esc_html__( 'Inbox', 'bp-follow' ) . ' &middot <a href="' . esc_url( $bp->loggedin_user->domain . 'messages/inbox/' ) . '">View All</a>' . $after_title; ?>
+		echo wp_kses_post( $before_title ) . esc_html__( 'Inbox', 'bp-follow' ) . ' &middot <a href="' . esc_url( $bp->loggedin_user->domain . 'messages/inbox/' ) . '">View All</a>' . wp_kses_post( $after_title ); ?>
 
 		<?php if ( bp_has_message_threads( 'per_page=5&max=5' ) ) : ?>
 
@@ -20,7 +20,7 @@ class BPOrg_Inbox_Widget extends WP_Widget {
 						<?php bp_message_thread_avatar() ?>
 						<div class="details">
 							<a class="title" href="<?php bp_message_thread_view_link() ?>" title="<?php esc_attr_e( "View Message", "buddypress" ); ?>"><?php bp_message_thread_subject() ?></a>
-							<div class="meta"><?php esc_html_e( 'From:', 'buddypress' ); ?> <?php bp_message_thread_from() ?> &middot; <?php bp_message_thread_last_post_date() ?></div>
+							<div class="meta"><?php esc_html_e( 'From:', 'buddypress' ); ?> <?php bp_message_thread_from(); ?> &middot; <?php bp_message_thread_last_post_date(); ?></div>
 						</div>
 					</li>
 

--- a/buddypress.org/public_html/wp-content/themes/codex-buddypress-org/widgets/inbox.php
+++ b/buddypress.org/public_html/wp-content/themes/codex-buddypress-org/widgets/inbox.php
@@ -9,7 +9,7 @@ class BPOrg_Inbox_Widget extends WP_Widget {
 
 	    extract( $args );
 		echo $before_widget;
-		echo $before_title . __( 'Inbox', 'bp-follow' ) . ' &middot <a href="' . esc_url( $bp->loggedin_user->domain . 'messages/inbox/' ) . '">View All</a>' . $after_title; ?>
+		echo $before_title . esc_html__( 'Inbox', 'bp-follow' ) . ' &middot <a href="' . esc_url( $bp->loggedin_user->domain . 'messages/inbox/' ) . '">View All</a>' . $after_title; ?>
 
 		<?php if ( bp_has_message_threads( 'per_page=5&max=5' ) ) : ?>
 
@@ -20,7 +20,7 @@ class BPOrg_Inbox_Widget extends WP_Widget {
 						<?php bp_message_thread_avatar() ?>
 						<div class="details">
 							<a class="title" href="<?php bp_message_thread_view_link() ?>" title="<?php esc_attr_e( "View Message", "buddypress" ); ?>"><?php bp_message_thread_subject() ?></a>
-							<div class="meta"><?php _e( 'From:', 'buddypress' ); ?> <?php bp_message_thread_from() ?> &middot; <?php bp_message_thread_last_post_date() ?></div>
+							<div class="meta"><?php esc_html_e( 'From:', 'buddypress' ); ?> <?php bp_message_thread_from() ?> &middot; <?php bp_message_thread_last_post_date() ?></div>
 						</div>
 					</li>
 

--- a/buddypress.org/public_html/wp-content/themes/codex-buddypress-org/widgets/login.php
+++ b/buddypress.org/public_html/wp-content/themes/codex-buddypress-org/widgets/login.php
@@ -13,7 +13,8 @@ class BPOrg_Login_Widget extends WP_Widget {
 
 			<?php
 				echo $before_widget;
-				echo $before_title . __( 'Logged In As', 'bp-follow' ) . $after_title; ?>
+				echo $before_title . esc_html__( 'Logged In As', 'bp-follow' ) . $after_title;
+			?>
 
 			<?php do_action( 'bp_before_sidebar_me' ) ?>
 
@@ -40,10 +41,11 @@ class BPOrg_Login_Widget extends WP_Widget {
 
 			<?php
 				echo $before_widget;
-				echo $before_title . __( 'Log In', 'bp-follow' ) . $after_title; ?>
+				echo $before_title . esc_html__( 'Log In', 'bp-follow' ) . $after_title;
+			?>
 
 			<p id="login-text">
-				<?php _e( 'To start connecting please log in first.', 'buddypress' ) ?>
+				<?php esc_html_e( 'To start connecting please log in first.', 'buddypress' ); ?>
 				<?php if ( bp_get_signup_allowed() ) : ?>
 					<?php
 					/* translators: %s: URL of the account registration page. */
@@ -53,13 +55,13 @@ class BPOrg_Login_Widget extends WP_Widget {
 			</p>
 
 			<form name="login-form" id="sidebar-login-form" class="standard-form" action="<?php echo esc_url( site_url( 'wp-login.php', 'login_post' ) ); ?>" method="post">
-				<label><?php _e( 'Username', 'buddypress' ) ?><br />
+				<label><?php esc_html_e( 'Username', 'buddypress' ) ?><br />
 				<input type="text" name="log" id="sidebar-user-login" class="input" value="<?php echo attribute_escape(stripslashes($user_login)); ?>" /></label>
 
-				<label><?php _e( 'Password', 'buddypress' ) ?><br />
+				<label><?php esc_html_e( 'Password', 'buddypress' ); ?><br />
 				<input type="password" name="pwd" id="sidebar-user-pass" class="input" value="" /></label>
 
-				<p class="forgetmenot"><label><input name="rememberme" type="checkbox" id="sidebar-rememberme" value="forever" /> <?php _e( 'Remember Me', 'buddypress' ) ?></label></p>
+				<p class="forgetmenot"><label><input name="rememberme" type="checkbox" id="sidebar-rememberme" value="forever" /> <?php esc_html_e( 'Remember Me', 'buddypress' ); ?></label></p>
 
 				<?php do_action( 'bp_sidebar_login_form' ) ?>
 				<input type="submit" name="wp-submit" id="sidebar-wp-submit" value="<?php esc_attr_e('Log In'); ?>" tabindex="100" />

--- a/buddypress.org/public_html/wp-content/themes/codex-buddypress-org/widgets/login.php
+++ b/buddypress.org/public_html/wp-content/themes/codex-buddypress-org/widgets/login.php
@@ -13,7 +13,7 @@ class BPOrg_Login_Widget extends WP_Widget {
 
 			<?php
 				echo $before_widget;
-				echo $before_title . esc_html__( 'Logged In As', 'bp-follow' ) . $after_title;
+				echo wp_kses_post( $before_title ) . esc_html__( 'Logged In As', 'bp-follow' ) . wp_kses_post( $after_title );
 			?>
 
 			<?php do_action( 'bp_before_sidebar_me' ) ?>
@@ -41,7 +41,7 @@ class BPOrg_Login_Widget extends WP_Widget {
 
 			<?php
 				echo $before_widget;
-				echo $before_title . esc_html__( 'Log In', 'bp-follow' ) . $after_title;
+				echo wp_kses_post( $before_title ) . esc_html__( 'Log In', 'bp-follow' ) . wp_kses_post( $after_title );
 			?>
 
 			<p id="login-text">
@@ -55,7 +55,7 @@ class BPOrg_Login_Widget extends WP_Widget {
 			</p>
 
 			<form name="login-form" id="sidebar-login-form" class="standard-form" action="<?php echo esc_url( site_url( 'wp-login.php', 'login_post' ) ); ?>" method="post">
-				<label><?php esc_html_e( 'Username', 'buddypress' ) ?><br />
+				<label><?php esc_html_e( 'Username', 'buddypress' ); ?><br />
 				<input type="text" name="log" id="sidebar-user-login" class="input" value="<?php echo attribute_escape(stripslashes($user_login)); ?>" /></label>
 
 				<label><?php esc_html_e( 'Password', 'buddypress' ); ?><br />

--- a/global.wordpress.org/public_html/wp-content/mu-plugins/downloads/rosetta-downloads.php
+++ b/global.wordpress.org/public_html/wp-content/mu-plugins/downloads/rosetta-downloads.php
@@ -143,6 +143,7 @@ class Rosetta_Downloads {
 			<p>
 				<?php
 				printf(
+					/* translators: 1: Download counter URL, 2: WordPress version. */
 					wp_kses_post( __( 'This page shows the <a href="%s">Download Counter</a> number &mdash; total downloads of WordPress %s &mdash; broken down by locale.', 'rosetta' ) ),
 					'https://wordpress.org/download/counter/',
 					esc_html( WP_CORE_STABLE_BRANCH )

--- a/global.wordpress.org/public_html/wp-content/mu-plugins/downloads/rosetta-downloads.php
+++ b/global.wordpress.org/public_html/wp-content/mu-plugins/downloads/rosetta-downloads.php
@@ -144,7 +144,7 @@ class Rosetta_Downloads {
 				<?php
 				printf(
 					/* translators: 1: Download counter URL, 2: WordPress version. */
-					wp_kses_post( __( 'This page shows the <a href="%s">Download Counter</a> number &mdash; total downloads of WordPress %s &mdash; broken down by locale.', 'rosetta' ) ),
+					wp_kses_post( __( 'This page shows the <a href="%1$s">Download Counter</a> number &mdash; total downloads of WordPress %2$s &mdash; broken down by locale.', 'rosetta' ) ),
 					'https://wordpress.org/download/counter/',
 					esc_html( WP_CORE_STABLE_BRANCH )
 				);

--- a/global.wordpress.org/public_html/wp-content/mu-plugins/downloads/rosetta-downloads.php
+++ b/global.wordpress.org/public_html/wp-content/mu-plugins/downloads/rosetta-downloads.php
@@ -139,11 +139,11 @@ class Rosetta_Downloads {
 		}
 		?>
 		<div class="wrap">
-			<h2><?php _e( 'Download Stats', 'rosetta' ); ?></h2>
+			<h2><?php esc_html_e( 'Download Stats', 'rosetta' ); ?></h2>
 			<p>
 				<?php
 				printf(
-					__( 'This page shows the <a href="%s">Download Counter</a> number &mdash; total downloads of WordPress %s &mdash; broken down by locale.', 'rosetta' ),
+					wp_kses_post( __( 'This page shows the <a href="%s">Download Counter</a> number &mdash; total downloads of WordPress %s &mdash; broken down by locale.', 'rosetta' ) ),
 					'https://wordpress.org/download/counter/',
 					esc_html( WP_CORE_STABLE_BRANCH )
 				);
@@ -153,16 +153,16 @@ class Rosetta_Downloads {
 			<table class="widefat fixed striped" style="width:auto">
 				<thead>
 					<tr>
-						<th scope="col"><?php _e( 'Locale', 'rosetta' ); ?></th>
-						<th scope="col" style="text-align:right"><?php _e( 'Release Package', 'rosetta' ); ?></th>
-						<th scope="col" style="text-align:right"><?php _e( 'Language Pack', 'rosetta' ); ?></th>
+						<th scope="col"><?php esc_html_e( 'Locale', 'rosetta' ); ?></th>
+						<th scope="col" style="text-align:right"><?php esc_html_e( 'Release Package', 'rosetta' ); ?></th>
+						<th scope="col" style="text-align:right"><?php esc_html_e( 'Language Pack', 'rosetta' ); ?></th>
 					</tr>
 				</thead>
 
 				<tbody>
 					<tr>
 						<td>
-							<strong><?php _ex( 'All', 'locales', 'rosetta' ); ?></strong>
+							<strong><?php echo esc_html_x( 'All', 'locales', 'rosetta' ); ?></strong>
 						</td>
 						<td style="text-align:right">
 							<strong><?php echo number_format_i18n( $total_release_counts ); ?></strong>
@@ -176,9 +176,9 @@ class Rosetta_Downloads {
 
 				<tfoot>
 					<tr>
-						<th scope="col" style="width:80px"><?php _e( 'Locale', 'rosetta' ); ?></th>
-						<th scope="col" style="text-align:right"><?php _e( 'Release Package', 'rosetta' ); ?></th>
-						<th scope="col" style="text-align:right"><?php _e( 'Language Pack', 'rosetta' ); ?></th>
+						<th scope="col" style="width:80px"><?php esc_html_e( 'Locale', 'rosetta' ); ?></th>
+						<th scope="col" style="text-align:right"><?php esc_html_e( 'Release Package', 'rosetta' ); ?></th>
+						<th scope="col" style="text-align:right"><?php esc_html_e( 'Language Pack', 'rosetta' ); ?></th>
 					</tr>
 				</tfoot>
 			</table>

--- a/global.wordpress.org/public_html/wp-content/mu-plugins/roles/class-translation-editors-list-table.php
+++ b/global.wordpress.org/public_html/wp-content/mu-plugins/roles/class-translation-editors-list-table.php
@@ -106,7 +106,7 @@ class Rosetta_Translation_Editors_List_Table extends WP_List_Table {
 	 * Output 'no users' message.
 	 */
 	public function no_items() {
-		_e( 'No translation editors were found.', 'rosetta' );
+		esc_html_e( 'No translation editors were found.', 'rosetta' );
 	}
 
 	/**
@@ -269,7 +269,7 @@ class Rosetta_Translation_Editors_List_Table extends WP_List_Table {
 	public function column_cb( $user ) {
 		if ( $this->user_can_promote ) {
 			?>
-			<label class="screen-reader-text" for="cb-select-<?php echo $user->ID; ?>"><?php _e( 'Select translation editor', 'rosetta' ); ?></label>
+			<label class="screen-reader-text" for="cb-select-<?php echo $user->ID; ?>"><?php esc_html_e( 'Select translation editor', 'rosetta' ); ?></label>
 			<input id="cb-select-<?php echo $user->ID; ?>" type="checkbox" name="translation-editors[]" value="<?php echo $user->ID; ?>">
 			<?php
 		}
@@ -326,12 +326,12 @@ class Rosetta_Translation_Editors_List_Table extends WP_List_Table {
 		$project_access_list = $this->rosetta_roles->get_users_projects( $user->ID );
 
 		if ( empty( $project_access_list ) ) {
-			_e( 'No projects', 'rosetta' );
+			esc_html_e( 'No projects', 'rosetta' );
 			return;
 		}
 
 		if ( in_array( 'all', $project_access_list, true ) ) {
-			_e( 'All projects', 'rosetta' );
+			esc_html_e( 'All projects', 'rosetta' );
 			return;
 		}
 

--- a/global.wordpress.org/public_html/wp-content/mu-plugins/roles/class-translation-editors-list-table.php
+++ b/global.wordpress.org/public_html/wp-content/mu-plugins/roles/class-translation-editors-list-table.php
@@ -269,7 +269,7 @@ class Rosetta_Translation_Editors_List_Table extends WP_List_Table {
 	public function column_cb( $user ) {
 		if ( $this->user_can_promote ) {
 			?>
-			<label class="screen-reader-text" for="cb-select-<?php echo $user->ID; ?>"><?php esc_html_e( 'Select translation editor', 'rosetta' ); ?></label>
+			<label class="screen-reader-text" for="cb-select-<?php echo (int) $user->ID; ?>"><?php esc_html_e( 'Select translation editor', 'rosetta' ); ?></label>
 			<input id="cb-select-<?php echo $user->ID; ?>" type="checkbox" name="translation-editors[]" value="<?php echo $user->ID; ?>">
 			<?php
 		}

--- a/global.wordpress.org/public_html/wp-content/mu-plugins/roles/views/cross-locale-pte.php
+++ b/global.wordpress.org/public_html/wp-content/mu-plugins/roles/views/cross-locale-pte.php
@@ -1,3 +1,11 @@
+<?php
+/**
+ * Admin view listing cross-locale project translation editors.
+ *
+ * @package Rosetta
+ */
+
+?>
 <div class="wrap">
 	<h2>
 		<?php esc_html_e( 'Cross-Locale PTEs', 'rosetta' ); ?>

--- a/global.wordpress.org/public_html/wp-content/mu-plugins/roles/views/cross-locale-pte.php
+++ b/global.wordpress.org/public_html/wp-content/mu-plugins/roles/views/cross-locale-pte.php
@@ -1,11 +1,11 @@
 <div class="wrap">
 	<h2>
-		<?php _e( 'Cross-Locale PTEs', 'rosetta' ); ?>
+		<?php esc_html_e( 'Cross-Locale PTEs', 'rosetta' ); ?>
 	</h2>
 
 	<?php echo $feedback_message; ?>
 
-	<p><?php _e( 'This is the list of our current Cross-Locale PTEs.', 'rosetta' ); ?></p>
+	<p><?php esc_html_e( 'This is the list of our current Cross-Locale PTEs.', 'rosetta' ); ?></p>
 	<table class="wp-list-table widefat fixed striped translation-editors">
 		<thead>
 		<tr>
@@ -40,12 +40,12 @@
 	</table>
 
 	<?php if ( current_user_can( Rosetta_Roles::MANAGE_TRANSLATION_EDITORS_CAP ) ) : ?>
-		<h3><?php _e( 'Add Cross-Locale PTE', 'rosetta' ); ?></h3>
-		<p><?php _e( 'Enter the email address or username of an existing user on wordpress.org.', 'rosetta' ); ?></p>
+		<h3><?php esc_html_e( 'Add Cross-Locale PTE', 'rosetta' ); ?></h3>
+		<p><?php esc_html_e( 'Enter the email address or username of an existing user on wordpress.org.', 'rosetta' ); ?></p>
 		<form action="" method="post">
 			<table class="form-table">
 				<tr>
-					<th scope="row"><label for="user"><?php _e( 'E-mail or Username', 'rosetta' ); ?></label></th>
+					<th scope="row"><label for="user"><?php esc_html_e( 'E-mail or Username', 'rosetta' ); ?></label></th>
 					<td><input type="text" class="regular-text" name="user" id="user"></td>
 				</tr>
 			</table>

--- a/global.wordpress.org/public_html/wp-content/mu-plugins/roles/views/edit-cross-locale-pte.php
+++ b/global.wordpress.org/public_html/wp-content/mu-plugins/roles/views/edit-cross-locale-pte.php
@@ -1,12 +1,12 @@
 <div class="wrap">
-	<h2><?php _e( 'Edit Cross-Locale PTE', 'rosetta' ); ?></h2>
+	<h2><?php esc_html_e( 'Edit Cross-Locale PTE', 'rosetta' ); ?></h2>
 
 	<?php echo $feedback_message; ?>
 
 	<p><?php
 		printf(
 			/* translators: %s: WP.org profile link */
-			__( 'You are currently editing the user %s.', 'rosetta' ),
+			esc_html__( 'You are currently editing the user %s.', 'rosetta' ),
 			sprintf( '<a href="%1$s">%2$s</a>',
 				'https://profiles.wordpress.org/' . $user->user_nicename . '/',
 				$user->user_login
@@ -19,19 +19,19 @@
 			<tbody>
 				<tr>
 					<th scope="row">
-						<?php _e( 'Add cross-locale PTE access for:', 'rosetta' ); ?><br>
+						<?php esc_html_e( 'Add cross-locale PTE access for:', 'rosetta' ); ?><br>
 					</th>
 					<td>
 						<fieldset id="projects">
-							<legend class="screen-reader-text"><span><?php _e( 'Add cross-locale PTE access for:', 'rosetta' ); ?></span></legend>
+							<legend class="screen-reader-text"><span><?php esc_html_e( 'Add cross-locale PTE access for:', 'rosetta' ); ?></span></legend>
 
 							<ul id="projects-list" class="projects-list">
 								<li id="project-loading" class="loading">
-									<?php _e( 'Loading&hellip;', 'rosetta' ); ?>
+									<?php esc_html_e( 'Loading&hellip;', 'rosetta' ); ?>
 								</li>
 							</ul>
 						</fieldset>
-						<p class="description"><?php _e( 'Each project includes sub projects and newly-added sub projects.', 'rosetta' ); ?></p>
+						<p class="description"><?php esc_html_e( 'Each project includes sub projects and newly-added sub projects.', 'rosetta' ); ?></p>
 					</td>
 				</tr>
 			</tbody>

--- a/global.wordpress.org/public_html/wp-content/mu-plugins/roles/views/edit-cross-locale-pte.php
+++ b/global.wordpress.org/public_html/wp-content/mu-plugins/roles/views/edit-cross-locale-pte.php
@@ -1,3 +1,11 @@
+<?php
+/**
+ * Admin view for editing a cross-locale project translation editor.
+ *
+ * @package Rosetta
+ */
+
+?>
 <div class="wrap">
 	<h2><?php esc_html_e( 'Edit Cross-Locale PTE', 'rosetta' ); ?></h2>
 

--- a/global.wordpress.org/public_html/wp-content/mu-plugins/roles/views/edit-translation-editor.php
+++ b/global.wordpress.org/public_html/wp-content/mu-plugins/roles/views/edit-translation-editor.php
@@ -1,5 +1,5 @@
 <div class="wrap">
-	<h2><?php _e( 'Edit Translation Editor', 'rosetta' ); ?></h2>
+	<h2><?php esc_html_e( 'Edit Translation Editor', 'rosetta' ); ?></h2>
 
 	<?php echo $feedback_message; ?>
 
@@ -7,7 +7,7 @@
 		$user = get_user_by( 'id', $user_id );
 		printf(
 			/* translators: %s: WP.org profile link */
-			__( 'You are currently editing the user %s.', 'rosetta' ),
+			esc_html__( 'You are currently editing the user %s.', 'rosetta' ),
 			sprintf( '<a href="%1$s">%2$s</a>',
 				'https://profiles.wordpress.org/' . $user->user_nicename . '/',
 				$user->user_login
@@ -20,27 +20,27 @@
 			<tbody>
 				<tr>
 					<th scope="row">
-						<?php _e( 'Add editor access for:', 'rosetta' ); ?><br>
+						<?php esc_html_e( 'Add editor access for:', 'rosetta' ); ?><br>
 					</th>
 					<td>
 						<fieldset id="projects">
-							<legend class="screen-reader-text"><span><?php _e( 'Add editor access for:', 'rosetta' ); ?></span></legend>
+							<legend class="screen-reader-text"><span><?php esc_html_e( 'Add editor access for:', 'rosetta' ); ?></span></legend>
 
 							<ul id="projects-list" class="projects-list">
 								<li id="project-all" class="active">
 									<label>
-										<input type="checkbox"<?php checked( in_array( 'all', $project_access_list ) ); ?>> <?php _e( 'All projects', 'rosetta' ); ?>
+										<input type="checkbox"<?php checked( in_array( 'all', $project_access_list ) ); ?>> <?php esc_html_e( 'All projects', 'rosetta' ); ?>
 									</label>
 									<div class="sub-projects-wrapper">
-										<?php _e( 'The translation editor has validation permissions for all projects, including newly-added projects.', 'rosetta' ); ?>
+										<?php esc_html_e( 'The translation editor has validation permissions for all projects, including newly-added projects.', 'rosetta' ); ?>
 									</div>
 								</li>
 								<li id="project-loading" class="loading">
-									<?php _e( 'Loading&hellip;', 'rosetta' ); ?>
+									<?php esc_html_e( 'Loading&hellip;', 'rosetta' ); ?>
 								</li>
 							</ul>
 						</fieldset>
-						<p class="description"><?php _e( 'Each project includes sub projects and newly-added sub projects.', 'rosetta' ); ?></p>
+						<p class="description"><?php esc_html_e( 'Each project includes sub projects and newly-added sub projects.', 'rosetta' ); ?></p>
 					</td>
 				</tr>
 			</tbody>

--- a/global.wordpress.org/public_html/wp-content/mu-plugins/roles/views/edit-translation-editor.php
+++ b/global.wordpress.org/public_html/wp-content/mu-plugins/roles/views/edit-translation-editor.php
@@ -1,3 +1,11 @@
+<?php
+/**
+ * Admin view for editing a translation editor.
+ *
+ * @package Rosetta
+ */
+
+?>
 <div class="wrap">
 	<h2><?php esc_html_e( 'Edit Translation Editor', 'rosetta' ); ?></h2>
 

--- a/global.wordpress.org/public_html/wp-content/mu-plugins/roles/views/translation-editors.php
+++ b/global.wordpress.org/public_html/wp-content/mu-plugins/roles/views/translation-editors.php
@@ -1,10 +1,10 @@
 <div class="wrap">
 	<h2>
 		<?php
-		_e( 'Translation Editors', 'rosetta' );
+		esc_html_e( 'Translation Editors', 'rosetta' );
 
 		if ( ! empty( $_REQUEST['s'] ) ) {
-			echo '<span class="subtitle">' . sprintf( __( 'Search results for &#8220;%s&#8221;', 'rosetta' ), esc_html( wp_unslash( $_REQUEST['s'] ) ) ) . '</span>';
+			echo '<span class="subtitle">' . sprintf( esc_html__( 'Search results for &#8220;%s&#8221;', 'rosetta' ), esc_html( wp_unslash( $_REQUEST['s'] ) ) ) . '</span>';
 		}
 		?>
 	</h2>
@@ -23,25 +23,25 @@
 	</form>
 
 	<?php if ( current_user_can( Rosetta_Roles::MANAGE_TRANSLATION_EDITORS_CAP ) ) : ?>
-		<h3><?php _e( 'Add Translation Editor', 'rosetta' ); ?></h3>
-		<p><?php _e( 'Enter the email address or username of an existing user on wordpress.org.', 'rosetta' ); ?></p>
+		<h3><?php esc_html_e( 'Add Translation Editor', 'rosetta' ); ?></h3>
+		<p><?php esc_html_e( 'Enter the email address or username of an existing user on wordpress.org.', 'rosetta' ); ?></p>
 		<form action="" method="post">
 			<table class="form-table">
 				<tr>
-					<th scope="row"><label for="user"><?php _e( 'E-mail or Username', 'rosetta' ); ?></label></th>
+					<th scope="row"><label for="user"><?php esc_html_e( 'E-mail or Username', 'rosetta' ); ?></label></th>
 					<td><input type="text" class="regular-text" name="user" id="user"></td>
 				</tr>
 				<tr>
-					<th scope="row"><label for="user"><?php _e( 'Add editor access for:', 'rosetta' ); ?></label></th>
+					<th scope="row"><label for="user"><?php esc_html_e( 'Add editor access for:', 'rosetta' ); ?></label></th>
 					<td>
 						<fieldset>
-							<legend class="screen-reader-text"><?php _e( 'Add editor access for:', 'rosetta' ); ?></legend>
+							<legend class="screen-reader-text"><?php esc_html_e( 'Add editor access for:', 'rosetta' ); ?></legend>
 							<label for="custom-projects">
-								<input type="radio" name="projects" value="custom" id="custom-projects" checked> <?php _e( 'Custom &ndash; After the user is added you will be redirected to set the projects.', 'rosetta' ); ?>
+								<input type="radio" name="projects" value="custom" id="custom-projects" checked> <?php esc_html_e( 'Custom &ndash; After the user is added you will be redirected to set the projects.', 'rosetta' ); ?>
 							</label>
 							<br>
 							<label for="all-projects" >
-								<input type="radio" name="projects" value="all" id="all-projects"> <?php _e( 'All projects &ndash; If selected, translation editor will have validation permissions for all projects, including newly-added projects.', 'rosetta' ); ?>
+								<input type="radio" name="projects" value="all" id="all-projects"> <?php esc_html_e( 'All projects &ndash; If selected, translation editor will have validation permissions for all projects, including newly-added projects.', 'rosetta' ); ?>
 							</label>
 						</fieldset>
 					</td>

--- a/global.wordpress.org/public_html/wp-content/mu-plugins/roles/views/translation-editors.php
+++ b/global.wordpress.org/public_html/wp-content/mu-plugins/roles/views/translation-editors.php
@@ -5,7 +5,7 @@
 
 		if ( ! empty( $_REQUEST['s'] ) ) {
 			/* translators: %s: Search term. */
-			echo '<span class="subtitle">' . sprintf( esc_html__( 'Search results for &#8220;%s&#8221;', 'rosetta' ), esc_html( wp_unslash( $_REQUEST['s'] ) ) ) . '</span>';
+			echo '<span class="subtitle">' . sprintf( esc_html__( 'Search results for &#8220;%s&#8221;', 'rosetta' ), esc_html( wp_unslash( $_REQUEST['s'] ) ) ) . '</span>'; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Escaped for display.
 		}
 		?>
 	</h2>

--- a/global.wordpress.org/public_html/wp-content/mu-plugins/roles/views/translation-editors.php
+++ b/global.wordpress.org/public_html/wp-content/mu-plugins/roles/views/translation-editors.php
@@ -4,6 +4,7 @@
 		esc_html_e( 'Translation Editors', 'rosetta' );
 
 		if ( ! empty( $_REQUEST['s'] ) ) {
+			/* translators: %s: Search term. */
 			echo '<span class="subtitle">' . sprintf( esc_html__( 'Search results for &#8220;%s&#8221;', 'rosetta' ), esc_html( wp_unslash( $_REQUEST['s'] ) ) ) . '</span>';
 		}
 		?>

--- a/global.wordpress.org/public_html/wp-content/mu-plugins/showcase/rosetta-showcase.php
+++ b/global.wordpress.org/public_html/wp-content/mu-plugins/showcase/rosetta-showcase.php
@@ -128,7 +128,7 @@ class Rosetta_Showcase {
 		<p><label for="rosetta_showcase_url"><?php esc_html_e( 'URL', 'rosetta' ); ?></label>
 			<input style="margin-left: 0; width: 98%" name="rosetta_showcase_url" id="rosetta_showcase_url" type="text" value="<?php echo esc_url( $url ); ?>" /></p>
 		<label for="excerpt"><?php esc_html_e( 'Description', 'rosetta' ); ?></label>
-		<textarea rows="1" cols="40" name="excerpt" tabindex="6" id="excerpt"><?php echo esc_textarea( $post->post_excerpt ); ?></textarea>
+		<textarea rows="1" cols="40" name="excerpt" tabindex="6" id="excerpt"><?php echo $post->post_excerpt; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The classic editor supplies an edit-context post; format_to_edit() has already escaped the excerpt for this textarea. ?></textarea>
 		<?php
 	}
 

--- a/global.wordpress.org/public_html/wp-content/mu-plugins/showcase/rosetta-showcase.php
+++ b/global.wordpress.org/public_html/wp-content/mu-plugins/showcase/rosetta-showcase.php
@@ -128,7 +128,7 @@ class Rosetta_Showcase {
 		<p><label for="rosetta_showcase_url"><?php esc_html_e( 'URL', 'rosetta' ); ?></label>
 			<input style="margin-left: 0; width: 98%" name="rosetta_showcase_url" id="rosetta_showcase_url" type="text" value="<?php echo esc_url( $url ); ?>" /></p>
 		<label for="excerpt"><?php esc_html_e( 'Description', 'rosetta' ); ?></label>
-		<textarea rows="1" cols="40" name="excerpt" tabindex="6" id="excerpt"><?php echo $post->post_excerpt; // textarea_escaped ?></textarea>
+		<textarea rows="1" cols="40" name="excerpt" tabindex="6" id="excerpt"><?php echo esc_textarea( $post->post_excerpt ); ?></textarea>
 		<?php
 	}
 

--- a/global.wordpress.org/public_html/wp-content/mu-plugins/showcase/rosetta-showcase.php
+++ b/global.wordpress.org/public_html/wp-content/mu-plugins/showcase/rosetta-showcase.php
@@ -125,9 +125,9 @@ class Rosetta_Showcase {
 	public function showcase_meta_box( $post ) {
 		$url = get_post_meta( $post->ID, '_rosetta_showcase_url', true );
 		?>
-		<p><label for="rosetta_showcase_url"><?php _e( 'URL', 'rosetta' ); ?></label>
+		<p><label for="rosetta_showcase_url"><?php esc_html_e( 'URL', 'rosetta' ); ?></label>
 			<input style="margin-left: 0; width: 98%" name="rosetta_showcase_url" id="rosetta_showcase_url" type="text" value="<?php echo esc_url( $url ); ?>" /></p>
-		<label for="excerpt"><?php _e( 'Description', 'rosetta' ); ?></label>
+		<label for="excerpt"><?php esc_html_e( 'Description', 'rosetta' ); ?></label>
 		<textarea rows="1" cols="40" name="excerpt" tabindex="6" id="excerpt"><?php echo $post->post_excerpt; // textarea_escaped ?></textarea>
 		<?php
 	}

--- a/global.wordpress.org/public_html/wp-content/themes/rosetta/404.php
+++ b/global.wordpress.org/public_html/wp-content/themes/rosetta/404.php
@@ -2,14 +2,14 @@
 
 <div id="headline">
 	<div class="wrapper">
-		<h2><?php _e( 'Page Not Found', 'rosetta' ); ?></h2>
+		<h2><?php esc_html_e( 'Page Not Found', 'rosetta' ); ?></h2>
 	</div>
 </div>
 
 <div id="pagebody">
 	<div class="wrapper">
 		<div class="col-12" role="main">
-			<p class="intro"><?php _e( 'The page you were looking for could not be found. I&#8217;m sorry, it&#8217;s not your fault&hellip; probably.', 'rosetta' ); ?></p>
+			<p class="intro"><?php esc_html_e( 'The page you were looking for could not be found. I&#8217;m sorry, it&#8217;s not your fault&hellip; probably.', 'rosetta' ); ?></p>
 		</div>
 	</div>
 </div>

--- a/global.wordpress.org/public_html/wp-content/themes/rosetta/archive.php
+++ b/global.wordpress.org/public_html/wp-content/themes/rosetta/archive.php
@@ -8,31 +8,37 @@
 				<?php
 				$blog_url = home_url( '/#blog' );
 				if ( 'page' === get_option( 'show_on_front' ) ) {
-					$blog_url = get_permalink( get_option('page_for_posts' ) );
+					$blog_url = get_permalink( get_option( 'page_for_posts' ) );
 				}
 				?>
-				<p><a href="<?php echo esc_url( $blog_url ); ?>"><?php _e( '&laquo; Back to blog', 'rosetta' ); ?></a></p>
+				<p><a href="<?php echo esc_url( $blog_url ); ?>"><?php esc_html_e( '&laquo; Back to blog', 'rosetta' ); ?></a></p>
 
 				<table class="widefat" >
 					<?php
 					$i = 0;
 					if ( have_posts() ) :
-						while ( have_posts() ) : the_post();
+						while ( have_posts() ) :
+							the_post();
 							$i++;
 							?>
-							<tr <?php if ( $i % 2 ) echo ' class="alt" '; ?>>
+							<tr 
+							<?php
+							if ( $i % 2 ) {
+								echo ' class="alt" ';}
+							?>
+							>
 								<th>
-									<?php the_date( '','<span class="date">', '</span>' ); ?>
+									<?php the_date( '', '<span class="date">', '</span>' ); ?>
 								</th>
 								<td>
-									<a href="<?php the_permalink() ?>"><?php the_title(); ?></a>
+									<a href="<?php the_permalink(); ?>"><?php the_title(); ?></a>
 								</td>
 							</tr>
 							<?php
 						endwhile;
 					else :
 						?>
-						<p><?php _e( 'Sorry, no posts matched your criteria.', 'rosetta' ); ?></p>
+						<p><?php esc_html_e( 'Sorry, no posts matched your criteria.', 'rosetta' ); ?></p>
 						<?php
 					endif;
 					?>
@@ -45,4 +51,5 @@
 		</div>
 	</div>
 
-<?php get_footer();
+<?php
+get_footer();

--- a/global.wordpress.org/public_html/wp-content/themes/rosetta/archive.php
+++ b/global.wordpress.org/public_html/wp-content/themes/rosetta/archive.php
@@ -1,3 +1,11 @@
+<?php
+/**
+ * The template for displaying archive pages.
+ *
+ * @package Rosetta
+ */
+
+?>
 <?php get_header(); ?>
 
 	<div id="pagebody">

--- a/global.wordpress.org/public_html/wp-content/themes/rosetta/comments.php
+++ b/global.wordpress.org/public_html/wp-content/themes/rosetta/comments.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * The template for displaying comments.
+ *
+ * @package Rosetta
+ */
+
 /*
  * If the current post is protected by a password and
  * the visitor has not yet entered the password we will
@@ -16,9 +22,9 @@ if ( post_password_required() ) {
 			<?php
 				printf(
 					/* translators: 1: Number of comments, 2: Post title. */
-					esc_html( _nx( 'One thought on &ldquo;%2$s&rdquo;', '%1$s thoughts on &ldquo;%2$s&rdquo;', get_comments_number(), 'comments title', 'rosetta' ) ),
-					number_format_i18n( get_comments_number() ),
-					get_the_title() 
+					esc_html( _nx( 'One thought on &ldquo;%2$s&rdquo;', '%1$s thoughts on &ldquo;%2$s&rdquo;', get_comments_number(), 'comments title', 'rosetta' ) ), // phpcs:ignore WordPress.WP.I18n.MissingSingularPlaceholder -- The singular form carries no count.
+					esc_html( number_format_i18n( get_comments_number() ) ),
+					esc_html( get_the_title() )
 				);
 			?>
 		</h2>
@@ -27,10 +33,10 @@ if ( post_password_required() ) {
 			<?php
 				wp_list_comments(
 					array(
-					'style'       => 'ol',
-					'short_ping'  => true,
-					'avatar_size' => 56,
-					) 
+						'style'       => 'ol',
+						'short_ping'  => true,
+						'avatar_size' => 56,
+					)
 				);
 			?>
 		</ol>

--- a/global.wordpress.org/public_html/wp-content/themes/rosetta/comments.php
+++ b/global.wordpress.org/public_html/wp-content/themes/rosetta/comments.php
@@ -15,6 +15,7 @@ if ( post_password_required() ) {
 		<h2 class="comments-title">
 			<?php
 				printf(
+					/* translators: 1: Number of comments, 2: Post title. */
 					esc_html( _nx( 'One thought on &ldquo;%2$s&rdquo;', '%1$s thoughts on &ldquo;%2$s&rdquo;', get_comments_number(), 'comments title', 'rosetta' ) ),
 					number_format_i18n( get_comments_number() ),
 					get_the_title() 

--- a/global.wordpress.org/public_html/wp-content/themes/rosetta/comments.php
+++ b/global.wordpress.org/public_html/wp-content/themes/rosetta/comments.php
@@ -14,18 +14,23 @@ if ( post_password_required() ) {
 	<?php if ( have_comments() ) : ?>
 		<h2 class="comments-title">
 			<?php
-				printf( _nx( 'One thought on &ldquo;%2$s&rdquo;', '%1$s thoughts on &ldquo;%2$s&rdquo;', get_comments_number(), 'comments title', 'rosetta' ),
-					number_format_i18n( get_comments_number() ), get_the_title() );
+				printf(
+					esc_html( _nx( 'One thought on &ldquo;%2$s&rdquo;', '%1$s thoughts on &ldquo;%2$s&rdquo;', get_comments_number(), 'comments title', 'rosetta' ) ),
+					number_format_i18n( get_comments_number() ),
+					get_the_title() 
+				);
 			?>
 		</h2>
 
 		<ol class="comment-list">
 			<?php
-				wp_list_comments( array(
+				wp_list_comments(
+					array(
 					'style'       => 'ol',
 					'short_ping'  => true,
 					'avatar_size' => 56,
-				) );
+					) 
+				);
 			?>
 		</ol>
 
@@ -33,9 +38,9 @@ if ( post_password_required() ) {
 
 	<?php
 		// If comments are closed and there are comments, let's leave a little note, shall we?
-		if ( ! comments_open() && get_comments_number() ) :
-	?>
-		<p class="no-comments"><?php _e( 'Comments are closed.', 'rosetta' ); ?></p>
+	if ( ! comments_open() && get_comments_number() ) :
+		?>
+		<p class="no-comments"><?php esc_html_e( 'Comments are closed.', 'rosetta' ); ?></p>
 	<?php endif; ?>
 
 	<?php comment_form(); ?>

--- a/global.wordpress.org/public_html/wp-content/themes/rosetta/contact.php
+++ b/global.wordpress.org/public_html/wp-content/themes/rosetta/contact.php
@@ -212,7 +212,7 @@ Sent From: ' . esc_url_raw( $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] );
 } else { // Empty $_POST['submit']
 
 	if ( false !== strpos( get_the_content(), 'The contents of this page are filled automatically' ) ) : ?>
-		<p><?php esc_html_e( 'You can contact translators and this site administrators via this form:', 'rosetta'); ?></p>
+		<p><?php esc_html_e( 'You can contact translators and this site administrators via this form:', 'rosetta' ); ?></p>
 		<?php /* translators: feel free to add links to places, where one can get support in your language. */ ?>
 		<p><?php echo wp_kses_post( __( '<strong>Please, do not post support requests here!</strong> They will probably be ignored.', 'rosetta' ) ); ?></p>
 	<?php else: ?>

--- a/global.wordpress.org/public_html/wp-content/themes/rosetta/contact.php
+++ b/global.wordpress.org/public_html/wp-content/themes/rosetta/contact.php
@@ -47,25 +47,25 @@ if ( ! empty( $_POST['submit'] ) ) {
 
 	if ( $error ) {
 		?>
-		<h3 id="return"><?php _e( 'Error', 'rosetta' ); ?></h3>
-		<p class="error"><?php _e( 'There seems to have been a problem with the information you entered. Please fix the field indicated and resubmit.', 'rosetta' ); ?></p>
+		<h3 id="return"><?php esc_html_e( 'Error', 'rosetta' ); ?></h3>
+		<p class="error"><?php esc_html_e( 'There seems to have been a problem with the information you entered. Please fix the field indicated and resubmit.', 'rosetta' ); ?></p>
 		<form id="contactme" method="post" action="/contact/#return">
 			<table id="form">
 
 				<?php if ( $your_name ) { ?>
 					<tr class="error">
 						<td class="label">
-							<label for="your_name"><?php _e( 'Your Name:', 'rosetta' ); ?> </label>
+							<label for="your_name"><?php esc_html_e( 'Your Name:', 'rosetta' ); ?> </label>
 						</td>
 						<td>
 							<span><input name="your_name" type="text" id="your_name" value="<?php echo esc_attr( $_POST['your_name'] ); ?>" /></span>
-							<?php _e( 'Let us know your name.', 'rosetta' ); ?>
+							<?php esc_html_e( 'Let us know your name.', 'rosetta' ); ?>
 						</td>
 					</tr>
 				<?php } else { ?>
 					<tr>
 						<td class="label">
-							<label for="your_name"><?php _e( 'Your Name:', 'rosetta' ); ?></label>
+							<label for="your_name"><?php esc_html_e( 'Your Name:', 'rosetta' ); ?></label>
 						</td>
 						<td>
 							<span><input name="your_name" type="text" id="your_name" value="<?php echo esc_attr( $_POST['your_name'] ); ?>" /></span>
@@ -76,17 +76,17 @@ if ( ! empty( $_POST['submit'] ) ) {
 				<?php if ( $your_email ) { ?>
 					<tr class="error">
 						<td class="label">
-							<label for="your_email"><?php _e( 'Your Email:', 'rosetta' ); ?></label>
+							<label for="your_email"><?php esc_html_e( 'Your Email:', 'rosetta' ); ?></label>
 						</td>
 						<td>
 							<span><input name="your_email" type="text" id="your_email" value="<?php echo esc_attr( $_POST['your_email'] ); ?>" /></span>
-							<?php _e( 'Your email address did not appear to be valid. Please check it.', 'rosetta' ); ?>
+							<?php esc_html_e( 'Your email address did not appear to be valid. Please check it.', 'rosetta' ); ?>
 						</td>
 					</tr>
 				<?php } else { ?>
 					<tr>
 						<td class="label">
-							<label for="your_email"><?php _e( 'Your Email:', 'rosetta' ); ?></label>
+							<label for="your_email"><?php esc_html_e( 'Your Email:', 'rosetta' ); ?></label>
 						</td>
 						<td>
 							<span><input name="your_email" type="text" id="your_email" value="<?php echo esc_attr( $_POST['your_email'] ); ?>" /></span>
@@ -96,7 +96,7 @@ if ( ! empty( $_POST['submit'] ) ) {
 
 				<tr>
 					<td class="label">
-						<label for="blog_url"><?php _e( 'URI of your blog:', 'rosetta' ); ?></label>
+						<label for="blog_url"><?php esc_html_e( 'URI of your blog:', 'rosetta' ); ?></label>
 					</td>
 					<td>
 						<span><input name="blog_url" type="text" id="blog_url" value="<?php echo esc_attr( $_POST['blog_url'] ); ?>" /></span>
@@ -106,17 +106,17 @@ if ( ! empty( $_POST['submit'] ) ) {
 				<?php if ( $subject ) { ?>
 					<tr class="error">
 						<td class="label">
-							<label for="subject"><?php _e( 'What&rsquo;s this about?', 'rosetta' ); ?></label>
+							<label for="subject"><?php esc_html_e( 'What&rsquo;s this about?', 'rosetta' ); ?></label>
 						</td>
 						<td>
 							<span><input name="subject" type="text" id="subject" value="<?php echo esc_attr( $_POST['subject'] ); ?>" /></span>
-							<?php _e( 'Write something!', 'rosetta' ); ?>
+							<?php esc_html_e( 'Write something!', 'rosetta' ); ?>
 						</td>
 					</tr>
 				<?php } else { ?>
 					<tr>
 						<td class="label">
-							<label for="subject"><?php _e('What&rsquo;s this about?', 'rosetta'); ?></label>
+							<label for="subject"><?php esc_html_e( 'What&rsquo;s this about?', 'rosetta' ); ?></label>
 						</td>
 						<td>
 							<span><input name="subject" type="text" id="subject" value="<?php echo esc_attr( $_POST['subject'] ); ?>" /></span>
@@ -127,17 +127,17 @@ if ( ! empty( $_POST['submit'] ) ) {
 				<?php if ( $blog_description ) { ?>
 					<tr class="error">
 						<td class="label">
-							<label for="message"><?php _e('Your Message:', 'rosetta'); ?></label>
+							<label for="message"><?php esc_html_e( 'Your Message:', 'rosetta' ); ?></label>
 						</td>
 						<td>
 							<span class="message"><textarea name="message" id="message"><?php echo esc_textarea( $_POST['message'] ); ?></textarea></span>
-							<?php _e( 'Say something!', 'rosetta' ); ?>
+							<?php esc_html_e( 'Say something!', 'rosetta' ); ?>
 						</td>
 					</tr>
 				<?php } else { ?>
 					<tr>
 						<td class="label">
-							<label for="message"><?php _e( 'Your Message:', 'rosetta' ); ?></label>
+							<label for="message"><?php esc_html_e( 'Your Message:', 'rosetta' ); ?></label>
 						</td>
 						<td>
 							<span class="message"><textarea name="message" id="message"><?php echo esc_textarea( $_POST['message'] ); ?></textarea></span>
@@ -203,8 +203,8 @@ Sent From: ' . esc_url_raw( $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] );
 		remove_action( 'phpmailer_init', 'rosetta_set_sender' );
 		?>
 		<div id="return">
-			<h3><?php _e( 'Submitted!', 'rosetta' ); ?></h3>
-			<p><strong><?php _e( 'Thank you!', 'rosetta' ); ?></strong></p>
+			<h3><?php esc_html_e( 'Submitted!', 'rosetta' ); ?></h3>
+			<p><strong><?php esc_html_e( 'Thank you!', 'rosetta' ); ?></strong></p>
 		</div>
 		<?php
 	}
@@ -212,9 +212,9 @@ Sent From: ' . esc_url_raw( $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] );
 } else { // Empty $_POST['submit']
 
 	if ( false !== strpos( get_the_content(), 'The contents of this page are filled automatically' ) ) : ?>
-		<p><?php _e( 'You can contact translators and this site administrators via this form:', 'rosetta'); ?></p>
+		<p><?php esc_html_e( 'You can contact translators and this site administrators via this form:', 'rosetta'); ?></p>
 		<?php /* translators: feel free to add links to places, where one can get support in your language. */ ?>
-		<p><?php _e( '<strong>Please, do not post support requests here!</strong> They will probably be ignored.', 'rosetta' ); ?></p>
+		<p><?php echo wp_kses_post( __( '<strong>Please, do not post support requests here!</strong> They will probably be ignored.', 'rosetta' ) ); ?></p>
 	<?php else: ?>
 		<?php the_content(); ?>
 	<?php endif; ?>
@@ -223,7 +223,7 @@ Sent From: ' . esc_url_raw( $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] );
 		<table id="form">
 			<tr>
 				<td class="label">
-					<label for="your_name"><?php _e( 'Your Name:', 'rosetta' ); ?></label> <?php _e( '(required)', 'rosetta' ); ?>
+					<label for="your_name"><?php esc_html_e( 'Your Name:', 'rosetta' ); ?></label> <?php esc_html_e( '(required)', 'rosetta' ); ?>
 				</td>
 				<td>
 					<span><input name="your_name" type="text" id="your_name" /></span>
@@ -231,7 +231,7 @@ Sent From: ' . esc_url_raw( $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] );
 			</tr>
 			<tr>
 				<td class="label">
-					<label for="your_email"><?php _e( 'Your Email:', 'rosetta' ); ?></label> <?php _e( '(required)', 'rosetta' ); ?>
+					<label for="your_email"><?php esc_html_e( 'Your Email:', 'rosetta' ); ?></label> <?php esc_html_e( '(required)', 'rosetta' ); ?>
 				</td>
 				<td>
 					<span><input name="your_email" type="text" id="your_email" /></span>
@@ -239,7 +239,7 @@ Sent From: ' . esc_url_raw( $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] );
 			</tr>
 			<tr>
 				<td class="label">
-					<label for="blog_url"><?php _e( 'URI of your blog:', 'rosetta' ); ?></label>
+					<label for="blog_url"><?php esc_html_e( 'URI of your blog:', 'rosetta' ); ?></label>
 				</td>
 				<td>
 					<span><input name="blog_url" type="text" id="blog_url" /></span>
@@ -247,7 +247,7 @@ Sent From: ' . esc_url_raw( $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] );
 			</tr>
 			<tr>
 				<td class="label">
-					<label for="subject"><?php _e( 'What&rsquo;s this about?', 'rosetta' ); ?></label> <?php _e( '(required)', 'rosetta' ); ?>
+					<label for="subject"><?php esc_html_e( 'What&rsquo;s this about?', 'rosetta' ); ?></label> <?php esc_html_e( '(required)', 'rosetta' ); ?>
 				</td>
 				<td>
 					<span><input name="subject" type="text" id="subject" /></span>
@@ -255,7 +255,7 @@ Sent From: ' . esc_url_raw( $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] );
 			</tr>
 			<tr>
 				<td class="label">
-					<label for="message"><?php _e( 'Tell us something:', 'rosetta' ); ?></label> <?php _e( '(required)', 'rosetta' ); ?>
+					<label for="message"><?php esc_html_e( 'Tell us something:', 'rosetta' ); ?></label> <?php esc_html_e( '(required)', 'rosetta' ); ?>
 				</td>
 				<td>
 					<span class="message"><textarea name="message" id="message"></textarea></span>

--- a/global.wordpress.org/public_html/wp-content/themes/rosetta/download.php
+++ b/global.wordpress.org/public_html/wp-content/themes/rosetta/download.php
@@ -35,6 +35,7 @@ the_post();
 		foreach ( $releases['branches'] as $branch => $branch_rels ):
 			rosetta_release_row( null, null, null, true );
 ?>
+			<?php /* translators: %s: Branch number. */ ?>
 			<h3><?php printf( esc_html__( '%s Branch', 'rosetta' ), $branch );?></h3>
 			<table class="releases">
 <?php

--- a/global.wordpress.org/public_html/wp-content/themes/rosetta/download.php
+++ b/global.wordpress.org/public_html/wp-content/themes/rosetta/download.php
@@ -36,7 +36,7 @@ the_post();
 			rosetta_release_row( null, null, null, true );
 ?>
 			<?php /* translators: %s: Branch number. */ ?>
-			<h3><?php printf( esc_html__( '%s Branch', 'rosetta' ), $branch );?></h3>
+			<h3><?php printf( esc_html__( '%s Branch', 'rosetta' ), esc_html( $branch ) ); ?></h3>
 			<table class="releases">
 <?php
 	foreach ( $branch_rels as $release ):

--- a/global.wordpress.org/public_html/wp-content/themes/rosetta/download.php
+++ b/global.wordpress.org/public_html/wp-content/themes/rosetta/download.php
@@ -22,7 +22,7 @@ the_post();
 		if ( isset( $releases['latest'] ) ):
 			rosetta_release_row( null, null, null, true );
 ?>
-			<h3 id="latest"><?php _e( 'Latest release', 'rosetta' ); ?></h3>
+			<h3 id="latest"><?php esc_html_e( 'Latest release', 'rosetta' ); ?></h3>
 			<table class="releases latest">
 				<?php echo rosetta_release_row( $releases['latest'], 'alt' ); ?>
 			</table>
@@ -35,7 +35,7 @@ the_post();
 		foreach ( $releases['branches'] as $branch => $branch_rels ):
 			rosetta_release_row( null, null, null, true );
 ?>
-			<h3><?php printf( __( '%s Branch', 'rosetta' ), $branch );?></h3>
+			<h3><?php printf( esc_html__( '%s Branch', 'rosetta' ), $branch );?></h3>
 			<table class="releases">
 <?php
 	foreach ( $branch_rels as $release ):
@@ -50,7 +50,7 @@ the_post();
 		endif; # any branches
 		if ( ! empty( $releases['betas'] ) ):
 ?>
-			<h3 id="betas"><?php _e( 'Beta &amp; RC releases', 'rosetta' ); ?></h3>
+			<h3 id="betas"><?php esc_html_e( 'Beta &amp; RC releases', 'rosetta' ); ?></h3>
 			<table id="beta" class="releases">
 <?php
 	rosetta_release_row( null, null, null, true );
@@ -66,7 +66,7 @@ the_post();
 		endif; # any betas
 	else: # no releases
 ?>
-	<p><?php _e( 'There are no releases, yet.', 'rosetta' ); ?></p>
+	<p><?php esc_html_e( 'There are no releases, yet.', 'rosetta' ); ?></p>
 <?php endif; # if releases?>
 			</div>
 		</div>

--- a/global.wordpress.org/public_html/wp-content/themes/rosetta/front-page.php
+++ b/global.wordpress.org/public_html/wp-content/themes/rosetta/front-page.php
@@ -73,7 +73,7 @@ if ( false === $latest_release && $rosetta->rosetta->get_latest_release() ) :
 	<div class="wrapper">
 		<div class="section">
 			<div class="col-12">
-				<h3><?php _e( 'Showcase', 'rosetta' ); ?></h3>
+				<h3><?php esc_html_e( 'Showcase', 'rosetta' ); ?></h3>
 				<ul id="showcase">
 <?php
 	foreach ( $showcase as $item ) :
@@ -93,7 +93,7 @@ if ( false === $latest_release && $rosetta->rosetta->get_latest_release() ) :
 		</a>
 		<?php echo esc_html( $item->post_title ); ?>
 		<br />
-		<a class="showcase-url" href="<?php echo esc_url( $url ); ?>" rel="nofollow"><?php _e( 'Visit the site &rarr;', 'rosetta' ); ?></a>
+		<a class="showcase-url" href="<?php echo esc_url( $url ); ?>" rel="nofollow"><?php esc_html_e( 'Visit the site &rarr;', 'rosetta' ); ?></a>
 	</li>
 <?php
 	endforeach;
@@ -108,7 +108,7 @@ if ( false === $latest_release && $rosetta->rosetta->get_latest_release() ) :
 		<div class="wrapper">
 			<div class="section">
 				<div class="col-12">
-					<h3><?php _e('Showcase', 'rosetta'); ?></h3>
+					<h3><?php esc_html_e( 'Showcase', 'rosetta' ); ?></h3>
 					<span id="showcase-front-slate">You can <a href="<?php echo esc_url( admin_url( 'edit.php?post_type=showcase' ) ); ?>">add notable sites</a> in your language and screenshot and description of random three of them will show here.</span>
 				</div>
 			</div>
@@ -134,7 +134,7 @@ if ( false === $latest_release && $rosetta->rosetta->get_latest_release() ) :
 		<div class="wrapper">
 			<div id="blog" class="section">
 				<div class="col-9">
-					<h3><?php _e('Blog', 'rosetta'); ?></h3>
+					<h3><?php esc_html_e('Blog', 'rosetta'); ?></h3>
 <?php
 	query_posts( 'showposts=5' );
 	while (have_posts()) : the_post();

--- a/global.wordpress.org/public_html/wp-content/themes/rosetta/front-page.php
+++ b/global.wordpress.org/public_html/wp-content/themes/rosetta/front-page.php
@@ -134,7 +134,7 @@ if ( false === $latest_release && $rosetta->rosetta->get_latest_release() ) :
 		<div class="wrapper">
 			<div id="blog" class="section">
 				<div class="col-9">
-					<h3><?php esc_html_e('Blog', 'rosetta'); ?></h3>
+					<h3><?php esc_html_e( 'Blog', 'rosetta' ); ?></h3>
 <?php
 	query_posts( 'showposts=5' );
 	while (have_posts()) : the_post();

--- a/global.wordpress.org/public_html/wp-content/themes/rosetta/functions.php
+++ b/global.wordpress.org/public_html/wp-content/themes/rosetta/functions.php
@@ -42,7 +42,7 @@ function rosetta_comment_form_support_hint() {
 	printf(
 		'<p>%s</p>',
 		/* translators: feel free to add links to places, where one can get support in your language. */
-		__( '<strong>Please, do not post support requests here!</strong> They will probably be ignored.', 'rosetta' )
+		wp_kses_post( __( '<strong>Please, do not post support requests here!</strong> They will probably be ignored.', 'rosetta' ) )
 	);
 }
 add_action( 'comment_form_top', 'rosetta_comment_form_support_hint' );

--- a/global.wordpress.org/public_html/wp-content/themes/rosetta/inc/template-tags.php
+++ b/global.wordpress.org/public_html/wp-content/themes/rosetta/inc/template-tags.php
@@ -4,7 +4,7 @@
  */
 function rosetta_entry_meta() {
 	if ( is_sticky() && is_home() && ! is_paged() ) {
-		printf( '<span class="sticky-post">%s</span> ', __( 'Featured', 'rosetta' ) );
+		printf( '<span class="sticky-post">%s</span> ', esc_html__( 'Featured', 'rosetta' ) );
 	}
 
 	$time_string = sprintf(
@@ -21,7 +21,7 @@ function rosetta_entry_meta() {
 
 	printf(
 		/* translators: 1: post date 2: post author */
-		__( 'Posted on %1$s by %2$s.', 'rosetta' ),
+		esc_html__( 'Posted on %1$s by %2$s.', 'rosetta' ),
 		$time_string,
 		$author_string
 	);
@@ -36,7 +36,7 @@ function rosetta_entry_meta() {
 		echo ' ';
 		printf(
 			/* translators: %s: list of categories */
-			__( 'Filed under %s.', 'rosetta' ),
+			esc_html__( 'Filed under %s.', 'rosetta' ),
 			$categories_string
 		);
 	}

--- a/global.wordpress.org/public_html/wp-content/themes/rosetta/index.php
+++ b/global.wordpress.org/public_html/wp-content/themes/rosetta/index.php
@@ -23,7 +23,7 @@
 					<?php comments_template(); ?>
 				<?php endwhile;
 			else: ?>
-				<p><?php _e( 'Sorry, no posts matched your criteria.', 'rosetta' ); ?></p>
+				<p><?php esc_html_e( 'Sorry, no posts matched your criteria.', 'rosetta' ); ?></p>
 			<?php endif; ?>
 
 			<nav class="posts-navigation">

--- a/global.wordpress.org/public_html/wp-content/themes/rosetta/sidebar-blog.php
+++ b/global.wordpress.org/public_html/wp-content/themes/rosetta/sidebar-blog.php
@@ -1,3 +1,11 @@
+<?php
+/**
+ * The sidebar shown on blog pages.
+ *
+ * @package Rosetta
+ */
+
+?>
 <h4><?php esc_html_e( 'Categories', 'rosetta' ); ?></h4>
 <ul>
 	<?php wp_list_categories( 'title_li=&show_count=1&orderby=count&order=DESC&number=10' ); ?>

--- a/global.wordpress.org/public_html/wp-content/themes/rosetta/sidebar-blog.php
+++ b/global.wordpress.org/public_html/wp-content/themes/rosetta/sidebar-blog.php
@@ -1,9 +1,9 @@
-<h4><?php _e( 'Categories', 'rosetta' ); ?></h4>
+<h4><?php esc_html_e( 'Categories', 'rosetta' ); ?></h4>
 <ul>
 	<?php wp_list_categories( 'title_li=&show_count=1&orderby=count&order=DESC&number=10' ); ?>
 </ul>
 
-<h4><?php _e( 'Blog Archives', 'rosetta' ); ?></h4>
+<h4><?php esc_html_e( 'Blog Archives', 'rosetta' ); ?></h4>
 <ul>
 	<?php wp_get_archives( 'type=monthly&limit=12' ); ?>
 </ul>

--- a/global.wordpress.org/public_html/wp-content/themes/rosetta/sidebar-page.php
+++ b/global.wordpress.org/public_html/wp-content/themes/rosetta/sidebar-page.php
@@ -19,11 +19,8 @@ if ( false !== $latest_release ) :
 	</p>
 
 	<p class="download-tar">
-		<a href="<?php echo $latest_release['targz_url']; ?>"><?php printf(
-			/* translators: %s: File size in megabytes. */
-			esc_html__( 'Download .tar.gz &mdash; %s MB', 'rosetta' ),
-			esc_html( $latest_release['tar_size_mb'] ) );
-		?></a>
+		<?php /* translators: %s: File size in megabytes. */ ?>
+		<a href="<?php echo esc_url( $latest_release['targz_url'] ); ?>"><?php printf( esc_html__( 'Download .tar.gz &mdash; %s MB', 'rosetta' ), esc_html( $latest_release['tar_size_mb'] ) ); ?></a>
 	</p>
 	<?php
 endif;

--- a/global.wordpress.org/public_html/wp-content/themes/rosetta/sidebar-page.php
+++ b/global.wordpress.org/public_html/wp-content/themes/rosetta/sidebar-page.php
@@ -22,7 +22,7 @@ if ( false !== $latest_release ) :
 		<a href="<?php echo $latest_release['targz_url']; ?>"><?php printf(
 			/* translators: %s: File size in megabytes. */
 			esc_html__( 'Download .tar.gz &mdash; %s MB', 'rosetta' ),
-			$latest_release['tar_size_mb'] );
+			esc_html( $latest_release['tar_size_mb'] ) );
 		?></a>
 	</p>
 	<?php

--- a/global.wordpress.org/public_html/wp-content/themes/rosetta/sidebar-page.php
+++ b/global.wordpress.org/public_html/wp-content/themes/rosetta/sidebar-page.php
@@ -4,12 +4,16 @@ $latest_release = $rosetta->rosetta->get_latest_release();
 if ( false !== $latest_release ) :
 	?>
 	<p class="download-meta">
-		<a class="button download-button button-large button-large" href="<?php echo $latest_release['zip_url']; ?>" role="button">
+		<a class="button download-button button-large button-large" href="<?php echo esc_url( $latest_release['zip_url'] ); ?>" role="button">
 			<strong><?php
-				echo apply_filters( 'no_orphans',
-					sprintf(
-						__( 'Download WordPress %s', 'rosetta' ),
-						$latest_release['version']
+				echo wp_kses_post(
+					apply_filters(
+						'no_orphans',
+						sprintf(
+							/* translators: %s: WordPress version. */
+							esc_html__( 'Download WordPress %s', 'rosetta' ),
+							esc_html( $latest_release['version'] )
+						)
 					)
 				);
 			?></strong>

--- a/global.wordpress.org/public_html/wp-content/themes/rosetta/sidebar-page.php
+++ b/global.wordpress.org/public_html/wp-content/themes/rosetta/sidebar-page.php
@@ -14,11 +14,13 @@ if ( false !== $latest_release ) :
 				);
 			?></strong>
 		</a>
+		<?php /* translators: %s: File size in megabytes. */ ?>
 		<span><?php printf( esc_html__( '.zip &mdash; %s MB', 'rosetta' ), $latest_release['zip_size_mb'] ); ?></span>
 	</p>
 
 	<p class="download-tar">
 		<a href="<?php echo $latest_release['targz_url']; ?>"><?php printf(
+			/* translators: %s: File size in megabytes. */
 			esc_html__( 'Download .tar.gz &mdash; %s MB', 'rosetta' ),
 			$latest_release['tar_size_mb'] );
 		?></a>

--- a/global.wordpress.org/public_html/wp-content/themes/rosetta/sidebar-page.php
+++ b/global.wordpress.org/public_html/wp-content/themes/rosetta/sidebar-page.php
@@ -14,12 +14,12 @@ if ( false !== $latest_release ) :
 				);
 			?></strong>
 		</a>
-		<span><?php printf( __( '.zip &mdash; %s MB', 'rosetta' ), $latest_release['zip_size_mb'] ); ?></span>
+		<span><?php printf( esc_html__( '.zip &mdash; %s MB', 'rosetta' ), $latest_release['zip_size_mb'] ); ?></span>
 	</p>
 
 	<p class="download-tar">
 		<a href="<?php echo $latest_release['targz_url']; ?>"><?php printf(
-			__( 'Download .tar.gz &mdash; %s MB', 'rosetta' ),
+			esc_html__( 'Download .tar.gz &mdash; %s MB', 'rosetta' ),
 			$latest_release['tar_size_mb'] );
 		?></a>
 	</p>
@@ -27,9 +27,9 @@ if ( false !== $latest_release ) :
 endif;
 ?>
 
-<h3><?php _e( 'Resources', 'rosetta' ); ?></h3>
+<h3><?php esc_html_e( 'Resources', 'rosetta' ); ?></h3>
 
-<p><?php _e( 'For help with installing or using WordPress, consult our documentation in your language.', 'rosetta' ); ?></p>
+<p><?php esc_html_e( 'For help with installing or using WordPress, consult our documentation in your language.', 'rosetta' ); ?></p>
 
 <?php
 if ( has_nav_menu( 'rosetta_resources' ) ) {

--- a/global.wordpress.org/public_html/wp-content/themes/rosetta/sidebar-page.php
+++ b/global.wordpress.org/public_html/wp-content/themes/rosetta/sidebar-page.php
@@ -15,7 +15,7 @@ if ( false !== $latest_release ) :
 			?></strong>
 		</a>
 		<?php /* translators: %s: File size in megabytes. */ ?>
-		<span><?php printf( esc_html__( '.zip &mdash; %s MB', 'rosetta' ), $latest_release['zip_size_mb'] ); ?></span>
+		<span><?php printf( esc_html__( '.zip &mdash; %s MB', 'rosetta' ), esc_html( $latest_release['zip_size_mb'] ) ); ?></span>
 	</p>
 
 	<p class="download-tar">

--- a/global.wordpress.org/public_html/wp-content/themes/rosetta/single.php
+++ b/global.wordpress.org/public_html/wp-content/themes/rosetta/single.php
@@ -34,7 +34,7 @@
 
 				endwhile;
 			else: ?>
-				<p><?php _e( 'Sorry, no posts matched your criteria.', 'rosetta' ); ?></p>
+				<p><?php esc_html_e( 'Sorry, no posts matched your criteria.', 'rosetta' ); ?></p>
 			<?php endif; ?>
 
 			<?php posts_nav_link(' &#8212; ', __( '&laquo; Newer Posts', 'rosetta' ), __( 'Older Posts &raquo;', 'rosetta' ) ); ?>

--- a/jobs.wordpress.net/public_html/wp-content/plugins/jobswp/jobswp-captcha.php
+++ b/jobs.wordpress.net/public_html/wp-content/plugins/jobswp/jobswp-captcha.php
@@ -190,7 +190,7 @@ class Jobs_Dot_WP_Captcha {
 	 */
 	public static function add_notice( $type ) {
 		if ( 'verify' == $type ) {
-			echo ' <strong><em>' . __( 'Note that you must also fill out the captcha field.', 'jobswp' ) . '</em></strong>';
+			echo ' <strong><em>' . esc_html__( 'Note that you must also fill out the captcha field.', 'jobswp' ) . '</em></strong>';
 		}
 	}
 }

--- a/jobs.wordpress.net/public_html/wp-content/plugins/jobswp/jobswp-moderation.php
+++ b/jobs.wordpress.net/public_html/wp-content/plugins/jobswp/jobswp-moderation.php
@@ -103,7 +103,7 @@ echo '</td>';
 			echo '</tbody>';
 			echo '</table>';
 		} else {
-			echo __( 'No similar jobs found.', 'jobswp' );
+			echo esc_html__( 'No similar jobs found.', 'jobswp' );
 		}
 	}
 

--- a/jobs.wordpress.net/public_html/wp-content/plugins/jobswp/jobswp-template.php
+++ b/jobs.wordpress.net/public_html/wp-content/plugins/jobswp/jobswp-template.php
@@ -173,6 +173,10 @@ function jobswp_required_field_classes( $field ) {
 /**
  * Returns the appropriate field value markup for use in appropriate form field.
  *
+ * The return value is always an escaped attribute fragment, so it is safe in an
+ * attribute context. The job description is not handled here because it carries
+ * HTML; see jobswp_field_description_value().
+ *
  * @param string $field Field name/key
  * @param string $option_value Related value, if appropriate. (e.g. the other
  *  value to compare against for selected() or checked())
@@ -181,23 +185,38 @@ function jobswp_required_field_classes( $field ) {
 function jobswp_field_value( $field, $option_value = '' ) {
 	$val = '';
 
-	if ( $_POST && isset( $_POST[ $field ] ) && ! empty( $_POST[ $field ] ) ) {
-		// Allow certain HTML in job_description field
-		if ( 'job_description' == $field )
-			$val = stripslashes( wp_filter_kses( trim( $_POST[ $field ] ) ) );
-		else
-			$val = esc_attr( trim( strip_tags( stripslashes( $_POST[ $field ] ) ) ) );
+	if ( $_POST && isset( $_POST[ $field ] ) && ! empty( $_POST[ $field ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Display-only form redisplay.
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput -- Slashes are stripped and the value is escaped on the same line.
+		$val = esc_attr( trim( strip_tags( stripslashes( $_POST[ $field ] ) ) ) );
 	}
 
 	// Output appropriate attribute based on field type
 	if ( $val ) {
 		if ( in_array( $field, array( 'category', 'howtoapply_method', 'jobtype' ) ) )
 			return selected( $val, $option_value, false );
-		elseif ( 'job_description' == $field )
-			return $val;
 		else
 			return "value='$val'";
 	}
+}
+
+/**
+ * Returns the submitted job description, with its allowed HTML preserved.
+ *
+ * The return value is kses-filtered HTML meant for an element body. It carries
+ * unescaped quotes, so unlike jobswp_field_value() it must never be printed
+ * into an attribute.
+ *
+ * @return string
+ */
+function jobswp_field_description_value() {
+	$field = 'job_description';
+
+	if ( $_POST && isset( $_POST[ $field ] ) && ! empty( $_POST[ $field ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Display-only form redisplay.
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput -- wp_filter_kses() sanitizes the value and handles the slashing itself.
+		return stripslashes( wp_filter_kses( trim( $_POST[ $field ] ) ) );
+	}
+
+	return '';
 }
 
 /**

--- a/jobs.wordpress.net/public_html/wp-content/plugins/jobswp/jobswp-template.php
+++ b/jobs.wordpress.net/public_html/wp-content/plugins/jobswp/jobswp-template.php
@@ -173,9 +173,11 @@ function jobswp_required_field_classes( $field ) {
 /**
  * Returns the appropriate field value markup for use in appropriate form field.
  *
- * The return value is always an escaped attribute fragment, so it is safe in an
- * attribute context. The job description is not handled here because it carries
- * HTML; see jobswp_field_description_value().
+ * Returns a complete attribute pair (`value='…'`), or selected() output for the
+ * select fields, meant to be echoed between attributes inside a tag rather than
+ * inside an attribute's quotes. The value is run through esc_attr(). Returns
+ * nothing when there is no submitted value. The job description is not handled
+ * here because it carries HTML; see jobswp_field_description_value().
  *
  * @param string $field Field name/key
  * @param string $option_value Related value, if appropriate. (e.g. the other
@@ -212,7 +214,7 @@ function jobswp_field_description_value() {
 	$field = 'job_description';
 
 	if ( $_POST && isset( $_POST[ $field ] ) && ! empty( $_POST[ $field ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Display-only form redisplay.
-		// phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput -- wp_filter_kses() sanitizes the value and handles the slashing itself.
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput -- wp_filter_kses() unslashes and kses-filters the value, then re-slashes it; the outer stripslashes() undoes that.
 		return stripslashes( wp_filter_kses( trim( $_POST[ $field ] ) ) );
 	}
 

--- a/jobs.wordpress.net/public_html/wp-content/plugins/jobswp/jobswp.php
+++ b/jobs.wordpress.net/public_html/wp-content/plugins/jobswp/jobswp.php
@@ -164,6 +164,19 @@ class Jobs_Dot_WP {
 	 * @return array The amended list of allowed tags
 	 */
 	public function wp_kses_allowed_html( $allowedtags, $content ) {
+		// Interface text needs links that are not permitted in job descriptions.
+		if ( 'jobswp-ui' === $content ) {
+			return array(
+				'a'      => array(
+					'href'  => true,
+					'rel'   => true,
+					'title' => true,
+				),
+				'em'     => array(),
+				'strong' => array(),
+			);
+		}
+
 		// Add permissable tags
 		$allowedtags['ol'] = array();
 		$allowedtags['ul'] = array();

--- a/jobs.wordpress.net/public_html/wp-content/plugins/jobswp/jobswp.php
+++ b/jobs.wordpress.net/public_html/wp-content/plugins/jobswp/jobswp.php
@@ -483,24 +483,28 @@ class Jobs_Dot_WP {
 	function handle_close_job() {
 		$post_id = isset( $_GET['post'] ) ? absint( $_GET['post'] ) : null;
 
-		if ( ! $post_id )
-			wp_die( __( 'No job specified to close.', 'jobswp' ) );
+		if ( ! $post_id ) {
+			wp_die( esc_html__( 'No job specified to close.', 'jobswp' ) );
+		}
 
 		check_admin_referer( 'close-job-post_' . $post_id );
 
 		$post = get_post( $post_id );
 
-		if ( ! $post )
-			wp_die( __( 'The job you are trying to close no longer exists.', 'jobswp' ) );
+		if ( ! $post ) {
+			wp_die( esc_html__( 'The job you are trying to close no longer exists.', 'jobswp' ) );
+		}
 
 		$post_type = $post->post_type;
 		$post_type_object = get_post_type_object( $post_type );
 
-		if ( ! $post_type_object )
-			wp_die( __( 'Unknown post type.' ) );
+		if ( ! $post_type_object ) {
+			wp_die( esc_html__( 'Unknown post type.' ) );
+		}
 
-		if ( ! current_user_can( 'delete_post', $post_id ) )
-			wp_die( __( 'You are not allowed to close this job.', 'jobswp' ) );
+		if ( ! current_user_can( 'delete_post', $post_id ) ) {
+			wp_die( esc_html__( 'You are not allowed to close this job.', 'jobswp' ) );
+		}
 
 		if ( $user_id = wp_check_post_lock( $post_id ) ) {
 			$user = get_userdata( $user_id );
@@ -508,8 +512,9 @@ class Jobs_Dot_WP {
 			wp_die( sprintf( esc_html__( 'You cannot close this job. %s is currently editing.', 'jobswp' ), esc_html( $user->display_name ) ) );
 		}
 
-		if ( ! $this->close_job( $post ) )
-			wp_die( __( 'Error in closing job.', 'jobswp' ) );
+		if ( ! $this->close_job( $post ) ) {
+			wp_die( esc_html__( 'Error in closing job.', 'jobswp' ) );
+		}
 
 		// Redirect back to jobs listing
 		$sendback = wp_get_referer();
@@ -544,7 +549,7 @@ class Jobs_Dot_WP {
 			return;
 
 		echo '<div class="updated"><p>';
-		_e( 'Job closed.', 'jobswp' );
+		esc_html_e( 'Job closed.', 'jobswp' );
 		echo '</p></div>';
 	}
 

--- a/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-list.php
+++ b/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-list.php
@@ -27,6 +27,7 @@
 		echo '<div class="row row-1">';
 		echo "<div class='no-job'>";
 		echo sprintf(
+			/* translators: %s: Post a job URL. */
 			wp_kses_post( __( 'There are no jobs in this category. If you\'re hiring, you can <a href="%s">post a new job</a>.', 'jobswp' ) ),
 			'/post-a-job'
 		);

--- a/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-list.php
+++ b/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-list.php
@@ -28,7 +28,7 @@
 		echo "<div class='no-job'>";
 		echo sprintf(
 			/* translators: %s: Post a job URL. */
-			wp_kses_post( __( 'There are no jobs in this category. If you&#8217;re hiring, you can <a href="%s">post a new job</a>.', 'jobswp' ) ),
+			wp_kses( __( 'There are no jobs in this category. If you&#8217;re hiring, you can <a href="%s">post a new job</a>.', 'jobswp' ), 'jobswp-ui' ),
 			'/post-a-job'
 		);
 		echo '</div>';
@@ -50,7 +50,7 @@
 			$link .= 'title="'. esc_attr( sprintf( __( 'View all jobs filed under %s', 'jobswp' ), $category->name ) ) . '"';
 			$link .= '>';
 			$link .= 'Show all '.apply_filters( 'list_terms', $category->name, $category ) . ' jobs &raquo;</a>';		
-			echo wp_kses_post( $link );
+			echo wp_kses( $link, 'jobswp-ui' );
 			echo '</p>';
 		} else {
 			jobswp_content_nav( 'all-job-categories' );

--- a/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-list.php
+++ b/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-list.php
@@ -27,7 +27,7 @@
 		echo '<div class="row row-1">';
 		echo "<div class='no-job'>";
 		echo sprintf(
-			__( 'There are no jobs in this category. If you\'re hiring, you can <a href="%s">post a new job</a>.', 'jobswp' ),
+			wp_kses_post( __( 'There are no jobs in this category. If you\'re hiring, you can <a href="%s">post a new job</a>.', 'jobswp' ) ),
 			'/post-a-job'
 		);
 		echo '</div>';

--- a/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-list.php
+++ b/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-list.php
@@ -28,7 +28,7 @@
 		echo "<div class='no-job'>";
 		echo sprintf(
 			/* translators: %s: Post a job URL. */
-			wp_kses_post( __( 'There are no jobs in this category. If you\'re hiring, you can <a href="%s">post a new job</a>.', 'jobswp' ) ),
+			wp_kses_post( __( 'There are no jobs in this category. If you&#8217;re hiring, you can <a href="%s">post a new job</a>.', 'jobswp' ) ),
 			'/post-a-job'
 		);
 		echo '</div>';

--- a/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-post-job-success.php
+++ b/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-post-job-success.php
@@ -44,5 +44,5 @@
 		?>
 	</p>
 
-	<p><?php esc_html_e( "Below you'll find a preview of your job posting.", 'jobswp' ); ?></p>
+	<p><?php esc_html_e( 'Below you&#8217;ll find a preview of your job posting.', 'jobswp' ); ?></p>
 </div>

--- a/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-post-job-success.php
+++ b/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-post-job-success.php
@@ -13,7 +13,7 @@
 		<?php
 		printf(
 			/* translators: %s: FAQ URL. */
-			wp_kses_post( __( 'Your job posting will be reviewed in the next 24-48 hours to ensure it meets the criteria listed in our <a href="%s">FAQ</a>. After approval, your posting will stay on the job board for a total of 21 days.', 'jobswp' ) ),
+			wp_kses( __( 'Your job posting will be reviewed in the next 24-48 hours to ensure it meets the criteria listed in our <a href="%s">FAQ</a>. After approval, your posting will stay on the job board for a total of 21 days.', 'jobswp' ), 'jobswp-ui' ),
 			'/faq/'
 		);
 		?>
@@ -23,7 +23,7 @@
 	<?php
 	printf(
 		/* translators: %s: Remove a job URL. */
-		wp_kses_post( __( '<strong>Important!</strong> Take note of the following job token. It is your only means of removing the job from the site in a <em>timely</em> fashion prior to its automatic expiration. (Otherwise, you would have to make a request via the feedback form which could take 24-48 hours or longer to honor). The token is used on the <a href="%s">job removal page</a>.', 'jobswp' ) ),
+		wp_kses( __( '<strong>Important!</strong> Take note of the following job token. It is your only means of removing the job from the site in a <em>timely</em> fashion prior to its automatic expiration. (Otherwise, you would have to make a request via the feedback form which could take 24-48 hours or longer to honor). The token is used on the <a href="%s">job removal page</a>.', 'jobswp' ), 'jobswp-ui' ),
 		'/remove-a-job/'
 	); ?></p>
 
@@ -38,7 +38,7 @@
 		<?php
 		printf(
 			/* translators: %s: Feedback form URL. */
-			wp_kses_post( __( 'If you would like to modify your posting, or you are having problems removing the job using the job token, please contact us using our <a href="%s">feedback form</a>. Be sure to specify the email address you supplied in your job posting.', 'jobswp' ) ),
+			wp_kses( __( 'If you would like to modify your posting, or you are having problems removing the job using the job token, please contact us using our <a href="%s">feedback form</a>. Be sure to specify the email address you supplied in your job posting.', 'jobswp' ), 'jobswp-ui' ),
 			'/feedback/'
 		);
 		?>

--- a/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-post-job-success.php
+++ b/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-post-job-success.php
@@ -30,7 +30,7 @@
 	<p class="job-token">
 		<?php
 		/* translators: %s: Job token. */
-		printf( esc_html__( 'Your job token is: %s', 'jobswp' ), esc_html( $_POST['job_token'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput -- Set by the plugin's form handler, not read from the request.
+		printf( esc_html__( 'Your job token is: %s', 'jobswp' ), esc_html( wp_unslash( $_POST['job_token'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Display-only form redisplay; the value is escaped with esc_html() at output.
 		?>
 	</p>
 

--- a/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-post-job-success.php
+++ b/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-post-job-success.php
@@ -8,10 +8,12 @@
 	<p>
 	<?php
 	printf(
+		/* translators: %s: Remove a job URL. */
 		wp_kses_post( __( '<strong>Important!</strong> Take note of the following job token. It is your only means of removing the job from the site in a <em>timely</em> fashion prior to its automatic expiration. (Otherwise, you would have to make a request via the feedback form which could take 24-48 hours or longer to honor). The token is used on the <a href="%s">job removal page</a>.', 'jobswp' ) ),
 		'/remove-a-job/'
 	); ?></p>
 
+	<?php /* translators: %s: Job token. */ ?>
 	<p class="job-token"><?php printf( esc_html__( 'Your job token is: %s', 'jobswp' ), esc_html( $_POST['job_token'] ) ); ?></p>
 
 	<p><?php printf( wp_kses_post( __( 'If you would like to modify your posting, or you are having problems removing the job using the job token, please contact us using our <a href="%s">feedback form</a>. Be sure to specify the email address you supplied in your job posting.',

--- a/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-post-job-success.php
+++ b/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-post-job-success.php
@@ -30,7 +30,7 @@
 	<p class="job-token">
 		<?php
 		/* translators: %s: Job token. */
-		printf( esc_html__( 'Your job token is: %s', 'jobswp' ), esc_html( wp_unslash( $_POST['job_token'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Display-only form redisplay; the value is escaped with esc_html() at output.
+		printf( esc_html__( 'Your job token is: %s', 'jobswp' ), esc_html( wp_unslash( $_POST['job_token'] ?? '' ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Display-only form redisplay; the value is escaped with esc_html() at output.
 		?>
 	</p>
 

--- a/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-post-job-success.php
+++ b/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-post-job-success.php
@@ -1,19 +1,22 @@
 <div class="notice notice-success">
-	<h2><?php _e( 'Thank you for submitting your job posting!', 'jobswp' ); ?></h2>
+	<h2><?php esc_html_e( 'Thank you for submitting your job posting!', 'jobswp' ); ?></h2>
 
-	<p><?php printf( __( 'Your job posting will be reviewed in the next 24-48 hours to ensure it meets the criteria listed in our <a href="%s">FAQ</a>. After approval, your posting will stay on the job board for a total of 21 days.',
-	'jobswp' ),
+	<p><?php printf( wp_kses_post( __( 'Your job posting will be reviewed in the next 24-48 hours to ensure it meets the criteria listed in our <a href="%s">FAQ</a>. After approval, your posting will stay on the job board for a total of 21 days.',
+	'jobswp' ) ),
 	'/faq/' ); ?></p>
 
-	<p><?php printf( __( '<strong>Important!</strong> Take note of the following job token. It is your only means of removing the job from the site in a <em>timely</em> fashion prior to its automatic expiration. (Otherwise, you would have to make a request via the feedback form which could take 24-48 hours or longer to honor). The token is used on the <a href="%s">job removal page</a>.', 'jobswp' ),
+	<p>
+	<?php
+	printf(
+		wp_kses_post( __( '<strong>Important!</strong> Take note of the following job token. It is your only means of removing the job from the site in a <em>timely</em> fashion prior to its automatic expiration. (Otherwise, you would have to make a request via the feedback form which could take 24-48 hours or longer to honor). The token is used on the <a href="%s">job removal page</a>.', 'jobswp' ) ),
 		'/remove-a-job/'
 	); ?></p>
 
-	<p class="job-token"><?php printf( __( 'Your job token is: %s', 'jobswp' ), esc_html( $_POST['job_token'] ) ); ?></p>
+	<p class="job-token"><?php printf( esc_html__( 'Your job token is: %s', 'jobswp' ), esc_html( $_POST['job_token'] ) ); ?></p>
 
-	<p><?php printf( __( 'If you would like to modify your posting, or you are having problems removing the job using the job token, please contact us using our <a href="%s">feedback form</a>. Be sure to specify the email address you supplied in your job posting.',
-	'jobswp' ),
+	<p><?php printf( wp_kses_post( __( 'If you would like to modify your posting, or you are having problems removing the job using the job token, please contact us using our <a href="%s">feedback form</a>. Be sure to specify the email address you supplied in your job posting.',
+	'jobswp' ) ),
 	'/feedback/' ); ?></p>
 
-	<p><?php _e( "Below you'll find a preview of your job posting.", 'jobswp' ); ?></p>
+	<p><?php esc_html_e( "Below you'll find a preview of your job posting.", 'jobswp' ); ?></p>
 </div>

--- a/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-post-job-success.php
+++ b/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-post-job-success.php
@@ -1,9 +1,23 @@
+<?php
+/**
+ * Confirmation shown after a job has been submitted.
+ *
+ * @package jobswp
+ */
+
+?>
 <div class="notice notice-success">
 	<h2><?php esc_html_e( 'Thank you for submitting your job posting!', 'jobswp' ); ?></h2>
 
-	<p><?php printf( wp_kses_post( __( 'Your job posting will be reviewed in the next 24-48 hours to ensure it meets the criteria listed in our <a href="%s">FAQ</a>. After approval, your posting will stay on the job board for a total of 21 days.',
-	'jobswp' ) ),
-	'/faq/' ); ?></p>
+	<p>
+		<?php
+		printf(
+			/* translators: %s: FAQ URL. */
+			wp_kses_post( __( 'Your job posting will be reviewed in the next 24-48 hours to ensure it meets the criteria listed in our <a href="%s">FAQ</a>. After approval, your posting will stay on the job board for a total of 21 days.', 'jobswp' ) ),
+			'/faq/'
+		);
+		?>
+	</p>
 
 	<p>
 	<?php
@@ -13,12 +27,22 @@
 		'/remove-a-job/'
 	); ?></p>
 
-	<?php /* translators: %s: Job token. */ ?>
-	<p class="job-token"><?php printf( esc_html__( 'Your job token is: %s', 'jobswp' ), esc_html( $_POST['job_token'] ) ); ?></p>
+	<p class="job-token">
+		<?php
+		/* translators: %s: Job token. */
+		printf( esc_html__( 'Your job token is: %s', 'jobswp' ), esc_html( $_POST['job_token'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput -- Set by the plugin's form handler, not read from the request.
+		?>
+	</p>
 
-	<p><?php printf( wp_kses_post( __( 'If you would like to modify your posting, or you are having problems removing the job using the job token, please contact us using our <a href="%s">feedback form</a>. Be sure to specify the email address you supplied in your job posting.',
-	'jobswp' ) ),
-	'/feedback/' ); ?></p>
+	<p>
+		<?php
+		printf(
+			/* translators: %s: Feedback form URL. */
+			wp_kses_post( __( 'If you would like to modify your posting, or you are having problems removing the job using the job token, please contact us using our <a href="%s">feedback form</a>. Be sure to specify the email address you supplied in your job posting.', 'jobswp' ) ),
+			'/feedback/'
+		);
+		?>
+	</p>
 
 	<p><?php esc_html_e( "Below you'll find a preview of your job posting.", 'jobswp' ); ?></p>
 </div>

--- a/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-post-job.php
+++ b/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-post-job.php
@@ -12,9 +12,9 @@
 
 	<div class="notice notice-error">
 		<?php
-		if ( is_string( $_POST['errors'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput -- Set by the plugin's form handler, not read from the request.
+		if ( is_string( $_POST['errors'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Display-only form redisplay; the value is only type-checked here and escaped at output.
 			/* translators: %s: Error message. */
-			printf( wp_kses_post( __( '<strong>ERROR:</strong> %s', 'jobswp' ) ), esc_html( $_POST['errors'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput -- Set by the plugin's form handler, not read from the request.
+			printf( wp_kses_post( __( '<strong>ERROR:</strong> %s', 'jobswp' ) ), esc_html( wp_unslash( $_POST['errors'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Display-only form redisplay; the value is escaped with esc_html() at output.
 		} else {
 			echo wp_kses_post( __( '<strong>ERROR:</strong> One or more required fields are missing a value.', 'jobswp' ) );
 		}
@@ -94,7 +94,6 @@
 			<select name="category" id="category" class="<?php echo jobswp_required_field_classes( 'category' ); ?>" required>
 				<option value="" selected="selected" disabled="disabled"></option>
 				<?php foreach ( Jobs_Dot_WP::get_job_categories() as $cat ) : ?>
-					<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- jobswp_field_value() returns selected() markup. ?>
 					<option value="<?php echo esc_attr( $cat->slug ); ?>" <?php echo jobswp_field_value( 'category', esc_attr( $cat->slug ) ); ?>><?php echo esc_html( $cat->name ); ?></option>
 				<?php endforeach; ?>
 			</select>
@@ -117,7 +116,7 @@
 
 		<div class="post-job-input">
 			<label for="job_description"><?php esc_html_e( 'Job Description', 'jobswp' ); ?>*</label>
-			<textarea name="job_description" id="job_description" rows="10" class="<?php echo jobswp_required_field_classes( 'job_description' ); ?>"><?php echo jobswp_field_value( 'job_description' ); ?></textarea>
+			<textarea name="job_description" id="job_description" rows="10" class="<?php echo esc_attr( jobswp_required_field_classes( 'job_description' ) ); ?>"><?php echo jobswp_field_description_value(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Filtered with wp_filter_kses() for this textarea body. ?></textarea>
 			<?php /* translators: %s: List of allowed HTML tags. */ ?>
 			<p><?php printf( wp_kses_post( __( 'Line and paragraph breaks are automatic. <acronym title="Hypertext Markup Language">HTML</acronym> allowed: <code>%s</code>', 'jobswp' ) ), esc_html( jobswp_allowed_tags() ) ); ?></p>
 			<p><?php esc_html_e( 'All job postings are moderated prior to appearing on the site.', 'jobswp' ); ?></p>

--- a/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-post-job.php
+++ b/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-post-job.php
@@ -91,7 +91,7 @@
 
 		<div class="post-job-input">
 			<label for="category"><?php esc_html_e( 'Category', 'jobswp' ); ?>*</label>
-			<select name="category" id="category" class="<?php echo jobswp_required_field_classes( 'category' ); ?>" required>
+			<select name="category" id="category" class="<?php echo esc_attr( jobswp_required_field_classes( 'category' ) ); ?>" required>
 				<option value="" selected="selected" disabled="disabled"></option>
 				<?php foreach ( Jobs_Dot_WP::get_job_categories() as $cat ) : ?>
 					<option value="<?php echo esc_attr( $cat->slug ); ?>" <?php echo jobswp_field_value( 'category', esc_attr( $cat->slug ) ); ?>><?php echo esc_html( $cat->name ); ?></option>

--- a/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-post-job.php
+++ b/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-post-job.php
@@ -1,11 +1,20 @@
+<?php
+/**
+ * The form for posting a job.
+ *
+ * @package jobswp
+ */
+
+?>
 <div class="items-required">* <?php esc_html_e( 'Items are required.', 'jobswp' ); ?></div>
 
 <?php if ( isset( $_POST['errors'] ) ) : ?>
 
 	<div class="notice notice-error">
-		<?php if ( is_string( $_POST['errors'] ) ) {
+		<?php
+		if ( is_string( $_POST['errors'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput -- Set by the plugin's form handler, not read from the request.
 			/* translators: %s: Error message. */
-			echo sprintf( wp_kses_post( __( '<strong>ERROR:</strong> %s', 'jobswp' ) ), esc_html( $_POST['errors'] ) );
+			printf( wp_kses_post( __( '<strong>ERROR:</strong> %s', 'jobswp' ) ), esc_html( $_POST['errors'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput -- Set by the plugin's form handler, not read from the request.
 		} else {
 			echo wp_kses_post( __( '<strong>ERROR:</strong> One or more required fields are missing a value.', 'jobswp' ) );
 		}
@@ -110,7 +119,7 @@
 			<label for="job_description"><?php esc_html_e( 'Job Description', 'jobswp' ); ?>*</label>
 			<textarea name="job_description" id="job_description" rows="10" class="<?php echo jobswp_required_field_classes( 'job_description' ); ?>"><?php echo jobswp_field_value( 'job_description' ); ?></textarea>
 			<?php /* translators: %s: List of allowed HTML tags. */ ?>
-			<p><?php printf( wp_kses_post( __( 'Line and paragraph breaks are automatic. <acronym title="Hypertext Markup Language">HTML</acronym> allowed: <code>%s</code>', 'jobswp' ) ), jobswp_allowed_tags() ); ?></p>
+			<p><?php printf( wp_kses_post( __( 'Line and paragraph breaks are automatic. <acronym title="Hypertext Markup Language">HTML</acronym> allowed: <code>%s</code>', 'jobswp' ) ), esc_html( jobswp_allowed_tags() ) ); ?></p>
 			<p><?php esc_html_e( 'All job postings are moderated prior to appearing on the site.', 'jobswp' ); ?></p>
 
 			<p><?php esc_html_e( 'Please review your job posting for accuracy. Once submitted, you will not be able to make any changes unless you do so by submitting a contact form request which can take 24 hours or longer to fulfill.', 'jobswp' ); ?></p>

--- a/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-post-job.php
+++ b/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-post-job.php
@@ -4,6 +4,7 @@
 
 	<div class="notice notice-error">
 		<?php if ( is_string( $_POST['errors'] ) ) {
+			/* translators: %s: Error message. */
 			echo sprintf( wp_kses_post( __( '<strong>ERROR:</strong> %s', 'jobswp' ) ), esc_html( $_POST['errors'] ) );
 		} else {
 			echo wp_kses_post( __( '<strong>ERROR:</strong> One or more required fields are missing a value.', 'jobswp' ) );
@@ -108,6 +109,7 @@
 		<div class="post-job-input">
 			<label for="job_description"><?php esc_html_e( 'Job Description', 'jobswp' ); ?>*</label>
 			<textarea name="job_description" id="job_description" rows="10" class="<?php echo jobswp_required_field_classes( 'job_description' ); ?>"><?php echo jobswp_field_value( 'job_description' ); ?></textarea>
+			<?php /* translators: %s: List of allowed HTML tags. */ ?>
 			<p><?php printf( wp_kses_post( __( 'Line and paragraph breaks are automatic. <acronym title="Hypertext Markup Language">HTML</acronym> allowed: <code>%s</code>', 'jobswp' ) ), jobswp_allowed_tags() ); ?></p>
 			<p><?php esc_html_e( 'All job postings are moderated prior to appearing on the site.', 'jobswp' ); ?></p>
 

--- a/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-post-job.php
+++ b/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-post-job.php
@@ -1,12 +1,13 @@
-<div class="items-required">* <?php _e( 'Items are required.', 'jobswp' ); ?></div>
+<div class="items-required">* <?php esc_html_e( 'Items are required.', 'jobswp' ); ?></div>
 
 <?php if ( isset( $_POST['errors'] ) ) : ?>
 
 	<div class="notice notice-error">
-		<?php if ( is_string( $_POST['errors'] ) )
-			echo sprintf( __( '<strong>ERROR:</strong> %s', 'jobswp' ), esc_html( $_POST['errors'] ) );
-		else
-			_e( '<strong>ERROR:</strong> One or more required fields are missing a value.', 'jobswp' );
+		<?php if ( is_string( $_POST['errors'] ) ) {
+			echo sprintf( wp_kses_post( __( '<strong>ERROR:</strong> %s', 'jobswp' ) ), esc_html( $_POST['errors'] ) );
+		} else {
+			echo wp_kses_post( __( '<strong>ERROR:</strong> One or more required fields are missing a value.', 'jobswp' ) );
+		}
 		?>
 		<?php do_action( 'jobswp_notice', 'error' ); ?>
 	</div>
@@ -15,7 +16,7 @@
 
 	<div class="notice notice-info">
 		<div>
-		<?php _e( 'Please review the data you submitted for accuracy. Make any necessary corrections, then re-submit this form.', 'jobswp' ); ?>
+		<?php esc_html_e( 'Please review the data you submitted for accuracy. Make any necessary corrections, then re-submit this form.', 'jobswp' ); ?>
 		<?php do_action( 'jobswp_notice', 'verify' ); ?>
 		</div>
 	</div>
@@ -25,8 +26,8 @@
 <form class="post-job" method="post" action="">
 
 <div class="post-job-contact-info">
-	<h3 class="post-field-section-header"><?php _e( 'Job Poster Contact Information', 'jobswp' ); ?></h3>
-	<div class="post-field-section-subheader"><?php _e( '(this information is not publicly displayed)', 'jobswp' ); ?></div>
+	<h3 class="post-field-section-header"><?php esc_html_e( 'Job Poster Contact Information', 'jobswp' ); ?></h3>
+	<div class="post-field-section-subheader"><?php esc_html_e( '(this information is not publicly displayed)', 'jobswp' ); ?></div>
 
 	<?php jobswp_text_field( 'first_name', __( 'First Name', 'jobswp' ), true ); ?>
 
@@ -37,27 +38,27 @@
 
 <div class="post-job-company-info">
 
-	<h3 class="post-field-section-header"><?php _e( 'Company Information', 'jobswp' ); ?></h3>
-	<div class="post-field-section-subheader"><?php _e( '(publicly displayed)', 'jobswp' ); ?></div>
+	<h3 class="post-field-section-header"><?php esc_html_e( 'Company Information', 'jobswp' ); ?></h3>
+	<div class="post-field-section-subheader"><?php esc_html_e( '(publicly displayed)', 'jobswp' ); ?></div>
 
 	<?php jobswp_text_field( 'company', __( 'Company Name', 'jobswp' ), true ); ?>
 
 	<?php jobswp_text_field( 'location', __( 'Location', 'jobswp' ), false, 'text',  __( 'The desired location for any applicants and not necessarily your business location. Use \'N/A\' or leave blank if allowing a remote worker from anywhere.', 'jobswp' ) ); ?>
 
 	<div class="post-job-input">
-		<label for="howtoapply"><?php _e( 'How to Apply', 'jobswp' ); ?>* <span><?php _e( '(also specify)', 'jobswp' ); ?></span></label>
+		<label for="howtoapply"><?php esc_html_e( 'How to Apply', 'jobswp' ); ?>* <span><?php esc_html_e( '(also specify)', 'jobswp' ); ?></span></label>
 		<div class="howtoapply-inputs">
 			<select name="howtoapply_method" id="howtoapply_method" class="<?php echo esc_attr( jobswp_required_field_classes( 'howtoapply_method' ) ); ?>" required>
 				<option value="" selected="selected" disabled="disabled"></option>
-				<option value="email" <?php echo jobswp_field_value( 'howtoapply_method', 'email' ); ?>><?php _e( 'Email Address', 'jobswp' ); ?></option>
-				<option value="phone" <?php echo jobswp_field_value( 'howtoapply_method', 'phone' ); ?>><?php _e( 'Phone Number', 'jobswp' ); ?></option>
-				<option value="web" <?php echo jobswp_field_value( 'howtoapply_method', 'web' ); ?>><?php _e( 'Online Form', 'jobswp' ); ?></option>
+				<option value="email" <?php echo jobswp_field_value( 'howtoapply_method', 'email' ); ?>><?php esc_html_e( 'Email Address', 'jobswp' ); ?></option>
+				<option value="phone" <?php echo jobswp_field_value( 'howtoapply_method', 'phone' ); ?>><?php esc_html_e( 'Phone Number', 'jobswp' ); ?></option>
+				<option value="web" <?php echo jobswp_field_value( 'howtoapply_method', 'web' ); ?>><?php esc_html_e( 'Online Form', 'jobswp' ); ?></option>
 			</select> :
 			<input type="text" name="howtoapply" id="howtoapply" class="<?php echo esc_attr( jobswp_required_field_classes( 'howtoapply' ) ); ?>" <?php echo jobswp_field_value( 'howtoapply' ); ?> />
 		</div>
 
 		<div class="job-help-text">
-			<?php _e( 'If choosing "Email Address", use an email address you are comfortable exposing to any visitor of the site. It need not match the private email address asked for in the Contact Information section.', 'jobswp' ); ?>
+			<?php esc_html_e( 'If choosing "Email Address", use an email address you are comfortable exposing to any visitor of the site. It need not match the private email address asked for in the Contact Information section.', 'jobswp' ); ?>
 		</div>
 	</div>
 
@@ -66,7 +67,7 @@
 <div class="clear"></div>
 
 <div class="post-job-job-info">
-	<h3 class="post-field-section-header"><?php _e( 'Job Details', 'jobswp' ); ?></h3>
+	<h3 class="post-field-section-header"><?php esc_html_e( 'Job Details', 'jobswp' ); ?></h3>
 
 	<div class="post-job-half">
 
@@ -79,7 +80,7 @@
 	<div class="post-job-half">
 
 		<div class="post-job-input">
-			<label for="category"><?php _e( 'Category', 'jobswp' ); ?>*</label>
+			<label for="category"><?php esc_html_e( 'Category', 'jobswp' ); ?>*</label>
 			<select name="category" id="category" class="<?php echo jobswp_required_field_classes( 'category' ); ?>" required>
 				<option value="" selected="selected" disabled="disabled"></option>
 				<?php foreach ( Jobs_Dot_WP::get_job_categories() as $cat ) : ?>
@@ -90,12 +91,12 @@
 		</div>
 
 		<div class="post-job-input">
-			<label for="jobtype"><?php _e( 'Job Type', 'jobswp' ); ?>*</label>
+			<label for="jobtype"><?php esc_html_e( 'Job Type', 'jobswp' ); ?>*</label>
 			<select name="jobtype" id="jobtype" class="<?php echo esc_attr( jobswp_required_field_classes( 'jobtype' ) ); ?>" required>
 				<option value="" selected="selected" disabled="disabled"></option>
-				<option value="ft" <?php echo jobswp_field_value( 'jobtype', 'ft' ); ?>><?php _e( 'Full Time', 'jobswp' ); ?></option>
-				<option value="pt" <?php echo jobswp_field_value( 'jobtype', 'pt' ); ?>><?php _e( 'Part Time', 'jobswp' ); ?></option>
-				<option value="ppt" <?php echo jobswp_field_value( 'jobtype', 'ppt' ); ?>><?php _e( 'Project', 'jobswp' ); ?></option>
+				<option value="ft" <?php echo jobswp_field_value( 'jobtype', 'ft' ); ?>><?php esc_html_e( 'Full Time', 'jobswp' ); ?></option>
+				<option value="pt" <?php echo jobswp_field_value( 'jobtype', 'pt' ); ?>><?php esc_html_e( 'Part Time', 'jobswp' ); ?></option>
+				<option value="ppt" <?php echo jobswp_field_value( 'jobtype', 'ppt' ); ?>><?php esc_html_e( 'Project', 'jobswp' ); ?></option>
 			</select>
 		</div>
 	</div>
@@ -105,12 +106,12 @@
 	<div class="post-job-full">
 
 		<div class="post-job-input">
-			<label for="job_description"><?php _e( 'Job Description', 'jobswp' ); ?>*</label>
+			<label for="job_description"><?php esc_html_e( 'Job Description', 'jobswp' ); ?>*</label>
 			<textarea name="job_description" id="job_description" rows="10" class="<?php echo jobswp_required_field_classes( 'job_description' ); ?>"><?php echo jobswp_field_value( 'job_description' ); ?></textarea>
-			<p><?php echo sprintf( __( 'Line and paragraph breaks are automatic. <acronym title="Hypertext Markup Language">HTML</acronym> allowed: <code>%s</code>', 'jobswp' ), jobswp_allowed_tags() ); ?></p>
-			<p><?php _e( 'All job postings are moderated prior to appearing on the site.', 'jobswp' ); ?></p>
+			<p><?php printf( wp_kses_post( __( 'Line and paragraph breaks are automatic. <acronym title="Hypertext Markup Language">HTML</acronym> allowed: <code>%s</code>', 'jobswp' ) ), jobswp_allowed_tags() ); ?></p>
+			<p><?php esc_html_e( 'All job postings are moderated prior to appearing on the site.', 'jobswp' ); ?></p>
 
-			<p><?php _e( 'Please review your job posting for accuracy. Once submitted, you will not be able to make any changes unless you do so by submitting a contact form request which can take 24 hours or longer to fulfill.', 'jobswp' ); ?></p>
+			<p><?php esc_html_e( 'Please review your job posting for accuracy. Once submitted, you will not be able to make any changes unless you do so by submitting a contact form request which can take 24 hours or longer to fulfill.', 'jobswp' ); ?></p>
 		</div>
 
 	</div>
@@ -127,7 +128,7 @@
 	?>
 		<input type="hidden" name="verify" value="1" />
 		<div class="notice notice-info accept">
-			<p><?php _e( 'By submitting a job to this site you acknowledge the following:', 'jobswp' ); ?></p>
+			<p><?php esc_html_e( 'By submitting a job to this site you acknowledge the following:', 'jobswp' ); ?></p>
 			<ul>
 				<li>
 					<?php
@@ -135,13 +136,13 @@
 					printf( wp_kses_post( __( 'You have read the <a href="%s">FAQ</a> and understand everything listed, especially pertaining to what is unacceptable for a job posting.', 'jobswp' ) ), esc_url( home_url( '/faq/' ) ) );
 					?>
 				</li>
-				<li><?php _e( 'If you provided a contact email address as your method of contact for job seekers, that email address will be made publicly available and you will likely receive a lot of email.', 'jobswp' );?></li>
-				<li><?php _e( 'Upon successful submission, you will not be able to make any edits. Proofread everything again to make sure it&#8217;s what you want.', 'jobswp' ); ?></li>
-				<li><?php _e( 'It rests on you to vet applicants in whatever manner you see fit. We make absolutely no claims or guarantees as to the identity, capabilities, or reliability of applicants. <strong>Hire at your own risk.</strong>', 'jobswp' ); ?></li>
-				<li><?php _e( 'Upon successful submission, you will be immediately presented with a job token. <strong>MAKE NOTE OF THE TOKEN</strong>. It is your only means of removing the job from the site in a <em>timely</em> fashion.', 'jobswp' ); ?></li>
+				<li><?php esc_html_e( 'If you provided a contact email address as your method of contact for job seekers, that email address will be made publicly available and you will likely receive a lot of email.', 'jobswp' ); ?></li>
+				<li><?php esc_html_e( 'Upon successful submission, you will not be able to make any edits. Proofread everything again to make sure it&#8217;s what you want.', 'jobswp' ); ?></li>
+				<li><?php echo wp_kses_post( __( 'It rests on you to vet applicants in whatever manner you see fit. We make absolutely no claims or guarantees as to the identity, capabilities, or reliability of applicants. <strong>Hire at your own risk.</strong>', 'jobswp' ) ); ?></li>
+				<li><?php echo wp_kses_post( __( 'Upon successful submission, you will be immediately presented with a job token. <strong>MAKE NOTE OF THE TOKEN</strong>. It is your only means of removing the job from the site in a <em>timely</em> fashion.', 'jobswp' ) ); ?></li>
 			</ul>
 			<p>
-				<input type="checkbox" name="accept" id="accept" value="1" required /><label for="accept"><?php _e( 'I agree to the terms stated above.', 'jobswp' ); ?>*</label>
+				<input type="checkbox" name="accept" id="accept" value="1" required /><label for="accept"><?php esc_html_e( 'I agree to the terms stated above.', 'jobswp' ); ?>*</label>
 			</p>
 		</div>
 	<?php } else {

--- a/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-post-job.php
+++ b/jobs.wordpress.net/public_html/wp-content/themes/jobswp/content-post-job.php
@@ -143,7 +143,7 @@
 				<li>
 					<?php
 					/* translators: %s: URL of the FAQ page. */
-					printf( wp_kses_post( __( 'You have read the <a href="%s">FAQ</a> and understand everything listed, especially pertaining to what is unacceptable for a job posting.', 'jobswp' ) ), esc_url( home_url( '/faq/' ) ) );
+					printf( wp_kses( __( 'You have read the <a href="%s">FAQ</a> and understand everything listed, especially pertaining to what is unacceptable for a job posting.', 'jobswp' ), 'jobswp-ui' ), esc_url( home_url( '/faq/' ) ) );
 					?>
 				</li>
 				<li><?php esc_html_e( 'If you provided a contact email address as your method of contact for job seekers, that email address will be made publicly available and you will likely receive a lot of email.', 'jobswp' ); ?></li>

--- a/jobs.wordpress.net/public_html/wp-content/themes/jobswp/inc/template-tags.php
+++ b/jobs.wordpress.net/public_html/wp-content/themes/jobswp/inc/template-tags.php
@@ -78,12 +78,14 @@ function jobswp_comment( $comment, $args, $depth ) {
 			<footer class="comment-meta">
 				<div class="comment-author vcard">
 					<?php if ( 0 != $args['avatar_size'] ) echo get_avatar( $comment, $args['avatar_size'] ); ?>
+					<?php /* translators: %s: Comment author link. */ ?>
 					<?php printf( wp_kses_post( __( '%s <span class="says">says:</span>', 'jobswp' ) ), sprintf( '<cite class="fn">%s</cite>', get_comment_author_link() ) ); ?>
 				</div><!-- .comment-author -->
 
 				<div class="comment-metadata">
 					<a href="<?php echo esc_url( get_comment_link( $comment->comment_ID ) ); ?>">
 						<time datetime="<?php comment_time( 'c' ); ?>">
+							<?php /* translators: 1: Comment date, 2: Comment time. */ ?>
 							<?php printf( esc_html_x( '%1$s at %2$s', '1: date, 2: time', 'jobswp' ), get_comment_date(), get_comment_time() ); ?>
 						</time>
 					</a>

--- a/jobs.wordpress.net/public_html/wp-content/themes/jobswp/inc/template-tags.php
+++ b/jobs.wordpress.net/public_html/wp-content/themes/jobswp/inc/template-tags.php
@@ -86,7 +86,7 @@ function jobswp_comment( $comment, $args, $depth ) {
 					<a href="<?php echo esc_url( get_comment_link( $comment->comment_ID ) ); ?>">
 						<time datetime="<?php comment_time( 'c' ); ?>">
 							<?php /* translators: 1: Comment date, 2: Comment time. */ ?>
-							<?php printf( esc_html_x( '%1$s at %2$s', '1: date, 2: time', 'jobswp' ), get_comment_date(), get_comment_time() ); ?>
+							<?php printf( esc_html_x( '%1$s at %2$s', '1: date, 2: time', 'jobswp' ), esc_html( get_comment_date() ), esc_html( get_comment_time() ) ); ?>
 						</time>
 					</a>
 					<?php edit_comment_link( __( 'Edit', 'jobswp' ), '<span class="edit-link">', '</span>' ); ?>

--- a/jobs.wordpress.net/public_html/wp-content/themes/jobswp/inc/template-tags.php
+++ b/jobs.wordpress.net/public_html/wp-content/themes/jobswp/inc/template-tags.php
@@ -31,7 +31,7 @@ function jobswp_content_nav( $nav_id ) {
 
 	?>
 	<nav role="navigation" id="<?php echo esc_attr( $nav_id ); ?>" class="<?php echo $nav_class; ?>">
-		<h1 class="screen-reader-text"><?php _e( 'Post navigation', 'jobswp' ); ?></h1>
+		<h1 class="screen-reader-text"><?php esc_html_e( 'Post navigation', 'jobswp' ); ?></h1>
 
 	<?php if ( is_single() ) : // navigation links for single posts ?>
 
@@ -68,7 +68,7 @@ function jobswp_comment( $comment, $args, $depth ) {
 
 	<li id="comment-<?php comment_ID(); ?>" <?php comment_class(); ?>>
 		<div class="comment-body">
-			<?php _e( 'Pingback:', 'jobswp' ); ?> <?php comment_author_link(); ?> <?php edit_comment_link( __( 'Edit', 'jobswp' ), '<span class="edit-link">', '</span>' ); ?>
+					<?php esc_html_e( 'Pingback:', 'jobswp' ); ?> <?php comment_author_link(); ?> <?php edit_comment_link( __( 'Edit', 'jobswp' ), '<span class="edit-link">', '</span>' ); ?>
 		</div>
 
 	<?php else : ?>
@@ -78,20 +78,20 @@ function jobswp_comment( $comment, $args, $depth ) {
 			<footer class="comment-meta">
 				<div class="comment-author vcard">
 					<?php if ( 0 != $args['avatar_size'] ) echo get_avatar( $comment, $args['avatar_size'] ); ?>
-					<?php printf( __( '%s <span class="says">says:</span>', 'jobswp' ), sprintf( '<cite class="fn">%s</cite>', get_comment_author_link() ) ); ?>
+					<?php printf( wp_kses_post( __( '%s <span class="says">says:</span>', 'jobswp' ) ), sprintf( '<cite class="fn">%s</cite>', get_comment_author_link() ) ); ?>
 				</div><!-- .comment-author -->
 
 				<div class="comment-metadata">
 					<a href="<?php echo esc_url( get_comment_link( $comment->comment_ID ) ); ?>">
 						<time datetime="<?php comment_time( 'c' ); ?>">
-							<?php printf( _x( '%1$s at %2$s', '1: date, 2: time', 'jobswp' ), get_comment_date(), get_comment_time() ); ?>
+							<?php printf( esc_html_x( '%1$s at %2$s', '1: date, 2: time', 'jobswp' ), get_comment_date(), get_comment_time() ); ?>
 						</time>
 					</a>
 					<?php edit_comment_link( __( 'Edit', 'jobswp' ), '<span class="edit-link">', '</span>' ); ?>
 				</div><!-- .comment-metadata -->
 
 				<?php if ( '0' == $comment->comment_approved ) : ?>
-				<p class="comment-awaiting-moderation"><?php _e( 'Your comment is awaiting moderation.', 'jobswp' ); ?></p>
+				<p class="comment-awaiting-moderation"><?php esc_html_e( 'Your comment is awaiting moderation.', 'jobswp' ); ?></p>
 				<?php endif; ?>
 			</footer><!-- .comment-meta -->
 

--- a/jobs.wordpress.net/public_html/wp-content/themes/jobswp/no-results.php
+++ b/jobs.wordpress.net/public_html/wp-content/themes/jobswp/no-results.php
@@ -10,22 +10,22 @@
 
 <section class="no-results not-found">
 	<header class="page-header">
-		<h1 class="page-title"><?php _e( 'Nothing Found', 'jobswp' ); ?></h1>
+		<h1 class="page-title"><?php esc_html_e( 'Nothing Found', 'jobswp' ); ?></h1>
 	</header><!-- .page-header -->
 
 	<div class="page-content">
 		<?php if ( is_home() && current_user_can( 'publish_posts' ) ) : ?>
 
-			<p><?php printf( __( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', 'jobswp' ), esc_url( admin_url( 'post-new.php' ) ) ); ?></p>
+			<p><?php printf( wp_kses_post( __( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', 'jobswp' ) ), esc_url( admin_url( 'post-new.php' ) ) ); ?></p>
 
 		<?php elseif ( is_search() ) : ?>
 
-			<p><?php _e( 'Sorry, but nothing matched your search terms. Please try again with some different keywords.', 'jobswp' ); ?></p>
+			<p><?php esc_html_e( 'Sorry, but nothing matched your search terms. Please try again with some different keywords.', 'jobswp' ); ?></p>
 			<?php get_search_form(); ?>
 
 		<?php else : ?>
 
-			<p><?php _e( 'It seems we can&rsquo;t find what you&rsquo;re looking for. Perhaps searching can help.', 'jobswp' ); ?></p>
+			<p><?php esc_html_e( 'It seems we can&rsquo;t find what you&rsquo;re looking for. Perhaps searching can help.', 'jobswp' ); ?></p>
 			<?php get_search_form(); ?>
 
 		<?php endif; ?>

--- a/jobs.wordpress.net/public_html/wp-content/themes/jobswp/no-results.php
+++ b/jobs.wordpress.net/public_html/wp-content/themes/jobswp/no-results.php
@@ -16,6 +16,7 @@
 	<div class="page-content">
 		<?php if ( is_home() && current_user_can( 'publish_posts' ) ) : ?>
 
+			<?php /* translators: %1$s: New post URL. */ ?>
 			<p><?php printf( wp_kses_post( __( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', 'jobswp' ) ), esc_url( admin_url( 'post-new.php' ) ) ); ?></p>
 
 		<?php elseif ( is_search() ) : ?>

--- a/jobs.wordpress.net/public_html/wp-content/themes/jobswp/no-results.php
+++ b/jobs.wordpress.net/public_html/wp-content/themes/jobswp/no-results.php
@@ -17,7 +17,7 @@
 		<?php if ( is_home() && current_user_can( 'publish_posts' ) ) : ?>
 
 			<?php /* translators: %1$s: New post URL. */ ?>
-			<p><?php printf( wp_kses_post( __( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', 'jobswp' ) ), esc_url( admin_url( 'post-new.php' ) ) ); ?></p>
+			<p><?php printf( wp_kses( __( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', 'jobswp' ), 'jobswp-ui' ), esc_url( admin_url( 'post-new.php' ) ) ); ?></p>
 
 		<?php elseif ( is_search() ) : ?>
 

--- a/jobs.wordpress.net/public_html/wp-content/themes/jobswp/page-remove-a-job.php
+++ b/jobs.wordpress.net/public_html/wp-content/themes/jobswp/page-remove-a-job.php
@@ -24,6 +24,7 @@ get_header(); ?>
 			<div class="entry-content">
 				<div class="notice notice-error">
 					<?php if ( is_string( $_POST['errors'] ) ) {
+						/* translators: %s: Error message. */
 						echo sprintf( wp_kses_post( __( '<strong>ERROR:</strong> %s', 'jobswp' ) ), esc_html( $_POST['errors'] ) );
 					} else {
 						echo wp_kses_post( __( '<strong>ERROR:</strong> One or more required fields are missing a value.', 'jobswp' ) );

--- a/jobs.wordpress.net/public_html/wp-content/themes/jobswp/page-remove-a-job.php
+++ b/jobs.wordpress.net/public_html/wp-content/themes/jobswp/page-remove-a-job.php
@@ -25,7 +25,7 @@ get_header(); ?>
 				<div class="notice notice-error">
 					<?php if ( is_string( $_POST['errors'] ) ) {
 						/* translators: %s: Error message. */
-						printf( wp_kses_post( __( '<strong>ERROR:</strong> %s', 'jobswp' ) ), esc_html( $_POST['errors'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput -- Set by the plugin's form handler, not read from the request.
+						printf( wp_kses_post( __( '<strong>ERROR:</strong> %s', 'jobswp' ) ), esc_html( wp_unslash( $_POST['errors'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Display-only form redisplay; the value is escaped with esc_html() at output.
 					} else {
 						echo wp_kses_post( __( '<strong>ERROR:</strong> One or more required fields are missing a value.', 'jobswp' ) );
 					} ?>

--- a/jobs.wordpress.net/public_html/wp-content/themes/jobswp/page-remove-a-job.php
+++ b/jobs.wordpress.net/public_html/wp-content/themes/jobswp/page-remove-a-job.php
@@ -25,7 +25,7 @@ get_header(); ?>
 				<div class="notice notice-error">
 					<?php if ( is_string( $_POST['errors'] ) ) {
 						/* translators: %s: Error message. */
-						echo sprintf( wp_kses_post( __( '<strong>ERROR:</strong> %s', 'jobswp' ) ), esc_html( $_POST['errors'] ) );
+						printf( wp_kses_post( __( '<strong>ERROR:</strong> %s', 'jobswp' ) ), esc_html( $_POST['errors'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput -- Set by the plugin's form handler, not read from the request.
 					} else {
 						echo wp_kses_post( __( '<strong>ERROR:</strong> One or more required fields are missing a value.', 'jobswp' ) );
 					} ?>

--- a/jobs.wordpress.net/public_html/wp-content/themes/jobswp/page-remove-a-job.php
+++ b/jobs.wordpress.net/public_html/wp-content/themes/jobswp/page-remove-a-job.php
@@ -24,9 +24,9 @@ get_header(); ?>
 			<div class="entry-content">
 				<div class="notice notice-error">
 					<?php if ( is_string( $_POST['errors'] ) ) {
-						echo sprintf( __( '<strong>ERROR:</strong> %s', 'jobswp' ), esc_html( $_POST['errors'] ) );
+						echo sprintf( wp_kses_post( __( '<strong>ERROR:</strong> %s', 'jobswp' ) ), esc_html( $_POST['errors'] ) );
 					} else {
-						_e( '<strong>ERROR:</strong> One or more required fields are missing a value.', 'jobswp' );
+						echo wp_kses_post( __( '<strong>ERROR:</strong> One or more required fields are missing a value.', 'jobswp' ) );
 					} ?>
 					<?php do_action( 'jobswp_notice', 'error' ); ?>
 				</div>
@@ -34,7 +34,7 @@ get_header(); ?>
 			<?php elseif ( isset( $_GET['removedjob'] ) && '1' === $_GET['removedjob'] ) : ?>
 			<div class="entry-content">
 				<div class="notice notice-success">
-					<strong><?php _e( 'Your job posting has been successfully removed.', 'jobswp' ); ?></strong>
+					<strong><?php esc_html_e( 'Your job posting has been successfully removed.', 'jobswp' ); ?></strong>
 				</div>
 			</div>
 			<?php endif; ?>

--- a/jobs.wordpress.net/public_html/wp-content/themes/jobswp/searchform.php
+++ b/jobs.wordpress.net/public_html/wp-content/themes/jobswp/searchform.php
@@ -7,7 +7,7 @@
 ?>
 <form role="search" method="get" class="search-form" action="<?php echo esc_url( home_url( '/' ) ); ?>">
 	<label>
-		<span class="screen-reader-text"><?php _ex( 'Search for:', 'label', 'jobswp' ); ?></span>
+		<span class="screen-reader-text"><?php echo esc_html_x( 'Search for:', 'label', 'jobswp' ); ?></span>
 		<input type="search" class="search-field" placeholder="<?php echo esc_attr_x( 'What kind of job are you looking for?', 'placeholder', 'jobswp' ); ?>" value="<?php echo esc_attr( get_search_query() ); ?>" name="s" title="<?php echo esc_attr_x( 'Find Jobs:', 'label', 'jobswp' ); ?>">
 	</label>
 	<input type="submit" class="btn btn-primary btn-sm search-submit" value="<?php echo esc_attr_x( 'Find Jobs', 'submit button', 'jobswp' ); ?>">

--- a/jobs.wordpress.net/public_html/wp-content/themes/jobswp/sidebar.php
+++ b/jobs.wordpress.net/public_html/wp-content/themes/jobswp/sidebar.php
@@ -9,10 +9,10 @@
 		<?php do_action( 'before_sidebar' ); ?>
 
 			<aside id="cats" class="widget">
-				<h3 class="widget-title"><?php _e( 'Position Types', 'jobswp' ); ?></h3>
+				<h3 class="widget-title"><?php esc_html_e( 'Position Types', 'jobswp' ); ?></h3>
 				<a href="#" class="menu-jobs-toggle"></a>
 				<ul class="menu-jobs">
-					<li class="job-cat-item job-cat-item-all"><a href="/" title="<?php esc_attr_e( 'View all job openings', 'jobswp' ); ?>"><?php _e( 'All Openings', 'jobswp' ) ?></a></li>
+					<li class="job-cat-item job-cat-item-all"><a href="/" title="<?php esc_attr_e( 'View all job openings', 'jobswp' ); ?>"><?php esc_html_e( 'All Openings', 'jobswp' ); ?></a></li>
 				<?php Jobs_Dot_WP::list_job_categories(); ?>
 				</ul>
 			</aside>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -147,6 +147,8 @@
 			<property name="customAutoEscapedFunctions" type="array">
 				<!-- Returns esc_url( $url ); see themes/pub/wporg-login/functions.php. -->
 				<element value="wporg_login_wordpress_url"/>
+				<!-- Returns selected() markup, a kses-filtered description, or an esc_attr()'d value; see jobs.wordpress.net plugins/jobswp/jobswp-template.php. -->
+				<element value="jobswp_field_value"/>
 			</property>
 		</properties>
 	</rule>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -147,7 +147,7 @@
 			<property name="customAutoEscapedFunctions" type="array">
 				<!-- Returns esc_url( $url ); see themes/pub/wporg-login/functions.php. -->
 				<element value="wporg_login_wordpress_url"/>
-				<!-- Returns selected() markup, a kses-filtered description, or an esc_attr()'d value; see jobs.wordpress.net plugins/jobswp/jobswp-template.php. -->
+				<!-- Returns selected() markup or an esc_attr()'d value attribute; see jobs.wordpress.net plugins/jobswp/jobswp-template.php. -->
 				<element value="jobswp_field_value"/>
 			</property>
 		</properties>

--- a/wordpress.org/public_html/wp-content/plugins/handbook/inc/admin-notices.php
+++ b/wordpress.org/public_html/wp-content/plugins/handbook/inc/admin-notices.php
@@ -86,7 +86,7 @@ class WPorg_Handbook_Admin_Notices {
 
 			printf(
 				/* translators: 1: example landing page title that includes post type name, 2: comma-separated list of acceptable post slugs */
-				__( '<strong>Welcome to your new handbook!</strong> It is recommended that the first post you create is the landing page for the handbook. You can title it anything you like (suggestions: <code>%1$s</code> or <code>Welcome</code>). However, you must ensure that it has one of the following slugs: %2$s. The slug will ultimately be omitted from the page&#8216;s permalink URL, but will still appear in the permalinks for sub-pages.', 'wporg' ),
+				wp_kses_post( __( '<strong>Welcome to your new handbook!</strong> It is recommended that the first post you create is the landing page for the handbook. You can title it anything you like (suggestions: <code>%1$s</code> or <code>Welcome</code>). However, you must ensure that it has one of the following slugs: %2$s. The slug will ultimately be omitted from the page&#8216;s permalink URL, but will still appear in the permalinks for sub-pages.', 'wporg' ) ),
 				WPorg_Handbook::get_name( $current_screen->post_type ),
 				implode( ', ', $suggested_slugs )
 			);
@@ -126,7 +126,7 @@ class WPorg_Handbook_Admin_Notices {
 		echo '<div class="notice notice-error"><p>';
 		printf(
 			/* translators: 1: example landing page title that includes post type name, 2: comma-separated list of acceptable post slugs */
-			__( '<strong>Warning:</strong> A landing page for this handbook has not been created or is not published. You can title it anything you like (suggestions: <code>%1$s</code> or <code>Welcome</code>). However, you must ensure that it has one of the following slugs: %2$s. The slug will ultimately be omitted from the page&#8216;s permalink URL, but will still appear in the permalinks for its sub-pages. Without this page your handbook&#8216;s URL will show a seemingly random handbook page.', 'wporg' ),
+			wp_kses_post( __( '<strong>Warning:</strong> A landing page for this handbook has not been created or is not published. You can title it anything you like (suggestions: <code>%1$s</code> or <code>Welcome</code>). However, you must ensure that it has one of the following slugs: %2$s. The slug will ultimately be omitted from the page&#8216;s permalink URL, but will still appear in the permalinks for its sub-pages. Without this page your handbook&#8216;s URL will show a seemingly random handbook page.', 'wporg' ) ),
 			WPorg_Handbook::get_name( $handbook_post_type ),
 			implode( ', ', $suggested_slugs )
 		);
@@ -172,7 +172,7 @@ class WPorg_Handbook_Admin_Notices {
 			echo '<div class="notice notice-info"><p>';
 			printf(
 				/* translators: 1: URL to remote manifest. 2: cron interval. */
-				__( '<strong>This is an imported handbook!</strong> This handbook is imported according to a <a href="%1$s">remote manifest</a>. Any local changes will be overwritten during the next import, so make any changes at the remote location. Import interval: <strong>%2$s</strong>.', 'wporg' ),
+				wp_kses_post( __( '<strong>This is an imported handbook!</strong> This handbook is imported according to a <a href="%1$s">remote manifest</a>. Any local changes will be overwritten during the next import, so make any changes at the remote location. Import interval: <strong>%2$s</strong>.', 'wporg' ) ),
 				$handbook_config['manifest'],
 				$interval_display
 			);
@@ -223,7 +223,7 @@ class WPorg_Handbook_Admin_Notices {
 			echo '<div class="notice notice-warning"><p>';
 			printf(
 				/* translators: %s: cron interval. */
-				__( '<strong>Misconfigured cron interval!</strong> This imported handbook has a misconfigured cron interval. The config defines an interval of <strong>%s</strong>, which has not been defined. The fallback import interval shown in a notice above includes the default cron interval currently in use.', 'wporg' ),
+				wp_kses_post( __( '<strong>Misconfigured cron interval!</strong> This imported handbook has a misconfigured cron interval. The config defines an interval of <strong>%s</strong>, which has not been defined. The fallback import interval shown in a notice above includes the default cron interval currently in use.', 'wporg' ) ),
 				$interval_display
 			);
 			echo "</p></div>\n";

--- a/wordpress.org/public_html/wp-content/plugins/handbook/inc/handbook.php
+++ b/wordpress.org/public_html/wp-content/plugins/handbook/inc/handbook.php
@@ -224,7 +224,7 @@ class WPorg_Handbook {
 			}
 		} elseif ( is_admin() && ( $config['manifest'] ?: false ) ) {
 			add_action( 'admin_notices', function () {
-				echo '<div class="notice notice-error"><p>' . __( 'Error: The <strong>WPORG Markdown Importer</strong> plugin needs to be activated in order to allow importing of handbooks.', 'wporg' ) . '</p></div>';
+				echo '<div class="notice notice-error"><p>' . wp_kses_post( __( 'Error: The <strong>WPORG Markdown Importer</strong> plugin needs to be activated in order to allow importing of handbooks.', 'wporg' ) ) . '</p></div>';
 			} );
 		}
 	}

--- a/wordpress.org/public_html/wp-content/plugins/handbook/inc/navigation.php
+++ b/wordpress.org/public_html/wp-content/plugins/handbook/inc/navigation.php
@@ -378,7 +378,7 @@ class WPorg_Handbook_Navigation {
 		?>
 
 		<nav class="handbook-navigation" role="navigation">
-			<h1 class="screen-reader-text"><?php _e( 'Handbook navigation', 'wporg' ); ?></h1>
+			<h1 class="screen-reader-text"><?php esc_html_e( 'Handbook navigation', 'wporg' ); ?></h1>
 			<div class="nav-links">
 
 			<?php

--- a/wordpress.org/public_html/wp-content/plugins/handbook/inc/watchlist.php
+++ b/wordpress.org/public_html/wp-content/plugins/handbook/inc/watchlist.php
@@ -160,15 +160,17 @@ class WPorg_Handbook_Watchlist {
 
 			if ( $watchlist && in_array( get_current_user_id(), $watchlist ) ) {
 				printf(
-					__( '<a href="%s" title="%s">Unwatch</a>', 'wporg' ),
+					'<a href="%s" title="%s">%s</a>',
 					esc_url( wp_nonce_url( admin_url( 'admin-post.php?action=wporg_watchlist&post_id=' . $post->ID ), 'unwatch-' . $post->ID ) ),
-					esc_attr__( 'Stop getting notified about changes to this page', 'wporg' )
+					esc_attr__( 'Stop getting notified about changes to this page', 'wporg' ),
+					esc_html__( 'Unwatch', 'wporg' )
 				);
 			} else {
 				printf(
-					__( '<a href="%s" title="%s">Watch</a>', 'wporg' ),
+					'<a href="%s" title="%s">%s</a>',
 					esc_url( wp_nonce_url( admin_url( 'admin-post.php?action=wporg_watchlist&watch=1&post_id=' . $post->ID ), 'watch-' . $post->ID ) ),
-					esc_attr__( 'Get notified about changes to this page', 'wporg' )
+					esc_attr__( 'Get notified about changes to this page', 'wporg' ),
+					esc_html__( 'Watch', 'wporg' )
 				);
 			}
 		}

--- a/wordpress.org/public_html/wp-content/plugins/handbook/inc/widgets.php
+++ b/wordpress.org/public_html/wp-content/plugins/handbook/inc/widgets.php
@@ -52,7 +52,7 @@ class WPorg_Handbook_Pages_Widget extends WP_Widget_Pages {
 		?>
 		<p>
 			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id('show_home') ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'show_home' ) ); ?>" type="checkbox" value="1" <?php echo $checked ?> />
-			<label for="<?php echo esc_attr( $this->get_field_id( 'show_home' ) ); ?>"><?php _e( 'List the home page', 'wporg' ); ?></label>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'show_home' ) ); ?>"><?php esc_html_e( 'List the home page', 'wporg' ); ?></label>
 		</p>
 		<?php
 	}

--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/admin.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/admin.php
@@ -1255,7 +1255,6 @@ class Admin {
 							'post_status' => 'pending',
 							'author'      => $author->ID,
 						];
-						/* translators: %s: Linked number of photos submitted by user that have been rejected. */
 						printf(
 							/* translators: %s: Number of pending photos, possibly linked. */
 							wp_kses_post( __( 'Pending photos: <strong>%s</strong>', 'wporg-photos' ) ),

--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/admin.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/admin.php
@@ -106,7 +106,7 @@ class Admin {
 			'<div id="message" class="notice notice-warning"><p>%s</p></div>' . "\n",
 			/* translators: %s: URL to settings page for enabling/disabling photo uploads. */
 			sprintf(
-				__( '<strong>Photo uploads are currently disabled for all users!</strong> Uncheck <a href="%s">the setting</a> to re-enable uploading.', 'wporg-photos' ),
+				wp_kses_post( __( '<strong>Photo uploads are currently disabled for all users!</strong> Uncheck <a href="%s">the setting</a> to re-enable uploading.', 'wporg-photos' ) ),
 				esc_url( admin_url( 'options-media.php' ) . '#' . Settings::KILLSWITCH_OPTION_NAME )
 			)
 		);
@@ -187,7 +187,7 @@ class Admin {
 			if ( $missing_taxonomies ) {
 				echo '<div class="notice notice-error is-dismissible notice-missing-taxonomies"><p>';
 				printf(
-					__( '<strong>Error:</strong> Photo was not published because the following taxonomies are missing terms: %s', 'wporg-photos' ),
+					wp_kses_post( __( '<strong>Error:</strong> Photo was not published because the following taxonomies are missing terms: %s', 'wporg-photos' ) ),
 					'<strong>' . implode( '</strong>, <strong>', $missing_taxonomies ) . '</strong>'
 				);
 
@@ -871,7 +871,7 @@ class Admin {
 		}
 
 		if ( ! $shown_photos ) {
-			echo '<p>' . __( 'This contributor does not have any other submitted photos.', 'wporg-photos' ) . "</p>\n";
+			echo '<p>' . esc_html__( 'This contributor does not have any other submitted photos.', 'wporg-photos' ) . "</p>\n";
 		}
 
 		echo '</div>' . "\n";
@@ -885,7 +885,7 @@ class Admin {
 			printf(
 				'<a href="%s">%s</a>',
 				esc_url( $link ),
-				__( "View all photos from this contributor &rarr;", 'wporg-photos' )
+				esc_html__( 'View all photos from this contributor &rarr;', 'wporg-photos' )
 			);
 			echo '</div>' . "\n";
 		}
@@ -1206,7 +1206,7 @@ class Admin {
 					<li><?php
 						/* translators: %s: Linked number of photos submitted by user. */
 						printf(
-							__( 'Published photos: <strong>%s</strong>', 'wporg-photos' ),
+							wp_kses_post( __( 'Published photos: <strong>%s</strong>', 'wporg-photos' ) ),
 							( 0 === $published_count )
 								? $published_count
 								: sprintf( '<a href="%s">%s</a>', esc_url( get_author_posts_url( $author->ID ) ), $published_count )
@@ -1221,7 +1221,7 @@ class Admin {
 						];
 						/* translators: %s: Linked number of photos submitted by user that have been rejected. */
 						printf(
-							__( 'Rejected photos: <strong>%s</strong>', 'wporg-photos' ),
+							wp_kses_post( __( 'Rejected photos: <strong>%s</strong>', 'wporg-photos' ) ),
 							( 0 === $rejected_count )
 								? $rejected_count
 								: sprintf( '<a href="%s">%d</a>', add_query_arg( $link_args, 'edit.php' ), $rejected_count )
@@ -1240,7 +1240,7 @@ class Admin {
 						}
 						printf(
 							/* translators: %s: Count of user's flagged photos possibly linked to listing of their flagged photos. */
-							_n( 'Flagged photos: <strong>%s</strong>', 'Flagged photos: <strong>%s</strong>', $flagged_count, 'wporg-photos' ),
+							wp_kses_post( _n( 'Flagged photos: <strong>%s</strong>', 'Flagged photos: <strong>%s</strong>', $flagged_count, 'wporg-photos' ) ),
 							$flagged_link ? sprintf( '<a href="%s">%d</a>', esc_url( $flagged_link ), (int) $flagged_count ) : (int) $flagged_count
 						);
 					?></li>
@@ -1253,7 +1253,7 @@ class Admin {
 						];
 						/* translators: %s: Linked number of photos submitted by user that have been rejected. */
 						printf(
-							__( 'Pending photos: <strong>%s</strong>', 'wporg-photos' ),
+							wp_kses_post( __( 'Pending photos: <strong>%s</strong>', 'wporg-photos' ) ),
 							( 0 === $pending_count )
 								? $pending_count
 								: sprintf( '<a href="%s">%d</a>', add_query_arg( $link_args, 'edit.php' ), $pending_count )
@@ -1261,7 +1261,9 @@ class Admin {
 					?></li>
 					<li><?php
 						/* translators: %s: Date user account was created. */
-						printf( __( 'Created: <strong>%s</strong>', 'wporg-photos' ), $account_created ); ?></li>
+						printf( wp_kses_post( __( 'Created: <strong>%s</strong>', 'wporg-photos' ) ), $account_created );
+					?>
+						</li>
 				</ul>
 			</div>
 			<div class="photo-contributor-more-info">
@@ -1299,7 +1301,7 @@ class Admin {
 
 					if ( $rejection_reasons ) {
 						echo '<table>';
-						echo '<tr><th>' . __( 'Reason', 'wporg-photos' ) . '</th><th>' . __( 'Total', 'wporg-photos' ) . '</th><th>%</th></tr>';
+						echo '<tr><th>' . esc_html__( 'Reason', 'wporg-photos' ) . '</th><th>' . esc_html__( 'Total', 'wporg-photos' ) . '</th><th>%</th></tr>';
 					}
 					foreach ( $rejection_reasons as $reason => $count ) {
 						echo '<tr>';
@@ -1320,7 +1322,7 @@ class Admin {
 
 					printf(
 						/* translators: %s: Rejection rate as a percentage. */
-						__( 'Total rejection rate: %s', 'wporg-photos'),
+						esc_html__( 'Total rejection rate: %s', 'wporg-photos'),
 						'<strong>' . $rejection_rate .'%</strong>'
 					);
 					echo "</p>\n";
@@ -1328,7 +1330,7 @@ class Admin {
 					if ( $submission_errors_count ) {
 						echo '<p>';
 						/* translators: %s: The number of submission errors. */
-						printf( __( 'Submission errors (which are\'t counted as submissions): %s', 'wporg-photos' ), $submission_errors_count );
+						printf( esc_html__( 'Submission errors (which are\'t counted as submissions): %s', 'wporg-photos' ), $submission_errors_count );
 						echo "</p>\n";
 					}
 				?>
@@ -1356,12 +1358,12 @@ class Admin {
 
 		// Output file hash.
 		if ( $file_hash = get_post_meta( $post_id, Registrations::get_meta_key( 'file_hash' ), true ) ) {
-			printf( $format, 'file-hash', __( 'File hash', 'wporg-photos' ), $file_hash );
+			printf( $format, 'file-hash', esc_html__( 'File hash', 'wporg-photos' ), $file_hash );
 		}
 
 		// Output original filename.
 		if ( $orig_filename = get_post_meta( $post_id, Registrations::get_meta_key( 'original_filename' ), true ) ) {
-			printf( $format, 'original-filename', __( 'Original file name', 'wporg-photos' ), esc_html( $orig_filename ) );
+			printf( $format, 'original-filename', esc_html__( 'Original file name', 'wporg-photos' ), esc_html( $orig_filename ) );
 		}
 
 		// Output moderator.
@@ -1446,7 +1448,7 @@ class Admin {
 		&&
 			! current_user_can( get_post_type_object( 'post' )->cap->create_posts )
 		) {
-			wp_die( __( 'Sorry, you are not allowed to access the media library.', 'wporg-photos' ) );
+			wp_die( esc_html__( 'Sorry, you are not allowed to access the media library.', 'wporg-photos' ) );
 		}
 	}
 
@@ -1682,7 +1684,7 @@ class Admin {
 			'<a href="%s" id="photo-dir-skip-photo" class="page-title-action" title="%s">%s</a>',
 			esc_url( add_query_arg( 'skipphoto', '1' ) ),
 			esc_attr__( 'Skip this photo and load another.', 'wporg-photos' ),
-			__( 'Skip Photo', 'wporg-photos')
+			esc_html__( 'Skip Photo', 'wporg-photos' )
 		);
 	}
 

--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/admin.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/admin.php
@@ -106,6 +106,7 @@ class Admin {
 			'<div id="message" class="notice notice-warning"><p>%s</p></div>' . "\n",
 			/* translators: %s: URL to settings page for enabling/disabling photo uploads. */
 			sprintf(
+				/* translators: %s: Media settings URL. */
 				wp_kses_post( __( '<strong>Photo uploads are currently disabled for all users!</strong> Uncheck <a href="%s">the setting</a> to re-enable uploading.', 'wporg-photos' ) ),
 				esc_url( admin_url( 'options-media.php' ) . '#' . Settings::KILLSWITCH_OPTION_NAME )
 			)
@@ -187,6 +188,7 @@ class Admin {
 			if ( $missing_taxonomies ) {
 				echo '<div class="notice notice-error is-dismissible notice-missing-taxonomies"><p>';
 				printf(
+					/* translators: %s: Missing taxonomy names. */
 					wp_kses_post( __( '<strong>Error:</strong> Photo was not published because the following taxonomies are missing terms: %s', 'wporg-photos' ) ),
 					'<strong>' . implode( '</strong>, <strong>', $missing_taxonomies ) . '</strong>'
 				);
@@ -1206,6 +1208,7 @@ class Admin {
 					<li><?php
 						/* translators: %s: Linked number of photos submitted by user. */
 						printf(
+							/* translators: %s: Number of published photos, possibly linked. */
 							wp_kses_post( __( 'Published photos: <strong>%s</strong>', 'wporg-photos' ) ),
 							( 0 === $published_count )
 								? $published_count
@@ -1221,6 +1224,7 @@ class Admin {
 						];
 						/* translators: %s: Linked number of photos submitted by user that have been rejected. */
 						printf(
+							/* translators: %s: Number of rejected photos, possibly linked. */
 							wp_kses_post( __( 'Rejected photos: <strong>%s</strong>', 'wporg-photos' ) ),
 							( 0 === $rejected_count )
 								? $rejected_count
@@ -1253,6 +1257,7 @@ class Admin {
 						];
 						/* translators: %s: Linked number of photos submitted by user that have been rejected. */
 						printf(
+							/* translators: %s: Number of pending photos, possibly linked. */
 							wp_kses_post( __( 'Pending photos: <strong>%s</strong>', 'wporg-photos' ) ),
 							( 0 === $pending_count )
 								? $pending_count

--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/admin.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/admin.php
@@ -1266,7 +1266,7 @@ class Admin {
 					?></li>
 					<li><?php
 						/* translators: %s: Date user account was created. */
-						printf( wp_kses_post( __( 'Created: <strong>%s</strong>', 'wporg-photos' ) ), $account_created );
+						printf( wp_kses_post( __( 'Created: <strong>%s</strong>', 'wporg-photos' ) ), esc_html( $account_created ) );
 					?>
 						</li>
 				</ul>
@@ -1327,7 +1327,7 @@ class Admin {
 
 					printf(
 						/* translators: %s: Rejection rate as a percentage. */
-						esc_html__( 'Total rejection rate: %s', 'wporg-photos'),
+						esc_html__( 'Total rejection rate: %s', 'wporg-photos' ),
 						'<strong>' . $rejection_rate .'%</strong>'
 					);
 					echo "</p>\n";
@@ -1335,7 +1335,7 @@ class Admin {
 					if ( $submission_errors_count ) {
 						echo '<p>';
 						/* translators: %s: The number of submission errors. */
-						printf( esc_html__( 'Submission errors (which are\'t counted as submissions): %s', 'wporg-photos' ), $submission_errors_count );
+						printf( esc_html__( 'Submission errors (which are\'t counted as submissions): %s', 'wporg-photos' ), (int) $submission_errors_count );
 						echo "</p>\n";
 					}
 				?>
@@ -1359,16 +1359,14 @@ class Admin {
 			return;
 		}
 
-		$format = '<div class="misc-pub-section misc-pub-%s">%s: <strong>%s</strong></div>';
-
 		// Output file hash.
 		if ( $file_hash = get_post_meta( $post_id, Registrations::get_meta_key( 'file_hash' ), true ) ) {
-			printf( $format, 'file-hash', esc_html__( 'File hash', 'wporg-photos' ), $file_hash );
+			printf( '<div class="misc-pub-section misc-pub-%s">%s: <strong>%s</strong></div>', 'file-hash', esc_html__( 'File hash', 'wporg-photos' ), esc_html( $file_hash ) );
 		}
 
 		// Output original filename.
 		if ( $orig_filename = get_post_meta( $post_id, Registrations::get_meta_key( 'original_filename' ), true ) ) {
-			printf( $format, 'original-filename', esc_html__( 'Original file name', 'wporg-photos' ), esc_html( $orig_filename ) );
+			printf( '<div class="misc-pub-section misc-pub-%s">%s: <strong>%s</strong></div>', 'original-filename', esc_html__( 'Original file name', 'wporg-photos' ), esc_html( $orig_filename ) );
 		}
 
 		// Output moderator.

--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/admin.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/admin.php
@@ -1359,14 +1359,16 @@ class Admin {
 			return;
 		}
 
+		$format = '<div class="misc-pub-section misc-pub-%s">%s: <strong>%s</strong></div>';
+
 		// Output file hash.
 		if ( $file_hash = get_post_meta( $post_id, Registrations::get_meta_key( 'file_hash' ), true ) ) {
-			printf( '<div class="misc-pub-section misc-pub-%s">%s: <strong>%s</strong></div>', 'file-hash', esc_html__( 'File hash', 'wporg-photos' ), esc_html( $file_hash ) );
+			echo wp_kses_post( sprintf( $format, 'file-hash', esc_html__( 'File hash', 'wporg-photos' ), esc_html( $file_hash ) ) );
 		}
 
 		// Output original filename.
 		if ( $orig_filename = get_post_meta( $post_id, Registrations::get_meta_key( 'original_filename' ), true ) ) {
-			printf( '<div class="misc-pub-section misc-pub-%s">%s: <strong>%s</strong></div>', 'original-filename', esc_html__( 'Original file name', 'wporg-photos' ), esc_html( $orig_filename ) );
+			echo wp_kses_post( sprintf( $format, 'original-filename', esc_html__( 'Original file name', 'wporg-photos' ), esc_html( $orig_filename ) ) );
 		}
 
 		// Output moderator.

--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/admin.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/admin.php
@@ -1335,7 +1335,7 @@ class Admin {
 					if ( $submission_errors_count ) {
 						echo '<p>';
 						/* translators: %s: The number of submission errors. */
-						printf( esc_html__( 'Submission errors (which are\'t counted as submissions): %s', 'wporg-photos' ), (int) $submission_errors_count );
+						printf( esc_html__( 'Submission errors (which aren&#8217;t counted as submissions): %s', 'wporg-photos' ), (int) $submission_errors_count );
 						echo "</p>\n";
 					}
 				?>

--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/flagged.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/flagged.php
@@ -394,7 +394,7 @@ class Flagged {
 					if (select) {
 						const optionExists = Array.from(select.options).some(opt => opt.value === post_status);
 						if (!optionExists) {
-							const newOption = new Option( "<?php echo esc_js( __( 'Flagged', 'wporg-photos' ) ); ?>", post_status);
+							const newOption = new Option( <?php echo wp_json_encode( __( 'Flagged', 'wporg-photos' ) ); ?>, post_status);
 							select.add(newOption);
 						}
 					}

--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/flagged.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/flagged.php
@@ -223,7 +223,7 @@ class Flagged {
 				// User can't manage flagged photos.
 				! current_user_can( self::get_capability() )
 			) {
-				wp_die( __( 'Sorry, you are not allowed to edit this post.', 'wporg-photos' ) );
+				wp_die( esc_html__( 'Sorry, you are not allowed to edit this post.', 'wporg-photos' ) );
 			}
 		}
 	}
@@ -394,7 +394,7 @@ class Flagged {
 					if (select) {
 						const optionExists = Array.from(select.options).some(opt => opt.value === post_status);
 						if (!optionExists) {
-							const newOption = new Option( "<?php _e( 'Flagged', 'wporg-photos' ); ?>", post_status);
+							const newOption = new Option( "<?php echo esc_js( __( 'Flagged', 'wporg-photos' ) ); ?>", post_status);
 							select.add(newOption);
 						}
 					}

--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/moderation.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/moderation.php
@@ -868,10 +868,10 @@ CSS;
 
 		echo '<table id="dashboard-photo-moderators" class="wp-list-table widefat fixed striped table-view-list">';
 		echo '<thead><tr>';
-		echo '<th>' . __( 'Moderator', 'wporg-photos' ) . '</th>';
+		echo '<th>' . esc_html__( 'Moderator', 'wporg-photos' ) . '</th>';
 		echo '<th class="col-num-approved" title="' . esc_attr__( 'Number of photos approved', 'wporg-photos' ) . '"><span class="dashicons dashicons-thumbs-up"></span></th>';
 		echo '<th class="col-num-rejected" title="' . esc_attr__( 'Number of photos rejected', 'wporg-photos' ) . '"><span class="dashicons dashicons-thumbs-down"></span></th>';
-		echo '<th class="col-last-mod-date">' . __( 'Last Moderated', 'wporg-photos' ) . '</th>';
+		echo '<th class="col-last-mod-date">' . esc_html__( 'Last Moderated', 'wporg-photos' ) . '</th>';
 		echo '</tr></thead>';
 		echo '<tbody>';
 

--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/rejection.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/rejection.php
@@ -873,9 +873,9 @@ class Rejection {
 		}
 
 		echo '<div class="misc-pub-section curtime misc-pub-curtime">';
-		printf( __( 'Rejected by: %s', 'wporg-photos' ), '<b>' . $rejection_user . '</b>' );
+		printf( esc_html__( 'Rejected by: %s', 'wporg-photos' ), '<b>' . $rejection_user . '</b>' );
 		echo '<br>';
-		printf( __( 'Rejected on: %s', 'wporg-photos' ), '<b>' . $rejection_date . '</b>' );
+		printf( esc_html__( 'Rejected on: %s', 'wporg-photos' ), '<b>' . $rejection_date . '</b>' );
 		echo '</div>';
 	}
 
@@ -1008,7 +1008,7 @@ JS;
 			echo "</label></div>\n";
 		}
 
-		echo '<label for="rejected_reason">' . __( 'Reject due to:', 'wporg-photos' ) . '<br>';
+		echo '<label for="rejected_reason">' . esc_html__( 'Reject due to:', 'wporg-photos' ) . '<br>';
 		printf(
 			'<select id="rejected_reason" name="rejected_reason"%s>',
 			disabled( true, $is_disabled, false )
@@ -1029,23 +1029,23 @@ JS;
 		$note_to_user_label_class = ( $is_disabled ? '' : ' pending_moderator_note_to_user' );
 
 		// Markup for optional note to send to user in rejection email.
-		echo '<label for="moderator_note_to_user" class="moderator_note_to_user' . esc_attr( $note_to_user_label_class ) . '">' . __( '(Optional) Note to user on rejection:', 'wporg-photos' );
-		echo '<p class="description"><em>' . __( 'Included in rejection email.', 'wporg-photos' ) . '</em></p>';
+		echo '<label for="moderator_note_to_user" class="moderator_note_to_user' . esc_attr( $note_to_user_label_class ) . '">' . esc_html__( '(Optional) Note to user on rejection:', 'wporg-photos' );
+		echo '<p class="description"><em>' . esc_html__( 'Included in rejection email.', 'wporg-photos' ) . '</em></p>';
 		echo '<textarea id="moderator_note_to_user" name="moderator_note_to_user" rows="4"' . disabled( true, $is_disabled, false ) . '>';
 		echo esc_textarea( self::get_moderator_note_to_user( $post, 'reject' ) );
 		echo '</textarea>';
 		echo '</label>';
 
 		// Markup for optional note sent to user in approval email.
-		echo '<label for="moderator_note_to_user_on_publish" class="moderator_note_to_user_on_publish' . esc_attr( $note_to_user_label_class ) . '">' . __( '(Optional) Note to user on approval:', 'wporg-photos' );
-		echo '<p class="description"><em>' . __( 'Included in approval email.', 'wporg-photos' ) . '</em></p>';
+		echo '<label for="moderator_note_to_user_on_publish" class="moderator_note_to_user_on_publish' . esc_attr( $note_to_user_label_class ) . '">' . esc_html__( '(Optional) Note to user on approval:', 'wporg-photos' );
+		echo '<p class="description"><em>' . esc_html__( 'Included in approval email.', 'wporg-photos' ) . '</em></p>';
 		echo '<textarea id="moderator_note_to_user_on_publish" name="moderator_note_to_user_on_publish" rows="4"' . disabled( true, $is_disabled, false ) . '>';
 		echo esc_textarea( self::get_moderator_note_to_user( $post, 'publish' ) );
 		echo '</textarea>';
 		echo '</label>';
 
 		// Markup for optional private note for moderator-eyes only.
-		echo '<label for="moderator_private_note">' . __( '(Optional) Private moderators-only note:', 'wporg-photos' );
+		echo '<label for="moderator_private_note">' . esc_html__( '(Optional) Private moderators-only note:', 'wporg-photos' );
 		echo '<textarea id="moderator_private_note" name="moderator_private_note" rows="4">';
 		echo esc_textarea( self::get_moderator_private_note( $post ) );
 		echo '</textarea>';
@@ -1368,7 +1368,7 @@ JS;
 
 		echo '<table id="dashboard-photo-rejection-stats" class="wp-list-table widefat fixed striped table-view-list">';
 		echo '<thead><tr>';
-		echo '<th>' . __( 'Rejection reason', 'wporg-photos' ) . '</th>';
+		echo '<th>' . esc_html__( 'Rejection reason', 'wporg-photos' ) . '</th>';
 		echo '<th class="col-num col-num-rejected" title="' . esc_attr__( 'Number of photos rejected', 'wporg-photos' ) . '"><span class="dashicons dashicons-thumbs-down"></span></th>';
 		echo '<th class="col-num col-percent-rejected" title="' . esc_attr( 'Percentage of overall rejections', 'wporg-photos' ) . '">%</th>';
 		echo '</tr></thead>';
@@ -1389,7 +1389,7 @@ JS;
 			echo "</tr>\n";
 		}
 
-		echo '<tr class="row-sum"><td>' . __( 'Total', 'wporg-photos' ) . '</td><td>' . number_format_i18n( $total_rejections ) . '</td><td>100%</td></tr>';
+		echo '<tr class="row-sum"><td>' . esc_html__( 'Total', 'wporg-photos' ) . '</td><td>' . number_format_i18n( $total_rejections ) . '</td><td>100%</td></tr>';
 		echo '</tbody></table>';
 		echo '</div>';
 	}

--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/rejection.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/rejection.php
@@ -873,8 +873,10 @@ class Rejection {
 		}
 
 		echo '<div class="misc-pub-section curtime misc-pub-curtime">';
+		/* translators: %s: Name of the rejecting user. */
 		printf( esc_html__( 'Rejected by: %s', 'wporg-photos' ), '<b>' . $rejection_user . '</b>' );
 		echo '<br>';
+		/* translators: %s: Rejection date. */
 		printf( esc_html__( 'Rejected on: %s', 'wporg-photos' ), '<b>' . $rejection_date . '</b>' );
 		echo '</div>';
 	}

--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/rejection.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/rejection.php
@@ -874,7 +874,7 @@ class Rejection {
 
 		echo '<div class="misc-pub-section curtime misc-pub-curtime">';
 		/* translators: %s: Name of the rejecting user. */
-		printf( esc_html__( 'Rejected by: %s', 'wporg-photos' ), '<b>' . esc_html( $rejection_user ) . '</b>' );
+		printf( esc_html__( 'Rejected by: %s', 'wporg-photos' ), '<b>' . wp_kses_post( $rejection_user ) . '</b>' );
 		echo '<br>';
 		/* translators: %s: Rejection date. */
 		printf( esc_html__( 'Rejected on: %s', 'wporg-photos' ), '<b>' . esc_html( $rejection_date ) . '</b>' );

--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/rejection.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/rejection.php
@@ -874,10 +874,10 @@ class Rejection {
 
 		echo '<div class="misc-pub-section curtime misc-pub-curtime">';
 		/* translators: %s: Name of the rejecting user. */
-		printf( esc_html__( 'Rejected by: %s', 'wporg-photos' ), '<b>' . $rejection_user . '</b>' );
+		printf( esc_html__( 'Rejected by: %s', 'wporg-photos' ), '<b>' . esc_html( $rejection_user ) . '</b>' );
 		echo '<br>';
 		/* translators: %s: Rejection date. */
-		printf( esc_html__( 'Rejected on: %s', 'wporg-photos' ), '<b>' . $rejection_date . '</b>' );
+		printf( esc_html__( 'Rejected on: %s', 'wporg-photos' ), '<b>' . esc_html( $rejection_date ) . '</b>' );
 		echo '</div>';
 	}
 
@@ -1391,7 +1391,7 @@ JS;
 			echo "</tr>\n";
 		}
 
-		echo '<tr class="row-sum"><td>' . esc_html__( 'Total', 'wporg-photos' ) . '</td><td>' . number_format_i18n( $total_rejections ) . '</td><td>100%</td></tr>';
+		echo '<tr class="row-sum"><td>' . esc_html__( 'Total', 'wporg-photos' ) . '</td><td>' . esc_html( number_format_i18n( $total_rejections ) ) . '</td><td>100%</td></tr>';
 		echo '</tbody></table>';
 		echo '</div>';
 	}

--- a/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/settings.php
+++ b/wordpress.org/public_html/wp-content/plugins/photo-directory/inc/settings.php
@@ -72,7 +72,7 @@ class Settings {
 			esc_attr( self::KILLSWITCH_OPTION_NAME ),
 			esc_attr( self::KILLSWITCH_OPTION_NAME ),
 			checked( true, self::is_killswitch_enabled(), false ),
-			__( 'Prevents all users from being able to upload any photos', 'wporg-photos' )
+			esc_html__( 'Prevents all users from being able to upload any photos', 'wporg-photos' )
 		);
 	}
 

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/class-customizations.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/class-customizations.php
@@ -181,7 +181,7 @@ class Customizations {
 		global $submenu;
 		?>
 		<div class="wrap">
-			<h1><?php _e( 'Plugin Tools', 'wporg-plugins' ); ?></h1>
+			<h1><?php esc_html_e( 'Plugin Tools', 'wporg-plugins' ); ?></h1>
 			<ul>
 				<?php
 				foreach ( $submenu['plugin-tools'] ?? [] as $page ) {
@@ -588,7 +588,7 @@ class Customizations {
 		if ( $existing_plugin && $existing_plugin->ID != $plugin->ID ) {
 			wp_die( sprintf(
 				/* translators: %s: plugin slug */
-				__( 'Error: The plugin %s already exists.', 'wporg-plugins' ),
+				esc_html__( 'Error: The plugin %s already exists.', 'wporg-plugins' ),
 				$new_slug
 			) );
 		}
@@ -668,7 +668,7 @@ class Customizations {
 		if ( $slug !== $original_slug ) {
 			wp_die( sprintf(
 				/* translators: %s: plugin slug */
-				__( 'Error: The plugin %s already exists.', 'wporg-plugins' ),
+				esc_html__( 'Error: The plugin %s already exists.', 'wporg-plugins' ),
 				$original_slug
 			) );
 		}
@@ -890,7 +890,7 @@ class Customizations {
 
 		$user = wp_get_current_user();
 		if ( ! $user->exists() ) {
-			wp_die( __( 'Sorry, you must be logged in to reply to a comment.', 'wporg-plugins' ) );
+			wp_die( esc_html__( 'Sorry, you must be logged in to reply to a comment.', 'wporg-plugins' ) );
 		}
 
 		$user_ID              = $user->ID;
@@ -912,7 +912,7 @@ class Customizations {
 		}
 
 		if ( '' == $comment_content ) {
-			wp_die( __( 'ERROR: please type a comment.', 'wporg-plugins' ) );
+			wp_die( esc_html__( 'ERROR: please type a comment.', 'wporg-plugins' ) );
 		}
 
 		$comment_parent = 0;

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/class-status-transitions.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/class-status-transitions.php
@@ -132,7 +132,10 @@ class Status_Transitions {
 		}
 
 		// ...DIE!!!!!
-		wp_die( __( 'You do not have permission to assign this post status to a plugin.', 'wporg-plugins' ), '', array(
+		wp_die(
+			esc_html__( 'You do not have permission to assign this post status to a plugin.', 'wporg-plugins' ),
+			'',
+			array(
 			'back_link' => true,
 		) );
 	}

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/class-status-transitions.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/class-status-transitions.php
@@ -136,8 +136,9 @@ class Status_Transitions {
 			esc_html__( 'You do not have permission to assign this post status to a plugin.', 'wporg-plugins' ),
 			'',
 			array(
-			'back_link' => true,
-		) );
+				'back_link' => true,
+			)
+		);
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/list-table/class-committers.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/list-table/class-committers.php
@@ -59,7 +59,7 @@ class Committers extends \WP_List_Table {
 	 * @access public
 	 */
 	public function no_items() {
-		_e( 'No committers found.', 'wporg-plugins' );
+		esc_html_e( 'No committers found.', 'wporg-plugins' );
 	}
 
 	/**
@@ -126,15 +126,15 @@ class Committers extends \WP_List_Table {
 		?>
 		<tr id="add-committer" class="add-committer wp-hidden-children">
 			<td colspan="2">
-				<button type="button" id="add-committer-toggle" class="button-link"><?php _e( '+ Add New Committer', 'wporg-plugins' ); ?></button>
+				<button type="button" id="add-committer-toggle" class="button-link"><?php esc_html_e( '+ Add New Committer', 'wporg-plugins' ); ?></button>
 				<p class="wp-hidden-child">
 					<?php wp_nonce_field( 'add-committer', '_ajax_nonce', false ); ?>
 					<span id="committer-error" class="notice notice-alt notice-error" style="display:none;"></span>
 					<label>
 						<input type="text" name="add_committer" class="form-required" value="" aria-required="true" placeholder="<?php esc_attr_e( 'WordPress.org username', 'wporg-plugins' ); ?>">
-						<span class="screen-reader-text"><?php _e( 'Add a new committer', 'wporg-plugins' ); ?></span>
+						<span class="screen-reader-text"><?php esc_html_e( 'Add a new committer', 'wporg-plugins' ); ?></span>
 					</label>
-					<input type="button" id="add-committer-submit" class="button" data-wp-lists="add:the-committer-list:add-committer::post_id=<?php echo get_post()->ID; ?>" value="<?php _e( 'Add Committer', 'wporg-plugins' ); ?>">
+					<input type="button" id="add-committer-submit" class="button" data-wp-lists="add:the-committer-list:add-committer::post_id=<?php echo get_post()->ID; ?>" value="<?php esc_attr_e( 'Add Committer', 'wporg-plugins' ); ?>">
 				</p>
 			</td>
 		</tr>

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/list-table/class-committers.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/list-table/class-committers.php
@@ -134,7 +134,7 @@ class Committers extends \WP_List_Table {
 						<input type="text" name="add_committer" class="form-required" value="" aria-required="true" placeholder="<?php esc_attr_e( 'WordPress.org username', 'wporg-plugins' ); ?>">
 						<span class="screen-reader-text"><?php esc_html_e( 'Add a new committer', 'wporg-plugins' ); ?></span>
 					</label>
-					<input type="button" id="add-committer-submit" class="button" data-wp-lists="add:the-committer-list:add-committer::post_id=<?php echo get_post()->ID; ?>" value="<?php esc_attr_e( 'Add Committer', 'wporg-plugins' ); ?>">
+					<input type="button" id="add-committer-submit" class="button" data-wp-lists="add:the-committer-list:add-committer::post_id=<?php echo (int) get_post()->ID; ?>" value="<?php esc_attr_e( 'Add Committer', 'wporg-plugins' ); ?>">
 				</p>
 			</td>
 		</tr>

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/list-table/class-plugin-posts.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/list-table/class-plugin-posts.php
@@ -333,11 +333,11 @@ class Plugin_Posts extends \WP_Posts_List_Table {
 			style="display: none"><td colspan="<?php echo $this->get_column_count(); ?>" class="colspanchange">
 
 		<fieldset class="inline-edit-col-left">
-			<legend class="inline-edit-legend"><?php _e( 'Quick Edit', 'wporg-plugins' ); ?></legend>
+			<legend class="inline-edit-legend"><?php esc_html_e( 'Quick Edit', 'wporg-plugins' ); ?></legend>
 			<div class="inline-edit-col">
 
 			<label>
-				<span class="title"><?php _e( 'Slug', 'wporg-plugins' ); ?></span>
+				<span class="title"><?php esc_html_e( 'Slug', 'wporg-plugins' ); ?></span>
 				<span class="input-text-wrap"><input type="text" name="post_name" value="" /></span>
 			</label>
 
@@ -362,9 +362,9 @@ class Plugin_Posts extends \WP_Posts_List_Table {
 	<?php endif; // count( $hierarchical_taxonomies ) ?>
 
 		<p class="submit inline-edit-save">
-			<button type="button" class="button cancel alignleft"><?php _e( 'Cancel', 'wporg-plugins' ); ?></button>
+			<button type="button" class="button cancel alignleft"><?php esc_html_e( 'Cancel', 'wporg-plugins' ); ?></button>
 			<?php wp_nonce_field( 'inlineeditnonce', '_inline_edit', false ); ?>
-			<button type="button" class="button button-primary save alignright"><?php _e( 'Update', 'wporg-plugins' ); ?></button>
+			<button type="button" class="button button-primary save alignright"><?php esc_html_e( 'Update', 'wporg-plugins' ); ?></button>
 			<span class="spinner"></span>
 			<input type="hidden" name="post_author" value="" />
 			<input type="hidden" name="post_view" value="<?php echo esc_attr( $m ); ?>" />

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/list-table/class-support-reps.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/list-table/class-support-reps.php
@@ -134,7 +134,7 @@ class Support_Reps extends \WP_List_Table {
 						<input type="text" name="add_support_rep" class="form-required" value="" aria-required="true" placeholder="<?php esc_attr_e( 'WordPress.org username', 'wporg-plugins' ); ?>">
 						<span class="screen-reader-text"><?php esc_html_e( 'Add a new support rep', 'wporg-plugins' ); ?></span>
 					</label>
-					<input type="button" id="add-support-rep-submit" class="button" data-wp-lists="add:the-support-rep-list:add-support-rep::post_id=<?php echo get_post()->ID; ?>" value="<?php esc_attr_e( 'Add Support Rep', 'wporg-plugins' ); ?>">
+					<input type="button" id="add-support-rep-submit" class="button" data-wp-lists="add:the-support-rep-list:add-support-rep::post_id=<?php echo (int) get_post()->ID; ?>" value="<?php esc_attr_e( 'Add Support Rep', 'wporg-plugins' ); ?>">
 				</p>
 			</td>
 		</tr>

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/list-table/class-support-reps.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/list-table/class-support-reps.php
@@ -59,7 +59,7 @@ class Support_Reps extends \WP_List_Table {
 	 * @access public
 	 */
 	public function no_items() {
-		_e( 'No support reps found.', 'wporg-plugins' );
+		esc_html_e( 'No support reps found.', 'wporg-plugins' );
 	}
 
 	/**
@@ -126,15 +126,15 @@ class Support_Reps extends \WP_List_Table {
 		?>
 		<tr id="add-support-rep" class="add-support-rep wp-hidden-children">
 			<td colspan="2">
-				<button type="button" id="add-support-rep-toggle" class="button-link"><?php _e( '+ Add New Support Rep', 'wporg-plugins' ); ?></button>
+				<button type="button" id="add-support-rep-toggle" class="button-link"><?php esc_html_e( '+ Add New Support Rep', 'wporg-plugins' ); ?></button>
 				<p class="wp-hidden-child">
 					<?php wp_nonce_field( 'add-support-rep', '_ajax_nonce', false ); ?>
 					<span id="support-rep-error" class="notice notice-alt notice-error" style="display:none;"></span>
 					<label>
 						<input type="text" name="add_support_rep" class="form-required" value="" aria-required="true" placeholder="<?php esc_attr_e( 'WordPress.org username', 'wporg-plugins' ); ?>">
-						<span class="screen-reader-text"><?php _e( 'Add a new support rep', 'wporg-plugins' ); ?></span>
+						<span class="screen-reader-text"><?php esc_html_e( 'Add a new support rep', 'wporg-plugins' ); ?></span>
 					</label>
-					<input type="button" id="add-support-rep-submit" class="button" data-wp-lists="add:the-support-rep-list:add-support-rep::post_id=<?php echo get_post()->ID; ?>" value="<?php _e( 'Add Support Rep', 'wporg-plugins' ); ?>">
+					<input type="button" id="add-support-rep-submit" class="button" data-wp-lists="add:the-support-rep-list:add-support-rep::post_id=<?php echo get_post()->ID; ?>" value="<?php esc_attr_e( 'Add Support Rep', 'wporg-plugins' ); ?>">
 				</p>
 			</td>
 		</tr>

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/metabox/class-author-card.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/metabox/class-author-card.php
@@ -154,6 +154,7 @@ class Author_Card {
 					<?php
 					/* translators: 1: time ago, 2: registration date */
 					printf(
+						/* translators: 1: Time since registration, 2: Registration date. */
 						esc_html__( 'Joined %1$s ago (%2$s)', 'wporg-plugins' ),
 						human_time_diff( strtotime( $author->user_registered ) ),
 						date( 'Y-M-d', strtotime( $author->user_registered ) )
@@ -237,6 +238,7 @@ class Author_Card {
 
 				/* translators: %s: comma-separated list of plugin author's IP addresses */
 				printf(
+					/* translators: %s: List of IP addresses. */
 					'<p>' . esc_html__( 'IPs : %s', 'wporg-plugins' ) . '</p>',
 					implode( ', ', array_map( array( __NAMESPACE__ . '\Author_Card', 'link_ip' ), $user_ips ) )
 				);
@@ -269,6 +271,7 @@ class Author_Card {
 			if ( empty( $author_commit ) && empty( $author_plugins ) ) {
 				esc_html_e( 'Not a developer on any plugin.', 'wporg-plugins' );
 			} else {
+				/* translators: %d: Number of plugins. */
 				echo '<strong>' . sprintf( esc_html( _n( '%d plugin:', '%d plugins:', count( $all_plugins ), 'wporg-plugins' ) ), count( $all_plugins ) ) . '</strong>';
 
 				echo '<ul>';

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/metabox/class-author-card.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/metabox/class-author-card.php
@@ -202,7 +202,7 @@ class Author_Card {
 						);
 					}
 					/* translators: %s: comma-separated list of negative user status labels */
-					echo '<p>' . sprintf( esc_html__( 'This user is: %s', 'wporg-plugins' ), esc_html( implode( ', ', $labels ) ) ) . '</p>';
+					echo '<p>' . sprintf( esc_html__( 'This user is: %s', 'wporg-plugins' ), wp_kses_post( implode( ', ', $labels ) ) ) . '</p>';
 				}
 
 				$user_notes = get_user_meta( $user->ID, '_wporg_bbp_user_notes', true );

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/metabox/class-author-card.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/metabox/class-author-card.php
@@ -133,8 +133,8 @@ class Author_Card {
 				?>
 
 				<span class="profile-links">
-					<a href="//profiles.wordpress.org/<?php echo $author->user_nicename; ?>/"><?php _e( 'profile', 'wporg-plugins' ); ?></a> |
-					<a href="//wordpress.org/support/users/<?php echo $author->user_nicename; ?>/"><?php _e( 'support', 'wporg-plugins' ); ?></a>
+					<a href="//profiles.wordpress.org/<?php echo $author->user_nicename; ?>/"><?php esc_html_e( 'profile', 'wporg-plugins' ); ?></a> |
+					<a href="//wordpress.org/support/users/<?php echo $author->user_nicename; ?>/"><?php esc_html_e( 'support', 'wporg-plugins' ); ?></a>
 				</span>
 
 				<div class="profile-email">
@@ -154,7 +154,7 @@ class Author_Card {
 					<?php
 					/* translators: 1: time ago, 2: registration date */
 					printf(
-						__( 'Joined %1$s ago (%2$s)', 'wporg-plugins' ),
+						esc_html__( 'Joined %1$s ago (%2$s)', 'wporg-plugins' ),
 						human_time_diff( strtotime( $author->user_registered ) ),
 						date( 'Y-M-d', strtotime( $author->user_registered ) )
 					);
@@ -165,7 +165,7 @@ class Author_Card {
 
 		<?php if ( ! empty( $author->user_url ) ) : ?>
 			<p class="profile-url">
-				<?php _e( 'Author URL:', 'wporg-plugins' ); ?>
+				<?php esc_html_e( 'Author URL:', 'wporg-plugins' ); ?>
 				<a href="<?php echo esc_url( $author->user_url ); ?>"><?php echo esc_html( $author->user_url ); ?></a>
 			</p>
 		<?php endif; ?>
@@ -201,7 +201,7 @@ class Author_Card {
 						);
 					}
 					/* translators: %s: comma-separated list of negative user status labels */
-					echo '<p>' . sprintf( __( 'This user is: %s', 'wporg-plugins' ), implode( ', ', $labels ) ) . '</p>';
+					echo '<p>' . sprintf( esc_html__( 'This user is: %s', 'wporg-plugins' ), implode( ', ', $labels ) ) . '</p>';
 				}
 
 				$user_notes = get_user_meta( $user->ID, '_wporg_bbp_user_notes', true );
@@ -210,7 +210,7 @@ class Author_Card {
 			// Include any warning flags.
 			$warning_flags = self::get_user_flags( $author->ID, $author_plugins );
 			if ( $warning_flags ) {
-				echo '<strong>' . __( 'Warning Flags:', 'wporg-plugins' ) . '</strong>';
+				echo '<strong>' . esc_html__( 'Warning Flags:', 'wporg-plugins' ) . '</strong>';
 				echo '<ul class="plugin-flagged">';
 				foreach ( $warning_flags as $flag => $reasons ) {
 					echo '<li class="plugin-flagged-' . esc_attr( $flag ) . '"><strong>' . esc_html( strtoupper( $flag ) ) . ' (' . esc_html( count( $reasons ) ) . '):</strong> ' . esc_html( implode( '; ', $reasons ) ) . '</li>';
@@ -237,14 +237,14 @@ class Author_Card {
 
 				/* translators: %s: comma-separated list of plugin author's IP addresses */
 				printf(
-					'<p>' . __( 'IPs : %s', 'wporg-plugins' ) . '</p>',
+					'<p>' . esc_html__( 'IPs : %s', 'wporg-plugins' ) . '</p>',
 					implode( ', ', array_map( array( __NAMESPACE__ . '\Author_Card', 'link_ip' ), $user_ips ) )
 				);
 			}
 
 			// Include any user notes.
 			if ( ! empty( $user_notes ) ) {
-				_e( 'User notes:', 'wporg-plugins' );
+				esc_html_e( 'User notes:', 'wporg-plugins' );
 				echo '<ul>';
 				foreach ( $user_notes as $note ) {
 					$note_meta = sprintf(
@@ -267,9 +267,9 @@ class Author_Card {
 		<div class="profile-plugins">
 			<?php
 			if ( empty( $author_commit ) && empty( $author_plugins ) ) {
-				_e( 'Not a developer on any plugin.', 'wporg-plugins' );
+				esc_html_e( 'Not a developer on any plugin.', 'wporg-plugins' );
 			} else {
-				echo '<strong>' . sprintf( _n( '%d plugin:', '%d plugins:', count( $all_plugins ), 'wporg-plugins' ), count( $all_plugins ) ) . '</strong>';
+				echo '<strong>' . sprintf( esc_html( _n( '%d plugin:', '%d plugins:', count( $all_plugins ), 'wporg-plugins' ) ), count( $all_plugins ) ) . '</strong>';
 
 				echo '<ul>';
 				self::display_plugin_links( $all_plugins, $author_plugins, $author_commit );
@@ -512,7 +512,7 @@ class Author_Card {
 					'<a href="%s" title="%s">%s</a>',
 					esc_url( get_edit_post_link( $plugin->ID, '' ) ),
 					esc_attr__( 'Edit this plugin', 'wporg-plugins' ),
-					__( 'Edit', 'wporg-plugins' )
+					esc_html__( 'Edit', 'wporg-plugins' )
 				),
 				sprintf(
 					'<a href="//make.wordpress.org/pluginrepo/?s=%s" title="%s">P2</a>',

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/metabox/class-author-card.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/metabox/class-author-card.php
@@ -115,7 +115,7 @@ class Author_Card {
 		<div class="profile-personal">
 			<?php echo get_avatar( $author->ID, 48 ); ?>
 			<div class="profile-details">
-				<strong><a href="//profiles.wordpress.org/<?php echo $author->user_nicename; ?>/"><?php echo $author->user_login; ?></a></strong>
+				<strong><a href="//profiles.wordpress.org/<?php echo esc_attr( $author->user_nicename ); ?>/"><?php echo esc_html( $author->user_login ); ?></a></strong>
 				<?php
 				$author_links = array(
 					sprintf(
@@ -133,8 +133,8 @@ class Author_Card {
 				?>
 
 				<span class="profile-links">
-					<a href="//profiles.wordpress.org/<?php echo $author->user_nicename; ?>/"><?php esc_html_e( 'profile', 'wporg-plugins' ); ?></a> |
-					<a href="//wordpress.org/support/users/<?php echo $author->user_nicename; ?>/"><?php esc_html_e( 'support', 'wporg-plugins' ); ?></a>
+					<a href="//profiles.wordpress.org/<?php echo esc_attr( $author->user_nicename ); ?>/"><?php esc_html_e( 'profile', 'wporg-plugins' ); ?></a> |
+					<a href="//wordpress.org/support/users/<?php echo esc_attr( $author->user_nicename ); ?>/"><?php esc_html_e( 'support', 'wporg-plugins' ); ?></a>
 				</span>
 
 				<div class="profile-email">
@@ -202,7 +202,7 @@ class Author_Card {
 						);
 					}
 					/* translators: %s: comma-separated list of negative user status labels */
-					echo '<p>' . sprintf( esc_html__( 'This user is: %s', 'wporg-plugins' ), implode( ', ', $labels ) ) . '</p>';
+					echo '<p>' . sprintf( esc_html__( 'This user is: %s', 'wporg-plugins' ), esc_html( implode( ', ', $labels ) ) ) . '</p>';
 				}
 
 				$user_notes = get_user_meta( $user->ID, '_wporg_bbp_user_notes', true );

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/metabox/class-author.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/metabox/class-author.php
@@ -25,7 +25,7 @@ class Author {
 		?>
 		<label><input id="post_author_username" type="text" value="<?php echo esc_attr( $user->user_login ); ?>" /></label>
 		<input id="post_author_override" type="hidden" name="post_author_override" value="<?php echo esc_attr( $value ); ?>" />
-		<label class="screen-reader-text"><?php _e( 'Author', 'wporg-plugins' ); ?></label>
+		<label class="screen-reader-text"><?php esc_html_e( 'Author', 'wporg-plugins' ); ?></label>
 
 		<script>
 			jQuery( function( $ ) {

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/metabox/class-controls.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/metabox/class-controls.php
@@ -234,19 +234,24 @@ class Controls {
 			<?php if ( 'closed' === $post->post_status ) : ?>
 
 				<?php /* translators: %s: Close reason. */ ?>
-				<p><?php printf( esc_html__( 'Close Reason: %s', 'wporg-plugins' ), '<strong>' . $close_reason_label . '</strong>' ); ?></p>
+				<p><?php printf( esc_html__( 'Close Reason: %s', 'wporg-plugins' ), '<strong>' . esc_html( $close_reason_label ) . '</strong>' ); ?></p>
 
 			<?php elseif ( 'disabled' === $post->post_status ) : ?>
 
 				<?php /* translators: %s: Disable reason. */ ?>
-				<p><?php printf( esc_html__( 'Disable Reason: %s', 'wporg-plugins' ), '<strong>' . $close_reason_label . '</strong>' ); ?></p>
+				<p><?php printf( esc_html__( 'Disable Reason: %s', 'wporg-plugins' ), '<strong>' . esc_html( $close_reason_label ) . '</strong>' ); ?></p>
 
 			<?php elseif ( 'rejected' === $post->post_status ) : ?>
 
-				<p><?php printf(
+				<p>
+					<?php
+					printf(
+						/* translators: %s: Rejection reason. */
 						esc_html__( 'Rejection Reason: %s', 'wporg-plugins' ),
-						'<strong>' . $rejection_reason_label . '</strong>'
-				); ?></p>
+						'<strong>' . esc_html( $rejection_reason_label ) . '</strong>'
+					);
+					?>
+				</p>
 
 			<?php elseif ( 'publish' === $post->post_status ) : ?>
 

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/metabox/class-controls.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/metabox/class-controls.php
@@ -233,10 +233,12 @@ class Controls {
 
 			<?php if ( 'closed' === $post->post_status ) : ?>
 
+				<?php /* translators: %s: Close reason. */ ?>
 				<p><?php printf( esc_html__( 'Close Reason: %s', 'wporg-plugins' ), '<strong>' . $close_reason_label . '</strong>' ); ?></p>
 
 			<?php elseif ( 'disabled' === $post->post_status ) : ?>
 
+				<?php /* translators: %s: Disable reason. */ ?>
 				<p><?php printf( esc_html__( 'Disable Reason: %s', 'wporg-plugins' ), '<strong>' . $close_reason_label . '</strong>' ); ?></p>
 
 			<?php elseif ( 'rejected' === $post->post_status ) : ?>

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/metabox/class-controls.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/metabox/class-controls.php
@@ -233,30 +233,30 @@ class Controls {
 
 			<?php if ( 'closed' === $post->post_status ) : ?>
 
-				<p><?php printf( __( 'Close Reason: %s', 'wporg-plugins' ), '<strong>' . $close_reason_label . '</strong>' ); ?></p>
+				<p><?php printf( esc_html__( 'Close Reason: %s', 'wporg-plugins' ), '<strong>' . $close_reason_label . '</strong>' ); ?></p>
 
 			<?php elseif ( 'disabled' === $post->post_status ) : ?>
 
-				<p><?php printf( __( 'Disable Reason: %s', 'wporg-plugins' ), '<strong>' . $close_reason_label . '</strong>' ); ?></p>
+				<p><?php printf( esc_html__( 'Disable Reason: %s', 'wporg-plugins' ), '<strong>' . $close_reason_label . '</strong>' ); ?></p>
 
 			<?php elseif ( 'rejected' === $post->post_status ) : ?>
 
 				<p><?php printf(
-						__( 'Rejection Reason: %s', 'wporg-plugins' ),
+						esc_html__( 'Rejection Reason: %s', 'wporg-plugins' ),
 						'<strong>' . $rejection_reason_label . '</strong>'
 				); ?></p>
 
 			<?php elseif ( 'publish' === $post->post_status ) : ?>
 
 				<?php if ( $active_installs >= '20000' ) : ?>
-					<p><strong><?php _e( 'Notice:', 'wporg-plugins' ); ?></strong> <?php _e( 'Due to the large volume of active users, the developers should be warned and their plugin remain open save under extreme circumstances.', 'wporg-plugins' ); ?>.</p>
+					<p><strong><?php esc_html_e( 'Notice:', 'wporg-plugins' ); ?></strong> <?php esc_html_e( 'Due to the large volume of active users, the developers should be warned and their plugin remain open save under extreme circumstances.', 'wporg-plugins' ); ?>.</p>
 				<?php endif; ?>
 
 			<?php endif; ?>
 
 			<?php if ( array_intersect( $statuses, [ 'closed', 'disabled' ] ) ) { ?>
 				<p>
-					<label for="close_reason"><?php _e( 'Close/Disable Reason:', 'wporg-plugins' ); ?></label>
+					<label for="close_reason"><?php esc_html_e( 'Close/Disable Reason:', 'wporg-plugins' ); ?></label>
 					<select name="close_reason" id="close_reason">
 						<?php foreach ( $close_reasons as $key => $label ) : ?>
 							<option value="<?php echo esc_attr( $key ); ?>"<?php selected( $key, $close_reason ); ?>><?php echo esc_html( $label ); ?></option>
@@ -276,7 +276,7 @@ class Controls {
 
 				if ( $status === 'rejected' ) { ?>
 					<p>
-						<label for="rejection_reason"><?php _e( 'Rejection Reason:', 'wporg-plugins' ); ?></label>
+						<label for="rejection_reason"><?php esc_html_e( 'Rejection Reason:', 'wporg-plugins' ); ?></label>
 						<select name="rejection_reason" id="rejection_reason">
 							<?php foreach ( $rejection_reasons as $key => $label ) : ?>
 								<option value="<?php echo esc_attr( $key ); ?>"<?php selected( $key, $rejection_reason ); ?>><?php echo esc_html( $label ); ?></option>
@@ -303,17 +303,17 @@ class Controls {
 		?>
 		<table class="misc-pub-section misc-pub-meta">
 			<tr>
-				<td><?php _e( 'Status:', 'wporg-plugins' ); ?></td>
+				<td><?php esc_html_e( 'Status:', 'wporg-plugins' ); ?></td>
 				<td><strong><?php echo esc_html( get_post_status_object( $post->post_status )->label ); ?></strong></td>
 			</tr>
 
 			<tr>
-				<td><?php _e( 'Version:', 'wporg-plugins' ); ?></td>
+				<td><?php esc_html_e( 'Version:', 'wporg-plugins' ); ?></td>
 				<td><strong><?php echo esc_html( $post->version ); ?></strong></td>
 			</tr>
 
 			<tr>
-				<td><?php _e( 'Updated:', 'wporg-plugins' ); ?></td>
+				<td><?php esc_html_e( 'Updated:', 'wporg-plugins' ); ?></td>
 				<td><strong><?php
 					printf(
 						'<span title="%s">%s ago</span>',
@@ -324,7 +324,7 @@ class Controls {
 			</tr>
 
 			<tr>
-				<td><?php _e( 'Submitted:', 'wporg-plugins' ); ?></td>
+				<td><?php esc_html_e( 'Submitted:', 'wporg-plugins' ); ?></td>
 				<td><strong><?php
 					$submitted_date = min( array_filter( [
 						$post->_submitted_date,           // Submitted date stored since 2017-04-11
@@ -341,7 +341,7 @@ class Controls {
 			</tr>
 
 			<tr>
-				<td><?php _e( 'Installs:', 'wporg-plugins' ); ?></td>
+				<td><?php esc_html_e( 'Installs:', 'wporg-plugins' ); ?></td>
 				<td><strong><?php echo Template::active_installs( false, $post ); ?></strong></td>
 			</tr>
 
@@ -364,7 +364,7 @@ class Controls {
 
 			<?php if ( $post->tested ) : ?>
 			<tr>
-				<td><?php _e( 'Tested With:', 'wporg-plugins' ); ?></td>
+				<td><?php esc_html_e( 'Tested With:', 'wporg-plugins' ); ?></td>
 				<td><strong><?php printf( 'WordPress %s', esc_html( $post->tested ) ); ?></strong></td>
 			</tr>
 			<?php endif; ?>

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/metabox/class-internal-notes.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/metabox/class-internal-notes.php
@@ -32,7 +32,7 @@ class Internal_Notes {
 		wp_nonce_field( 'get-comments', 'add_comment_nonce', false );
 		?>
 		<p class="hide-if-no-js" id="add-new-comment">
-			<a class="button" href="#commentstatusdiv"><?php _e( 'Add note', 'wporg-plugins' ); ?></a>
+			<a class="button" href="#commentstatusdiv"><?php esc_html_e( 'Add note', 'wporg-plugins' ); ?></a>
 		</p>
 		<?php
 		$wp_list_table->display( true );

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/metabox/class-review-tools.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/metabox/class-review-tools.php
@@ -159,7 +159,7 @@ class Review_Tools {
 		if ( in_array( $post->post_status, [ 'draft', 'pending', 'new' ], true ) ) {
 			echo '<label>
 				<input type="file" class="plugin-file" name="zip_file" size="25" accept=".zip"/>
-				<button class="button button-secondary plugin-upload-zip">' . __( 'Upload', 'wporg-plugins' ) . '</button>
+				<button class="button button-secondary plugin-upload-zip">' . esc_html__( 'Upload', 'wporg-plugins' ) . '</button>
 				</label>';
 		}
 

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/tools/class-author-cards.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/tools/class-author-cards.php
@@ -78,22 +78,22 @@ class Author_Cards {
 		$usernames = ! empty( $_REQUEST['users'] ) ? $_REQUEST['users'] : '';
 
 		echo '<div class="wrap author-cards">';
-		echo '<h1>' . __( 'Author Cards', 'wporg-plugins' ) . '</h1>';
+		echo '<h1>' . esc_html__( 'Author Cards', 'wporg-plugins' ) . '</h1>';
 
-		echo '<p>' . __( 'This is a tool to display an author card for one or more specified users.', 'wporg-plugins' ) . '</p>';
+		echo '<p>' . esc_html__( 'This is a tool to display an author card for one or more specified users.', 'wporg-plugins' ) . '</p>';
 
 		echo '<form method="GET">';
 		echo '<table class="form-table"><tbody><tr>';
-		echo '<th scope="row"><label for="users">' . __( 'Users', 'wporg-plugins' ) . '</label></th><td>';
+		echo '<th scope="row"><label for="users">' . esc_html__( 'Users', 'wporg-plugins' ) . '</label></th><td>';
 		echo '<input name="page" type="hidden" value="' . esc_attr( $_REQUEST['page'] ) . '">';
 		echo '<input name="users" type="text" id="users" value="' . esc_attr( $usernames ) . '" class="regular-text">';
-		echo '<p>' . __( 'Comma-separated list of user slugs, logins, and/or email addresses.', 'wporg-plugins' ) . '</p>';
+		echo '<p>' . esc_html__( 'Comma-separated list of user slugs, logins, and/or email addresses.', 'wporg-plugins' ) . '</p>';
 		echo '</td></tr></tbody></table>';
 		echo '<p class="submit"><input type="submit" id="submit" class="button button-primary" value="' . esc_attr__( 'Submit', 'wporg-plugins' ) . '"></p>';
 		echo '</form>';
 
 		if ( $usernames ) {
-			echo '<h2>' . __( 'Results', 'wporg-plugins' ) . '</h2>';
+			echo '<h2>' . esc_html__( 'Results', 'wporg-plugins' ) . '</h2>';
 
 			echo '<div class="main">';
 
@@ -130,7 +130,7 @@ class Author_Cards {
 						echo '<img class="avatar" src="https://gravatar.com/avatar/?d=mystery"><span class="profile-details"><strong>';
 						echo esc_html( $username );
 						echo '</strong></span></p>';
-						echo '<p><em>' . __( 'No user found with this slug, login, or email address.', 'wporg-plugins' ) . '</em></p>';
+						echo '<p><em>' . esc_html__( 'No user found with this slug, login, or email address.', 'wporg-plugins' ) . '</em></p>';
 						echo '</div>';
 					}
 				}

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/tools/class-stats-report.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/tools/class-stats-report.php
@@ -376,6 +376,7 @@ class Stats_Report {
 		<?php
 			/* translators: %s: today's date */
 			printf(
+				/* translators: %s: Today's date. */
 				esc_html__( 'The day up to which stats are to be gathered. In YYYY-MM-DD format. Defaults to today (%s).', 'wporg-plugins' ),
 				esc_html( $date )
 			);
@@ -389,6 +390,7 @@ class Stats_Report {
 		<?php
 			/* translators: %d: 7 */
 			printf(
+				/* translators: %d: Default number of days. */
 				esc_html__( 'The number of days before "Date" to include in stats. Default is %d.', 'wporg-plugins' ),
 				7
 			);
@@ -402,6 +404,7 @@ class Stats_Report {
 		<?php
 			/* translators: %d: 7 */
 			printf(
+				/* translators: %d: Default number of days. */
 				esc_html__( 'The number of days before today to consider as being "recent" (stats marked with **). Default is %d.', 'wporg-plugins' ),
 				7
 			);
@@ -419,6 +422,7 @@ class Stats_Report {
 		<?php
 			/* translators: 1: number of days, 2: selected date, 3: number of most recent days */
 			printf(
+				/* translators: 1: Number of days, 2: Date, 3: Number of recent days. */
 				esc_html__( 'Displaying stats for the %1$d days preceding %2$s (and other stats for the %3$d most recent days).', 'wporg-plugins' ),
 				esc_html( $stats['num_days'] ),
 				esc_html( $stats['date'] ),
@@ -434,6 +438,7 @@ class Stats_Report {
 			<?php
 				/* translators: %d: number of requested plugins */
 				printf(
+					/* translators: %d: Number of plugins. */
 					esc_html__( 'Plugins requested : %d', 'wporg-plugins' ),
 					esc_html( $stats['plugin_new'] )
 				);
@@ -443,6 +448,7 @@ class Stats_Report {
 			<?php
 				/* translators: %s: number of rejected plugins */
 				printf(
+					/* translators: %s: Number of plugins. */
 					esc_html__( 'Plugins rejected : %s', 'wporg-plugins' ),
 					esc_html( $stats['plugin_reject'] )
 				);
@@ -452,6 +458,7 @@ class Stats_Report {
 			<?php
 				/* translators: %s: number of closed plugins */
 				printf(
+					/* translators: %s: Number of plugins. */
 					esc_html__( 'Plugins closed : %s', 'wporg-plugins' ),
 					esc_html( $stats['plugin_delist'] )
 				);
@@ -470,6 +477,7 @@ class Stats_Report {
 			<?php
 				/* translators: %s: number of approved plugins */
 				printf(
+					/* translators: %s: Number of plugins. */
 					esc_html__( 'Plugins approved : %s', 'wporg-plugins' ),
 					esc_html( $stats['plugin_approve'] )
 				);
@@ -484,6 +492,7 @@ class Stats_Report {
 			<?php
 				/* translators: %d: number of plugins in the queue */
 				printf(
+					/* translators: %d: Number of plugins. */
 					esc_html__( 'Plugins in the queue (new and pending)* : %d', 'wporg-plugins' ),
 					esc_html( $stats['in_queue'] )
 				);
@@ -493,6 +502,7 @@ class Stats_Report {
 			<?php
 				/* translators: 1: number of most recent days, 2: number of older plugins in the queue */
 				printf(
+					/* translators: 1: Number of days, 2: Number of plugins. */
 					esc_html__( '&rarr; (older than %1$d days ago)** : %2$d', 'wporg-plugins' ),
 					esc_html( $stats['recentdays'] ),
 					esc_html( $stats['in_queue_old'] )
@@ -503,6 +513,7 @@ class Stats_Report {
 			<?php
 				/* translators: 1: start date, 2: end date, 3: number of plugins in the queue within defined time window */
 				printf(
+					/* translators: 1: Start date, 2: End date, 3: Number of plugins. */
 					esc_html__( '&rarr; (%1$s - %2$s) : %3$d', 'wporg-plugins' ),
 					esc_html( $start_date ),
 					esc_html( $stats['date'] ),
@@ -514,6 +525,7 @@ class Stats_Report {
 			<?php
 				/* translators: %d: number of new plugins */
 				printf(
+					/* translators: %d: Number of plugins. */
 					esc_html__( '&rarr; (new; not processed or replied to yet)* : %d', 'wporg-plugins' ),
 					esc_html( $stats['in_queue_new'] )
 				);
@@ -523,6 +535,7 @@ class Stats_Report {
 			<?php
 				/* translators: %d: number of pending plugins */
 				printf(
+					/* translators: %d: Number of plugins. */
 					esc_html__( '&rarr; (pending; replied to)* : %d', 'wporg-plugins' ),
 					esc_html( $stats['in_queue_pending'] )
 				);
@@ -532,6 +545,7 @@ class Stats_Report {
 			<?php
 				/* translators: %d: number of pending plugins */
 				printf(
+					/* translators: %d: Number of plugins. */
 					esc_html__( '&rarr; (pending; waiting on author)* : %d', 'wporg-plugins' ),
 					esc_html( $stats['in_queue_pending_why']['author'] ?? 0 )
 				);
@@ -541,6 +555,7 @@ class Stats_Report {
 			<?php
 				/* translators: %d: number of pending plugins */
 				printf(
+					/* translators: %d: Number of plugins. */
 					esc_html__( '&rarr; (pending; waiting on reviewer)* : %d', 'wporg-plugins' ),
 					esc_html( $stats['in_queue_pending_why']['reviewer'] ?? 0 )
 				);
@@ -551,6 +566,7 @@ class Stats_Report {
 				<?php
 					/* translators: %d: number of pending plugins */
 					printf(
+						/* translators: %d: Number of plugins. */
 						esc_html__( '&rarr; (pending; waiting on reviewer, email not yet sent)* : %d', 'wporg-plugins' ),
 						esc_html( $stats['in_queue_pending_why']['noemail'] )
 					);

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/tools/class-stats-report.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/tools/class-stats-report.php
@@ -365,44 +365,44 @@ class Stats_Report {
 
 		<div class="wrap stats-report">
 
-		<h1><?php _e( 'Plugin Repository and email Stats Report', 'wporg-plugins' ); ?></h1>
+		<h1><?php esc_html_e( 'Plugin Repository and email Stats Report', 'wporg-plugins' ); ?></h1>
 
 		<form method="get">
 		<input type="hidden" name="page" value="<?php echo esc_attr( $_REQUEST['page'] ); ?>"/>
 		<table class="form-table"><tbody>
-		<tr><th scope="row"><label for="date"><?php _e( 'Date', 'wporg-plugins' ); ?></label></th><td>
+		<tr><th scope="row"><label for="date"><?php esc_html_e( 'Date', 'wporg-plugins' ); ?></label></th><td>
 		<input name="date" type="text" id="date" value="<?php echo esc_attr( $args['date'] ); ?>" class="text">
 		<p>
 		<?php
 			/* translators: %s: today's date */
 			printf(
-				__( 'The day up to which stats are to be gathered. In YYYY-MM-DD format. Defaults to today (%s).', 'wporg-plugins' ),
+				esc_html__( 'The day up to which stats are to be gathered. In YYYY-MM-DD format. Defaults to today (%s).', 'wporg-plugins' ),
 				esc_html( $date )
 			);
 		?>
 		</p>
 		</td></tr>
 
-		<tr><th scope="row"><label for="days"><?php _e( 'Number of days', 'wporg-plugins' ); ?></label></th><td>
+		<tr><th scope="row"><label for="days"><?php esc_html_e( 'Number of days', 'wporg-plugins' ); ?></label></th><td>
 		<input name="days" type="text" id="days" value="<?php echo esc_attr( $args['num_days'] ); ?>" class="small-text">
 		<p>
 		<?php
 			/* translators: %d: 7 */
 			printf(
-				__( 'The number of days before "Date" to include in stats. Default is %d.', 'wporg-plugins' ),
+				esc_html__( 'The number of days before "Date" to include in stats. Default is %d.', 'wporg-plugins' ),
 				7
 			);
 		?>
 		</p>
 		</td></tr>
 
-		<tr><th scope="row"><label for="recentdays"><?php _e( '"Recent" number of days', 'wporg-plugins' ); ?></label></th><td>
+		<tr><th scope="row"><label for="recentdays"><?php esc_html_e( '"Recent" number of days', 'wporg-plugins' ); ?></label></th><td>
 		<input name="recentdays" type="text" id="recentdays" value="<?php echo esc_attr( $args['recentdays'] ); ?>" class="small-text">
 		<p>
 		<?php
 			/* translators: %d: 7 */
 			printf(
-				__( 'The number of days before today to consider as being "recent" (stats marked with **). Default is %d.', 'wporg-plugins' ),
+				esc_html__( 'The number of days before today to consider as being "recent" (stats marked with **). Default is %d.', 'wporg-plugins' ),
 				7
 			);
 		?>
@@ -413,13 +413,13 @@ class Stats_Report {
 		<p class="submit"><input type="submit" name="submit" id="submit" class="button button-primary" value="<?php esc_attr_e( 'Submit', 'wporg-plugins' ); ?>"></p>
 		</form>
 
-		<h2><?php _e( 'Stats', 'wporg-plugins' ); ?></h2>
+		<h2><?php esc_html_e( 'Stats', 'wporg-plugins' ); ?></h2>
 
 		<p>
 		<?php
 			/* translators: 1: number of days, 2: selected date, 3: number of most recent days */
 			printf(
-				__( 'Displaying stats for the %1$d days preceding %2$s (and other stats for the %3$d most recent days).', 'wporg-plugins' ),
+				esc_html__( 'Displaying stats for the %1$d days preceding %2$s (and other stats for the %3$d most recent days).', 'wporg-plugins' ),
 				esc_html( $stats['num_days'] ),
 				esc_html( $stats['date'] ),
 				esc_html( $stats['recentdays'] )
@@ -427,14 +427,14 @@ class Stats_Report {
 		?>
 		</p>
 
-		<h3><?php _e( 'Plugin Status Change Stats', 'wporg-plugins' ); ?></h3>
+		<h3><?php esc_html_e( 'Plugin Status Change Stats', 'wporg-plugins' ); ?></h3>
 
 		<ul style="font-family:Courier New;">
 			<li>
 			<?php
 				/* translators: %d: number of requested plugins */
 				printf(
-					__( 'Plugins requested : %d', 'wporg-plugins' ),
+					esc_html__( 'Plugins requested : %d', 'wporg-plugins' ),
 					esc_html( $stats['plugin_new'] )
 				);
 			?>
@@ -443,7 +443,7 @@ class Stats_Report {
 			<?php
 				/* translators: %s: number of rejected plugins */
 				printf(
-					__( 'Plugins rejected : %s', 'wporg-plugins' ),
+					esc_html__( 'Plugins rejected : %s', 'wporg-plugins' ),
 					esc_html( $stats['plugin_reject'] )
 				);
 			?>
@@ -452,7 +452,7 @@ class Stats_Report {
 			<?php
 				/* translators: %s: number of closed plugins */
 				printf(
-					__( 'Plugins closed : %s', 'wporg-plugins' ),
+					esc_html__( 'Plugins closed : %s', 'wporg-plugins' ),
 					esc_html( $stats['plugin_delist'] )
 				);
 				$reasons = array();
@@ -470,21 +470,21 @@ class Stats_Report {
 			<?php
 				/* translators: %s: number of approved plugins */
 				printf(
-					__( 'Plugins approved : %s', 'wporg-plugins' ),
+					esc_html__( 'Plugins approved : %s', 'wporg-plugins' ),
 					esc_html( $stats['plugin_approve'] )
 				);
 			?>
 			</li>
 		</ul>
 
-		<h3><?php _e( 'Plugin Queue Stats (current)', 'wporg-plugins' ); ?></h3>
+		<h3><?php esc_html_e( 'Plugin Queue Stats (current)', 'wporg-plugins' ); ?></h3>
 
 		<ul style="font-family:Courier New;">
 			<li>
 			<?php
 				/* translators: %d: number of plugins in the queue */
 				printf(
-					__( 'Plugins in the queue (new and pending)* : %d', 'wporg-plugins' ),
+					esc_html__( 'Plugins in the queue (new and pending)* : %d', 'wporg-plugins' ),
 					esc_html( $stats['in_queue'] )
 				);
 			?>
@@ -493,7 +493,7 @@ class Stats_Report {
 			<?php
 				/* translators: 1: number of most recent days, 2: number of older plugins in the queue */
 				printf(
-					__( '&rarr; (older than %1$d days ago)** : %2$d', 'wporg-plugins' ),
+					esc_html__( '&rarr; (older than %1$d days ago)** : %2$d', 'wporg-plugins' ),
 					esc_html( $stats['recentdays'] ),
 					esc_html( $stats['in_queue_old'] )
 				);
@@ -503,7 +503,7 @@ class Stats_Report {
 			<?php
 				/* translators: 1: start date, 2: end date, 3: number of plugins in the queue within defined time window */
 				printf(
-					__( '&rarr; (%1$s - %2$s) : %3$d', 'wporg-plugins' ),
+					esc_html__( '&rarr; (%1$s - %2$s) : %3$d', 'wporg-plugins' ),
 					esc_html( $start_date ),
 					esc_html( $stats['date'] ),
 					esc_html( $stats['in_queue_from_time_window'] )
@@ -514,7 +514,7 @@ class Stats_Report {
 			<?php
 				/* translators: %d: number of new plugins */
 				printf(
-					__( '&rarr; (new; not processed or replied to yet)* : %d', 'wporg-plugins' ),
+					esc_html__( '&rarr; (new; not processed or replied to yet)* : %d', 'wporg-plugins' ),
 					esc_html( $stats['in_queue_new'] )
 				);
 			?>
@@ -523,7 +523,7 @@ class Stats_Report {
 			<?php
 				/* translators: %d: number of pending plugins */
 				printf(
-					__( '&rarr; (pending; replied to)* : %d', 'wporg-plugins' ),
+					esc_html__( '&rarr; (pending; replied to)* : %d', 'wporg-plugins' ),
 					esc_html( $stats['in_queue_pending'] )
 				);
 			?>
@@ -532,7 +532,7 @@ class Stats_Report {
 			<?php
 				/* translators: %d: number of pending plugins */
 				printf(
-					__( '&rarr; (pending; waiting on author)* : %d', 'wporg-plugins' ),
+					esc_html__( '&rarr; (pending; waiting on author)* : %d', 'wporg-plugins' ),
 					esc_html( $stats['in_queue_pending_why']['author'] ?? 0 )
 				);
 			?>
@@ -541,7 +541,7 @@ class Stats_Report {
 			<?php
 				/* translators: %d: number of pending plugins */
 				printf(
-					__( '&rarr; (pending; waiting on reviewer)* : %d', 'wporg-plugins' ),
+					esc_html__( '&rarr; (pending; waiting on reviewer)* : %d', 'wporg-plugins' ),
 					esc_html( $stats['in_queue_pending_why']['reviewer'] ?? 0 )
 				);
 			?>
@@ -551,7 +551,7 @@ class Stats_Report {
 				<?php
 					/* translators: %d: number of pending plugins */
 					printf(
-						__( '&rarr; (pending; waiting on reviewer, email not yet sent)* : %d', 'wporg-plugins' ),
+						esc_html__( '&rarr; (pending; waiting on reviewer, email not yet sent)* : %d', 'wporg-plugins' ),
 						esc_html( $stats['in_queue_pending_why']['noemail'] )
 					);
 				?>
@@ -560,7 +560,7 @@ class Stats_Report {
 		</ul>
 
 		<?php if ( defined( 'HELPSCOUT_PLUGINS_MAILBOXID' ) ) : ?>
-		<h3><?php _e( 'Help Scout Queue Stats', 'wporg-plugins' ); ?></h3>
+		<h3><?php esc_html_e( 'Help Scout Queue Stats', 'wporg-plugins' ); ?></h3>
 
 		<ul style="font-family:Courier New;">
 			<li>
@@ -631,8 +631,8 @@ class Stats_Report {
 		<?php endif; ?>
 
 		<ul style="font-style:italic;">
-			<li><code>*</code> : <?php _e( "Stat reflects current size of queue and does not take into account 'date' or 'day' interval", 'wporg-plugins' ); ?></li>
-			<li><code>**</code> : <?php _e( "Stat reflects activity only within the 'recentdays' from today", 'wporg-plugins' ); ?></li>
+			<li><code>*</code> : <?php esc_html_e( "Stat reflects current size of queue and does not take into account 'date' or 'day' interval", 'wporg-plugins' ); ?></li>
+			<li><code>**</code> : <?php esc_html_e( "Stat reflects activity only within the 'recentdays' from today", 'wporg-plugins' ); ?></li>
 		</ul>
 
 		<h3>Reviewer Stats</h3>

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/tools/class-upload-token.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/tools/class-upload-token.php
@@ -171,6 +171,7 @@ class Upload_Token {
 		printf(
 			'<div class="notice inline notice-success"><p>%s</p></div>',
 			sprintf(
+				/* translators: %1$s: Upload URL. */
 				wp_kses_post( __( 'Token created. Please provide the author with the following URL: <a href="%1$s">%1$s</a>', 'wporg-plugins' ) ),
 				esc_url(
 					add_query_arg(

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/tools/class-upload-token.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/admin/tools/class-upload-token.php
@@ -118,20 +118,20 @@ class Upload_Token {
 		}
 
 		echo '<div class="wrap author-cards">';
-		echo '<h1>' . __( 'Upload Token', 'wporg-plugins' ) . '</h1>';
-		echo '<p>' . __( 'This tool allows the generation of a one-time-use token to allow a plugin author to upload a plugin bypassing certain checks.', 'wporg-plugins' ) . '</p>';
+		echo '<h1>' . esc_html__( 'Upload Token', 'wporg-plugins' ) . '</h1>';
+		echo '<p>' . esc_html__( 'This tool allows the generation of a one-time-use token to allow a plugin author to upload a plugin bypassing certain checks.', 'wporg-plugins' ) . '</p>';
 		echo '<ol>';
-		echo '<li>' . __( 'Trademarked terms', 'wporg-plugins' ) . '</li>';
-		echo '<li>' . __( 'Active Installs', 'wporg-plugins' ) . '</li>';
-		echo '<li>' . __( 'Plugin Check', 'wporg-plugins' ) . '</li>';
+		echo '<li>' . esc_html__( 'Trademarked terms', 'wporg-plugins' ) . '</li>';
+		echo '<li>' . esc_html__( 'Active Installs', 'wporg-plugins' ) . '</li>';
+		echo '<li>' . esc_html__( 'Plugin Check', 'wporg-plugins' ) . '</li>';
 		echo '</ol>';
 
 		echo '<form method="post">';
 		echo '<table class="form-table"><tbody>';
-		echo '<tr><th scope="row"><label for="users">' . __( 'User', 'wporg-plugins' ) . '</label></th><td>';
+		echo '<tr><th scope="row"><label for="users">' . esc_html__( 'User', 'wporg-plugins' ) . '</label></th><td>';
 		echo '<input name="user" type="text" id="user" value="' . esc_attr( $username ) . '" class="regular-text">';
 		echo '</td></tr>';
-		echo '<tr><th scope="row"><label for="expiration">' . __( 'Expiration', 'wporg-plugins' ) . '</label></th><td>';
+		echo '<tr><th scope="row"><label for="expiration">' . esc_html__( 'Expiration', 'wporg-plugins' ) . '</label></th><td>';
 		echo '<input name="expiration" type="datetime-local" id="expiration" value="' . esc_attr( $expiration ) . '" class="regular-text">';
 		echo '</td></tr>';
 		echo '</tbody></table>';
@@ -153,7 +153,7 @@ class Upload_Token {
 		if ( ! $user ) {
 			printf(
 				'<div class="notice inline notice-error"><p>%s</p></div>',
-				__( 'User not found.', 'wporg-plugins' )
+				esc_html__( 'User not found.', 'wporg-plugins' )
 			);
 			return;
 		}
@@ -162,7 +162,7 @@ class Upload_Token {
 		if ( $user_token && $user_token['expiration'] > time() ) {
 			printf(
 				'<div class="notice inline notice-error"><p>%s</p></div>',
-				__( 'User already had a valid token, replacing it.', 'wporg-plugins' )
+				esc_html__( 'User already had a valid token, replacing it.', 'wporg-plugins' )
 			);
 		}
 
@@ -171,7 +171,7 @@ class Upload_Token {
 		printf(
 			'<div class="notice inline notice-success"><p>%s</p></div>',
 			sprintf(
-				__( 'Token created. Please provide the author with the following URL: <a href="%1$s">%1$s</a>', 'wporg-plugins' ),
+				wp_kses_post( __( 'Token created. Please provide the author with the following URL: <a href="%1$s">%1$s</a>', 'wporg-plugins' ) ),
 				esc_url(
 					add_query_arg(
 						'upload_token',

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/api/routes/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/api/routes/class-plugin.php
@@ -420,7 +420,7 @@ class Plugin extends Base {
 				$review_author_markup .= '</a>';
 
 				printf(
-					__( 'By %1$s on %2$s', 'wporg-plugins' ),
+					esc_html__( 'By %1$s on %2$s', 'wporg-plugins' ),
 					$review_author_markup,
 					'<span class="review-date">' . date_i18n( get_option( 'date_format' ), strtotime( $review->post_modified ) ) . '</span>'
 				);

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/api/routes/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/api/routes/class-plugin.php
@@ -413,9 +413,9 @@ class Plugin extends Base {
 				$review_author_markup         = '<a href="' . $review_author_markup_profile . '">';
 				$review_author_markup        .= get_avatar( $reviewer->ID, 16, 'monsterid' ) . '</a>';
 				$review_author_markup        .= '<a href="' . $review_author_markup_profile . '" class="reviewer-name">';
-				$review_author_markup        .= $reviewer->display_name;
+				$review_author_markup        .= esc_html( $reviewer->display_name );
 				if ( $reviewer->display_name != $reviewer->user_login ) {
-					$review_author_markup .= " <small>({$reviewer->user_login})</small>";
+					$review_author_markup .= ' <small>(' . esc_html( $reviewer->user_login ) . ')</small>';
 				}
 				$review_author_markup .= '</a>';
 

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/api/routes/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/api/routes/class-plugin.php
@@ -420,6 +420,7 @@ class Plugin extends Base {
 				$review_author_markup .= '</a>';
 
 				printf(
+					/* translators: 1: Review author, 2: Review date. */
 					esc_html__( 'By %1$s on %2$s', 'wporg-plugins' ),
 					$review_author_markup,
 					'<span class="review-date">' . date_i18n( get_option( 'date_format' ), strtotime( $review->post_modified ) ) . '</span>'

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-block-validator.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-block-validator.php
@@ -181,11 +181,11 @@ class Block_Validator {
 		if ( self::plugin_is_in_block_directory( $plugin->post_name ) ) {
 			echo wp_nonce_field( 'block-directory-edit-' . $plugin->ID, 'block-directory-nonce' );
 			// translators: %s plugin title.
-			echo '<button class="button button-secondary button-large" type="submit" name="block-directory-edit" value="remove">' . sprintf( esc_html__( 'Remove %s from Block Directory', 'wporg-plugins' ), $plugin->post_title ) . '</button>';
+			echo '<button class="button button-secondary button-large" type="submit" name="block-directory-edit" value="remove">' . sprintf( esc_html__( 'Remove %s from Block Directory', 'wporg-plugins' ), esc_html( $plugin->post_title ) ) . '</button>';
 		} else if ( ! $has_errors ) {
 			echo wp_nonce_field( 'block-directory-edit-' . $plugin->ID, 'block-directory-nonce' );
 			// translators: %s plugin title.
-			echo '<button class="button button-primary button-large" type="submit" name="block-directory-edit" value="add">' . sprintf( esc_html__( 'Add %s to Block Directory', 'wporg-plugins' ), $plugin->post_title ) . '</button>';
+			echo '<button class="button button-primary button-large" type="submit" name="block-directory-edit" value="add">' . sprintf( esc_html__( 'Add %s to Block Directory', 'wporg-plugins' ), esc_html( $plugin->post_title ) ) . '</button>';
 		}
 
 		echo '</p>';

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-block-validator.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-block-validator.php
@@ -274,6 +274,7 @@ class Block_Validator {
 				<p>
 					<?php
 					printf(
+						/* translators: %s: Plugin submission URL. */
 						wp_kses_post( __( 'Your plugin passed the checks, but only plugins hosted on WordPress.org can be added to the Block Directory. <a href="%s">Upload your plugin to the WordPress.org repo,</a> then come back here to add it to the Block Directory.', 'wporg-plugins' ) ),
 						esc_url( home_url( 'developers' ) )
 					);

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-block-validator.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-block-validator.php
@@ -20,7 +20,7 @@ class Block_Validator {
 
 		<div class="wrap block-validator">
 			<form method="post" action="." class="block-validator__plugin-form">
-				<label for="plugin_url"><?php _e( 'Plugin repo URL', 'wporg-plugins' ); ?></label>
+				<label for="plugin_url"><?php esc_html_e( 'Plugin repo URL', 'wporg-plugins' ); ?></label>
 				<div class="block-validator__plugin-input-container">
 					<input type="text" class="block-validator__plugin-input" id="plugin_url" name="plugin_url" placeholder="https://plugins.svn.wordpress.org/" value="<?php echo esc_attr( $plugin_url ); ?>" />
 					<input type="submit" class="wp-block-button__link block-validator__plugin-submit" value="<?php esc_attr_e( 'Check Plugin!', 'wporg-plugins' ); ?>" />
@@ -37,7 +37,7 @@ class Block_Validator {
 
 				<div class="plugin-upload-form-controls">
 					<input type="file" id="zip_file" class="plugin-file" name="zip_file" size="25" accept=".zip"/>
-					<label id="zip-file-label" for="zip_file"><?php _e( 'Select File', 'wporg-plugins' ); ?></label>
+					<label id="zip-file-label" for="zip_file"><?php esc_html_e( 'Select File', 'wporg-plugins' ); ?></label>
 
 					<div class="wp-block-button is-small">
 						<input id="upload_button" name="block-directory-upload" class="wp-block-button__link" type="submit" value="<?php esc_attr_e( 'Upload', 'wporg-plugins' ); ?>"/>
@@ -91,7 +91,7 @@ class Block_Validator {
 		</div>
 		<?php else : ?>
 		<div class="wrap block-validator">
-			<p><?php _e( 'Please log in to use the block plugin checker.', 'wporg-plugins' ); ?></p>
+			<p><?php esc_html_e( 'Please log in to use the block plugin checker.', 'wporg-plugins' ); ?></p>
 		</div>
 		<?php endif;
 		return ob_get_clean();
@@ -132,10 +132,10 @@ class Block_Validator {
 						Tools::audit_log( 'Plugin added to block directory.', $post->ID );
 						self::maybe_send_email_plugin_added( $post );
 						Plugin_Import::queue( $post->post_name, array( 'tags_touched' => array( $post->stable_tag ) ) );
-						echo '<div class="notice notice-success notice-alt"><p>' . __( 'Plugin added to the block directory.', 'wporg-plugins' ) . '</p></div>';
+						echo '<div class="notice notice-success notice-alt"><p>' . esc_html__( 'Plugin added to the block directory.', 'wporg-plugins' ) . '</p></div>';
 					} elseif ( 'remove' === $_POST['block-directory-edit'] ) {
 						Tools::audit_log( 'Plugin removed from block directory.', $post->ID );
-						echo '<div class="notice notice-info notice-alt"><p>' . __( 'Plugin removed from the block directory.', 'wporg-plugins' ) . '</p></div>';
+						echo '<div class="notice notice-info notice-alt"><p>' . esc_html__( 'Plugin removed from the block directory.', 'wporg-plugins' ) . '</p></div>';
 					}
 				}
 			}
@@ -149,7 +149,7 @@ class Block_Validator {
 		if ( $post && 'error' === $_POST['block-directory-email'] && wp_verify_nonce( $_POST['block-directory-email-nonce'], 'block-directory-email-' . $post->ID ) ) {
 			if ( current_user_can( 'edit_post', $post->ID ) ) {
 				if ( self::maybe_send_email_block_error( $post ) ) {
-						echo '<div class="notice notice-success notice-alt"><p>' . __( 'Email sent.', 'wporg-plugins' ) . '</p></div>';
+						echo '<div class="notice notice-success notice-alt"><p>' . esc_html__( 'Email sent.', 'wporg-plugins' ) . '</p></div>';
 				}
 			}
 		}
@@ -181,11 +181,11 @@ class Block_Validator {
 		if ( self::plugin_is_in_block_directory( $plugin->post_name ) ) {
 			echo wp_nonce_field( 'block-directory-edit-' . $plugin->ID, 'block-directory-nonce' );
 			// translators: %s plugin title.
-			echo '<button class="button button-secondary button-large" type="submit" name="block-directory-edit" value="remove">' . sprintf( __( 'Remove %s from Block Directory', 'wporg-plugins' ), $plugin->post_title ) . '</button>';
+			echo '<button class="button button-secondary button-large" type="submit" name="block-directory-edit" value="remove">' . sprintf( esc_html__( 'Remove %s from Block Directory', 'wporg-plugins' ), $plugin->post_title ) . '</button>';
 		} else if ( ! $has_errors ) {
 			echo wp_nonce_field( 'block-directory-edit-' . $plugin->ID, 'block-directory-nonce' );
 			// translators: %s plugin title.
-			echo '<button class="button button-primary button-large" type="submit" name="block-directory-edit" value="add">' . sprintf( __( 'Add %s to Block Directory', 'wporg-plugins' ), $plugin->post_title ) . '</button>';
+			echo '<button class="button button-primary button-large" type="submit" name="block-directory-edit" value="add">' . sprintf( esc_html__( 'Add %s to Block Directory', 'wporg-plugins' ), $plugin->post_title ) . '</button>';
 		}
 
 		echo '</p>';
@@ -222,7 +222,7 @@ class Block_Validator {
 	 */
 	protected static function display_results( $checker ) {
 
-		echo '<h2>' . __( 'Results', 'wporg-plugins' ) . '</h2>';
+		echo '<h2>' . esc_html__( 'Results', 'wporg-plugins' ) . '</h2>';
 
 		$results = $checker->get_results();
 
@@ -230,7 +230,7 @@ class Block_Validator {
 			echo '<p>';
 			printf(
 				// translators: %1$s is the repo URL, %2$s is a version number.
-				__( 'Results for %1$s revision %2$s', 'wporg-plugins' ),
+				esc_html__( 'Results for %1$s revision %2$s', 'wporg-plugins' ),
 				'<code>' . esc_url( $checker->repo_url ) . '</code>',
 				esc_html( $checker->repo_revision )
 			);
@@ -253,20 +253,20 @@ class Block_Validator {
 		if ( $has_errors ) :
 			?>
 			<div class="notice notice-error notice-alt">
-				<p><?php _e( 'Some problems were found. They need to be addressed for your plugin to be included in the Block Directory.', 'wporg-plugins' ); ?></p>
+				<p><?php esc_html_e( 'Some problems were found. They need to be addressed for your plugin to be included in the Block Directory.', 'wporg-plugins' ); ?></p>
 			</div>
 		<?php elseif ( $checker->slug ) : ?>
 			<?php if ( self::plugin_is_in_block_directory( $checker->slug ) ) : ?>
 				<div class="notice notice-info notice-alt">
-					<p><?php _e( 'This plugin is already in the Block Directory.', 'wporg-plugins' ); ?></p>
+					<p><?php esc_html_e( 'This plugin is already in the Block Directory.', 'wporg-plugins' ); ?></p>
 				</div>
 			<?php elseif ( $has_warnings ) : ?>
 				<div class="notice notice-info notice-alt">
-					<p><?php _e( 'You can add your plugin to the Block Directory.', 'wporg-plugins' ); ?></p>
+					<p><?php esc_html_e( 'You can add your plugin to the Block Directory.', 'wporg-plugins' ); ?></p>
 				</div>
 			<?php else : ?>
 				<div class="notice notice-success notice-alt">
-					<p><?php _e( 'No issues were found. You can add your plugin to the Block Directory.', 'wporg-plugins' ); ?></p>
+					<p><?php esc_html_e( 'No issues were found. You can add your plugin to the Block Directory.', 'wporg-plugins' ); ?></p>
 				</div>
 			<?php endif; ?>
 		<?php else : ?>
@@ -274,7 +274,7 @@ class Block_Validator {
 				<p>
 					<?php
 					printf(
-						__( 'Your plugin passed the checks, but only plugins hosted on WordPress.org can be added to the Block Directory. <a href="%s">Upload your plugin to the WordPress.org repo,</a> then come back here to add it to the Block Directory.', 'wporg-plugins' ),
+						wp_kses_post( __( 'Your plugin passed the checks, but only plugins hosted on WordPress.org can be added to the Block Directory. <a href="%s">Upload your plugin to the WordPress.org repo,</a> then come back here to add it to the Block Directory.', 'wporg-plugins' ) ),
 						esc_url( home_url( 'developers' ) )
 					);
 					?>
@@ -287,20 +287,20 @@ class Block_Validator {
 			$plugin = Plugin_Directory::get_plugin_post( $checker->slug );
 			if ( current_user_can( 'edit_post', $plugin->ID ) ) {
 				// Plugin reviewers etc
-				echo '<h3>' . __( 'Plugin Review Tools', 'wporg-plugins' ) . '</h3>';
+				echo '<h3>' . esc_html__( 'Plugin Review Tools', 'wporg-plugins' ) . '</h3>';
 
 				echo '<ul>';
 				echo '<li><a href="' . esc_url( (string) get_edit_post_link( $plugin->ID ) ) . '">' . esc_html__( 'Edit plugin', 'wporg-plugins' ) . '</a></li>';
-				echo '<li><a href="' . esc_url( 'https://plugins.trac.wordpress.org/browser/' . $checker->slug . '/trunk' ) . '">' . __( 'Trac browser', 'wporg-plugins' ) . '</a></li>';
+				echo '<li><a href="' . esc_url( 'https://plugins.trac.wordpress.org/browser/' . $checker->slug . '/trunk' ) . '">' . esc_html__( 'Trac browser', 'wporg-plugins' ) . '</a></li>';
 				echo '</ul>';
 
 				self::render_plugin_actions( $plugin, $has_errors );
 
 			} elseif ( current_user_can( 'plugin_admin_edit', $plugin->ID ) ) {
 				// Plugin committers
-				echo '<h3>' . __( 'Committer Tools', 'wporg-plugins' ) . '</h3>';
+				echo '<h3>' . esc_html__( 'Committer Tools', 'wporg-plugins' ) . '</h3>';
 				echo '<ul>';
-				echo '<li><a href="' . esc_url( 'https://plugins.trac.wordpress.org/browser/' . $checker->slug . '/trunk' ) . '">' . __( 'Browse code on trac', 'wporg-plugins' ) . '</a></li>';
+				echo '<li><a href="' . esc_url( 'https://plugins.trac.wordpress.org/browser/' . $checker->slug . '/trunk' ) . '">' . esc_html__( 'Browse code on trac', 'wporg-plugins' ) . '</a></li>';
 				echo '</ul>';
 
 				self::render_plugin_actions( $plugin, $has_errors );

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-readme-validator.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-readme-validator.php
@@ -61,7 +61,7 @@ class Readme_Validator {
 				</p>
 			</form>
 
-			<p><?php _e( '... or paste your <code>readme.txt</code> here:', 'wporg-plugins' ); ?></p>
+			<p><?php echo wp_kses_post( __( '... or paste your <code>readme.txt</code> here:', 'wporg-plugins' ) ); ?></p>
 				<textarea rows="20" cols="100" name="readme_visible" placeholder="=== Plugin Name ==="><?php echo esc_textarea( $readme_contents ); ?></textarea>
 				<form id="readme-data" method="post" action="">
 					<input type="hidden" name="readme" value="" />

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-release-confirmation.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-release-confirmation.php
@@ -268,7 +268,7 @@ class Release_Confirmation {
 				sprintf(
 					/* translators: 1: User name, 2: Time since the release was discarded. */
 					esc_html__( 'Discarded by %1$s, %2$s ago.', 'wporg-plugins' ),
-					$user->display_name ?: $user->user_login,
+					esc_html( $user->display_name ?: $user->user_login ),
 					human_time_diff( $data['discarded']['time'] )
 				)
 			);

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-release-confirmation.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-release-confirmation.php
@@ -76,6 +76,7 @@ class Release_Confirmation {
 			printf(
 				'<div class="plugin-notice notice notice-error notice-alt"><p>%s</p></div>',
 				sprintf(
+					/* translators: %s: Two-factor authentication setup URL. */
 					wp_kses_post( __( 'Your account has elevated privileges and requires extra security before you can manage plugin releases. Please <a href="%s">enable two-factor authentication now</a>.', 'wporg-plugins' ) ),
 					esc_url( get_2fa_onboarding_url() )
 				)
@@ -105,6 +106,7 @@ class Release_Confirmation {
 
 		if ( $not_enabled ) {
 			printf(
+				/* translators: %s: List of plugin links. */
 				'<p><em>' . esc_html__( 'The following plugins do not have release confirmations enabled: %s', 'wporg-plugins') . '</em></p>',
 				wp_sprintf_l( '%l', array_filter( array_map( function( $plugin ) {
 					if ( 'publish' == get_post_status( $plugin ) ) {
@@ -165,6 +167,7 @@ class Release_Confirmation {
 					</td>
 				</tr>',
 				sprintf(
+					/* translators: %s: Version number, linked. */
 					esc_html__( 'Version %s', 'wporg-plugins' ),
 					sprintf(
 						'<a href="%s">%s</a>',
@@ -224,6 +227,7 @@ class Release_Confirmation {
 			esc_html_e( 'Waiting for confirmation.', 'wporg-plugins' );
 		} else {
 			printf(
+				/* translators: 1: Number of confirmations, 2: Number of required confirmations. */
 				esc_html__( '%s of %s required confirmations.', 'wporg-plugins' ),
 				number_format_i18n( count( $data['confirmations'] ) ),
 				number_format_i18n( $plugin->release_confirmation )
@@ -262,6 +266,7 @@ class Release_Confirmation {
 				'<span title="%s">%s</span><br>',
 				esc_attr( gmdate( 'Y-m-d H:i:s', $data['discarded']['time'] ) ),
 				sprintf(
+					/* translators: 1: User name, 2: Time since the release was discarded. */
 					esc_html__( 'Discarded by %1$s, %2$s ago.', 'wporg-plugins' ),
 					$user->display_name ?: $user->user_login,
 					human_time_diff( $data['discarded']['time'] )
@@ -591,6 +596,7 @@ class Release_Confirmation {
 		printf(
 			'<div class="plugin-notice notice notice-info notice-alt"><p>%s</p></div>',
 			sprintf(
+				/* translators: %s: Releases page URL. */
 				wp_kses_post( __( 'This plugin has <a href="%s">a pending release that requires confirmation</a>.', 'wporg-plugins' ) ),
 				esc_url( home_url( '/developers/releases/' ) ) // TODO: Hardcoded URL.
 			)

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-release-confirmation.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-release-confirmation.php
@@ -107,7 +107,7 @@ class Release_Confirmation {
 		if ( $not_enabled ) {
 			printf(
 				/* translators: %s: List of plugin links. */
-				'<p><em>' . esc_html__( 'The following plugins do not have release confirmations enabled: %s', 'wporg-plugins') . '</em></p>',
+				'<p><em>' . esc_html__( 'The following plugins do not have release confirmations enabled: %s', 'wporg-plugins' ) . '</em></p>',
 				wp_sprintf_l( '%l', array_filter( array_map( function( $plugin ) {
 					if ( 'publish' == get_post_status( $plugin ) ) {
 						return sprintf(
@@ -228,7 +228,7 @@ class Release_Confirmation {
 		} else {
 			printf(
 				/* translators: 1: Number of confirmations, 2: Number of required confirmations. */
-				esc_html__( '%s of %s required confirmations.', 'wporg-plugins' ),
+				esc_html__( '%1$s of %2$s required confirmations.', 'wporg-plugins' ),
 				number_format_i18n( count( $data['confirmations'] ) ),
 				number_format_i18n( $plugin->release_confirmation )
 			);

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-release-confirmation.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-release-confirmation.php
@@ -76,16 +76,16 @@ class Release_Confirmation {
 			printf(
 				'<div class="plugin-notice notice notice-error notice-alt"><p>%s</p></div>',
 				sprintf(
-					__( 'Your account has elevated privileges and requires extra security before you can manage plugin releases. Please <a href="%s">enable two-factor authentication now</a>.', 'wporg-plugins' ),
+					wp_kses_post( __( 'Your account has elevated privileges and requires extra security before you can manage plugin releases. Please <a href="%s">enable two-factor authentication now</a>.', 'wporg-plugins' ) ),
 					esc_url( get_2fa_onboarding_url() )
 				)
 			);
 		}
 
-		echo '<p>' . __( 'This page is for authorized committers to view and manage releases of their plugins. Plugins with confirmations enabled require an extra action on this page to approve each new release.', 'wporg-plugins' ) . '</p>';
+		echo '<p>' . esc_html__( 'This page is for authorized committers to view and manage releases of their plugins. Plugins with confirmations enabled require an extra action on this page to approve each new release.', 'wporg-plugins' ) . '</p>';
 
 		/* translators: %s: plugins@wordpress.org */
-		echo '<p>' . sprintf( __( 'Release confirmations can be enabled on the Advanced view of plugin pages. If you need to disable release confirmations for a plugin, please contact %s.', 'wporg-plugins' ), 'plugins@wordpress.org' ) . '</p>';
+		echo '<p>' . sprintf( esc_html__( 'Release confirmations can be enabled on the Advanced view of plugin pages. If you need to disable release confirmations for a plugin, please contact %s.', 'wporg-plugins' ), 'plugins@wordpress.org' ) . '</p>';
 
 		$not_enabled = [];
 		foreach ( $plugins as $plugin ) {
@@ -105,7 +105,7 @@ class Release_Confirmation {
 
 		if ( $not_enabled ) {
 			printf(
-				'<p><em>' . __( 'The following plugins do not have release confirmations enabled: %s', 'wporg-plugins') . '</em></p>',
+				'<p><em>' . esc_html__( 'The following plugins do not have release confirmations enabled: %s', 'wporg-plugins') . '</em></p>',
 				wp_sprintf_l( '%l', array_filter( array_map( function( $plugin ) {
 					if ( 'publish' == get_post_status( $plugin ) ) {
 						return sprintf(
@@ -134,12 +134,12 @@ class Release_Confirmation {
 		</colgroup>
 		<thead>
 			<tr>
-				<th>' . _x( 'Release', 'Releases Table header', 'wporg-plugins' ) . '</th>
+				<th>' . esc_html_x( 'Release', 'Releases Table header', 'wporg-plugins' ) . '</th>
 				<th>&nbsp;</th>
 		</thead>';
 
 		if ( ! $releases ) {
-			echo '<tr class="no-items"><td colspan="5"><em>' . __( 'No releases.', 'wporg-plugins' ) . '</em></td></tr>';
+			echo '<tr class="no-items"><td colspan="5"><em>' . esc_html__( 'No releases.', 'wporg-plugins' ) . '</em></td></tr>';
 		}
 
 		foreach ( $releases as $data ) {
@@ -165,7 +165,7 @@ class Release_Confirmation {
 					</td>
 				</tr>',
 				sprintf(
-					__( 'Version %s', 'wporg-plugins' ),
+					esc_html__( 'Version %s', 'wporg-plugins' ),
 					sprintf(
 						'<a href="%s">%s</a>',
 						esc_url( sprintf(
@@ -178,7 +178,7 @@ class Release_Confirmation {
 				),
 				sprintf(
 					/* translators: 1: time eg. '3 hours ago', 2: the committer(s). */
-					__( 'Released %1$s by %2$s', 'wporg-plugins' ),
+					esc_html__( 'Released %1$s by %2$s', 'wporg-plugins' ),
 					sprintf(
 						'<span title="%s">%s</span>',
 						esc_attr( gmdate( 'Y-m-d H:i:s', $data['date'] ) ),
@@ -213,18 +213,18 @@ class Release_Confirmation {
 		ob_start();
 
 		if ( ! $data['confirmations_required'] ) {
-			_e( 'Release did not require confirmation.', 'wporg-plugins' );
+			esc_html_e( 'Release did not require confirmation.', 'wporg-plugins' );
 		} else if ( ! empty( $data['discarded'] ) ) {
-			_e( 'Release discarded.', 'wporg-plugins' );
+			esc_html_e( 'Release discarded.', 'wporg-plugins' );
 		} elseif ( $data['confirmed'] && ! $data['zips_built'] ) {
-			_e( 'Release confirmed, waiting for processing.', 'wporg-plugins' );
+			esc_html_e( 'Release confirmed, waiting for processing.', 'wporg-plugins' );
 		} else if ( $data['confirmed'] ) {
-			_e( 'Release confirmed.', 'wporg-plugins' );
+			esc_html_e( 'Release confirmed.', 'wporg-plugins' );
 		} else if ( 1 == $data['confirmations_required'] ) {
-			_e( 'Waiting for confirmation.', 'wporg-plugins' );
+			esc_html_e( 'Waiting for confirmation.', 'wporg-plugins' );
 		} else {
 			printf(
-				__( '%s of %s required confirmations.', 'wporg-plugins' ),
+				esc_html__( '%s of %s required confirmations.', 'wporg-plugins' ),
 				number_format_i18n( count( $data['confirmations'] ) ),
 				number_format_i18n( $plugin->release_confirmation )
 			);
@@ -262,7 +262,7 @@ class Release_Confirmation {
 				'<span title="%s">%s</span><br>',
 				esc_attr( gmdate( 'Y-m-d H:i:s', $data['discarded']['time'] ) ),
 				sprintf(
-					__( 'Discarded by %1$s, %2$s ago.', 'wporg-plugins' ),
+					esc_html__( 'Discarded by %1$s, %2$s ago.', 'wporg-plugins' ),
 					$user->display_name ?: $user->user_login,
 					human_time_diff( $data['discarded']['time'] )
 				)
@@ -273,7 +273,7 @@ class Release_Confirmation {
 		if ( $data['confirmed'] && ! $data['zips_built'] ) {
 			printf(
 				'<span>%s</span><br>',
-				__( 'The ZIP files for this release have not yet been built by WordPress.org.', 'wporg-plugins' )
+				esc_html__( 'The ZIP files for this release have not yet been built by WordPress.org.', 'wporg-plugins' )
 			);
 		}
 
@@ -439,7 +439,7 @@ class Release_Confirmation {
 
 		ob_start();
 		echo '<div class="release-strategy">';
-		echo '<h3>' . __( 'Rollout Strategy', 'wporg-plugins' ) . '</h3>';
+		echo '<h3>' . esc_html__( 'Rollout Strategy', 'wporg-plugins' ) . '</h3>';
 
 		echo '<select
 			id="rollout_strategy"
@@ -591,7 +591,7 @@ class Release_Confirmation {
 		printf(
 			'<div class="plugin-notice notice notice-info notice-alt"><p>%s</p></div>',
 			sprintf(
-				__( 'This plugin has <a href="%s">a pending release that requires confirmation</a>.', 'wporg-plugins' ),
+				wp_kses_post( __( 'This plugin has <a href="%s">a pending release that requires confirmation</a>.', 'wporg-plugins' ) ),
 				esc_url( home_url( '/developers/releases/' ) ) // TODO: Hardcoded URL.
 			)
 		);

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-release-confirmation.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-release-confirmation.php
@@ -94,7 +94,7 @@ class Release_Confirmation {
 				'<h2 id="releases-%s"><a href="%s">%s</a></h2>',
 				esc_attr( $plugin->post_name ),
 				esc_url( get_permalink( $plugin ) ),
-				get_the_title( $plugin )
+				esc_html( get_the_title( $plugin ) )
 			);
 
 			self::single_plugin( $plugin );
@@ -112,8 +112,8 @@ class Release_Confirmation {
 					if ( 'publish' == get_post_status( $plugin ) ) {
 						return sprintf(
 							'<a href="%s">%s</a>',
-							get_permalink( $plugin ),
-							get_the_title( $plugin )
+							esc_url( get_permalink( $plugin ) ),
+							esc_html( get_the_title( $plugin ) )
 						);
 					}
 				}, $not_enabled ) ) )

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-reviews.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-reviews.php
@@ -54,7 +54,7 @@ class Reviews {
 								<span class="review-author author vcard"><?php the_author_posts_link(); ?></span>
 								<span class="review-date"><?php echo date_i18n( get_option( 'date_format' ), strtotime( $review->post_modified ) ); ?></span>
 								<?php if ( $reply_count ) : ?>
-								<span class="review-replies"><?php printf( _n( '%s reply', '%s replies', $reply_count, 'wporg-plugins' ), number_format_i18n( $reply_count ) ); ?></span>
+								<span class="review-replies"><?php printf( esc_html( _n( '%s reply', '%s replies', $reply_count, 'wporg-plugins' ) ), number_format_i18n( $reply_count ) ); ?></span>
 								<?php endif; ?>
 							</div>
 						</header>
@@ -75,7 +75,7 @@ class Reviews {
 		<a class="reviews-link" href="<?php echo esc_url( 'https://wordpress.org/support/plugin/' . get_post()->post_name . '/reviews/' ); ?>">
 			<?php
 				/* translators: %s: number of reviews */
-				printf( _n( 'Read all %s review', 'Read all %s reviews', $review_count, 'wporg-plugins' ), number_format_i18n( $review_count ) );
+				printf( esc_html( _n( 'Read all %s review', 'Read all %s reviews', $review_count, 'wporg-plugins' ) ), number_format_i18n( $review_count ) );
 			?>
 		</a>
 

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-reviews.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-reviews.php
@@ -54,6 +54,7 @@ class Reviews {
 								<span class="review-author author vcard"><?php the_author_posts_link(); ?></span>
 								<span class="review-date"><?php echo date_i18n( get_option( 'date_format' ), strtotime( $review->post_modified ) ); ?></span>
 								<?php if ( $reply_count ) : ?>
+								<?php /* translators: %s: Number of replies. */ ?>
 								<span class="review-replies"><?php printf( esc_html( _n( '%s reply', '%s replies', $reply_count, 'wporg-plugins' ) ), number_format_i18n( $reply_count ) ); ?></span>
 								<?php endif; ?>
 							</div>

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-reviews.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-reviews.php
@@ -54,8 +54,7 @@ class Reviews {
 								<span class="review-author author vcard"><?php the_author_posts_link(); ?></span>
 								<span class="review-date"><?php echo date_i18n( get_option( 'date_format' ), strtotime( $review->post_modified ) ); ?></span>
 								<?php if ( $reply_count ) : ?>
-								<?php /* translators: %s: Number of replies. */ ?>
-								<span class="review-replies"><?php printf( esc_html( _n( '%s reply', '%s replies', $reply_count, 'wporg-plugins' ) ), number_format_i18n( $reply_count ) ); ?></span>
+								<span class="review-replies"><?php /* translators: %s: Number of replies. */ printf( esc_html( _n( '%s reply', '%s replies', $reply_count, 'wporg-plugins' ) ), esc_html( number_format_i18n( $reply_count ) ) ); ?></span>
 								<?php endif; ?>
 							</div>
 						</header>
@@ -76,7 +75,7 @@ class Reviews {
 		<a class="reviews-link" href="<?php echo esc_url( 'https://wordpress.org/support/plugin/' . get_post()->post_name . '/reviews/' ); ?>">
 			<?php
 				/* translators: %s: number of reviews */
-				printf( esc_html( _n( 'Read all %s review', 'Read all %s reviews', $review_count, 'wporg-plugins' ) ), number_format_i18n( $review_count ) );
+				printf( esc_html( _n( 'Read all %s review', 'Read all %s reviews', $review_count, 'wporg-plugins' ) ), esc_html( number_format_i18n( $review_count ) ) );
 			?>
 		</a>
 

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-upload.php
@@ -178,7 +178,7 @@ class Upload {
 
 					// If the queue is currently beyond 10 days, display a warning to that effect.
 					if ( $queue_length_in_days >= 10 ) {
-						echo ' ' . __( 'The review queue is currently longer than normal, we apologize for the delays and ask for patience.', 'wporg-plugins' );
+						echo ' ' . esc_html__( 'The review queue is currently longer than normal, we apologize for the delays and ask for patience.', 'wporg-plugins' );
 					}
 				}
 				?>
@@ -229,7 +229,7 @@ class Upload {
 					</p>
 
 					<p>
-						<?php _e( 'Please review the Plugin Check results for your plugin, and fix any significant problems. This will help streamline the preview process and reduce delays by ensuring your plugin already meets the required standards when the Plugins Team examines it.', 'wporg-plugins' ); ?>
+						<?php esc_html_e( 'Please review the Plugin Check results for your plugin, and fix any significant problems. This will help streamline the preview process and reduce delays by ensuring your plugin already meets the required standards when the Plugins Team examines it.', 'wporg-plugins' ); ?>
 					</p>
 
 					<ul>
@@ -244,14 +244,14 @@ class Upload {
 							printf(
 								'<div class="plugin-submission-submited-date">%s</div>',
 								sprintf(
-									__( 'Submitted on: %s', 'wporg-plugins' ),
+									esc_html__( 'Submitted on: %s', 'wporg-plugins' ),
 									esc_html( wp_date( get_option( 'date_format' ), strtotime( $plugin->post_date_gmt ) ) )
 								)
 							);
 							printf(
 								'<div class="plugin-submission-status">%s</div>',
 								sprintf(
-									__( 'Review status: %s', 'wporg-plugins' ),
+									esc_html__( 'Review status: %s', 'wporg-plugins' ),
 									$plugin->status
 								)
 							);
@@ -264,7 +264,7 @@ class Upload {
 								printf(
 									'<div class="plugin-submission-email">✉️✔️ %s</div>',
 									sprintf(
-										__( 'Our team emailed you on <strong>%s</strong> regarding your submission. The subject line is: "<strong>%s</strong>".', 'wporg-plugins' ),
+										wp_kses_post( __( 'Our team emailed you on <strong>%s</strong> regarding your submission. The subject line is: "<strong>%s</strong>".', 'wporg-plugins' ) ),
 										esc_html( wp_date( get_option( 'date_format' ), strtotime( $plugin->review_email->created ) ) ),
 										esc_html( $plugin->review_email->subject )
 									)
@@ -277,7 +277,7 @@ class Upload {
 								printf(
 									'<div class="plugin-submission-email">✉️⏳ %s</div>',
 									sprintf(
-										__( 'Please be patient and wait for the review email. It will be sent to your email address, <strong>%s</strong>, with the subject line: "<strong>%s</strong>".', 'wporg-plugins' ),
+										wp_kses_post( __( 'Please be patient and wait for the review email. It will be sent to your email address, <strong>%s</strong>, with the subject line: "<strong>%s</strong>".', 'wporg-plugins' ) ),
 										esc_html( get_userdata( $plugin->post_author )->user_email ),
 										'[WordPress Plugin Directory] Review in Progress: ' . $plugin->post_title
 									)
@@ -288,40 +288,40 @@ class Upload {
 							}
 							echo '<div class="plugin-submission-assigned-slug">';
 							printf(
-								__( 'Current assigned slug: %s', 'wporg-plugins' ),
+								esc_html__( 'Current assigned slug: %s', 'wporg-plugins' ),
 								'<code>' . esc_html( $plugin->post_name ) . '</code>'
 							);
 							?>
 							<?php if ( $can_change_slug ) : ?>
-								<a href="#" class="hide-if-no-js" onclick="event.preventDefault(); this.nextElementSibling.showModal()"><?php _e( 'change', 'wporg-plugins' ); ?></a>
+								<a href="#" class="hide-if-no-js" onclick="event.preventDefault(); this.nextElementSibling.showModal()"><?php esc_html_e( 'change', 'wporg-plugins' ); ?></a>
 								<dialog class="slug-change hide-if-no-js">
 									<a onclick="this.parentNode.close()" class="close dashicons dashicons-no-alt"></a>
-									<strong><?php _e( 'Request to change your plugin slug', 'wporg-plugins' ); ?></strong>
+									<strong><?php esc_html_e( 'Request to change your plugin slug', 'wporg-plugins' ); ?></strong>
 									<form>
 										<input type="hidden" name="action" value="request-slug-change" />
 										<input type="hidden" name="id" value="<?php echo esc_attr( $plugin->ID ); ?>" />
 
 										<div class="notice notice-info notice-alt">
-											<p><?php _e( 'Your chosen slug cannot be guaranteed, and is subject to change based on the results of your review.', 'wporg-plugins' ); ?></p>
+											<p><?php esc_html_e( 'Your chosen slug cannot be guaranteed, and is subject to change based on the results of your review.', 'wporg-plugins' ); ?></p>
 											<p><?php
 												printf(
 													/* Translators: URL */
-													__( "Your slug is used to generate your plugins URL. Currently it's %s", 'wporg-plugins' ),
+													esc_html__( "Your slug is used to generate your plugins URL. Currently it's %s", 'wporg-plugins' ),
 													'<code>' . esc_url( home_url( $plugin->post_name ) . '/' ) . '</code>'
 												);
 											?></p>
-											<p><?php _e( 'Your slug (aka permalink) cannot be changed once your review is completed. Please choose carefully.', 'wporg-plugins' ); ?></p>
+											<p><?php esc_html_e( 'Your slug (aka permalink) cannot be changed once your review is completed. Please choose carefully.', 'wporg-plugins' ); ?></p>
 										</div>
 										<div class="notice notice-error notice-alt hidden"><p></p></div>
 										<p>
 											<label>
-												<strong><?php _e( 'Plugin Name', 'wporg-plugins' ); ?></strong><br>
+												<strong><?php esc_html_e( 'Plugin Name', 'wporg-plugins' ); ?></strong><br>
 												<?php echo esc_html( $plugin->post_title ); ?>
 											</label>
 										</p>
 										<p>
 											<label>
-												<strong><?php _e( 'Desired Slug', 'wporg-plugins' ); ?></strong><br>
+												<strong><?php esc_html_e( 'Desired Slug', 'wporg-plugins' ); ?></strong><br>
 												<input type="text" name="post_name" required maxlength="200" pattern="[a-z0-9-]*" value="<?php echo esc_attr( $plugin->post_name ); ?>" />
 											</label>
 										</p>
@@ -332,7 +332,7 @@ class Upload {
 												<?php
 													printf(
 														/* Translators: URL to plugin guidelines */
-														__( 'I confirm that my slug choice <a href="%s">meets the guidelines for plugin slugs</a>.', 'wporg-plugins' ),
+														wp_kses_post( __( 'I confirm that my slug choice <a href="%s">meets the guidelines for plugin slugs</a>.', 'wporg-plugins' ) ),
 														'https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/#17-plugins-must-respect-trademarks-copyrights-and-project-names'
 													);
 												?>
@@ -360,7 +360,7 @@ class Upload {
 
 							if ( $can_upload_extras ) {
 								echo '<div class="plugin-submission-update-code wp-block-button is-small">';
-								echo '<a href="#" class="show-upload-additional hide-if-no-js wp-block-button__link">' . sprintf( __( 'Upload updated "%s" plugin for review.', 'wporg-plugins' ), esc_html( $plugin->post_title ) ) . '</a>';
+								echo '<a href="#" class="show-upload-additional hide-if-no-js wp-block-button__link">' . sprintf( esc_html__( 'Upload updated "%s" plugin for review.', 'wporg-plugins' ), esc_html( $plugin->post_title ) ) . '</a>';
 
 								?>
 								<form class="plugin-upload-form hidden" enctype="multipart/form-data" method="POST" action="">
@@ -369,14 +369,14 @@ class Upload {
 									<input type="hidden" name="plugin_id" value="<?php echo esc_attr( $plugin->ID ); ?>" />
 
 									<label>
-										<?php _e( 'Additional Information', 'wporg-plugins' ); ?><br>
+								<?php esc_html_e( 'Additional Information', 'wporg-plugins' ); ?><br>
 										<textarea name="comment" rows="3" cols="80"></textarea>
 									</label>
 									<br>
 
 									<label class="wp-block-button__link zip-file">
 										<input type="file" class="plugin-file" name="zip_file" size="25" accept=".zip" required data-maxbytes="<?php echo esc_attr( wp_max_upload_size() ); ?>" />
-										<span><?php _e( 'Select File', 'wporg-plugins' ); ?></span>
+										<span><?php esc_html_e( 'Select File', 'wporg-plugins' ); ?></span>
 									</label>
 
 									<input class="upload-button wp-block-button__link" type="submit" value="<?php esc_attr_e( 'Upload', 'wporg-plugins' ); ?>" data-uploading-label="<?php esc_attr_e( 'Uploading…', 'wporg-plugins' ); ?>"/>
@@ -386,7 +386,7 @@ class Upload {
 							}
 
 							echo '<div class="plugin-submission-submitted-files">';
-							echo '<strong>' . __( 'Submitted files:', 'wporg-plugins' ) . '</strong>';
+							echo '<strong>' . esc_html__( 'Submitted files:', 'wporg-plugins' ) . '</strong>';
 							foreach ( $attached_media as $attachment_post_id => $upload ) {
 								echo '<div class="plugin-submission-file">';
 								echo '<table class="plugin-submission-file__meta">';
@@ -419,7 +419,7 @@ class Upload {
 										'<div class="plugin-submission-file__pcp wp-block-button is-small"><a href="%s" class="%s" target="_blank">%s</a></div>',
 										esc_url( Template::preview_link_zip( $plugin->post_name, $upload->ID, 'pcp' ) ),
 										'wp-block-button__link',
-										__( 'Check with Plugin Check', 'wporg-plugins' )
+										esc_html__( 'Check with Plugin Check', 'wporg-plugins' )
 									);
 								}
 								echo '</div>';
@@ -440,7 +440,7 @@ class Upload {
 			printf(
 				'<div class="notice notice-error notice-alt"><p>%s</p></div>',
 				sprintf(
-					__( 'New plugin submissions are currently disabled. Please check back after the <a href="%s">holiday break.</a>', 'wporg-plugins' ),
+					wp_kses_post( __( 'New plugin submissions are currently disabled. Please check back after the <a href="%s">holiday break.</a>', 'wporg-plugins' ) ),
 					'https://wordpress.org/news/2024/12/holiday-break/'
 				)
 			);
@@ -448,7 +448,7 @@ class Upload {
 			echo '<div class="notice notice-error notice-alt"><p>' .
 				sprintf(
 					/* translators: %s: Profile edit url. */
-					__( 'Your email host has email deliverability problems. Please <a href="%s">Update your email address</a> first.', 'wporg-plugins'),
+					wp_kses_post( __( 'Your email host has email deliverability problems. Please <a href="%s">Update your email address</a> first.', 'wporg-plugins' ) ),
 					esc_url( 'https://wordpress.org/support/users/' . wp_get_current_user()->user_nicename . '/edit' )
 					) .
 					"</p></div>\n";
@@ -614,7 +614,7 @@ class Upload {
 
 				<label class="wp-block-button__link zip-file">
 					<input type="file" class="plugin-file" name="zip_file" size="25" accept=".zip" required data-maxbytes="<?php echo esc_attr( wp_max_upload_size() ); ?>" />
-					<span><?php _e( 'Select File', 'wporg-plugins' ); ?></span>
+					<span><?php esc_html_e( 'Select File', 'wporg-plugins' ); ?></span>
 				</label>
 
 				<div>
@@ -631,7 +631,7 @@ class Upload {
 
 				<p>
 					<label>
-						<?php _e( 'Additional Information', 'wporg-plugins' ); ?><br>
+						<?php esc_html_e( 'Additional Information', 'wporg-plugins' ); ?><br>
 						<textarea name="comment" rows="3" cols="80"><?php
 							if ( ! empty( $_REQUEST['comment'] ) ) {
 								echo esc_textarea( $_REQUEST['comment'] );

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-upload.php
@@ -267,7 +267,7 @@ class Upload {
 									'<div class="plugin-submission-email">✉️✔️ %s</div>',
 									sprintf(
 										/* translators: 1: Email date, 2: Email subject. */
-										wp_kses_post( __( 'Our team emailed you on <strong>%s</strong> regarding your submission. The subject line is: "<strong>%s</strong>".', 'wporg-plugins' ) ),
+										wp_kses_post( __( 'Our team emailed you on <strong>%1$s</strong> regarding your submission. The subject line is: "<strong>%2$s</strong>".', 'wporg-plugins' ) ),
 										esc_html( wp_date( get_option( 'date_format' ), strtotime( $plugin->review_email->created ) ) ),
 										esc_html( $plugin->review_email->subject )
 									)
@@ -281,7 +281,7 @@ class Upload {
 									'<div class="plugin-submission-email">✉️⏳ %s</div>',
 									sprintf(
 										/* translators: 1: Email address, 2: Email subject. */
-										wp_kses_post( __( 'Please be patient and wait for the review email. It will be sent to your email address, <strong>%s</strong>, with the subject line: "<strong>%s</strong>".', 'wporg-plugins' ) ),
+										wp_kses_post( __( 'Please be patient and wait for the review email. It will be sent to your email address, <strong>%1$s</strong>, with the subject line: "<strong>%2$s</strong>".', 'wporg-plugins' ) ),
 										esc_html( get_userdata( $plugin->post_author )->user_email ),
 										'[WordPress Plugin Directory] Review in Progress: ' . $plugin->post_title
 									)

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-upload.php
@@ -244,6 +244,7 @@ class Upload {
 							printf(
 								'<div class="plugin-submission-submited-date">%s</div>',
 								sprintf(
+									/* translators: %s: Submission date. */
 									esc_html__( 'Submitted on: %s', 'wporg-plugins' ),
 									esc_html( wp_date( get_option( 'date_format' ), strtotime( $plugin->post_date_gmt ) ) )
 								)
@@ -251,6 +252,7 @@ class Upload {
 							printf(
 								'<div class="plugin-submission-status">%s</div>',
 								sprintf(
+									/* translators: %s: Review status. */
 									esc_html__( 'Review status: %s', 'wporg-plugins' ),
 									$plugin->status
 								)
@@ -264,6 +266,7 @@ class Upload {
 								printf(
 									'<div class="plugin-submission-email">✉️✔️ %s</div>',
 									sprintf(
+										/* translators: 1: Email date, 2: Email subject. */
 										wp_kses_post( __( 'Our team emailed you on <strong>%s</strong> regarding your submission. The subject line is: "<strong>%s</strong>".', 'wporg-plugins' ) ),
 										esc_html( wp_date( get_option( 'date_format' ), strtotime( $plugin->review_email->created ) ) ),
 										esc_html( $plugin->review_email->subject )
@@ -277,6 +280,7 @@ class Upload {
 								printf(
 									'<div class="plugin-submission-email">✉️⏳ %s</div>',
 									sprintf(
+										/* translators: 1: Email address, 2: Email subject. */
 										wp_kses_post( __( 'Please be patient and wait for the review email. It will be sent to your email address, <strong>%s</strong>, with the subject line: "<strong>%s</strong>".', 'wporg-plugins' ) ),
 										esc_html( get_userdata( $plugin->post_author )->user_email ),
 										'[WordPress Plugin Directory] Review in Progress: ' . $plugin->post_title
@@ -288,6 +292,7 @@ class Upload {
 							}
 							echo '<div class="plugin-submission-assigned-slug">';
 							printf(
+								/* translators: %s: Plugin slug. */
 								esc_html__( 'Current assigned slug: %s', 'wporg-plugins' ),
 								'<code>' . esc_html( $plugin->post_name ) . '</code>'
 							);
@@ -360,6 +365,7 @@ class Upload {
 
 							if ( $can_upload_extras ) {
 								echo '<div class="plugin-submission-update-code wp-block-button is-small">';
+								/* translators: %s: Plugin name. */
 								echo '<a href="#" class="show-upload-additional hide-if-no-js wp-block-button__link">' . sprintf( esc_html__( 'Upload updated "%s" plugin for review.', 'wporg-plugins' ), esc_html( $plugin->post_title ) ) . '</a>';
 
 								?>
@@ -440,6 +446,7 @@ class Upload {
 			printf(
 				'<div class="notice notice-error notice-alt"><p>%s</p></div>',
 				sprintf(
+					/* translators: %s: Holiday break announcement URL. */
 					wp_kses_post( __( 'New plugin submissions are currently disabled. Please check back after the <a href="%s">holiday break.</a>', 'wporg-plugins' ) ),
 					'https://wordpress.org/news/2024/12/holiday-break/'
 				)

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-upload.php
@@ -283,7 +283,7 @@ class Upload {
 										/* translators: 1: Email address, 2: Email subject. */
 										wp_kses_post( __( 'Please be patient and wait for the review email. It will be sent to your email address, <strong>%1$s</strong>, with the subject line: "<strong>%2$s</strong>".', 'wporg-plugins' ) ),
 										esc_html( get_userdata( $plugin->post_author )->user_email ),
-										'[WordPress Plugin Directory] Review in Progress: ' . $plugin->post_title
+										'[WordPress Plugin Directory] Review in Progress: ' . esc_html( $plugin->post_title )
 									)
 								);
 								echo '<div class="plugin-submission-email-clarification">';

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-upload.php
@@ -311,7 +311,7 @@ class Upload {
 											<p><?php
 												printf(
 													/* Translators: URL */
-													esc_html__( "Your slug is used to generate your plugins URL. Currently it's %s", 'wporg-plugins' ),
+													esc_html__( 'Your slug is used to generate your plugins URL. Currently it&#8217;s %s', 'wporg-plugins' ),
 													'<code>' . esc_url( home_url( $plugin->post_name ) . '/' ) . '</code>'
 												);
 											?></p>

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/widgets/class-adopt-me.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/widgets/class-adopt-me.php
@@ -36,9 +36,9 @@ class Adopt_Me extends \WP_Widget {
 
 			<div>
 				<p>
-					<?php _e( 'This plugin is seeking new, active, developers. Are you interested in assuming that responsibility?', 'wporg-plugins' ); ?></p>
+					<?php esc_html_e( 'This plugin is seeking new, active, developers. Are you interested in assuming that responsibility?', 'wporg-plugins' ); ?></p>
 				<p>
-					<a class="button" href="https://developer.wordpress.org/plugins/wordpress-org/take-over-an-existing-plugin/"><?php _e( 'Read more', 'wporg-plugins' ); ?></a>
+					<a class="button" href="https://developer.wordpress.org/plugins/wordpress-org/take-over-an-existing-plugin/"><?php esc_html_e( 'Read more', 'wporg-plugins' ); ?></a>
 				</p>
 			</div>
 			<?php

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/widgets/class-committers.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/widgets/class-committers.php
@@ -61,7 +61,7 @@ class Committers extends \WP_Widget {
 					<?php if ( current_user_can( 'plugin_remove_committer', $post ) ) : ?>
 					<small>
 						<?php echo current_user_can( 'plugin_review' ) ? esc_html( $committer->user_email ) . ' ' : ''; ?>
-						<button class="button-link remove"><?php _e( 'Remove', 'wporg-plugins' ); ?></button>
+						<button class="button-link remove"><?php esc_html_e( 'Remove', 'wporg-plugins' ); ?></button>
 					</small>
 					<?php endif; ?>
 				</li>
@@ -84,7 +84,7 @@ class Committers extends \WP_Widget {
 							<# if ( data.email ) { #>
 								<span class="email">{{ data.email }}</span>
 							<# } #>
-							<button class="button-link remove"><?php _e( 'Remove', 'wporg-plugins' ); ?></button>
+							<button class="button-link remove"><?php esc_html_e( 'Remove', 'wporg-plugins' ); ?></button>
 						</small>
 					</li>
 				</script>

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/widgets/class-donate.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/widgets/class-donate.php
@@ -34,10 +34,10 @@ class Donate extends \WP_Widget {
 			echo $args['before_title'] . $title . $args['after_title'];
 			?>
 
-			<p class="aside"><?php _e( 'Would you like to support the advancement of this plugin?', 'wporg-plugins' ); ?></p>
+			<p class="aside"><?php esc_html_e( 'Would you like to support the advancement of this plugin?', 'wporg-plugins' ); ?></p>
 			<p>
 				<a href="<?php echo esc_url( $donate_link ); ?>" rel="nofollow ugc">
-					<?php _e( 'Donate to this plugin', 'wporg-plugins' ); ?>
+					<?php esc_html_e( 'Donate to this plugin', 'wporg-plugins' ); ?>
 				</a>
 			</p>
 

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/widgets/class-meta.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/widgets/class-meta.php
@@ -41,7 +41,7 @@ class Meta extends \WP_Widget {
 					<?php
 					printf(
 						/* translators: %s: term list */
-						__( 'Designed to work with: %s', 'wporg-plugins' ),
+						esc_html__( 'Designed to work with: %s', 'wporg-plugins' ),
 						esc_html( $built_for )
 					);
 					?>
@@ -52,7 +52,7 @@ class Meta extends \WP_Widget {
 				<?php
 				printf(
 					/* translators: %s: version number */
-					__( 'Version %s', 'wporg-plugins' ),
+					esc_html__( 'Version %s', 'wporg-plugins' ),
 					'<strong>' . esc_html( get_post_meta( $post->ID, 'version', true ) ) . '</strong>'
 				);
 				?>
@@ -71,7 +71,7 @@ class Meta extends \WP_Widget {
 
 				printf(
 					/* translators: %s: time since the last update */
-					__( 'Last updated %s', 'wporg-plugins' ),
+					esc_html__( 'Last updated %s', 'wporg-plugins' ),
 					/* translators: %s: time since the last update */
 					'<strong>' . wp_kses( sprintf( __( '%s ago', 'wporg-plugins' ), '<span>' . human_time_diff( $last_updated ) . '</span>' ), array( 'span' => true ) ) . '</strong>'
 				);
@@ -81,7 +81,7 @@ class Meta extends \WP_Widget {
 				<?php
 				printf(
 					/* translators: %s: active installations count */
-					__( 'Active installations %s', 'wporg-plugins' ),
+					esc_html__( 'Active installations %s', 'wporg-plugins' ),
 					'<strong>' . esc_html( Template::active_installs( false ) ) . '</strong>'
 				);
 				?>
@@ -107,7 +107,7 @@ class Meta extends \WP_Widget {
 					<?php
 					printf(
 						/* translators: %s: version number */
-						__( 'Tested up to %s', 'wporg-plugins' ),
+						esc_html__( 'Tested up to %s', 'wporg-plugins' ),
 						'<strong>' . esc_html( $tested_up_to ) . '</strong>'
 					);
 					?>
@@ -150,7 +150,7 @@ class Meta extends \WP_Widget {
 							<?php
 							printf(
 								/* translators: %s: Number of available languages */
-								_nx( 'See all %s', 'See all %s', $available_languages_count, 'languages', 'wporg-plugins' ),
+								esc_html( _nx( 'See all %s', 'See all %s', $available_languages_count, 'languages', 'wporg-plugins' ) ),
 								$available_languages_count
 							);
 							?>
@@ -159,7 +159,7 @@ class Meta extends \WP_Widget {
 							<div class="popover-arrow"></div>
 
 							<button type="button" class="button-link popover-close" aria-label="<?php esc_attr_e( 'Close this popover', 'wporg-plugins' ); ?>">
-								<?php _e( 'Close', 'wporg-plugins' ); ?>
+								<?php esc_html_e( 'Close', 'wporg-plugins' ); ?>
 							</button>
 
 							<div class="popover-inner">
@@ -169,7 +169,7 @@ class Meta extends \WP_Widget {
 									printf(
 										'<a href="%s">%s</a>',
 										esc_url( 'https://translate.wordpress.org/projects/wp-plugins/' . $post->post_name ),
-										__( 'Translate into your language', 'wporg-plugins' )
+										esc_html__( 'Translate into your language', 'wporg-plugins' )
 									);
 								?>
 								</p>
@@ -210,7 +210,7 @@ class Meta extends \WP_Widget {
 					echo '<li class="clear">';
 					printf(
 						/* translators: %s: tag list */
-						_n( 'Tag %s', 'Tags %s', count( $term_links ), 'wporg-plugins' ),
+						esc_html( _n( 'Tag %s', 'Tags %s', count( $term_links ), 'wporg-plugins' ) ),
 						'<div class="tags">' . wp_kses_post( implode( $term_links ) ) . '</div>'
 					);
 					echo '</li>';
@@ -223,7 +223,7 @@ class Meta extends \WP_Widget {
 					printf(
 						'<a class="plugin-admin" href="%s">%s</a>',
 						esc_url( get_permalink() . 'advanced/' ),
-						__( 'Advanced View', 'wporg-plugins' )
+						esc_html__( 'Advanced View', 'wporg-plugins' )
 					);
 					?>
 				</li>

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/widgets/class-support-reps.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/widgets/class-support-reps.php
@@ -65,7 +65,7 @@ class Support_Reps extends \WP_Widget {
 					<?php if ( current_user_can( 'plugin_remove_support_rep', $post ) ) : ?>
 					<small>
 						<?php echo current_user_can( 'plugin_review' ) ? esc_html( $support_rep->user_email ) . ' ' : ''; ?>
-						<button class="button-link remove"><?php _e( 'Remove', 'wporg-plugins' ); ?></button>
+						<button class="button-link remove"><?php esc_html_e( 'Remove', 'wporg-plugins' ); ?></button>
 					</small>
 					<?php endif; ?>
 				</li>
@@ -88,7 +88,7 @@ class Support_Reps extends \WP_Widget {
 							<# if ( data.email ) { #>
 								<span class="email">{{ data.email }}</span>
 							<# } #>
-							<button class="button-link remove"><?php _e( 'Remove', 'wporg-plugins' ); ?></button>
+							<button class="button-link remove"><?php esc_html_e( 'Remove', 'wporg-plugins' ); ?></button>
 						</small>
 					</li>
 				</script>

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/widgets/class-support.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/widgets/class-support.php
@@ -52,7 +52,7 @@ class Support extends \WP_Widget {
 				<span class="counter-count">
 					<?php
 					/* Translators: 1: Amount of resolved threads; 2: Amount of total threads; */
-					printf( esc_html__( '%1$s out of %2$s', 'wporg-plugins' ), $resolved, $threads );
+					printf( esc_html__( '%1$s out of %2$s', 'wporg-plugins' ), (int) $resolved, (int) $threads );
 					?>
 				</span>
 			</p>

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/widgets/class-support.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/widgets/class-support.php
@@ -44,7 +44,7 @@ class Support extends \WP_Widget {
 
 		if ( $resolutions ) :
 		?>
-			<p class="aside"><?php _e( 'Issues resolved in last two months:', 'wporg-plugins' ); ?></p>
+			<p class="aside"><?php esc_html_e( 'Issues resolved in last two months:', 'wporg-plugins' ); ?></p>
 			<p class="counter-container">
 				<span class="counter-back">
 					<span class="counter-bar" style="width: <?php echo esc_attr( 100 * $resolved / $threads ); ?>%;"></span>
@@ -52,17 +52,17 @@ class Support extends \WP_Widget {
 				<span class="counter-count">
 					<?php
 					/* Translators: 1: Amount of resolved threads; 2: Amount of total threads; */
-					printf( __( '%1$s out of %2$s', 'wporg-plugins' ), $resolved, $threads );
+					printf( esc_html__( '%1$s out of %2$s', 'wporg-plugins' ), $resolved, $threads );
 					?>
 				</span>
 			</p>
 
 		<?php else : ?>
-			<p><?php _e( 'Got something to say? Need help?', 'wporg-plugins' ); ?></p>
+			<p><?php esc_html_e( 'Got something to say? Need help?', 'wporg-plugins' ); ?></p>
 		<?php endif; ?>
 
 		<p>
-			<a href="<?php echo esc_url( $support_url ); ?>"><?php _e( 'View support forum', 'wporg-plugins' ); ?></a>
+			<a href="<?php echo esc_url( $support_url ); ?>"><?php esc_html_e( 'View support forum', 'wporg-plugins' ); ?></a>
 		</p>
 
 		<?php

--- a/wordpress.org/public_html/wp-content/plugins/rosetta/inc/admin/network/class-locale-associations-view.php
+++ b/wordpress.org/public_html/wp-content/plugins/rosetta/inc/admin/network/class-locale-associations-view.php
@@ -37,8 +37,8 @@ class Locale_Associations_View implements Admin_Page_View {
 		?>
 		<div class="wrap">
 			<h1><?php echo esc_html( $this->get_title() ); ?></h1>
-			<p><?php _e( 'Manage the locale association for localized sites. Without an association the site&#8217;s front end is not available.', 'rosetta' ); ?></p>
-			<p><a href="#add-new-associations"><?php _e( 'Add New Association', 'rosetta' ); ?></a> | <a  href="#existing-associations"><?php _e( 'Existing Associations', 'rosetta' ); ?></a> | <a href="#sites-without-locale-association"><?php _e( 'Sites Without Locale Association', 'rosetta' ); ?></a></p>
+			<p><?php esc_html_e( 'Manage the locale association for localized sites. Without an association the site&#8217;s front end is not available.', 'rosetta' ); ?></p>
+			<p><a href="#add-new-associations"><?php esc_html_e( 'Add New Association', 'rosetta' ); ?></a> | <a  href="#existing-associations"><?php esc_html_e( 'Existing Associations', 'rosetta' ); ?></a> | <a href="#sites-without-locale-association"><?php esc_html_e( 'Sites Without Locale Association', 'rosetta' ); ?></a></p>
 			<hr/>
 			<?php
 			$this->render_message();
@@ -70,37 +70,37 @@ class Locale_Associations_View implements Admin_Page_View {
 			case 'delete-association|delete_failure' :
 				printf(
 					'<div class="notice notice-error"><p>%s</p></div>',
-					__( 'An error occurred. Please try again.', 'rosetta' )
+					esc_html__( 'An error occurred. Please try again.', 'rosetta' )
 				);
 				break;
 			case 'add-association|missing_data' :
 				printf(
 					'<div class="notice notice-error"><p>%s</p></div>',
-					__( 'Please provide a locale and a subdomain.', 'rosetta' )
+					esc_html__( 'Please provide a locale and a subdomain.', 'rosetta' )
 				);
 				break;
 			case 'add-association|locale_does_not_exist' :
 				printf(
 					'<div class="notice notice-error"><p>%s</p></div>',
-					__( 'The locale does not exist yet.', 'rosetta' )
+					esc_html__( 'The locale does not exist yet.', 'rosetta' )
 				);
 				break;
 			case 'add-association|success' :
 				printf(
 					'<div class="notice notice-success"><p>%s</p></div>',
-					__( 'The new association has been added.', 'rosetta' )
+					esc_html__( 'The new association has been added.', 'rosetta' )
 				);
 				break;
 			case 'delete-association|missing_data' :
 				printf(
 					'<div class="notice notice-error"><p>%s</p></div>',
-					__( 'The ID of the association is missing. Please try again.', 'rosetta' )
+					esc_html__( 'The ID of the association is missing. Please try again.', 'rosetta' )
 				);
 				break;
 			case 'delete-association|success' :
 				printf(
 					'<div class="notice notice-success"><p>%s</p></div>',
-					__( 'The association has been deleted.', 'rosetta' )
+					esc_html__( 'The association has been deleted.', 'rosetta' )
 				);
 				break;
 		}
@@ -111,15 +111,15 @@ class Locale_Associations_View implements Admin_Page_View {
 	 */
 	private function render_form() {
 		?>
-		<h2 id="add-new-associations"><?php _e( 'Add New Association', 'rosetta' ); ?> <a href="#wpbody-content"><small>&uarr;</small></a></h2>
+		<h2 id="add-new-associations"><?php esc_html_e( 'Add New Association', 'rosetta' ); ?> <a href="#wpbody-content"><small>&uarr;</small></a></h2>
 		<form action="" method="post">
 			<?php wp_nonce_field( 'add-association' ); ?>
 			<input type="hidden" name="action" value="add-association" />
 
 			<p>
-				<label for="locale"><?php _e( 'Locale:', 'rosetta' ); ?></label>
+				<label for="locale"><?php esc_html_e( 'Locale:', 'rosetta' ); ?></label>
 				<select id="locale" name="locale" required>
-					<option value=""><?php _e( '&mdash; Select &mdash;', 'rosetta' ); ?></option>
+					<option value=""><?php esc_html_e( '&mdash; Select &mdash;', 'rosetta' ); ?></option>
 					<?php
 					foreach ( $this->page->get_available_wp_locales() as $locale ) {
 						printf(
@@ -131,7 +131,7 @@ class Locale_Associations_View implements Admin_Page_View {
 					?>
 				</select>
 
-				<label for="subdomain"><?php _e( 'Subdomain:', 'rosetta' ); ?></label>
+				<label for="subdomain"><?php esc_html_e( 'Subdomain:', 'rosetta' ); ?></label>
 				<input type="text" id="subdomain" name="subdomain" class="code" required />
 			</p>
 
@@ -147,14 +147,14 @@ class Locale_Associations_View implements Admin_Page_View {
 	 */
 	private function render_table() {
 		?>
-		<h2 id="existing-associations"><?php _e( 'Existing Associations', 'rosetta' ); ?> <a href="#wpbody-content"><small>&uarr;</small></a></h2>
+		<h2 id="existing-associations"><?php esc_html_e( 'Existing Associations', 'rosetta' ); ?> <a href="#wpbody-content"><small>&uarr;</small></a></h2>
 		<table class="widefat striped">
 			<thead>
 				<tr>
-					<th><?php _e( 'Locale', 'rosetta' ); ?></th>
-					<th><?php _e( 'Subdomain', 'rosetta' ); ?></th>
-					<th><?php _e( 'Sites', 'rosetta' ); ?></th>
-					<th><?php _e( 'Latest Release', 'rosetta' ); ?></th>
+					<th><?php esc_html_e( 'Locale', 'rosetta' ); ?></th>
+					<th><?php esc_html_e( 'Subdomain', 'rosetta' ); ?></th>
+					<th><?php esc_html_e( 'Sites', 'rosetta' ); ?></th>
+					<th><?php esc_html_e( 'Latest Release', 'rosetta' ); ?></th>
 					<th>&mdash;</th>
 				</tr>
 			</thead>
@@ -207,7 +207,7 @@ class Locale_Associations_View implements Admin_Page_View {
 	 */
 	public function render_sites_without_locale() {
 		?>
-		<h2 id="sites-without-locale-association"><?php _e( 'Sites Without Locale Association', 'rosetta' ); ?> <a href="#wpbody-content"><small>&uarr;</small></a></h2>
+		<h2 id="sites-without-locale-association"><?php esc_html_e( 'Sites Without Locale Association', 'rosetta' ); ?> <a href="#wpbody-content"><small>&uarr;</small></a></h2>
 		<?php
 		$domains_with_locale = wp_list_pluck( $this->page->get_associations(), 'subdomain' );
 		array_walk( $domains_with_locale, function( &$domain ) {

--- a/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-blocks.php
+++ b/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-blocks.php
@@ -266,6 +266,7 @@ class Blocks {
 			</p>',
 			checked( get_user_option( 'block_editor', $user_id ), 'disabled', false ),
 			sprintf(
+				/* translators: %s: Block editor documentation URL. */
 				wp_kses_post( __( 'Disable the <a href="%s">Block Editor</a> for new topics and replies.', 'wporg-forums' ) ),
 				'https://wordpress.org/support/article/wordpress-editor/'
 			)

--- a/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-blocks.php
+++ b/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-blocks.php
@@ -266,7 +266,7 @@ class Blocks {
 			</p>',
 			checked( get_user_option( 'block_editor', $user_id ), 'disabled', false ),
 			sprintf(
-				__( 'Disable the <a href="%s">Block Editor</a> for new topics and replies.', 'wporg-forums' ),
+				wp_kses_post( __( 'Disable the <a href="%s">Block Editor</a> for new topics and replies.', 'wporg-forums' ) ),
 				'https://wordpress.org/support/article/wordpress-editor/'
 			)
 		);

--- a/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-hooks.php
+++ b/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-hooks.php
@@ -1028,12 +1028,12 @@ class Hooks {
 				// Display site URL for logged-in users only.
 				if ( is_user_logged_in() ) {
 					printf( '<p class="wporg-bbp-topic-site-url">%1$s <a href="%2$s" rel="nofollow ugc">%2$s</a></p>',
-						__( 'The page I need help with:', 'wporg-forums' ),
+						esc_html__( 'The page I need help with:', 'wporg-forums' ),
 						esc_url( $site_url )
 					);
 				} else {
 					printf( '<p class="wporg-bbp-topic-site-url">%1$s <em>%2$s</em></p>',
-						__( 'The page I need help with:', 'wporg-forums' ),
+						esc_html__( 'The page I need help with:', 'wporg-forums' ),
 						/* translators: %s: URL of the log in page. */
 						sprintf( wp_kses_post( __( '[<a href="%s">log in</a> to see the link]', 'wporg-forums' ) ), esc_url( wp_login_url() ) )
 					);
@@ -1056,9 +1056,9 @@ class Hooks {
 			$site_url = ( bbp_is_topic_edit() ) ? get_post_meta( $topic_id, self::SITE_URL_META, true ) : '';
 			?>
 			<p>
-				<label for="site_url"><?php _e( 'Link to the page you need help with:', 'wporg-forums' ) ?></label><br />
+				<label for="site_url"><?php esc_html_e( 'Link to the page you need help with:', 'wporg-forums' ); ?></label><br />
 				<input type="text" id="site_url" value="<?php echo esc_attr( $site_url ); ?>" size="40" name="site_url" maxlength="400" aria-describedby="site_url_description" /><br />
-				<em id="site_url_description"><?php _e( 'This link will only be shown to logged-in users.', 'wporg-forums' ); ?></em>
+				<em id="site_url_description"><?php esc_html_e( 'This link will only be shown to logged-in users.', 'wporg-forums' ); ?></em>
 			</p>
 			<?php
 		endif;

--- a/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-moderators.php
+++ b/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-moderators.php
@@ -1225,7 +1225,7 @@ class Moderators {
 		$user = get_user_by( 'id', get_post_meta( bbp_get_reply_id(), self::MODERATOR_REPLY_AUTHOR, true ) );
 
 		printf(
-			'<em>' . __( 'Posted by <a href="%s">@%s</a>.', 'wporg-forums' ) . '</em><br/>',
+			'<em>' . wp_kses_post( __( 'Posted by <a href="%s">@%s</a>.', 'wporg-forums' ) ) . '</em><br/>',
 			esc_url( bbp_get_user_profile_url( $user->ID ) ),
 			esc_html( $user->user_nicename )
 		);

--- a/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-moderators.php
+++ b/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-moderators.php
@@ -1226,7 +1226,7 @@ class Moderators {
 
 		printf(
 			/* translators: 1: Profile URL, 2: Username. */
-			'<em>' . wp_kses_post( __( 'Posted by <a href="%s">@%s</a>.', 'wporg-forums' ) ) . '</em><br/>',
+			'<em>' . wp_kses_post( __( 'Posted by <a href="%1$s">@%2$s</a>.', 'wporg-forums' ) ) . '</em><br/>',
 			esc_url( bbp_get_user_profile_url( $user->ID ) ),
 			esc_html( $user->user_nicename )
 		);

--- a/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-moderators.php
+++ b/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-moderators.php
@@ -1225,6 +1225,7 @@ class Moderators {
 		$user = get_user_by( 'id', get_post_meta( bbp_get_reply_id(), self::MODERATOR_REPLY_AUTHOR, true ) );
 
 		printf(
+			/* translators: 1: Profile URL, 2: Username. */
 			'<em>' . wp_kses_post( __( 'Posted by <a href="%s">@%s</a>.', 'wporg-forums' ) ) . '</em><br/>',
 			esc_url( bbp_get_user_profile_url( $user->ID ) ),
 			esc_html( $user->user_nicename )

--- a/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-nsfw-handler.php
+++ b/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-nsfw-handler.php
@@ -29,7 +29,7 @@ class NSFW_Handler {
 	 */
 	public function add_term_meta() {
 		// Output a helping text indicating what to use the description field for.
-		echo '<p>' . __( 'Please provide a reason for adding this term in the description field', 'wporg-forums' ) . '</p>';
+		echo '<p>' . esc_html__( 'Please provide a reason for adding this term in the description field', 'wporg-forums' ) . '</p>';
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-ratings-compat.php
+++ b/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-ratings-compat.php
@@ -270,13 +270,15 @@ class Ratings_Compat {
 		if ( $filter > 0 && $filter < 6 ) {
 			echo '<p class="reviews-filtered-msg" style="margin-top:12px;font-size:0.8rem;">';
 			printf(
-				/* translators: %d: number of stars */
-				wp_kses_post( _n(
-					'You are currently viewing the reviews that provided a rating of <strong>%d star</strong>.',
-					'You are currently viewing the reviews that provided a rating of <strong>%d stars</strong>.',
-					$filter,
-					'wporg-forums'
-				) ) . ' ',
+				wp_kses_post(
+					/* translators: %d: number of stars */
+					_n(
+						'You are currently viewing the reviews that provided a rating of <strong>%d star</strong>.',
+						'You are currently viewing the reviews that provided a rating of <strong>%d stars</strong>.',
+						$filter,
+						'wporg-forums'
+					)
+				) . ' ',
 				$filter
 			);
 			printf(

--- a/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-ratings-compat.php
+++ b/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-ratings-compat.php
@@ -223,23 +223,23 @@ class Ratings_Compat {
 ?>
 <div class="review-ratings">
 	<div>
-		<div style="font-weight:bold;"><?php _e( 'Average Rating', 'wporg-forums' ); ?></div>
+		<div style="font-weight:bold;"><?php esc_html_e( 'Average Rating', 'wporg-forums' ); ?></div>
 		<?php echo do_blocks( '<!-- wp:wporg/ratings-stars /-->' ); ?>
 		<div class="reviews-submit-link">
 		<?php
 			if ( is_user_logged_in() ) {
 				echo '<a href="#new-post" class="btn">';
 				if ( $this->review_exists() ) {
-					_e( 'Edit your review', 'wporg-forums' );
+					esc_html_e( 'Edit your review', 'wporg-forums' );
 				} else {
-					_e( 'Add your own review', 'wporg-forums' );
+					esc_html_e( 'Add your own review', 'wporg-forums' );
 				}
 				echo '</a>';
 			} else {
 				echo '<span class="reviews-need-login">';
 				printf(
 					/* translators: %s: login URL */
-					__( 'You must be <a href="%s" rel="nofollow">logged in</a> to submit a review.', 'wporg-forums' ),
+					wp_kses_post( __( 'You must be <a href="%s" rel="nofollow">logged in</a> to submit a review.', 'wporg-forums' ) ),
 					add_query_arg(
 						'redirect_to',
 						urlencode( esc_url_raw( sprintf( home_url( '/%s/%s/reviews/' ), $this->compat, $this->slug ) ) ),
@@ -256,7 +256,7 @@ class Ratings_Compat {
 		<div class="reviews-total-count"><?php
 			printf(
 				/* translators: %s: number of reviews */
-				_n( '%s review', '%s reviews', $this->reviews_count, 'wporg-forums' ),
+				esc_html( _n( '%s review', '%s reviews', $this->reviews_count, 'wporg-forums' ) ),
 				'<span>' . number_format_i18n( $this->reviews_count ) . '</span>'
 			);
 		?></div>
@@ -271,17 +271,17 @@ class Ratings_Compat {
 			echo '<p class="reviews-filtered-msg" style="margin-top:12px;font-size:0.8rem;">';
 			printf(
 				/* translators: %d: number of stars */
-				_n(
+				wp_kses_post( _n(
 					'You are currently viewing the reviews that provided a rating of <strong>%d star</strong>.',
 					'You are currently viewing the reviews that provided a rating of <strong>%d stars</strong>.',
 					$filter,
 					'wporg-forums'
-				) . ' ',
+				) ) . ' ',
 				$filter
 			);
 			printf(
 				/* translators: %s: plugin/theme reviews URL */
-				__( '<a href="%s">See all reviews</a>.', 'wporg-forums' ),
+				wp_kses_post( __( '<a href="%s">See all reviews</a>.', 'wporg-forums' ) ),
 				esc_url( sprintf( home_url( '/%s/%s/reviews/' ), $this->compat, $this->slug ) )
 			);
 			echo "</p>\n";
@@ -430,7 +430,7 @@ class Ratings_Compat {
 			echo '<div class="bbp-template-notice"><p>';
 			printf(
 				/* translators: %s: login URL */
-				__( 'You must be <a href="%s" rel="nofollow">logged in</a> to submit a review.', 'wporg-forums' ),
+				wp_kses_post( __( 'You must be <a href="%s" rel="nofollow">logged in</a> to submit a review.', 'wporg-forums' ) ),
 				add_query_arg(
 					'redirect_to',
 					urlencode( esc_url_raw( sprintf( home_url( '/%s/%s/reviews/' ), $this->compat, $this->slug ) ) ),
@@ -455,12 +455,12 @@ class Ratings_Compat {
 
 	public function do_template_notice() {
 		if ( $this->object->post_author == get_current_user_id() ) { ?>
-			<p><?php _e( 'A review should be the review of an experience a user has with your project, not for self-promotion.', 'wporg-forums' ); ?></p>
+			<p><?php esc_html_e( 'A review should be the review of an experience a user has with your project, not for self-promotion.', 'wporg-forums' ); ?></p>
 
 			<?php if ( 'plugin' === $this->compat ) : ?>
-				<p><?php _e( 'Since you work on this plugin, please consider <em>not</em> leaving a review on your own work. You were probably going to give it five stars anyway.', 'wporg-forums' ); ?></p>
+				<p><?php echo wp_kses_post( __( 'Since you work on this plugin, please consider <em>not</em> leaving a review on your own work. You were probably going to give it five stars anyway.', 'wporg-forums' ) ); ?></p>
 			<?php elseif ( 'theme' === $this->compat ) : ?>
-				<p><?php _e( 'Since you work on this theme, please consider <em>not</em> leaving a review on your own work. You were probably going to give it five stars anyway.', 'wporg-forums' ); ?></p>
+				<p><?php echo wp_kses_post( __( 'Since you work on this theme, please consider <em>not</em> leaving a review on your own work. You were probably going to give it five stars anyway.', 'wporg-forums' ) ); ?></p>
 			<?php endif;
 
 			return;
@@ -480,7 +480,7 @@ class Ratings_Compat {
 				break;
 		}
 		?>
-		<p><?php _e( 'When posting a review, follow these guidelines:', 'wporg-forums' ); ?></p>
+		<p><?php esc_html_e( 'When posting a review, follow these guidelines:', 'wporg-forums' ); ?></p>
 		<ul>
 			<li><?php printf( $report, esc_url( sprintf( home_url( '/%s/%s/' ), $this->compat, $this->slug ) ) ); ?></li>
 			<li><?php echo esc_html( $rate ); ?></li>
@@ -488,7 +488,7 @@ class Ratings_Compat {
 			<li><?php
 				printf(
 					/* translators: %s: Forum user guide URL */
-					__( 'Please <a href="%s">do not add links to your review</a>, keep the review about your experience in text only.', 'wporg-forums' ),
+					wp_kses_post( __( 'Please <a href="%s">do not add links to your review</a>, keep the review about your experience in text only.', 'wporg-forums' ) ),
 					esc_url( __( 'https://wordpress.org/support/forum-user-guide/faq/#why-are-links-not-allowed-in-reviews', 'wporg-forums' ) )
 				);
 			?></li>
@@ -517,7 +517,7 @@ class Ratings_Compat {
 
 		printf(
 			'<label for="rating">%s</label>',
-			__( 'Your Rating:', 'wporg-forums' )
+			esc_html__( 'Your Rating:', 'wporg-forums' )
 		);
 
 		\WPORG_Ratings::get_dashicons_form( $this->compat, $this->slug, true );

--- a/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-ratings-compat.php
+++ b/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-ratings-compat.php
@@ -271,7 +271,7 @@ class Ratings_Compat {
 			echo '<p class="reviews-filtered-msg" style="margin-top:12px;font-size:0.8rem;">';
 			printf(
 				wp_kses_post(
-					/* translators: %d: number of stars */
+					/* translators: %d: Number of stars. */
 					_n(
 						'You are currently viewing the reviews that provided a rating of <strong>%d star</strong>.',
 						'You are currently viewing the reviews that provided a rating of <strong>%d stars</strong>.',
@@ -484,7 +484,7 @@ class Ratings_Compat {
 		?>
 		<p><?php esc_html_e( 'When posting a review, follow these guidelines:', 'wporg-forums' ); ?></p>
 		<ul>
-			<li><?php printf( $report, esc_url( sprintf( home_url( '/%s/%s/' ), $this->compat, $this->slug ) ) ); ?></li>
+			<li><?php printf( wp_kses_post( $report ), esc_url( sprintf( home_url( '/%s/%s/' ), $this->compat, $this->slug ) ) ); ?></li>
 			<li><?php echo esc_html( $rate ); ?></li>
 			<li><?php esc_html_e( 'Please provide as much detail as you can to justify your rating and to help others.', 'wporg-forums' ); ?></li>
 			<li><?php

--- a/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-report-topic.php
+++ b/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-report-topic.php
@@ -408,7 +408,7 @@ The WordPress.org Team',
 			'<p>%s</p>',
 			sprintf(
 			    // translators: 1: Title of reported topic as a link.
-				__( 'Reported topic: %s', 'wporg-forums' ),
+				esc_html__( 'Reported topic: %s', 'wporg-forums' ),
 				sprintf(
 					'<a href="%s">%s</a>',
 					esc_url( get_the_permalink( $topic ) ),
@@ -421,7 +421,7 @@ The WordPress.org Team',
 			'<p>%s</p>',
 			sprintf(
 			    // translators: 1: Number of posts in the topic.
-				__( 'Replies in this topic: %d', 'wporg-forums' ),
+				esc_html__( 'Replies in this topic: %d', 'wporg-forums' ),
 				esc_html( bbp_get_topic_reply_count( $topic ) )
 			)
 		);
@@ -430,7 +430,7 @@ The WordPress.org Team',
 			'<p>%s</p>',
 			sprintf(
 			    // translators: 1: Number of participants in the topic.
-				__( 'Participants in this topic: %d', 'wporg-forums' ),
+				esc_html__( 'Participants in this topic: %d', 'wporg-forums' ),
 				esc_html( bbp_get_topic_voice_count( $topic ) )
 			)
 		);
@@ -451,7 +451,7 @@ The WordPress.org Team',
 			'<p>%s</p>',
 			sprintf(
 			    // translators: 1: The display-name of the reporter, as a link to their user profile.
-				__( 'Reporter: %s', 'wporg-forums' ),
+				esc_html__( 'Reporter: %s', 'wporg-forums' ),
 				sprintf(
 					'<a href="%s">%s</a>',
 					esc_url( bbp_get_user_profile_url( $author_id ) ),
@@ -464,7 +464,7 @@ The WordPress.org Team',
 			'<p>%s</p>',
 			sprintf(
 			    // translators: 1: The IP address the report was submitted from.
-				__( 'IP Address: %s', 'wporg-forums' ),
+				esc_html__( 'IP Address: %s', 'wporg-forums' ),
 				esc_html( $reporter_ip )
 			)
 		);
@@ -677,7 +677,7 @@ The WordPress.org Team',
 				<?php wp_nonce_field( $action ); ?>
 				<input type="hidden" name="wporg-support-report-topic" value="<?php echo esc_attr( bbp_get_topic_id() ); ?>">
 
-				<label for="topic-report-reason"><?php _e( 'Report this topic for:', 'wporg-forums' ); ?></label>
+				<label for="topic-report-reason"><?php esc_html_e( 'Report this topic for:', 'wporg-forums' ); ?></label>
 				<?php
 				wp_dropdown_categories(
 					array(
@@ -693,7 +693,7 @@ The WordPress.org Team',
 				?>
 
 				<p>
-					<label for="topic-report-reason-details"><?php _e( 'Why are you reporting this topic:', 'wporg-forums' ); ?></label>
+					<label for="topic-report-reason-details"><?php esc_html_e( 'Why are you reporting this topic:', 'wporg-forums' ); ?></label>
 					<textarea type="text" name="topic-report-reason-details" id="topic-report-reason-details" class="widefat" required="required"></textarea>
 				</p>
 
@@ -741,7 +741,7 @@ The WordPress.org Team',
 
 			printf(
 				'<li class="topic-previous-reports">%s<ul class="previous-reports">%s</ul></li>',
-				__( 'Previous reports:', 'wporg-support' ),
+				esc_html__( 'Previous reports:', 'wporg-support' ),
 				implode( ' ', $lines )
 			);
 		}

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/admin-edit.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/admin-edit.php
@@ -473,8 +473,9 @@ function wporg_theme_no_delete_repopackage( $post_id ) {
 			esc_html__( 'Repopackages can not be deleted.', 'wporg-themes' ),
 			'',
 			array(
-			'back_link' => true,
-		) );
+				'back_link' => true,
+			)
+		);
 	}
 }
 add_filter( 'before_delete_post', 'wporg_theme_no_delete_repopackage' );

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/admin-edit.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/admin-edit.php
@@ -248,15 +248,15 @@ function wporg_themes_suspend_theme() {
 	$post = get_post( $post_id );
 
 	if ( 'suspend' == $post->post_status ) {
-		wp_die( __( 'This item has already been suspended.', 'wporg-themes' ) );
+		wp_die( esc_html__( 'This item has already been suspended.', 'wporg-themes' ) );
 	}
 
 	if ( ! get_post_type_object( $post->post_type ) ) {
-		wp_die( __( 'Unknown post type.', 'wporg-themes' ) );
+		wp_die( esc_html__( 'Unknown post type.', 'wporg-themes' ) );
 	}
 
 	if ( ! current_user_can( 'suspend_theme', $post_id ) || 'repopackage' != $post->post_type ) {
-		wp_die( __( 'You are not allowed to suspend this item.', 'wporg-themes' ) );
+		wp_die( esc_html__( 'You are not allowed to suspend this item.', 'wporg-themes' ) );
 	}
 
 	wp_update_post( array(
@@ -285,15 +285,15 @@ function wporg_themes_reinstate_theme() {
 	$post = get_post( $post_id );
 
 	if ( 'suspend' != $post->post_status ) {
-		wp_die( __( 'This item has already been reinstated.', 'wporg-themes' ) );
+		wp_die( esc_html__( 'This item has already been reinstated.', 'wporg-themes' ) );
 	}
 
 	if ( ! get_post_type_object( $post->post_type ) ) {
-		wp_die( __( 'Unknown post type.', 'wporg-themes' ) );
+		wp_die( esc_html__( 'Unknown post type.', 'wporg-themes' ) );
 	}
 
 	if ( ! current_user_can( 'reinstate_theme', $post_id ) || 'repopackage' != $post->post_type ) {
-		wp_die( __( 'You are not allowed to reinstate this item.', 'wporg-themes' ) );
+		wp_die( esc_html__( 'You are not allowed to reinstate this item.', 'wporg-themes' ) );
 	}
 
 	wp_update_post( array(
@@ -348,15 +348,15 @@ function wporg_themes_delist_theme() {
 	$post = get_post( $post_id );
 
 	if ( 'delist' == $post->post_status ) {
-		wp_die( __( 'This item has already been delisted.', 'wporg-themes' ) );
+		wp_die( esc_html__( 'This item has already been delisted.', 'wporg-themes' ) );
 	}
 
 	if ( ! get_post_type_object( $post->post_type ) ) {
-		wp_die( __( 'Unknown post type.', 'wporg-themes' ) );
+		wp_die( esc_html__( 'Unknown post type.', 'wporg-themes' ) );
 	}
 
 	if ( ! current_user_can( 'suspend_theme', $post_id ) || 'repopackage' != $post->post_type ) {
-		wp_die( __( 'You are not allowed to delist this item.', 'wporg-themes' ) );
+		wp_die( esc_html__( 'You are not allowed to delist this item.', 'wporg-themes' ) );
 	}
 
 	wp_update_post( array(
@@ -385,15 +385,15 @@ function wporg_themes_relist_theme() {
 	$post = get_post( $post_id );
 
 	if ( 'delist' != $post->post_status ) {
-		wp_die( __( 'This item has already been relisted.', 'wporg-themes' ) );
+		wp_die( esc_html__( 'This item has already been relisted.', 'wporg-themes' ) );
 	}
 
 	if ( ! get_post_type_object( $post->post_type ) ) {
-		wp_die( __( 'Unknown post type.', 'wporg-themes' ) );
+		wp_die( esc_html__( 'Unknown post type.', 'wporg-themes' ) );
 	}
 
 	if ( ! current_user_can( 'reinstate_theme', $post_id ) || 'repopackage' != $post->post_type ) {
-		wp_die( __( 'You are not allowed to relist this item.', 'wporg-themes' ) );
+		wp_die( esc_html__( 'You are not allowed to relist this item.', 'wporg-themes' ) );
 	}
 
 	wp_update_post( array(
@@ -469,7 +469,10 @@ add_filter( 'post_thumbnail_html', 'wporg_themes_post_thumbnail_html', 10, 5 );
  */
 function wporg_theme_no_delete_repopackage( $post_id ) {
 	if ( 'repopackage' == get_post( $post_id )->post_type ) {
-		wp_die( __( 'Repopackages can not be deleted.', 'wporg-themes' ), '', array(
+		wp_die(
+			esc_html__( 'Repopackages can not be deleted.', 'wporg-themes' ),
+			'',
+			array(
 			'back_link' => true,
 		) );
 	}

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
@@ -1440,9 +1440,9 @@ class WPORG_Themes_Upload {
 
 		// Display the errors.
 		$verdict = $result ? array( 'tc-pass', __( 'Pass', 'wporg-themes' ) ) : array( 'tc-fail', __( 'Fail', 'wporg-themes' ) );
-		echo '<h2>' . sprintf( __( 'Results of Automated Theme Scanning: %s', 'wporg-themes' ), vsprintf( '<span class="%1$s">%2$s</span>', $verdict ) ) . '</h2>';
+		echo '<h2>' . sprintf( esc_html__( 'Results of Automated Theme Scanning: %s', 'wporg-themes' ), vsprintf( '<span class="%1$s">%2$s</span>', $verdict ) ) . '</h2>';
 		echo '<ul class="tc-result">' . display_themechecks() . '</ul>';
-		echo '<div class="notice notice-info"><p>' . __( 'Note: While the automated theme scan is based on the Theme Review Guidelines, it is not a complete review. A successful result from the scan does not guarantee that the theme will pass review. All submitted themes are reviewed manually before approval.', 'wporg-themes' ) . '</p></div>';
+		echo '<div class="notice notice-info"><p>' . esc_html__( 'Note: While the automated theme scan is based on the Theme Review Guidelines, it is not a complete review. A successful result from the scan does not guarantee that the theme will pass review. All submitted themes are reviewed manually before approval.', 'wporg-themes' ) . '</p></div>';
 
 		return $result;
 	}

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
@@ -1441,7 +1441,7 @@ class WPORG_Themes_Upload {
 		// Display the errors.
 		$verdict = $result ? array( 'tc-pass', __( 'Pass', 'wporg-themes' ) ) : array( 'tc-fail', __( 'Fail', 'wporg-themes' ) );
 		/* translators: %s: Scan verdict. */
-		echo '<h2>' . sprintf( esc_html__( 'Results of Automated Theme Scanning: %s', 'wporg-themes' ), vsprintf( '<span class="%1$s">%2$s</span>', $verdict ) ) . '</h2>';
+		echo '<h2>' . sprintf( esc_html__( 'Results of Automated Theme Scanning: %s', 'wporg-themes' ), vsprintf( '<span class="%1$s">%2$s</span>', array_map( 'esc_html', $verdict ) ) ) . '</h2>';
 		echo '<ul class="tc-result">' . display_themechecks() . '</ul>';
 		echo '<div class="notice notice-info"><p>' . esc_html__( 'Note: While the automated theme scan is based on the Theme Review Guidelines, it is not a complete review. A successful result from the scan does not guarantee that the theme will pass review. All submitted themes are reviewed manually before approval.', 'wporg-themes' ) . '</p></div>';
 

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
@@ -1440,6 +1440,7 @@ class WPORG_Themes_Upload {
 
 		// Display the errors.
 		$verdict = $result ? array( 'tc-pass', __( 'Pass', 'wporg-themes' ) ) : array( 'tc-fail', __( 'Fail', 'wporg-themes' ) );
+		/* translators: %s: Scan verdict. */
 		echo '<h2>' . sprintf( esc_html__( 'Results of Automated Theme Scanning: %s', 'wporg-themes' ), vsprintf( '<span class="%1$s">%2$s</span>', $verdict ) ) . '</h2>';
 		echo '<ul class="tc-result">' . display_themechecks() . '</ul>';
 		echo '<div class="notice notice-info"><p>' . esc_html__( 'Note: While the automated theme scan is based on the Theme Review Guidelines, it is not a complete review. A successful result from the scan does not guarantee that the theme will pass review. All submitted themes are reviewed manually before approval.', 'wporg-themes' ) . '</p></div>';

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/theme-directory.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/theme-directory.php
@@ -373,7 +373,7 @@ function wporg_themes_author_metabox_override( $post_type, $post ) {
 function wporg_themes_post_author_meta_box( $post ) {
 	global $user_ID;
 ?>
-<label class="screen-reader-text" for="post_author_override"><?php esc_html_e('Author'); ?></label>
+<label class="screen-reader-text" for="post_author_override"><?php esc_html_e( 'Author' ); ?></label>
 <?php
 	$value = empty($post->ID) ? $user_ID : $post->post_author;
 

--- a/wordpress.org/public_html/wp-content/plugins/theme-directory/theme-directory.php
+++ b/wordpress.org/public_html/wp-content/plugins/theme-directory/theme-directory.php
@@ -373,7 +373,7 @@ function wporg_themes_author_metabox_override( $post_type, $post ) {
 function wporg_themes_post_author_meta_box( $post ) {
 	global $user_ID;
 ?>
-<label class="screen-reader-text" for="post_author_override"><?php _e('Author'); ?></label>
+<label class="screen-reader-text" for="post_author_override"><?php esc_html_e('Author'); ?></label>
 <?php
 	$value = empty($post->ID) ? $user_ID : $post->post_author;
 

--- a/wordpress.org/public_html/wp-content/plugins/trac-notifications/trac-components.php
+++ b/wordpress.org/public_html/wp-content/plugins/trac-notifications/trac-components.php
@@ -649,6 +649,7 @@ jQuery( function( $ ) {
 		}
 
 		if ( is_singular() ) {
+			/* translators: %s: Number of tickets. */
 			echo '<h3>' . sprintf( esc_html( _n( '%s open ticket', '%s open tickets', $component_count ) ), $component_count ) . ' in the ' . $component . ' component</h3>';
 		}
 
@@ -712,6 +713,7 @@ jQuery( function( $ ) {
 
 		if ( $unreplied_tickets ) {
 			$count = count( $unreplied_tickets );
+			/* translators: %d: Number of tickets. */
 			echo '<h3>' . sprintf( esc_html( _n( '%d ticket that has no replies', '%d tickets that have no replies', $count ) ), $count ) . '</h3>';
 			echo '<a href="' . $this->trac_query( array( 'component' => $component, 'id' => implode( ',', wp_list_pluck( $unreplied_tickets, 'id' ) ) ) ) . '">View list on Trac</a>';
 			$this->render_tickets( $unreplied_tickets );
@@ -730,6 +732,7 @@ jQuery( function( $ ) {
 		$tickets_by_type = (array) $this->api->get_ticket_counts_for_component( $component );
 
 		$count = array_sum( $tickets_by_type );
+		/* translators: %s: Number of tickets. */
 		echo '<h3>' . sprintf( esc_html( _n( '%s open ticket', '%s open tickets', $count ) ), $count ) . '</h3>';
 
 		$types = array(

--- a/wordpress.org/public_html/wp-content/plugins/trac-notifications/trac-components.php
+++ b/wordpress.org/public_html/wp-content/plugins/trac-notifications/trac-components.php
@@ -650,7 +650,7 @@ jQuery( function( $ ) {
 
 		if ( is_singular() ) {
 			/* translators: %s: Number of tickets. */
-			echo '<h3>' . sprintf( esc_html( _n( '%s open ticket', '%s open tickets', $component_count ) ), $component_count ) . ' in the ' . $component . ' component</h3>';
+			echo '<h3>' . sprintf( esc_html( _n( '%s open ticket', '%s open tickets', $component_count ) ), (int) $component_count ) . ' in the ' . esc_html( $component ) . ' component</h3>';
 		}
 
 		$history = $this->api->get_component_history( $component, self::last_x_days );
@@ -714,7 +714,7 @@ jQuery( function( $ ) {
 		if ( $unreplied_tickets ) {
 			$count = count( $unreplied_tickets );
 			/* translators: %d: Number of tickets. */
-			echo '<h3>' . sprintf( esc_html( _n( '%d ticket that has no replies', '%d tickets that have no replies', $count ) ), $count ) . '</h3>';
+			echo '<h3>' . sprintf( esc_html( _n( '%d ticket that has no replies', '%d tickets that have no replies', $count ) ), (int) $count ) . '</h3>';
 			echo '<a href="' . $this->trac_query( array( 'component' => $component, 'id' => implode( ',', wp_list_pluck( $unreplied_tickets, 'id' ) ) ) ) . '">View list on Trac</a>';
 			$this->render_tickets( $unreplied_tickets );
 		}
@@ -724,7 +724,12 @@ jQuery( function( $ ) {
 		if ( $next_milestone ) {
 			$count = count( $next_milestone );
 			$next_milestone_object = (object) $next_milestone[0];
-			echo '<h3>' . sprintf( esc_html( _n( '%s ticket slated for ' . $next_milestone_object->milestone, '%s tickets slated for ' . $next_milestone_object->milestone, $count ) ), $count ) . '</h3>';
+			echo '<h3>' . sprintf(
+				/* translators: 1: Number of tickets, 2: Milestone name. */
+				esc_html( _n( '%1$s ticket slated for %2$s', '%1$s tickets slated for %2$s', $count ) ),
+				(int) $count,
+				esc_html( $next_milestone_object->milestone )
+			) . '</h3>';
 			echo $this->trac_query_link( 'View list in Trac', array( 'component' => $component, 'milestone' => $next_milestone_object->milestone ) );
 			$this->render_tickets( $next_milestone );
 		}
@@ -733,7 +738,7 @@ jQuery( function( $ ) {
 
 		$count = array_sum( $tickets_by_type );
 		/* translators: %s: Number of tickets. */
-		echo '<h3>' . sprintf( esc_html( _n( '%s open ticket', '%s open tickets', $count ) ), $count ) . '</h3>';
+		echo '<h3>' . sprintf( esc_html( _n( '%s open ticket', '%s open tickets', $count ) ), (int) $count ) . '</h3>';
 
 		$types = array(
 			'enhancement'     => 'Open enhancements',

--- a/wordpress.org/public_html/wp-content/plugins/trac-notifications/trac-components.php
+++ b/wordpress.org/public_html/wp-content/plugins/trac-notifications/trac-components.php
@@ -649,8 +649,12 @@ jQuery( function( $ ) {
 		}
 
 		if ( is_singular() ) {
-			/* translators: %s: Number of tickets. */
-			echo '<h3>' . sprintf( esc_html( _n( '%s open ticket', '%s open tickets', $component_count ) ), (int) $component_count ) . ' in the ' . esc_html( $component ) . ' component</h3>';
+			echo '<h3>' . sprintf(
+				/* translators: 1: Number of tickets. 2: Component name. */
+				esc_html( _n( '%1$s open ticket in the %2$s component', '%1$s open tickets in the %2$s component', $component_count ) ),
+				(int) $component_count,
+				esc_html( $component )
+			) . '</h3>';
 		}
 
 		$history = $this->api->get_component_history( $component, self::last_x_days );

--- a/wordpress.org/public_html/wp-content/plugins/trac-notifications/trac-components.php
+++ b/wordpress.org/public_html/wp-content/plugins/trac-notifications/trac-components.php
@@ -649,7 +649,7 @@ jQuery( function( $ ) {
 		}
 
 		if ( is_singular() ) {
-			echo '<h3>' . sprintf( _n( '%s open ticket', '%s open tickets', $component_count ), $component_count ) . ' in the ' . $component . ' component</h3>';
+			echo '<h3>' . sprintf( esc_html( _n( '%s open ticket', '%s open tickets', $component_count ) ), $component_count ) . ' in the ' . $component . ' component</h3>';
 		}
 
 		$history = $this->api->get_component_history( $component, self::last_x_days );
@@ -712,7 +712,7 @@ jQuery( function( $ ) {
 
 		if ( $unreplied_tickets ) {
 			$count = count( $unreplied_tickets );
-			echo '<h3>' . sprintf( _n( '%d ticket that has no replies', '%d tickets that have no replies', $count ), $count ) . '</h3>';
+			echo '<h3>' . sprintf( esc_html( _n( '%d ticket that has no replies', '%d tickets that have no replies', $count ) ), $count ) . '</h3>';
 			echo '<a href="' . $this->trac_query( array( 'component' => $component, 'id' => implode( ',', wp_list_pluck( $unreplied_tickets, 'id' ) ) ) ) . '">View list on Trac</a>';
 			$this->render_tickets( $unreplied_tickets );
 		}
@@ -722,7 +722,7 @@ jQuery( function( $ ) {
 		if ( $next_milestone ) {
 			$count = count( $next_milestone );
 			$next_milestone_object = (object) $next_milestone[0];
-			echo '<h3>' . sprintf( _n( '%s ticket slated for ' . $next_milestone_object->milestone, '%s tickets slated for ' . $next_milestone_object->milestone, $count ), $count ) . '</h3>';
+			echo '<h3>' . sprintf( esc_html( _n( '%s ticket slated for ' . $next_milestone_object->milestone, '%s tickets slated for ' . $next_milestone_object->milestone, $count ) ), $count ) . '</h3>';
 			echo $this->trac_query_link( 'View list in Trac', array( 'component' => $component, 'milestone' => $next_milestone_object->milestone ) );
 			$this->render_tickets( $next_milestone );
 		}
@@ -730,7 +730,7 @@ jQuery( function( $ ) {
 		$tickets_by_type = (array) $this->api->get_ticket_counts_for_component( $component );
 
 		$count = array_sum( $tickets_by_type );
-		echo '<h3>' . sprintf( _n( '%s open ticket', '%s open tickets', $count ), $count ) . '</h3>';
+		echo '<h3>' . sprintf( esc_html( _n( '%s open ticket', '%s open tickets', $count ) ), $count ) . '</h3>';
 
 		$types = array(
 			'enhancement'     => 'Open enhancements',

--- a/wordpress.org/public_html/wp-content/plugins/wp-i18n-teams/inc/locales.php
+++ b/wordpress.org/public_html/wp-content/plugins/wp-i18n-teams/inc/locales.php
@@ -53,6 +53,7 @@ function render_wp_locales_shortcode(): string {
 			printf(
 				'<div class="callout callout-warning"><p>%s</p><p><a href="%s">%s</a></p></div>',
 				sprintf(
+					/* translators: %s: Locale slug. */
 					esc_html__( 'Locale %s doesn&#8217;t exist.', 'wporg' ),
 					'<code>' . esc_html( $_GET['locale'] ) . '</code>'
 				),

--- a/wordpress.org/public_html/wp-content/plugins/wp-i18n-teams/inc/locales.php
+++ b/wordpress.org/public_html/wp-content/plugins/wp-i18n-teams/inc/locales.php
@@ -53,11 +53,11 @@ function render_wp_locales_shortcode(): string {
 			printf(
 				'<div class="callout callout-warning"><p>%s</p><p><a href="%s">%s</a></p></div>',
 				sprintf(
-					__( 'Locale %s doesn&#8217;t exist.', 'wporg' ),
+					esc_html__( 'Locale %s doesn&#8217;t exist.', 'wporg' ),
 					'<code>' . esc_html( $_GET['locale'] ) . '</code>'
 				),
 				esc_url( get_permalink() ),
-				__( 'Return to All Locales', 'wporg' )
+				esc_html__( 'Return to All Locales', 'wporg' )
 			);
 		}
 	}

--- a/wordpress.org/public_html/wp-content/plugins/wp-i18n-teams/views/all-locales.php
+++ b/wordpress.org/public_html/wp-content/plugins/wp-i18n-teams/views/all-locales.php
@@ -1,7 +1,7 @@
 <div class="translators-info show-all">
 	<p class="locale-filters">
 	<?php
-		_e( 'Releases:', 'worg' );
+		esc_html_e( 'Releases:', 'worg' );
 
 		$release_statuses = array(
 			'all' => _n_noop( '%s locale.', '%s locales.', 'wporg' ),
@@ -27,7 +27,7 @@
 
 	<p class="locale-filters">
 	<?php
-		_e( 'Translations:', 'worg' );
+		esc_html_e( 'Translations:', 'worg' );
 
 		$translation_statuses = array(
 			'all' => _n_noop( '%s locale.', '%s locales.', 'wporg' ),
@@ -57,17 +57,17 @@
 		<thead>
 			<tr>
 				<th colspan="2">
-					<?php _e( 'Locale', 'wporg' ); ?><br>
-					<small><?php _e( '(English &amp; Native)', 'wporg' ); ?></small>
+					<?php esc_html_e( 'Locale', 'wporg' ); ?><br>
+					<small><?php esc_html_e( '(English &amp; Native)', 'wporg' ); ?></small>
 				</th>
-				<th><?php _e( 'WP Locale', 'wporg' ); ?></th>
+				<th><?php esc_html_e( 'WP Locale', 'wporg' ); ?></th>
 				<th colspan="2">
-					<?php _e( 'Version', 'wporg' ); ?><br>
-					<small><?php _e( '(Release &amp; Language Pack)', 'wporg' ); ?></small>
+					<?php esc_html_e( 'Version', 'wporg' ); ?><br>
+					<small><?php esc_html_e( '(Release &amp; Language Pack)', 'wporg' ); ?></small>
 				</th>
 				<th colspan="2">
-					<?php _e( 'GlotPress', 'wporg' ); ?><br>
-					<small><?php _e( '(Translated &amp; Slug)', 'wporg' ); ?></small>
+					<?php esc_html_e( 'GlotPress', 'wporg' ); ?><br>
+					<small><?php esc_html_e( '(Translated &amp; Slug)', 'wporg' ); ?></small>
 				</th>
 				<th><!-- intentionally blank --></th>
 			</tr>
@@ -101,10 +101,10 @@
 								if ( $locale_data[ $locale->wp_locale ]['latest_release'] ) {
 									echo esc_html( $locale_data[ $locale->wp_locale ]['latest_release'] );
 								} else {
-									_e( 'None', 'wporg' );
+									esc_html_e( 'None', 'wporg' );
 								}
 							} else {
-								_e( 'No&nbsp;site', 'wporg' );
+								esc_html_e( 'None', 'wporg' );
 							}
 						?>
 					</td>
@@ -113,7 +113,7 @@
 						if ( isset( $language_packs_data[ $locale->wp_locale ] ) ) {
 							echo max( $language_packs_data[ $locale->wp_locale ] );
 						} else {
-							_e( 'No&nbsp;LP', 'wporg' );
+							esc_html_e( 'No&nbsp;LP', 'wporg' );
 						}
 						?>
 						<?php
@@ -144,7 +144,7 @@
 
 					<td class="center">
 						<a href="<?php echo esc_url( add_query_arg( 'locale', $locale->wp_locale ) ); ?>">
-							<?php _e( 'View Team Page', 'wporg' ); ?>
+							<?php esc_html_e( 'View Team Page', 'wporg' ); ?>
 						</a>
 					</td>
 				</tr>

--- a/wordpress.org/public_html/wp-content/plugins/wp-i18n-teams/views/all-locales.php
+++ b/wordpress.org/public_html/wp-content/plugins/wp-i18n-teams/views/all-locales.php
@@ -104,7 +104,7 @@
 									esc_html_e( 'None', 'wporg' );
 								}
 							} else {
-								esc_html_e( 'None', 'wporg' );
+								esc_html_e( 'No&nbsp;site', 'wporg' );
 							}
 						?>
 					</td>

--- a/wordpress.org/public_html/wp-content/plugins/wp-i18n-teams/views/locale-details.php
+++ b/wordpress.org/public_html/wp-content/plugins/wp-i18n-teams/views/locale-details.php
@@ -68,6 +68,7 @@
 </div>
 
 <?php if ( ! empty( $locale_data['locale_managers'] ) ) : ?>
+	<?php /* translators: %s: Number of locale managers. */ ?>
 	<h2><?php printf( esc_html__( 'Locale Managers (%s)', 'wporg' ), number_format_i18n( count( $locale_data['locale_managers'] ) ) ); ?></h2>
 
 	<ul class="validators">
@@ -89,6 +90,7 @@
 <?php endif; ?>
 
 <?php if ( ! empty( $locale_data['validators'] ) ) : ?>
+	<?php /* translators: %s: Number of general translation editors. */ ?>
 	<h2><?php printf( esc_html__( 'General Translation Editors (%s)', 'wporg' ), number_format_i18n( count( $locale_data['validators'] ) ) ); ?></h2>
 
 	<ul class="validators">
@@ -110,6 +112,7 @@
 <?php endif; ?>
 
 <?php if ( ! empty( $locale_data['project_validators'] ) ) : ?>
+	<?php /* translators: %s: Number of project translation editors. */ ?>
 	<h2><?php printf( esc_html__( 'Project Translation Editors (%s)', 'wporg' ), number_format_i18n( count( $locale_data['project_validators'] ) ) ); ?></h2>
 
 	<ul class="validators project-validators">
@@ -131,6 +134,7 @@
 <?php endif; ?>
 
 <?php if ( ! empty( $locale_data['translators'] ) ) : ?>
+	<?php /* translators: %s: Number of current contributors. */ ?>
 	<h2><?php printf( esc_html__( 'Current Translation Contributors (%s)', 'wporg' ), number_format_i18n( count( $locale_data['translators'] ) ) ); ?></h2>
 
 	<p>
@@ -149,6 +153,7 @@
 <?php endif; ?>
 
 <?php if ( ! empty( $locale_data['translators_past'] ) ) : ?>
+	<?php /* translators: %s: Number of past contributors. */ ?>
 	<h2><?php printf( esc_html__( 'Past Translation Contributors (%s)', 'wporg' ), number_format_i18n( count( $locale_data['translators_past'] ) ) ); ?></h2>
 
 	<p>

--- a/wordpress.org/public_html/wp-content/plugins/wp-i18n-teams/views/locale-details.php
+++ b/wordpress.org/public_html/wp-content/plugins/wp-i18n-teams/views/locale-details.php
@@ -1,4 +1,4 @@
-<p><a href="<?php echo esc_url( get_permalink() ); ?>"><?php _e( '&larr; All locales', 'wporg' ); ?></a></p>
+<p><a href="<?php echo esc_url( get_permalink() ); ?>"><?php esc_html_e( '&larr; All locales', 'wporg' ); ?></a></p>
 <div id="locale-header">
 	<h1>
 		<?php echo esc_html( $locale->native_name ); ?>
@@ -10,7 +10,7 @@
 
 	<ul id="locale-details">
 		<li>
-			<strong><?php _e( 'Sites:', 'wporg' ); ?></strong>
+			<strong><?php esc_html_e( 'Sites:', 'wporg' ); ?></strong>
 			<?php
 			if ( $locale_data['sites'] ) :
 				echo implode( ', ', array_map( function( $site ) {
@@ -26,19 +26,19 @@
 			<?php endif; ?>
 		</li>
 		<li>
-			<strong><?php _e( 'Latest release:', 'wporg' ); ?></strong>
+			<strong><?php esc_html_e( 'Latest release:', 'wporg' ); ?></strong>
 			<?php echo $locale_data['latest_release'] ? $locale_data['latest_release'] : '&mdash;'; ?>
 		</li>
 		<li>
-			<strong><?php _e( 'WordPress Locale:', 'wporg' ); ?></strong>
+			<strong><?php esc_html_e( 'WordPress Locale:', 'wporg' ); ?></strong>
 			<?php echo esc_html( $locale->wp_locale ); ?>
 		</li>
 		<li>
-			<strong><?php _e( 'GlotPress Locale Code:', 'wporg' ); ?></strong>
+			<strong><?php esc_html_e( 'GlotPress Locale Code:', 'wporg' ); ?></strong>
 			<?php echo esc_html( $locale->slug ); ?>
 		</li>
 		<li>
-			<strong><?php _e( 'Translation Projects:', 'wporg' ); ?></strong>
+			<strong><?php esc_html_e( 'Translation Projects:', 'wporg' ); ?></strong>
 			<a href="https://translate.wordpress.org/locale/<?php echo $locale->slug; ?>">translate.wordpress.org/locale/<?php echo $locale->slug; ?></a>
 		</li>
 	</ul>
@@ -49,7 +49,7 @@
 				<a class="wp-block-button__link wp-element-button" href="<?php echo esc_url( $locale_data['localized_core_url'] ); ?>">
 					<?php
 					// translators: %s is the english variant of the locale name.
-					printf( __( 'Download WordPress in %s', 'wporg' ), $locale->english_name );
+					printf( esc_html__( 'Download WordPress in %s', 'wporg' ), $locale->english_name );
 					?>
 				</a>
 			</div>
@@ -58,7 +58,7 @@
 					<a class="wp-block-button__link wp-element-button" href="<?php echo esc_url( $locale_data['language_pack_url'] ); ?>" role="button">
 						<?php
 						// translators: %s is the latest version.
-						printf( __( 'Download language pack (%s)', 'wporg' ), $locale_data['language_pack_version'] );
+						printf( esc_html__( 'Download language pack (%s)', 'wporg' ), $locale_data['language_pack_version'] );
 						?>
 					</a>
 				</div>
@@ -68,7 +68,7 @@
 </div>
 
 <?php if ( ! empty( $locale_data['locale_managers'] ) ) : ?>
-	<h2><?php printf( __( 'Locale Managers (%s)', 'wporg' ), number_format_i18n( count( $locale_data['locale_managers'] ) ) ); ?></h2>
+	<h2><?php printf( esc_html__( 'Locale Managers (%s)', 'wporg' ), number_format_i18n( count( $locale_data['locale_managers'] ) ) ); ?></h2>
 
 	<ul class="validators">
 		<?php foreach ( $locale_data['locale_managers'] as $locale_manager ) :
@@ -89,7 +89,7 @@
 <?php endif; ?>
 
 <?php if ( ! empty( $locale_data['validators'] ) ) : ?>
-	<h2><?php printf( __( 'General Translation Editors (%s)', 'wporg' ), number_format_i18n( count( $locale_data['validators'] ) ) ); ?></h2>
+	<h2><?php printf( esc_html__( 'General Translation Editors (%s)', 'wporg' ), number_format_i18n( count( $locale_data['validators'] ) ) ); ?></h2>
 
 	<ul class="validators">
 		<?php foreach ( $locale_data['validators'] as $validator ) :
@@ -110,7 +110,7 @@
 <?php endif; ?>
 
 <?php if ( ! empty( $locale_data['project_validators'] ) ) : ?>
-	<h2><?php printf( __( 'Project Translation Editors (%s)', 'wporg' ), number_format_i18n( count( $locale_data['project_validators'] ) ) ); ?></h2>
+	<h2><?php printf( esc_html__( 'Project Translation Editors (%s)', 'wporg' ), number_format_i18n( count( $locale_data['project_validators'] ) ) ); ?></h2>
 
 	<ul class="validators project-validators">
 		<?php foreach ( $locale_data['project_validators'] as $validator ) :
@@ -131,7 +131,7 @@
 <?php endif; ?>
 
 <?php if ( ! empty( $locale_data['translators'] ) ) : ?>
-	<h2><?php printf( __( 'Current Translation Contributors (%s)', 'wporg' ), number_format_i18n( count( $locale_data['translators'] ) ) ); ?></h2>
+	<h2><?php printf( esc_html__( 'Current Translation Contributors (%s)', 'wporg' ), number_format_i18n( count( $locale_data['translators'] ) ) ); ?></h2>
 
 	<p>
 		<?php
@@ -149,7 +149,7 @@
 <?php endif; ?>
 
 <?php if ( ! empty( $locale_data['translators_past'] ) ) : ?>
-	<h2><?php printf( __( 'Past Translation Contributors (%s)', 'wporg' ), number_format_i18n( count( $locale_data['translators_past'] ) ) ); ?></h2>
+	<h2><?php printf( esc_html__( 'Past Translation Contributors (%s)', 'wporg' ), number_format_i18n( count( $locale_data['translators_past'] ) ) ); ?></h2>
 
 	<p>
 		<?php

--- a/wordpress.org/public_html/wp-content/plugins/wp-i18n-teams/views/locale-details.php
+++ b/wordpress.org/public_html/wp-content/plugins/wp-i18n-teams/views/locale-details.php
@@ -1,3 +1,11 @@
+<?php
+/**
+ * View showing the translation team of a single locale.
+ *
+ * @package WordPressdotorg\I18nTeams
+ */
+
+?>
 <p><a href="<?php echo esc_url( get_permalink() ); ?>"><?php esc_html_e( '&larr; All locales', 'wporg' ); ?></a></p>
 <div id="locale-header">
 	<h1>
@@ -49,7 +57,7 @@
 				<a class="wp-block-button__link wp-element-button" href="<?php echo esc_url( $locale_data['localized_core_url'] ); ?>">
 					<?php
 					// translators: %s is the english variant of the locale name.
-					printf( esc_html__( 'Download WordPress in %s', 'wporg' ), $locale->english_name );
+					printf( esc_html__( 'Download WordPress in %s', 'wporg' ), esc_html( $locale->english_name ) );
 					?>
 				</a>
 			</div>
@@ -58,7 +66,7 @@
 					<a class="wp-block-button__link wp-element-button" href="<?php echo esc_url( $locale_data['language_pack_url'] ); ?>" role="button">
 						<?php
 						// translators: %s is the latest version.
-						printf( esc_html__( 'Download language pack (%s)', 'wporg' ), $locale_data['language_pack_version'] );
+						printf( esc_html__( 'Download language pack (%s)', 'wporg' ), esc_html( $locale_data['language_pack_version'] ) );
 						?>
 					</a>
 				</div>
@@ -69,7 +77,7 @@
 
 <?php if ( ! empty( $locale_data['locale_managers'] ) ) : ?>
 	<?php /* translators: %s: Number of locale managers. */ ?>
-	<h2><?php printf( esc_html__( 'Locale Managers (%s)', 'wporg' ), number_format_i18n( count( $locale_data['locale_managers'] ) ) ); ?></h2>
+	<h2><?php printf( esc_html__( 'Locale Managers (%s)', 'wporg' ), esc_html( number_format_i18n( count( $locale_data['locale_managers'] ) ) ) ); ?></h2>
 
 	<ul class="validators">
 		<?php foreach ( $locale_data['locale_managers'] as $locale_manager ) :
@@ -91,7 +99,7 @@
 
 <?php if ( ! empty( $locale_data['validators'] ) ) : ?>
 	<?php /* translators: %s: Number of general translation editors. */ ?>
-	<h2><?php printf( esc_html__( 'General Translation Editors (%s)', 'wporg' ), number_format_i18n( count( $locale_data['validators'] ) ) ); ?></h2>
+	<h2><?php printf( esc_html__( 'General Translation Editors (%s)', 'wporg' ), esc_html( number_format_i18n( count( $locale_data['validators'] ) ) ) ); ?></h2>
 
 	<ul class="validators">
 		<?php foreach ( $locale_data['validators'] as $validator ) :
@@ -113,7 +121,7 @@
 
 <?php if ( ! empty( $locale_data['project_validators'] ) ) : ?>
 	<?php /* translators: %s: Number of project translation editors. */ ?>
-	<h2><?php printf( esc_html__( 'Project Translation Editors (%s)', 'wporg' ), number_format_i18n( count( $locale_data['project_validators'] ) ) ); ?></h2>
+	<h2><?php printf( esc_html__( 'Project Translation Editors (%s)', 'wporg' ), esc_html( number_format_i18n( count( $locale_data['project_validators'] ) ) ) ); ?></h2>
 
 	<ul class="validators project-validators">
 		<?php foreach ( $locale_data['project_validators'] as $validator ) :
@@ -135,7 +143,7 @@
 
 <?php if ( ! empty( $locale_data['translators'] ) ) : ?>
 	<?php /* translators: %s: Number of current contributors. */ ?>
-	<h2><?php printf( esc_html__( 'Current Translation Contributors (%s)', 'wporg' ), number_format_i18n( count( $locale_data['translators'] ) ) ); ?></h2>
+	<h2><?php printf( esc_html__( 'Current Translation Contributors (%s)', 'wporg' ), esc_html( number_format_i18n( count( $locale_data['translators'] ) ) ) ); ?></h2>
 
 	<p>
 		<?php
@@ -154,7 +162,7 @@
 
 <?php if ( ! empty( $locale_data['translators_past'] ) ) : ?>
 	<?php /* translators: %s: Number of past contributors. */ ?>
-	<h2><?php printf( esc_html__( 'Past Translation Contributors (%s)', 'wporg' ), number_format_i18n( count( $locale_data['translators_past'] ) ) ); ?></h2>
+	<h2><?php printf( esc_html__( 'Past Translation Contributors (%s)', 'wporg' ), esc_html( number_format_i18n( count( $locale_data['translators_past'] ) ) ) ); ?></h2>
 
 	<p>
 		<?php

--- a/wordpress.org/public_html/wp-content/plugins/wporg-bbp-also-viewing/wporg-bbp-also-viewing.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-bbp-also-viewing/wporg-bbp-also-viewing.php
@@ -200,7 +200,7 @@ function bbp_user_edit_after() {
 		</p>',
 		checked( enabled( $user_id ), true, false ),
 		sprintf(
-			__( 'Enable the <a href="%s">Also Viewing</a> feature.', 'wporg-forums' ),
+			wp_kses_post( __( 'Enable the <a href="%s">Also Viewing</a> feature.', 'wporg-forums' ) ),
 			'https://make.wordpress.org/support/handbook/appendix/helpful-tools/#avoiding-overlapping-replies'
 		)
 	);

--- a/wordpress.org/public_html/wp-content/plugins/wporg-bbp-also-viewing/wporg-bbp-also-viewing.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-bbp-also-viewing/wporg-bbp-also-viewing.php
@@ -200,6 +200,7 @@ function bbp_user_edit_after() {
 		</p>',
 		checked( enabled( $user_id ), true, false ),
 		sprintf(
+			/* translators: %s: Handbook URL. */
 			wp_kses_post( __( 'Enable the <a href="%s">Also Viewing</a> feature.', 'wporg-forums' ) ),
 			'https://make.wordpress.org/support/handbook/appendix/helpful-tools/#avoiding-overlapping-replies'
 		)

--- a/wordpress.org/public_html/wp-content/plugins/wporg-bbp-topic-resolution/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-bbp-topic-resolution/inc/class-plugin.php
@@ -117,7 +117,7 @@ class Plugin {
 			return;
 		}
 
-		echo '<span class="topic-resolved-indicator">' . __( 'Resolved', 'wporg-forums' ) . '</span>';
+		echo '<span class="topic-resolved-indicator">' . esc_html__( 'Resolved', 'wporg-forums' ) . '</span>';
 	}
 
 	/**

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/helper-functions.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/helper-functions.php
@@ -460,10 +460,10 @@ function wporg_gp_translate_textarea( $entry, $permissions, $index = 0 ) {
 			foreach ( $warnings as $key => $value ) :
 				?>
 				<div class="warning secondary">
-					<strong><?php _e( 'Warning:', 'glotpress' ); ?></strong> <?php echo esc_html( $value ); ?>
+					<strong><?php esc_html_e( 'Warning:', 'glotpress' ); ?></strong> <?php echo esc_html( $value ); ?>
 
 					<?php if ( $can_approve ) : ?>
-						<a href="#" class="discard-warning" data-nonce="<?php echo esc_attr( wp_create_nonce( 'discard-warning_' . $index . $key ) ); ?>" data-key="<?php echo esc_attr( $key ); ?>" data-index="<?php echo esc_attr( $index ); ?>"><?php _e( 'Discard', 'glotpress' ); ?></a>
+						<a href="#" class="discard-warning" data-nonce="<?php echo esc_attr( wp_create_nonce( 'discard-warning_' . $index . $key ) ); ?>" data-key="<?php echo esc_attr( $key ); ?>" data-index="<?php echo esc_attr( $index ); ?>"><?php esc_html_e( 'Discard', 'glotpress' ); ?></a>
 					<?php endif; ?>
 				</div>
 				<?php

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/index-locales.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/index-locales.php
@@ -6,9 +6,9 @@ gp_tmpl_header();
 
 	<div class="filter-header">
 		<ul class="filter-header-links">
-			<li><span class="current"><?php _e( 'Find your locale' ); ?></span></li>
-			<li><a href="/stats"><?php _e( 'Stats' ); ?></a></li>
-			<li><a href="/consistency"><?php _e( 'Consistency' ); ?></a></li>
+			<li><span class="current"><?php esc_html_e( 'Find your locale' ); ?></span></li>
+			<li><a href="/stats"><?php esc_html_e( 'Stats' ); ?></a></li>
+			<li><a href="/consistency"><?php esc_html_e( 'Consistency' ); ?></a></li>
 		</ul>
 		<div class="search-form">
 			<label class="screen-reader-text" for="locales-filter"><?php esc_attr_e( 'Search locales...' ); ?></label>

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/locale-project.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/locale-project.php
@@ -57,11 +57,11 @@ gp_tmpl_header();
 				</li>
 				<?php if ( $locale_glossary ) : ?>
 					<li class="locale-glossary">
-						<a href="<?php echo esc_url( gp_url_join( gp_url( '/locale' ), $locale_slug, $set_slug, 'glossary' ) ); ?>" class="glossary-link"><?php _e( 'Locale Glossary', 'glotpress' ); ?></a>
+						<a href="<?php echo esc_url( gp_url_join( gp_url( '/locale' ), $locale_slug, $set_slug, 'glossary' ) ); ?>" class="glossary-link"><?php esc_html_e( 'Locale Glossary', 'glotpress' ); ?></a>
 					</li>
 				<?php elseif ( $can_create_locale_glossary ) : ?>
 					<li class="locale-glossary">
-						<a href="<?php echo esc_url( gp_url_join( gp_url( '/locale' ), $locale_slug, $set_slug, 'glossary' ) ); ?>" class="glossary-link"><?php _e( 'Create Locale Glossary', 'glotpress' ); ?></a>
+						<a href="<?php echo esc_url( gp_url_join( gp_url( '/locale' ), $locale_slug, $set_slug, 'glossary' ) ); ?>" class="glossary-link"><?php esc_html_e( 'Create Locale Glossary', 'glotpress' ); ?></a>
 					</li>
 				<?php endif; ?>
 			</ul>
@@ -147,12 +147,12 @@ if ( 'wp-plugins' === $project->path ) {
 	<table class="gp-table locale-sub-projects">
 		<thead>
 			<tr>
-				<th class="header"><?php _e( 'Set / Sub Project' ); ?></th>
-				<th><?php _e( 'Translated' ); ?></th>
-				<th><?php _e( 'Fuzzy' ); ?></th>
-				<th><?php _e( 'Untranslated' ); ?></th>
-				<th><?php _e( 'Waiting' ); ?></th>
-				<th><?php _e( 'Changes requested' ); ?></th>
+				<th class="header"><?php esc_html_e( 'Set / Sub Project' ); ?></th>
+				<th><?php esc_html_e( 'Translated' ); ?></th>
+				<th><?php esc_html_e( 'Fuzzy' ); ?></th>
+				<th><?php esc_html_e( 'Untranslated' ); ?></th>
+				<th><?php esc_html_e( 'Waiting' ); ?></th>
+				<th><?php esc_html_e( 'Changes requested' ); ?></th>
 			</tr>
 		</thead>
 		<tbody>

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/locale-projects.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/locale-projects.php
@@ -42,11 +42,11 @@ gp_tmpl_header();
 			</li>
 			<?php if ( $locale_glossary ) : ?>
 				<li class="locale-glossary">
-					<a href="<?php echo esc_url( gp_url_join( gp_url( '/locale' ), $locale_slug, $set_slug, 'glossary' ) ); ?>" class="glossary-link"><?php _e( 'Locale Glossary', 'glotpress' ); ?></a>
+					<a href="<?php echo esc_url( gp_url_join( gp_url( '/locale' ), $locale_slug, $set_slug, 'glossary' ) ); ?>" class="glossary-link"><?php esc_html_e( 'Locale Glossary', 'glotpress' ); ?></a>
 				</li>
 			<?php elseif ( $can_create_locale_glossary ) : ?>
 				<li class="locale-glossary">
-					<a href="<?php echo esc_url( gp_url_join( gp_url( '/locale' ), $locale_slug, $set_slug, 'glossary' ) ); ?>" class="glossary-link"><?php _e( 'Create Locale Glossary', 'glotpress' ); ?></a>
+					<a href="<?php echo esc_url( gp_url_join( gp_url( '/locale' ), $locale_slug, $set_slug, 'glossary' ) ); ?>" class="glossary-link"><?php esc_html_e( 'Create Locale Glossary', 'glotpress' ); ?></a>
 				</li>
 			<?php endif; ?>
 		</ul>

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/project-form.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/project-form.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Template for the project edit form.
+ * Shared project form fields, used by both the new-project and edit-project templates.
  *
  * @package GlotPress
  */

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/project-form.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/project-form.php
@@ -1,33 +1,33 @@
 <dl>
-	<dt><label for="project[name]"><?php _e( 'Name', 'glotpress' ); ?></label></dt>
+	<dt><label for="project[name]"><?php esc_html_e( 'Name', 'glotpress' ); ?></label></dt>
 	<dd><input type="text" name="project[name]" value="<?php echo esc_html( $project->name ); ?>" id="project[name]"></dd>
 
 	<!-- TODO: make slug edit WordPress style -->
-	<dt><label for="project[slug]"><?php _e( 'Slug', 'glotpress' ); ?></label></dt>
+	<dt><label for="project[slug]"><?php esc_html_e( 'Slug', 'glotpress' ); ?></label></dt>
 	<dd>
 		<input type="text" name="project[slug]" value="<?php echo esc_html( $project->slug ); ?>" id="project[slug]">
-		<small><?php _e( 'If you leave the slug empty, it will be derived from the name.', 'glotpress' ); ?></small>
+		<small><?php esc_html_e( 'If you leave the slug empty, it will be derived from the name.', 'glotpress' ); ?></small>
 	</dd>
 
-	<dt><label for="project[description]"><?php _e( 'Description', 'glotpress' ); ?></label> <span class="ternary"><?php _e( 'can include HTML', 'glotpress' ); ?></span></dt>
+	<dt><label for="project[description]"><?php esc_html_e( 'Description', 'glotpress' ); ?></label> <span class="ternary"><?php esc_html_e( 'can include HTML', 'glotpress' ); ?></span></dt>
 	<dd><textarea name="project[description]" rows="4" cols="40" id="project[description]"><?php echo esc_html( $project->description ); ?></textarea></dd>
 
-	<dt><label for="project[source_url_template]"><?php _e( 'Source file URL', 'glotpress' ); ?></label></dt>
+	<dt><label for="project[source_url_template]"><?php esc_html_e( 'Source file URL', 'glotpress' ); ?></label></dt>
 	<dd>
 		<input type="text" value="<?php echo esc_html( $project->source_url_template ); ?>" name="project[source_url_template]" id="project[source_url_template]" style="width: 30em;" />
 		<span class="ternary"><?php printf(
 			/* translators: 1: %file%, 2: %line%, 3: https://trac.example.org/browser/%file%#L%line% */
-			__( 'Public URL to a source file in the project. You can use %1$s and %2$s. Ex. %3$s', 'glotpress' ),
+			esc_html__( 'Public URL to a source file in the project. You can use %1$s and %2$s. Ex. %3$s', 'glotpress' ),
 			'<code>%file%</code>',
 			'<code>%line%</code>',
 			'<code>https://trac.example.org/browser/%file%#L%line%</code>'
 		); ?></span>
 	</dd>
 
-	<dt><label for="project[parent_project_id]"><?php _e( 'Parent Project (ID)', 'glotpress' ); ?></label></dt>
+	<dt><label for="project[parent_project_id]"><?php esc_html_e( 'Parent Project (ID)', 'glotpress' ); ?></label></dt>
 	<dd><input type="text" name="project[parent_project_id]" value="<?php echo esc_attr( $project->parent_project_id ); ?>" id="project[parent_project_id]">
 
-	<dt><label for="project[active]"><?php _e( 'Active', 'glotpress' ); ?></label> <input type="checkbox" id="project[active]" name="project[active]" <?php gp_checked( $project->active ); ?> /></dt>
+	<dt><label for="project[active]"><?php esc_html_e( 'Active', 'glotpress' ); ?></label> <input type="checkbox" id="project[active]" name="project[active]" <?php gp_checked( $project->active ); ?> /></dt>
 </dl>
 
 <?php echo gp_js_focus_on( 'project[name]' ); ?>

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/project-form.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/project-form.php
@@ -1,3 +1,11 @@
+<?php
+/**
+ * Template for the project edit form.
+ *
+ * @package GlotPress
+ */
+
+?>
 <dl>
 	<dt><label for="project[name]"><?php esc_html_e( 'Name', 'glotpress' ); ?></label></dt>
 	<dd><input type="text" name="project[name]" value="<?php echo esc_html( $project->name ); ?>" id="project[name]"></dd>

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/project-mass-create-sets.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/project-mass-create-sets.php
@@ -3,13 +3,16 @@ gp_title( sprintf( __( 'Mass-create Translation Sets &lt; %s &lt; GlotPress', 'g
 gp_breadcrumb_project( $project );
 gp_tmpl_header();
 ?>
-<h2><?php _e( 'Mass-create Translation Sets', 'glotpress' ); ?></h2>
-<p><?php _e( 'Here you can mass-create translation sets in this project.
+<h2><?php esc_html_e( 'Mass-create Translation Sets', 'glotpress' ); ?></h2>
+<p>
+<?php
+esc_html_e(
+	'Here you can mass-create translation sets in this project.
 The list of translation sets will be mirrored with the sets of a project you choose.
 Usually this is one of the parent projects.', 'glotpress' ); ?></p>
 <form action="<?php echo esc_url( gp_url_current() ); ?>" method="post">
 	<dl>
-		<dt><label for="project_id"><?php _e( 'Project to take translation sets from:', 'glotpress' );  ?></label></dt>
+		<dt><label for="project_id"><?php esc_html_e( 'Project to take translation sets from:', 'glotpress' ); ?></label></dt>
 		<dd><input type="text" name="project_id" value="" id="project_id">
 	</dl>
 	<div id="preview"></div>

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/projects-wp-plugins-contributors.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/projects-wp-plugins-contributors.php
@@ -99,7 +99,7 @@ gp_tmpl_header();
 				</div>',
 				$has_editors ? ' has-editors' : ' no-editors',
 				$locale->english_name,
-				sprintf( _n( '%s person', '%s persons', $data['count'] ), number_format_i18n( $data['count'] ) ),
+				sprintf( esc_html( _n( '%s person', '%s persons', $data['count'] ) ), number_format_i18n( $data['count'] ) ),
 				esc_url( gp_url_join( '/locale', $locale->slug, 'default', $project->path ) ),
 				$locale->wp_locale,
 				wp_sprintf( '%l', $editors_list ),

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/projects-wp-plugins-contributors.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/projects-wp-plugins-contributors.php
@@ -99,6 +99,7 @@ gp_tmpl_header();
 				</div>',
 				$has_editors ? ' has-editors' : ' no-editors',
 				$locale->english_name,
+				/* translators: %s: Number of people. */
 				sprintf( esc_html( _n( '%s person', '%s persons', $data['count'] ) ), number_format_i18n( $data['count'] ) ),
 				esc_url( gp_url_join( '/locale', $locale->slug, 'default', $project->path ) ),
 				$locale->wp_locale,

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/projects-wp-plugins-contributors.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/projects-wp-plugins-contributors.php
@@ -100,7 +100,7 @@ gp_tmpl_header();
 				$has_editors ? ' has-editors' : ' no-editors',
 				$locale->english_name,
 				/* translators: %s: Number of people. */
-				sprintf( esc_html( _n( '%s person', '%s persons', $data['count'] ) ), number_format_i18n( $data['count'] ) ),
+				sprintf( esc_html( _n( '%s person', '%s persons', $data['count'] ) ), esc_html( number_format_i18n( $data['count'] ) ) ),
 				esc_url( gp_url_join( '/locale', $locale->slug, 'default', $project->path ) ),
 				$locale->wp_locale,
 				wp_sprintf( '%l', $editors_list ),

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/projects-wp-themes-contributors.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/projects-wp-themes-contributors.php
@@ -99,6 +99,7 @@ gp_tmpl_header();
 				</div>',
 				$has_editors ? ' has-editors' : ' no-editors',
 				$locale->english_name,
+				/* translators: %s: Number of people. */
 				sprintf( esc_html( _n( '%s person', '%s persons', $data['count'] ) ), number_format_i18n( $data['count'] ) ),
 				$locale->wp_locale,
 				wp_sprintf( '%l', $editors_list ),

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/projects-wp-themes-contributors.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/projects-wp-themes-contributors.php
@@ -100,7 +100,7 @@ gp_tmpl_header();
 				$has_editors ? ' has-editors' : ' no-editors',
 				$locale->english_name,
 				/* translators: %s: Number of people. */
-				sprintf( esc_html( _n( '%s person', '%s persons', $data['count'] ) ), number_format_i18n( $data['count'] ) ),
+				sprintf( esc_html( _n( '%s person', '%s persons', $data['count'] ) ), esc_html( number_format_i18n( $data['count'] ) ) ),
 				$locale->wp_locale,
 				wp_sprintf( '%l', $editors_list ),
 				wp_sprintf( '%l', $contributor_list )

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/projects-wp-themes-contributors.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/projects-wp-themes-contributors.php
@@ -99,7 +99,7 @@ gp_tmpl_header();
 				</div>',
 				$has_editors ? ' has-editors' : ' no-editors',
 				$locale->english_name,
-				sprintf( _n( '%s person', '%s persons', $data['count'] ), number_format_i18n( $data['count'] ) ),
+				sprintf( esc_html( _n( '%s person', '%s persons', $data['count'] ) ), number_format_i18n( $data['count'] ) ),
 				$locale->wp_locale,
 				wp_sprintf( '%l', $editors_list ),
 				wp_sprintf( '%l', $contributor_list )

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/settings.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/settings.php
@@ -27,7 +27,7 @@ if ( ! is_array( $default_sort ) ) {
 	);
 }
 ?>
-<h2><?php _e( 'Your Settings', 'glotpress' ); ?></h2>
+<h2><?php esc_html_e( 'Your Settings', 'glotpress' ); ?></h2>
 <form action="" method="post">
 	<?php require_once __DIR__ . '/settings-edit.php'; ?>
 	<br>

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/stats-overview.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/stats-overview.php
@@ -18,7 +18,7 @@ gp_tmpl_header();
 	<table id="stats-table" class="table">
 		<thead>
 			<tr>
-				<th class="col-locale-code"><?php _e( 'Locale' ); ?></th>
+				<th class="col-locale-code"><?php esc_html_e( 'Locale' ); ?></th>
 				<?php foreach ( $projects as $slug => $project ) :
 					$name = str_replace( array( 'WordPress.org ', 'WordPress for ', 'WordPress ', 'ectory', ' - Development' ), '', $project->name );
 					if ( $slug == 'wp-plugins' || $slug == 'wp-themes' ) {

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/translation-row-editor.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/translation-row-editor.php
@@ -129,7 +129,7 @@ $more_links = apply_filters( 'gp_translation_row_template_more_links', $more_lin
 						if ( $translation->extracted_comments ) :
 							?>
 							<details open class="source-details__comment">
-								<summary><?php _e( 'Comment', 'glotpress' ); ?></summary>
+								<summary><?php esc_html_e( 'Comment', 'glotpress' ); ?></summary>
 								<p>
 									<?php
 									/**
@@ -271,26 +271,26 @@ $more_links = apply_filters( 'gp_translation_row_template_more_links', $more_lin
 							<div class="status-actions">
 								<?php if ( $can_approve_translation ) : ?>
 									<?php if ( 'current' !== $translation->translation_status ) : ?>
-										<button class="button  is-primary approve" tabindex="-1" data-nonce="<?php echo esc_attr( wp_create_nonce( 'update-translation-status-current_' . $translation->id ) ); ?>"><strong>+</strong> <?php _e( 'Approve', 'glotpress' ); ?></button>
+										<button class="button  is-primary approve" tabindex="-1" data-nonce="<?php echo esc_attr( wp_create_nonce( 'update-translation-status-current_' . $translation->id ) ); ?>"><strong>+</strong> <?php esc_html_e( 'Approve', 'glotpress' ); ?></button>
 									<?php endif; ?>
 									<?php if ( 'rejected' !== $translation->translation_status ) : ?>
-										<button class="button reject" tabindex="-1" data-nonce="<?php echo esc_attr( wp_create_nonce( 'update-translation-status-rejected_' . $translation->id ) ); ?>"><strong>&minus;</strong> <?php _e( 'Reject', 'glotpress' ); ?></button>
+										<button class="button reject" tabindex="-1" data-nonce="<?php echo esc_attr( wp_create_nonce( 'update-translation-status-rejected_' . $translation->id ) ); ?>"><strong>&minus;</strong> <?php esc_html_e( 'Reject', 'glotpress' ); ?></button>
 										<?php if ( apply_filters( 'gp_enable_changesrequested_status', false ) ) : // todo: delete when we merge the gp-translation-helpers in GlotPress ?>
-											<button class="button changesrequested" style="display: none;" data-nonce="<?php echo esc_attr( wp_create_nonce( 'update-translation-status-changesrequested_' . $translation->id ) ); ?>" title="<?php esc_attr_e( 'Request changes for this translation. The existing translation will be kept as part of the translation history.', 'glotpress' ); ?>"><strong>&minus;</strong> <?php _ex( 'Request changes', 'Action', 'glotpress' ); ?></button>
+											<button class="button changesrequested" style="display: none;" data-nonce="<?php echo esc_attr( wp_create_nonce( 'update-translation-status-changesrequested_' . $translation->id ) ); ?>" title="<?php esc_attr_e( 'Request changes for this translation. The existing translation will be kept as part of the translation history.', 'glotpress' ); ?>"><strong>&minus;</strong> <?php echo esc_html_x( 'Request changes', 'Action', 'glotpress' ); ?></button>
 										<?php endif; ?>
 									<?php endif; ?>
 									<?php if ( 'fuzzy' !== $translation->translation_status ) : ?>
-										<button class="button fuzzy" tabindex="-1" data-nonce="<?php echo esc_attr( wp_create_nonce( 'update-translation-status-fuzzy_' . $translation->id ) ); ?>"><strong>~</strong> <?php _e( 'Fuzzy', 'glotpress' ); ?></button>
+										<button class="button fuzzy" tabindex="-1" data-nonce="<?php echo esc_attr( wp_create_nonce( 'update-translation-status-fuzzy_' . $translation->id ) ); ?>"><strong>~</strong> <?php esc_html_e( 'Fuzzy', 'glotpress' ); ?></button>
 									<?php endif; ?>
 								<?php elseif ( $can_reject_self ) : ?>
-									<button class="button reject" tabindex="-1" data-nonce="<?php echo esc_attr( wp_create_nonce( 'update-translation-status-rejected_' . $translation->id ) ); ?>"><strong>&minus;</strong> <?php _e( 'Reject Suggestion', 'glotpress' ); ?></button>
-									<button class="button fuzzy" tabindex="-1" data-nonce="<?php echo esc_attr( wp_create_nonce( 'update-translation-status-fuzzy_' . $translation->id ) ); ?>"><strong>~</strong> <?php _e( 'Fuzzy', 'glotpress' ); ?></button>
+									<button class="button reject" tabindex="-1" data-nonce="<?php echo esc_attr( wp_create_nonce( 'update-translation-status-rejected_' . $translation->id ) ); ?>"><strong>&minus;</strong> <?php esc_html_e( 'Reject Suggestion', 'glotpress' ); ?></button>
+									<button class="button fuzzy" tabindex="-1" data-nonce="<?php echo esc_attr( wp_create_nonce( 'update-translation-status-fuzzy_' . $translation->id ) ); ?>"><strong>~</strong> <?php esc_html_e( 'Fuzzy', 'glotpress' ); ?></button>
 								<?php endif; ?>
 							</div>
 						<?php endif; ?>
 
 						<dl>
-							<dt><?php _e( 'Status:', 'glotpress' ); ?></dt>
+							<dt><?php esc_html_e( 'Status:', 'glotpress' ); ?></dt>
 							<dd>
 								<?php echo display_status( $translation->translation_status ); ?>
 							</dd>
@@ -298,19 +298,19 @@ $more_links = apply_filters( 'gp_translation_row_template_more_links', $more_lin
 
 						<?php if ( $translation->translation_added && $translation->translation_added !== '0000-00-00 00:00:00' ) : ?>
 							<dl>
-								<dt><?php _e( 'Added:', 'glotpress' ); ?></dt>
+								<dt><?php esc_html_e( 'Added:', 'glotpress' ); ?></dt>
 								<dd><?php echo $translation->translation_added; ?> UTC</dd>
 							</dl>
 						<?php endif; ?>
 						<?php if ( $translation->date_modified && $translation->date_modified !== '0000-00-00 00:00:00' && $translation->date_modified !== $translation->translation_added ) : ?>
 							<dl>
-								<dt><?php _e( 'Last modified:', 'glotpress' ); ?></dt>
+								<dt><?php esc_html_e( 'Last modified:', 'glotpress' ); ?></dt>
 								<dd><?php echo $translation->date_modified; ?> UTC</dd>
 							</dl>
 						<?php endif; ?>
 						<?php if ( $translation->user ) : ?>
 							<dl>
-								<dt><?php _e( 'Translated by:', 'glotpress' ); ?></dt>
+								<dt><?php esc_html_e( 'Translated by:', 'glotpress' ); ?></dt>
 								<dd><?php gp_link_user( $translation->user ); ?></dd>
 							</dl>
 						<?php endif; ?>
@@ -319,11 +319,11 @@ $more_links = apply_filters( 'gp_translation_row_template_more_links', $more_lin
 								<dt>
 								<?php
 								if ( 'current' === $translation->translation_status ) {
-									_e( 'Approved by:', 'glotpress' );
+									esc_html_e( 'Approved by:', 'glotpress' );
 								} elseif ( 'rejected' === $translation->translation_status ) {
-									_e( 'Rejected by:', 'glotpress' );
+									esc_html_e( 'Rejected by:', 'glotpress' );
 								} else {
-									_e( 'Last updated by:', 'glotpress' );
+									esc_html_e( 'Last updated by:', 'glotpress' );
 								}
 								?>
 								</dt>
@@ -332,7 +332,7 @@ $more_links = apply_filters( 'gp_translation_row_template_more_links', $more_lin
 						<?php endif; ?>
 
 						<dl>
-							<dt><?php _e( 'Priority of the original:', 'glotpress' ); ?></dt>
+							<dt><?php esc_html_e( 'Priority of the original:', 'glotpress' ); ?></dt>
 							<?php if ( $can_write ) : ?>
 								<dd>
 								<?php

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/translation-row-preview.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/translation-row-preview.php
@@ -132,7 +132,7 @@ $priority_char = array(
 		endif; ?>
 	</td>
 	<td class="actions">
-		<a href="#" class="action edit"><?php _e( 'Details', 'glotpress' ); ?></a>
+		<a href="#" class="action edit"><?php esc_html_e( 'Details', 'glotpress' ); ?></a>
 	</td>
 	<?php if ( wporg_translate_inline_actions_enabled_for_current_user( get_defined_vars() ) ) : ?>
 		<td class="inline-actions">

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/translation-set-form.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/translation-set-form.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Template for the translation set edit form.
+ * Shared translation set form fields, used by both the new and edit templates.
  *
  * @package GlotPress
  */

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/translation-set-form.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/translation-set-form.php
@@ -1,18 +1,18 @@
 <dl>
-	<dt><label for="set[locale]"><?php _e( 'Locale', 'glotpress' ); ?></label></dt>
+	<dt><label for="set[locale]"><?php esc_html_e( 'Locale', 'glotpress' ); ?></label></dt>
 	<dd>
 		<?php echo gp_locales_dropdown( 'set[locale]', $set->locale ); ?>
-		<a href="#" id="copy"><?php _e( 'Use as name', 'glotpress' ); ?></a>
+		<a href="#" id="copy"><?php esc_html_e( 'Use as name', 'glotpress' ); ?></a>
 	</dd>
 
-	<dt><label for="set[name]"><?php _e( 'Name', 'glotpress' ); ?></label></dt>
+	<dt><label for="set[name]"><?php esc_html_e( 'Name', 'glotpress' ); ?></label></dt>
 	<dd><input type="text" name="set[name]" value="<?php echo esc_html( $set->name ); ?>" id="set[name]"></dd>
 
 	<!-- TODO: make slug edit WordPress style -->
-	<dt><label for="set[slug]"><?php _e( 'Slug', 'glotpress' ); ?></label></dt>
+	<dt><label for="set[slug]"><?php esc_html_e( 'Slug', 'glotpress' ); ?></label></dt>
 	<dd><input type="text" name="set[slug]" value="<?php echo esc_html( $set->slug? $set->slug : 'default' ); ?>" id="set[slug]"></dd>
 
-	<dt><label for="set[project_id]"><?php _e( 'Project (ID)', 'glotpress' ); ?></label></dt>
+	<dt><label for="set[project_id]"><?php esc_html_e( 'Project (ID)', 'glotpress' ); ?></label></dt>
 	<dd><input type="text" name="set[project_id]" value="<?php echo esc_attr( $set->project_id ); ?>" id="set[project_id]">
 </dl>
 <?php echo gp_js_focus_on( 'set[locale]' ) . "\n"; ?>

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/translation-set-form.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/translation-set-form.php
@@ -1,3 +1,11 @@
+<?php
+/**
+ * Template for the translation set edit form.
+ *
+ * @package GlotPress
+ */
+
+?>
 <dl>
 	<dt><label for="set[locale]"><?php esc_html_e( 'Locale', 'glotpress' ); ?></label></dt>
 	<dd>

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-discussions/inc/class-plugin.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-discussions/inc/class-plugin.php
@@ -130,7 +130,7 @@ class Plugin {
 							</fieldset>
 
 							<label class="feedback">
-								<?php _e( 'Comment:', 'glotpress' ); ?>
+								<?php esc_html_e( 'Comment:', 'glotpress' ); ?>
 								<textarea placeholder="Let the contributor know what they did wrong…" name="comment" rows="4"></textarea>
 							</label>
 
@@ -158,7 +158,7 @@ class Plugin {
 					<div class="wporg-translate-modal__content">
 						<form action="POST">
 							<label class="feedback">
-								<?php _e( 'Comment:', 'glotpress' ); ?>
+								<?php esc_html_e( 'Comment:', 'glotpress' ); ?>
 								<textarea required placeholder="Type your question or feedback to this string…" name="comment" rows="4"></textarea>
 							</label>
 

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-rosetta-roles/inc/admin/class-translators.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-rosetta-roles/inc/admin/class-translators.php
@@ -74,7 +74,7 @@ class Translators {
 
 				if ( ! empty( $_REQUEST['s'] ) ) {
 					/* translators: %s: Search term. */
-					echo '<span class="subtitle">' . sprintf( esc_html__( 'Search results for &#8220;%s&#8221;', 'wporg-translate' ), esc_html( wp_unslash( $_REQUEST['s'] ) ) ) . '</span>';
+					echo '<span class="subtitle">' . sprintf( esc_html__( 'Search results for &#8220;%s&#8221;', 'wporg-translate' ), esc_html( wp_unslash( $_REQUEST['s'] ) ) ) . '</span>'; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Escaped for display.
 				}
 				?>
 			</h2>

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-rosetta-roles/inc/admin/class-translators.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-rosetta-roles/inc/admin/class-translators.php
@@ -70,10 +70,10 @@ class Translators {
 		<div class="wrap">
 			<h2>
 				<?php
-				_e( 'Translators', 'wporg-translate' );
+				esc_html_e( 'Translators', 'wporg-translate' );
 
 				if ( ! empty( $_REQUEST['s'] ) ) {
-					echo '<span class="subtitle">' . sprintf( __( 'Search results for &#8220;%s&#8221;', 'wporg-translate' ), esc_html( wp_unslash( $_REQUEST['s'] ) ) ) . '</span>';
+					echo '<span class="subtitle">' . sprintf( esc_html__( 'Search results for &#8220;%s&#8221;', 'wporg-translate' ), esc_html( wp_unslash( $_REQUEST['s'] ) ) ) . '</span>';
 				}
 				?>
 			</h2>

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-rosetta-roles/inc/admin/class-translators.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-rosetta-roles/inc/admin/class-translators.php
@@ -73,6 +73,7 @@ class Translators {
 				esc_html_e( 'Translators', 'wporg-translate' );
 
 				if ( ! empty( $_REQUEST['s'] ) ) {
+					/* translators: %s: Search term. */
 					echo '<span class="subtitle">' . sprintf( esc_html__( 'Search results for &#8220;%s&#8221;', 'wporg-translate' ), esc_html( wp_unslash( $_REQUEST['s'] ) ) ) . '</span>';
 				}
 				?>

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-rosetta-roles/inc/admin/list-table/class-translators.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-rosetta-roles/inc/admin/list-table/class-translators.php
@@ -97,7 +97,7 @@ class Translators extends WP_List_Table {
 	 * Output 'no users' message.
 	 */
 	public function no_items() {
-		_e( 'No translators were found.', 'wporg-translate' );
+		esc_html_e( 'No translators were found.', 'wporg-translate' );
 	}
 
 	/**
@@ -158,7 +158,7 @@ class Translators extends WP_List_Table {
 	public function column_cb( $user ) {
 		if ( $this->user_can_promote ) {
 			?>
-			<label class="screen-reader-text" for="cb-select-<?php echo $user->ID; ?>"><?php _e( 'Select translator', 'wporg-translate' ); ?></label>
+			<label class="screen-reader-text" for="cb-select-<?php echo $user->ID; ?>"><?php esc_html_e( 'Select translator', 'wporg-translate' ); ?></label>
 			<input id="cb-select-<?php echo $user->ID; ?>" type="checkbox" name="translators[]" value="<?php echo $user->ID; ?>">
 			<?php
 		}

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-rosetta-roles/inc/admin/list-table/class-translators.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-rosetta-roles/inc/admin/list-table/class-translators.php
@@ -158,7 +158,7 @@ class Translators extends WP_List_Table {
 	public function column_cb( $user ) {
 		if ( $this->user_can_promote ) {
 			?>
-			<label class="screen-reader-text" for="cb-select-<?php echo $user->ID; ?>"><?php esc_html_e( 'Select translator', 'wporg-translate' ); ?></label>
+			<label class="screen-reader-text" for="cb-select-<?php echo (int) $user->ID; ?>"><?php esc_html_e( 'Select translator', 'wporg-translate' ); ?></label>
 			<input id="cb-select-<?php echo $user->ID; ?>" type="checkbox" name="translators[]" value="<?php echo $user->ID; ?>">
 			<?php
 		}

--- a/wordpress.org/public_html/wp-content/plugins/wporg-meeting-posttype/wporg-meeting-posttype.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-meeting-posttype/wporg-meeting-posttype.php
@@ -258,71 +258,71 @@ class Meeting_Post_Type {
 
 		<p>
 		<label for="team">
-			<?php _e( 'Team: ', 'wporg' ); ?>
+			<?php esc_html_e( 'Team: ', 'wporg' ); ?>
 			<input type="text" id="team" name="team" class="regular-text wide" value="<?php echo esc_attr( $team ); ?>">
 		</label>
 		</p>
 		<p>
 		<label for="start_date">
-			<?php _e( 'Start Date', 'wporg' ); ?>
+			<?php esc_html_e( 'Start Date', 'wporg' ); ?>
 			<input type="text" name="start_date" id="start_date" class="date" value="<?php echo esc_attr( $start ); ?>">
 		</label>
 		<label for="end_date">
-			<?php _e( 'End Date', 'wporg' ); ?>
+			<?php esc_html_e( 'End Date', 'wporg' ); ?>
 			<input type="text" name="end_date" id="end_date" class="date" value="<?php echo esc_attr( $end ); ?>">
 		</label>
 		</p>
 		<p>
 		<label for="time">
-			<?php _e( 'Time (UTC)', 'wporg' ); ?>
+			<?php esc_html_e( 'Time (UTC)', 'wporg' ); ?>
 			<input type="text" name="time" id="time" class="time" value="<?php echo esc_attr( $time ); ?>">
 		</label>
 		</p>
 		<p class="recurring">
-		<?php _e( 'Recurring: ', 'wporg' ); ?><br />
+			<?php esc_html_e( 'Recurring: ', 'wporg' ); ?><br />
 		<label for="weekly">
 			<input type="radio" name="recurring" value="weekly" id="weekly" class="regular-radio" <?php checked( $recurring, 'weekly' ); ?>>
-			<?php _e( 'Weekly', 'wporg' ); ?>
+			<?php esc_html_e( 'Weekly', 'wporg' ); ?>
 		</label><br />
 
 		<label for="biweekly">
 			<input type="radio" name="recurring" value="biweekly" id="biweekly" class="regular-radio" <?php checked( $recurring, 'biweekly' ); ?>>
-			<?php _e( 'Biweekly', 'wporg' ); ?>
+			<?php esc_html_e( 'Biweekly', 'wporg' ); ?>
 		</label><br />
 
 		<label for="occurrence">
 			<input type="radio" name="recurring" value="occurrence" id="occurrence" class="regular-radio" <?php checked( $recurring, 'occurrence' ); ?>>
-			<?php _e( 'Occurrence in a month:', 'wporg' ); ?>
+			<?php esc_html_e( 'Occurrence in a month:', 'wporg' ); ?>
 		</label>
 		<label for="week-1">
 			<input type="checkbox" name="occurrence[]" value="1" id="week-1" <?php checked( in_array( 1, $occurrence ) ); ?>>
-			<?php _e( '1st', 'wporg' ); ?>
+			<?php esc_html_e( '1st', 'wporg' ); ?>
 		</label>
 		<label for="week-2">
 			<input type="checkbox" name="occurrence[]" value="2" id="week-2" <?php checked( in_array( 2, $occurrence ) ); ?>>
-			<?php _e( '2nd', 'wporg' ); ?>
+			<?php esc_html_e( '2nd', 'wporg' ); ?>
 		</label>
 		<label for="week-3">
 			<input type="checkbox" name="occurrence[]" value="3" id="week-3" <?php checked( in_array( 3, $occurrence ) ); ?>>
-			<?php _e( '3rd', 'wporg' ); ?>
+			<?php esc_html_e( '3rd', 'wporg' ); ?>
 		</label>
 		<label for="week-4">
 			<input type="checkbox" name="occurrence[]" value="4" id="week-4" <?php checked( in_array( 4, $occurrence ) ); ?>>
-			<?php _e( '4th', 'wporg' ); ?>
+			<?php esc_html_e( '4th', 'wporg' ); ?>
 		</label><br />
 
 		<label for="monthly">
 			<input type="radio" name="recurring" value="monthly" id="monthly" class="regular-radio" <?php checked( $recurring, 'monthly' ); ?>>
-			<?php _e( 'Monthly', 'wporg' ); ?>
+			<?php esc_html_e( 'Monthly', 'wporg' ); ?>
 		</label>
 		</p>
 		<p>
-		<label for="link"><?php _e( 'Link: ', 'wporg' ); ?>
+		<label for="link"><?php esc_html_e( 'Link: ', 'wporg' ); ?>
 			<input type="text" name="link" id="link" class="regular-text wide" value="<?php echo esc_url( $link ); ?>">
 		</label>
 		</p>
 		<p>
-		<label for="location"><?php _e( 'Location: ', 'wporg' ); ?>
+		<label for="location"><?php esc_html_e( 'Location: ', 'wporg' ); ?>
 			<input type="text" name="location" id="location" class="regular-text wide" value="<?php echo esc_attr( $location ); ?>">
 		</label>
 		</p>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/functions.php
@@ -388,7 +388,7 @@ function welcome_box() {
 	add_filter( 'o2_post_fragment', '__return_empty_array' );
 	?>
 	<div class="make-welcome">
-		<a href="#" id="secondary-toggle" onclick="return false;"><strong><?php _e( 'Menu' ); ?></strong></a>
+		<a href="#" id="secondary-toggle" onclick="return false;"><strong><?php esc_html_e( 'Menu' ); ?></strong></a>
 		<div class="entry-meta">
 			<?php edit_post_link( __( 'Edit', 'wporg' ), '', '', $welcome->ID, 'post-edit-link make-welcome-edit-post-link' ); ?>
 			<button
@@ -396,7 +396,7 @@ function welcome_box() {
 				id="make-welcome-toggle"
 				data-show="<?php esc_attr_e( 'Show welcome box', 'wporg' ); ?>"
 				data-hide="<?php esc_attr_e( 'Hide welcome box', 'wporg' ); ?>"
-			><span><?php _e( 'Hide welcome box', 'wporg' ); ?></span></button>
+			><span><?php esc_html_e( 'Hide welcome box', 'wporg' ); ?></span></button>
 		</div>
 		<div class="entry-content clear" id="make-welcome-content" data-cookie="<?php echo $cookie; ?>" data-hash="<?php echo $content_hash; ?>">
 			<script type="text/javascript">
@@ -439,7 +439,7 @@ add_action( 'wporg_breathe_after_header', __NAMESPACE__ . '\welcome_box' );
 function javascript_notice() {
 	?>
 	<noscript class="js-disabled-notice">
-		<?php _e( 'Please enable JavaScript to view this page properly.', 'wporg' ); ?>
+		<?php esc_html_e( 'Please enable JavaScript to view this page properly.', 'wporg' ); ?>
 	</noscript>
 	<?php
 }
@@ -726,7 +726,7 @@ function breathe_content_nav( $nav_id ) {
 
 	?>
 	<nav role="navigation" id="<?php echo esc_attr( $nav_id ); ?>" class="<?php echo $nav_class; ?>">
-		<h2 class="screen-reader-text"><?php _e( 'Post navigation', 'wporg' ); ?></h2>
+		<h2 class="screen-reader-text"><?php esc_html_e( 'Post navigation', 'wporg' ); ?></h2>
 
 	<?php if ( is_single() ) : // navigation links for single posts ?>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/search.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/search.php
@@ -21,8 +21,10 @@ get_header(); ?>
 			<header class="page-header">
 				<h1 class="page-title">
 					<?php if ( $is_handbook ) {
+						/* translators: %s: Search query. */
 						printf( esc_html__( 'Handbook Search Results for: %s', 'wporg' ), '<span>' . get_search_query() . '</span>' );
 					} else {
+						/* translators: %s: Search query. */
 						printf( esc_html__( 'Search Results for: %s', 'wporg' ), '<span>' . get_search_query() . '</span>' );
 					} ?>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/search.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/search.php
@@ -21,9 +21,9 @@ get_header(); ?>
 			<header class="page-header">
 				<h1 class="page-title">
 					<?php if ( $is_handbook ) {
-						printf( __( 'Handbook Search Results for: %s', 'wporg' ), '<span>' . get_search_query() . '</span>' );
+						printf( esc_html__( 'Handbook Search Results for: %s', 'wporg' ), '<span>' . get_search_query() . '</span>' );
 					} else {
-						printf( __( 'Search Results for: %s', 'wporg' ), '<span>' . get_search_query() . '</span>' );
+						printf( esc_html__( 'Search Results for: %s', 'wporg' ), '<span>' . get_search_query() . '</span>' );
 					} ?>
 
 					<span class="controls">

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/searchform.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/searchform.php
@@ -7,7 +7,7 @@
 ?>
 <?php $search_url = function_exists( 'wporg_is_handbook' ) && wporg_is_handbook() ? wporg_get_current_handbook_home_url() : home_url( '/' ); ?>
 <form method="get" id="searchform" class="searchform" action="<?php echo esc_url( $search_url ); ?>" role="search">
-	<label for="s" class="screen-reader-text"><?php _ex( 'Search', 'label', 'wporg' ); ?></label>
-	<input type="search" class="field" name="s" value="<?php echo get_search_query(); ?>" id="s" placeholder="<?php _ex( 'Search &hellip;', 'placeholder', 'wporg' ); ?>">
+	<label for="s" class="screen-reader-text"><?php echo esc_html_x( 'Search', 'label', 'wporg' ); ?></label>
+	<input type="search" class="field" name="s" value="<?php echo get_search_query(); ?>" id="s" placeholder="<?php echo esc_attr_x( 'Search &hellip;', 'placeholder', 'wporg' ); ?>">
 	<input type="submit" class="submit" id="searchsubmit" value="<?php echo esc_attr_x( 'Search', 'submit button', 'wporg' ); ?>">
 </form>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/single-handbook.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-breathe-2024/single-handbook.php
@@ -37,7 +37,7 @@ get_header(); ?>
 
 			printf(
 				/* translators: %s: Date of last update. */
-				'<p class="handbook-last-updated">' . __( 'Last updated: %s', 'wporg' ) . '</p>',
+				'<p class="handbook-last-updated">' . esc_html__( 'Last updated: %s', 'wporg' ) . '</p>',
 				sprintf(
 					'<time datetime="%s">%s</time>',
 					esc_attr( get_the_modified_date( DATE_W3C ) ),

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/backup-codes.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/backup-codes.php
@@ -39,9 +39,9 @@ get_header();
 
 <h2 class="center"><?php
 	if ( $used_backup_code ) {
-		_e( 'Backup Code used', 'wporg' );
+		esc_html_e( 'Backup Code used', 'wporg' );
 	} else {
-		_e( 'Account Backup Codes', 'wporg' );
+		esc_html_e( 'Account Backup Codes', 'wporg' );
 	}
 ?></h2>
 
@@ -49,18 +49,18 @@ get_header();
 
 <p><?php
 	if ( $used_backup_code ) {
-		_e( "You've logged in with a backup code.<br>These codes are intended to be used when you lose access to your authentication device.<br>Please take a moment to review your account settings and ensure your two-factor settings are up-to-date.", 'wporg' );
+		echo wp_kses_post( __( "You've logged in with a backup code.<br>These codes are intended to be used when you lose access to your authentication device.<br>Please take a moment to review your account settings and ensure your two-factor settings are up-to-date.", 'wporg' ) );
 	} else {
 		if ( ! $codes_available ) {
-			_e( 'You do not have any backup codes remaining.', 'wporg' );
+			esc_html_e( 'You do not have any backup codes remaining.', 'wporg' );
 		} else {
 			printf(
-				_n(
+				esc_html( _n(
 					'You have %s backup code remaining.',
 					'You have %s backup codes remaining.',
 					$codes_available,
 					'wporg'
-				),
+				) ),
 				'<code>' . number_format_i18n( $codes_available ) . '</code>'
 			);
 		}
@@ -73,16 +73,16 @@ get_header();
 <p>&nbsp;</p>
 
 <p><?php
-	_e( 'If you run out of backup codes and no longer have access to your authentication device, you are at risk of being locked out of your WordPress.org account if we are unable to verify account ownership.', 'wporg' );
+	esc_html_e( 'If you run out of backup codes and no longer have access to your authentication device, you are at risk of being locked out of your WordPress.org account if we are unable to verify account ownership.', 'wporg' );
 ?></p>
 
 <p>&nbsp;</p>
 
-<p><a href="<?php echo esc_url( $account_settings_url ); ?>"><button class="button-primary"><?php _e( 'View my account settings', 'wporg' ); ?></button></a></p>
+<p><a href="<?php echo esc_url( $account_settings_url ); ?>"><button class="button-primary"><?php esc_html_e( 'View my account settings', 'wporg' ); ?></button></a></p>
 
 <?php if ( $can_ignore ) { ?>
 	<p id="nav">
-		<a href="<?php echo esc_url( $redirect_to ); ?>" style="font-style: italic;"><?php _e( "I'll do this later", 'wporg' ); ?></a>
+		<a href="<?php echo esc_url( $redirect_to ); ?>" style="font-style: italic;"><?php esc_html_e( "I'll do this later", 'wporg' ); ?></a>
 	</p>
 <?php } ?>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/backup-codes.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/backup-codes.php
@@ -55,12 +55,15 @@ get_header();
 			esc_html_e( 'You do not have any backup codes remaining.', 'wporg' );
 		} else {
 			printf(
-				esc_html( _n(
-					'You have %s backup code remaining.',
-					'You have %s backup codes remaining.',
-					$codes_available,
-					'wporg'
-				) ),
+				esc_html(
+					/* translators: %s: Number of backup codes. */
+					_n(
+						'You have %s backup code remaining.',
+						'You have %s backup codes remaining.',
+						$codes_available,
+						'wporg'
+					)
+				),
 				'<code>' . number_format_i18n( $codes_available ) . '</code>'
 			);
 		}

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/backup-codes.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/backup-codes.php
@@ -49,7 +49,7 @@ get_header();
 
 <p><?php
 	if ( $used_backup_code ) {
-		echo wp_kses_post( __( "You've logged in with a backup code.<br>These codes are intended to be used when you lose access to your authentication device.<br>Please take a moment to review your account settings and ensure your two-factor settings are up-to-date.", 'wporg' ) );
+		echo wp_kses_post( __( 'You&#8217;ve logged in with a backup code.<br>These codes are intended to be used when you lose access to your authentication device.<br>Please take a moment to review your account settings and ensure your two-factor settings are up-to-date.', 'wporg' ) );
 	} else {
 		if ( ! $codes_available ) {
 			esc_html_e( 'You do not have any backup codes remaining.', 'wporg' );
@@ -85,7 +85,7 @@ get_header();
 
 <?php if ( $can_ignore ) { ?>
 	<p id="nav">
-		<a href="<?php echo esc_url( $redirect_to ); ?>" style="font-style: italic;"><?php esc_html_e( "I'll do this later", 'wporg' ); ?></a>
+		<a href="<?php echo esc_url( $redirect_to ); ?>" style="font-style: italic;"><?php esc_html_e( 'I&#8217;ll do this later', 'wporg' ); ?></a>
 	</p>
 <?php } ?>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/checkemail.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/checkemail.php
@@ -8,11 +8,11 @@
 get_header();
 ?>
 
-<p class="center singleline"><?php _e( 'Check your email for a confirmation link.', 'wporg' ); ?></p>
+<p class="center singleline"><?php esc_html_e( 'Check your email for a confirmation link.', 'wporg' ); ?></p>
 
 <p id="nav">
-	<a href="/"><?php _e( '&larr; Back to login', 'wporg' ); ?></a> &nbsp; • &nbsp;
-	<a href="<?php echo wporg_login_wordpress_url(); ?>"><?php _e( 'WordPress.org', 'wporg' ); ?></a>
+	<a href="/"><?php esc_html_e( '&larr; Back to login', 'wporg' ); ?></a> &nbsp; • &nbsp;
+	<a href="<?php echo wporg_login_wordpress_url(); ?>"><?php esc_html_e( 'WordPress.org', 'wporg' ); ?></a>
 </p>
 
 <?php get_footer(); ?>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/enable-2fa.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/enable-2fa.php
@@ -44,6 +44,7 @@ get_header();
 
 <p>&nbsp;</p>
 
+<?php /* translators: %s: Documentation URL. */ ?>
 <p><?php printf( wp_kses_post( __( 'For more information on our two-factor options, please read the <a href="%s" target="_blank">documentation</a>.', 'wporg' ) ), 'https://make.wordpress.org/meta/handbook/tutorials-guides/configuring-two-factor-authentication/' ); ?></p>
 
 <p>&nbsp;</p>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/enable-2fa.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/enable-2fa.php
@@ -30,29 +30,29 @@ update_user_meta( $user->ID, 'last_2fa_nag', time() );
 get_header();
 ?>
 
-<h2 class="center"><?php _e( 'Two-Factor Authentication', 'wporg' ); ?></h2>
+<h2 class="center"><?php esc_html_e( 'Two-Factor Authentication', 'wporg' ); ?></h2>
 
 <p>&nbsp;</p>
 
 <p><?php
 	if ( $requires_2fa ) {
-		_e( 'WordPress.org now requires that your account be protected by two-factor authentication. Some capabilities may be limited until your account is protected.', 'wporg' );
+		esc_html_e( 'WordPress.org now requires that your account be protected by two-factor authentication. Some capabilities may be limited until your account is protected.', 'wporg' );
 	} else {
-		_e( "WordPress.org supports two-factor authentication and you'll soon be required to configure it on your account.", 'wporg' );
+		esc_html_e( "WordPress.org supports two-factor authentication and you'll soon be required to configure it on your account.", 'wporg' );
 	}
 ?></p>
 
 <p>&nbsp;</p>
 
-<p><?php printf( __( 'For more information on our two-factor options, please read the <a href="%s" target="_blank">documentation</a>.', 'wporg' ), 'https://make.wordpress.org/meta/handbook/tutorials-guides/configuring-two-factor-authentication/' ); ?></p>
+<p><?php printf( wp_kses_post( __( 'For more information on our two-factor options, please read the <a href="%s" target="_blank">documentation</a>.', 'wporg' ) ), 'https://make.wordpress.org/meta/handbook/tutorials-guides/configuring-two-factor-authentication/' ); ?></p>
 
 <p>&nbsp;</p>
 
-<p><a href="<?php echo esc_url( add_query_arg( 'redirect_to', urlencode( $redirect_to ), get_onboarding_account_url() ) ); ?>"><button class="button-primary"><?php _e( "OK, I'll setup Two-Factor now.", 'wporg' ); ?></button></a></p>
+<p><a href="<?php echo esc_url( add_query_arg( 'redirect_to', urlencode( $redirect_to ), get_onboarding_account_url() ) ); ?>"><button class="button-primary"><?php esc_html_e( "OK, I'll setup Two-Factor now.", 'wporg' ); ?></button></a></p>
 
 <?php if ( ! $requires_2fa ) { ?>
 <p id="nav">
-	<a href="<?php echo esc_url( $redirect_to ); ?>" style="font-style: italic;"><?php _e( "I'll do it later", 'wporg' ); ?></a>
+	<a href="<?php echo esc_url( $redirect_to ); ?>" style="font-style: italic;"><?php esc_html_e( "I'll do it later", 'wporg' ); ?></a>
 </p>
 <?php } ?>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/enable-2fa.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/enable-2fa.php
@@ -38,7 +38,7 @@ get_header();
 	if ( $requires_2fa ) {
 		esc_html_e( 'WordPress.org now requires that your account be protected by two-factor authentication. Some capabilities may be limited until your account is protected.', 'wporg' );
 	} else {
-		esc_html_e( "WordPress.org supports two-factor authentication and you'll soon be required to configure it on your account.", 'wporg' );
+		esc_html_e( 'WordPress.org supports two-factor authentication and you&#8217;ll soon be required to configure it on your account.', 'wporg' );
 	}
 ?></p>
 
@@ -49,11 +49,11 @@ get_header();
 
 <p>&nbsp;</p>
 
-<p><a href="<?php echo esc_url( add_query_arg( 'redirect_to', urlencode( $redirect_to ), get_onboarding_account_url() ) ); ?>"><button class="button-primary"><?php esc_html_e( "OK, I'll setup Two-Factor now.", 'wporg' ); ?></button></a></p>
+<p><a href="<?php echo esc_url( add_query_arg( 'redirect_to', urlencode( $redirect_to ), get_onboarding_account_url() ) ); ?>"><button class="button-primary"><?php esc_html_e( 'OK, I&#8217;ll setup Two-Factor now.', 'wporg' ); ?></button></a></p>
 
 <?php if ( ! $requires_2fa ) { ?>
 <p id="nav">
-	<a href="<?php echo esc_url( $redirect_to ); ?>" style="font-style: italic;"><?php esc_html_e( "I'll do it later", 'wporg' ); ?></a>
+	<a href="<?php echo esc_url( $redirect_to ); ?>" style="font-style: italic;"><?php esc_html_e( 'I&#8217;ll do it later', 'wporg' ); ?></a>
 </p>
 <?php } ?>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/functions-registration.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/functions-registration.php
@@ -68,7 +68,7 @@ function wporg_login_create_pending_user( $user_login, $user_email, $meta = arra
 		if ( is_wp_error( $pre_register_error ) ) {
 			wp_die( $pre_register_error );
 		}
-		wp_die( __( 'Registration Blocked. Please stop.', 'wporg' ) );
+		wp_die( esc_html__( 'Registration Blocked. Please stop.', 'wporg' ) );
 	}
 
 	$profile_key        = wp_generate_password( 24, false, false );
@@ -160,7 +160,7 @@ function wporg_login_create_pending_user( $user_login, $user_email, $meta = arra
 
 	$inserted = wporg_update_pending_user( $pending_user );
 	if ( ! $inserted ) {
-		wp_die( __( 'Error! Something went wrong with your registration. Try again?', 'wporg' ) );
+		wp_die( esc_html__( 'Error! Something went wrong with your registration. Try again?', 'wporg' ) );
 	}
 
 	wporg_login_send_confirmation_email( $user_email );
@@ -372,7 +372,7 @@ function wporg_login_create_user_from_pending( $pending_user, $password = false 
 		wp_slash( $user_email )
 	);
 	if ( ! $user_id ) {
-		wp_die( __( 'Error! Something went wrong with your registration. Try again?', 'wporg' ) );
+		wp_die( esc_html__( 'Error! Something went wrong with your registration. Try again?', 'wporg' ) );
 	}
 
 	// Update the registration date to the earlier one.

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/functions.php
@@ -330,7 +330,7 @@ function wporg_login_language_switcher( $display = true ) {
 			<?php endif; ?>
 			<label for="language-switcher-locales">
 				<span aria-hidden="true" class="dashicons dashicons-translation"></span>
-				<span class="screen-reader-text"><?php _e( 'Select the language:', 'wporg' ); ?></span>
+				<span class="screen-reader-text"><?php esc_html_e( 'Select the language:', 'wporg' ); ?></span>
 			</label>
 			<select id="language-switcher-locales" name="locale">
 				<?php

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/linkexpired.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/linkexpired.php
@@ -11,55 +11,55 @@ $user   = WP_WPOrg_SSO::$matched_route_params['user'] ?? false;
 get_header();
 ?>
 
-<h2 class="center"><?php _e( 'Link Expired', 'wporg' ); ?></h2>
+<h2 class="center"><?php esc_html_e( 'Link Expired', 'wporg' ); ?></h2>
 
 <?php
 if ( 'register' == $reason && $user ) {
-	echo '<p class="center">' . __( "The link you've followed has expired.", 'wporg' ) . '</p>';
+	echo '<p class="center">' . esc_html__( "The link you've followed has expired.", 'wporg' ) . '</p>';
 
 	echo '<p class="center"><a href="' . esc_url( home_url( '/register/' . urlencode( $user ) ) ) . '">' .
 		sprintf(
 			/* translators: %s: An account name. */
-			__( 'Start over, and register %s.', 'wporg' ),
+			esc_html__( 'Start over, and register %s.', 'wporg' ),
 			'<code>' . esc_html( $user ) . '</code>'
 		) .
 		'</a></p>';
 } elseif ( 'lostpassword' == $reason && $user ) {
-	echo '<p class="center">' . __( "The link you've followed has expired.", 'wporg' ) . '</p>';
+	echo '<p class="center">' . esc_html__( "The link you've followed has expired.", 'wporg' ) . '</p>';
 	echo '<p class="center"><a href="' . esc_url( home_url( '/lostpassword/'  . urlencode( $user ) ) ) . '">' .
-			__( 'Reset your password.', 'wporg' ) .
+			esc_html__( 'Reset your password.', 'wporg' ) .
 			'</a></p>';
 } elseif ( 'account-created' === $reason ) {
-	echo '<p class="center">' . __( "That account has already been created.", 'wporg' ) . '</p>';
+	echo '<p class="center">' . esc_html__( 'That account has already been created.', 'wporg' ) . '</p>';
 
-	echo '<p class="center"><a href="' . esc_url( add_query_arg( 'user', $user, home_url() ) ) . '">' . __( 'Please log in to continue.', 'wporg' ) . '</a></p>';
+	echo '<p class="center"><a href="' . esc_url( add_query_arg( 'user', $user, home_url() ) ) . '">' . esc_html__( 'Please log in to continue.', 'wporg' ) . '</a></p>';
 
 	echo '<p class="center"><a href="' . esc_url( home_url( '/lostpassword/'  . urlencode( $user ) ) ) . '">' .
-		__( 'Reset your password.', 'wporg' ) .
+		esc_html__( 'Reset your password.', 'wporg' ) .
 		'</a></p>';
 
 } elseif ( 'register-logged-in' === $reason ) {
 	echo '<p class="center">' . sprintf(
-		__( 'Please do not make multiple WordPress.org accounts. Please read the <a href="%s">Forum Guidelines</a> for more information.', 'wporg' ),
+		wp_kses_post( __( 'Please do not make multiple WordPress.org accounts. Please read the <a href="%s">Forum Guidelines</a> for more information.', 'wporg' ) ),
 		'https://wordpress.org/support/guidelines/#do-not-create-multiple-accounts-sockpuppets'
 	) . '</p>';
 
-	echo '<p class="center">' . __( 'Please log out, and follow the link again to complete the registration.', 'wporg' ) . '</p>';
+	echo '<p class="center">' . esc_html__( 'Please log out, and follow the link again to complete the registration.', 'wporg' ) . '</p>';
 
 	echo '<p class="center">' . sprintf(
 		/* translators: %s: logout URL */
-		__( 'Do you really want to <a href="%s">log out</a>?', 'wporg' ),
+		wp_kses_post( __( 'Do you really want to <a href="%s">log out</a>?', 'wporg' ) ),
 		esc_url( wp_logout_url() )
 	) . '</p>';
 
 } else {
-	echo '<p class="center">' . __( "The link you've followed has expired.", 'wporg' ) . '</p>';
+	echo '<p class="center">' . esc_html__( "The link you've followed has expired.", 'wporg' ) . '</p>';
 }
 ?>
 
 <p id="nav">
-	<a href="/"><?php _e( '&larr; Back to login', 'wporg' ); ?></a>  &nbsp; • &nbsp;
-	<a href="<?php echo wporg_login_wordpress_url(); ?>"><?php _e( 'WordPress.org', 'wporg' ); ?></a>
+	<a href="/"><?php esc_html_e( '&larr; Back to login', 'wporg' ); ?></a>  &nbsp; • &nbsp;
+	<a href="<?php echo wporg_login_wordpress_url(); ?>"><?php esc_html_e( 'WordPress.org', 'wporg' ); ?></a>
 </p>
 
 <?php get_footer(); ?>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/linkexpired.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/linkexpired.php
@@ -15,7 +15,7 @@ get_header();
 
 <?php
 if ( 'register' == $reason && $user ) {
-	echo '<p class="center">' . esc_html__( "The link you've followed has expired.", 'wporg' ) . '</p>';
+	echo '<p class="center">' . esc_html__( 'The link you&#8217;ve followed has expired.', 'wporg' ) . '</p>';
 
 	echo '<p class="center"><a href="' . esc_url( home_url( '/register/' . urlencode( $user ) ) ) . '">' .
 		sprintf(
@@ -25,7 +25,7 @@ if ( 'register' == $reason && $user ) {
 		) .
 		'</a></p>';
 } elseif ( 'lostpassword' == $reason && $user ) {
-	echo '<p class="center">' . esc_html__( "The link you've followed has expired.", 'wporg' ) . '</p>';
+	echo '<p class="center">' . esc_html__( 'The link you&#8217;ve followed has expired.', 'wporg' ) . '</p>';
 	echo '<p class="center"><a href="' . esc_url( home_url( '/lostpassword/'  . urlencode( $user ) ) ) . '">' .
 			esc_html__( 'Reset your password.', 'wporg' ) .
 			'</a></p>';
@@ -54,7 +54,7 @@ if ( 'register' == $reason && $user ) {
 	) . '</p>';
 
 } else {
-	echo '<p class="center">' . esc_html__( "The link you've followed has expired.", 'wporg' ) . '</p>';
+	echo '<p class="center">' . esc_html__( 'The link you&#8217;ve followed has expired.', 'wporg' ) . '</p>';
 }
 ?>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/linkexpired.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/linkexpired.php
@@ -40,6 +40,7 @@ if ( 'register' == $reason && $user ) {
 
 } elseif ( 'register-logged-in' === $reason ) {
 	echo '<p class="center">' . sprintf(
+		/* translators: %s: Forum guidelines URL. */
 		wp_kses_post( __( 'Please do not make multiple WordPress.org accounts. Please read the <a href="%s">Forum Guidelines</a> for more information.', 'wporg' ) ),
 		'https://wordpress.org/support/guidelines/#do-not-create-multiple-accounts-sockpuppets'
 	) . '</p>';

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/loggedout.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/loggedout.php
@@ -8,7 +8,7 @@
 get_header();
 ?>
 
-<p class="center"><?php _e( 'You are now logged out.', 'wporg' ); ?></p>
+<p class="center"><?php esc_html_e( 'You are now logged out.', 'wporg' ); ?></p>
 
 <?php
 	$redirect_to = wp_unslash( $_REQUEST['redirect_to'] ?? '' );
@@ -22,7 +22,7 @@ get_header();
 		echo '<p class="center">';
 		printf(
 			/* translators: 1: url, 2: Hostname, ie. wordcamp.org */
-			__( 'Return to <a href="%1$s">%2$s</a>.', 'wporg' ),
+			wp_kses_post( __( 'Return to <a href="%1$s">%2$s</a>.', 'wporg' ) ),
 			esc_url( $redirect_to ),
 			esc_html( $hostname )
 		);
@@ -31,8 +31,8 @@ get_header();
 ?>
 
 <p id="nav">
-	<a href="/"><?php _e( '&larr; Back to login', 'wporg' ); ?></a> &nbsp; • &nbsp;
-	<a href="<?php echo wporg_login_wordpress_url(); ?>"><?php _e( 'WordPress.org', 'wporg' ); ?></a>
+	<a href="/"><?php esc_html_e( '&larr; Back to login', 'wporg' ); ?></a> &nbsp; • &nbsp;
+	<a href="<?php echo wporg_login_wordpress_url(); ?>"><?php esc_html_e( 'WordPress.org', 'wporg' ); ?></a>
 </p>
 
 <?php get_footer(); ?>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/login.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/login.php
@@ -26,11 +26,11 @@ if ( ! empty( $_REQUEST['redirect_to'] ) && is_string( $_REQUEST['redirect_to'] 
 <form name="loginform" id="loginform" action="<?php echo esc_url( site_url( 'wp-login.php', 'login_post' ) ); ?>" method="post">
 	<p class="intro"><?php echo wporg_login_wporg_is_starpress(); ?></p>
 	<p class="login-username">
-		<label for="user_login"><?php _e( 'Username or Email Address', 'wporg' ); ?></label>
+		<label for="user_login"><?php esc_html_e( 'Username or Email Address', 'wporg' ); ?></label>
 		<input type="text" name="log" id="user_login" class="input" value="<?php echo esc_attr( $username ); ?>" size="20" />
 	</p>
 	<p class="login-password">
-		<label for="user_pass"><?php _e( 'Password', 'wporg' ); ?></label>
+		<label for="user_pass"><?php esc_html_e( 'Password', 'wporg' ); ?></label>
 		<span class="wp-pwd" style="display:block;">
 			<input type="password" name="pwd" id="user_pass" class="input password-input" value="" size="20" />
 			<button type="button" id="wp-hide-pw" class="button button-secondary wp-hide-pw hide-if-no-js" aria-label="<?php esc_attr_e( 'Show password', 'wporg' ); ?>">
@@ -39,7 +39,7 @@ if ( ! empty( $_REQUEST['redirect_to'] ) && is_string( $_REQUEST['redirect_to'] 
 		</span>
 	</p>
 	<?php do_action( 'login_form' ); ?>
-	<p class="login-remember"><label><input name="rememberme" type="checkbox" id="rememberme" value="forever" /> <?php _e( 'Remember me', 'wporg' ); ?></label></p>
+	<p class="login-remember"><label><input name="rememberme" type="checkbox" id="rememberme" value="forever" /> <?php esc_html_e( 'Remember me', 'wporg' ); ?></label></p>
 	<p class="login-submit">
 		<input type="submit" name="wp-submit" id="wp-submit" class="button button-primary" value="<?php esc_attr_e( 'Log In', 'wporg' ); ?>" />
 		<input type="hidden" name="redirect_to" value="<?php echo esc_url( $redirect ); ?>" />
@@ -47,8 +47,8 @@ if ( ! empty( $_REQUEST['redirect_to'] ) && is_string( $_REQUEST['redirect_to'] 
 </form>
 
 <p id="nav">
-	<a href="<?php echo esc_url( wp_lostpassword_url() ); ?>" title="<?php _e( 'Lost your password?', 'wporg' ); ?>"><?php _e( 'Lost your password?', 'wporg' ); ?></a> &nbsp; • &nbsp;
-	<a href="<?php echo esc_url( wp_registration_url() ); ?>" title="<?php _e( 'Create an account', 'wporg' ); ?>"><?php _e( 'Create an account', 'wporg' ); ?></a>
+	<a href="<?php echo esc_url( wp_lostpassword_url() ); ?>" title="<?php esc_attr_e( 'Lost your password?', 'wporg' ); ?>"><?php esc_html_e( 'Lost your password?', 'wporg' ); ?></a> &nbsp; • &nbsp;
+	<a href="<?php echo esc_url( wp_registration_url() ); ?>" title="<?php esc_attr_e( 'Create an account', 'wporg' ); ?>"><?php esc_html_e( 'Create an account', 'wporg' ); ?></a>
 </p>
 
 <script type="text/javascript">

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/logout.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/logout.php
@@ -15,13 +15,13 @@ if ( ! is_user_logged_in() ) {
 
 get_header();
 ?>
-<p class="intro"><?php _e( 'You are attempting to log out of WordPress.org.', 'wporg' ); ?></p>
+<p class="intro"><?php esc_html_e( 'You are attempting to log out of WordPress.org.', 'wporg' ); ?></p>
 
 <?php
 
 printf(
 	/* translators: %s: logout URL */
-	__( 'Do you really want to <a href="%s">log out</a>?', 'wporg' ),
+	wp_kses_post( __( 'Do you really want to <a href="%s">log out</a>?', 'wporg' ) ),
 	esc_url( wp_logout_url( $redirect_to ) )
 );
 ?>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/lostpassword.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/lostpassword.php
@@ -11,9 +11,9 @@ get_header();
 ?>
 
 <form name="lostpasswordform" id="lostpasswordform" action="/wp-login.php?action=lostpassword" method="post">
-	<p class="intro"><?php _e( 'Please enter your username or email address. You will receive a link to create a new password via email.', 'wporg' ); ?></p>
+	<p class="intro"><?php esc_html_e( 'Please enter your username or email address. You will receive a link to create a new password via email.', 'wporg' ); ?></p>
 	<p>
-		<label for="user_login"><?php _e( 'Username or Email', 'wporg' ); ?>
+		<label for="user_login"><?php esc_html_e( 'Username or Email', 'wporg' ); ?>
 		<input type="text" name="user_login" id="user_login" value="<?php echo esc_attr( $user ); ?>" size="20"></label>
 	</p>
 	<?php do_action( 'lostpassword_form' ); ?>
@@ -23,7 +23,7 @@ get_header();
 	</p>
 </form>
 <p id="nav">
-	<a href="/"><?php _e( '&larr; Back to login', 'wporg' ); ?></a>
+	<a href="/"><?php esc_html_e( '&larr; Back to login', 'wporg' ); ?></a>
 </p>
 
 <?php get_footer(); ?>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/partials/register-profilefields.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/partials/register-profilefields.php
@@ -20,23 +20,23 @@ if ( empty( $fields ) ) {
 
 ?>
 <p class="login-website">
-	<label for="user_website"><?php _e( 'Website', 'wporg' ); ?></label>
+	<label for="user_website"><?php esc_html_e( 'Website', 'wporg' ); ?></label>
 	<input type="text" name="user_fields[url]" id="user_url" class="input" value="<?php echo esc_attr( $fields['url'] ?? '' ); ?>" size="20" placeholder="https://" data-pattern-after-blur="(https?:\/\/)?([a-zA-Z0-9\-]+\.\S+)?" />
-	<span class="invalid-message"><?php _e( 'That URL appears to be invalid.', 'wporg' ); ?></span>
+	<span class="invalid-message"><?php esc_html_e( 'That URL appears to be invalid.', 'wporg' ); ?></span>
 </p>
 
 <p class="login-location">
-	<label for="user_location"><?php _e( 'Location', 'wporg' ); ?></label>
+	<label for="user_location"><?php esc_html_e( 'Location', 'wporg' ); ?></label>
 	<input type="text" name="user_fields[from]" id="user_location" class="input" value="<?php echo esc_attr( $fields['from'] ?? '' ); ?>" size="20" />
 </p>
 
 <p class="login-occupation">
-	<label for="user_occupation"><?php _e( 'Occupation', 'wporg' ); ?></label>
+	<label for="user_occupation"><?php esc_html_e( 'Occupation', 'wporg' ); ?></label>
 	<input type="text" name="user_fields[occ]" id="user_occupation" class="input" value="<?php echo esc_attr( $fields['occ'] ?? '' ); ?>" size="20" />
 </p>
 
 <p class="login-interests">
-	<label for="user_interests"><?php _e( 'Interests', 'wporg' ); ?></label>
+	<label for="user_interests"><?php esc_html_e( 'Interests', 'wporg' ); ?></label>
 	<input type="text" name="user_fields[interests]" id="user_interests" class="input" value="<?php echo esc_attr( $fields['interests'] ?? '' ); ?>" size="20" />
 </p>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/pending-create.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/pending-create.php
@@ -153,6 +153,7 @@ get_header();
 			printf(
 				/* translators: %s Email address */
 				esc_html__( 'Your account is pending approval. You will receive an email at %s to set your password when approved.', 'wporg' ) . '<br>' .
+				/* translators: %s: Support email address. */
 				esc_html__( 'Please contact %s for more details.', 'wporg' ),
 				'<code>' . esc_html( $pending_user['user_email'] ) . '</code>',
 				'<a href="mailto:' . $sso::SUPPORT_EMAIL . '">' . $sso::SUPPORT_EMAIL . '</a>'

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/pending-create.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/pending-create.php
@@ -152,8 +152,8 @@ get_header();
 		<p><?php
 			printf(
 				/* translators: %s Email address */
-				__( 'Your account is pending approval. You will receive an email at %s to set your password when approved.', 'wporg' ) . '<br>' .
-				__( 'Please contact %s for more details.', 'wporg' ),
+				esc_html__( 'Your account is pending approval. You will receive an email at %s to set your password when approved.', 'wporg' ) . '<br>' .
+				esc_html__( 'Please contact %s for more details.', 'wporg' ),
 				'<code>' . esc_html( $pending_user['user_email'] ) . '</code>',
 				'<a href="mailto:' . $sso::SUPPORT_EMAIL . '">' . $sso::SUPPORT_EMAIL . '</a>'
 			);
@@ -162,17 +162,17 @@ get_header();
 	<?php } ?>
 
 	<p class="intro">
-		<?php _e( 'Set your password and complete your WordPress.org Profile information.', 'wporg' ); ?>
+		<?php esc_html_e( 'Set your password and complete your WordPress.org Profile information.', 'wporg' ); ?>
 	</p>
 
 	<p class="login-login">
-		<label for="user_login"><?php _e( 'Username', 'wporg' ); ?></label>
+		<label for="user_login"><?php esc_html_e( 'Username', 'wporg' ); ?></label>
 		<input type="text" disabled="disabled" class="disabled" value="<?php echo esc_attr( $activation_user ); ?>" size="20" />
 	</p>
 
 	<div class="user-pass1-wrap" <?php echo ( $pending_user['cleared'] ? '' : "style='display:none;'" ); ?>>
 		<p>
-			<label for="pass1"><?php _e( 'Password', 'wporg' ); ?></label>
+			<label for="pass1"><?php esc_html_e( 'Password', 'wporg' ); ?></label>
 		</p>
 
 		<div class="wp-pwd">
@@ -183,7 +183,7 @@ get_header();
 			<button type="button" class="button button-secondary wp-hide-pw hide-if-no-js" aria-label="<?php esc_attr_e( 'Hide password', 'wporg' ); ?>">
 				<span class="dashicons dashicons-hidden" aria-hidden="true"></span>
 			</button>
-			<div id="pass-strength-result" class="hide-if-no-js" aria-live="polite"><?php _e( 'Strength indicator', 'wporg' ); ?></div>
+			<div id="pass-strength-result" class="hide-if-no-js" aria-live="polite"><?php esc_html_e( 'Strength indicator', 'wporg' ); ?></div>
 		</div>
 	</div>
 
@@ -194,7 +194,7 @@ get_header();
 
 	<?php
 		if ( $error_recapcha_status ) {
-			echo '<div class="message error"><p>' . __( 'Please try again.', 'wporg' ) . '</p></div>';
+			echo '<div class="message error"><p>' . esc_html__( 'Please try again.', 'wporg' ) . '</p></div>';
 		}
 	?>
 
@@ -205,7 +205,7 @@ get_header();
 </form>
 
 <p id="nav">
-	<a href="<?php echo wporg_login_wordpress_url(); ?>"><?php _e( 'WordPress.org', 'wporg' ); ?></a>
+	<a href="<?php echo wporg_login_wordpress_url(); ?>"><?php esc_html_e( 'WordPress.org', 'wporg' ); ?></a>
 </p>
 
 <?php get_footer();

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/pending-profile.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/pending-profile.php
@@ -79,6 +79,7 @@ get_header();
 			'<h2>' . esc_html__( 'Your account is pending approval', 'wporg' ) . '</h2>' .
 			/* translators: %s Email address */
 			'<p>' . esc_html__( 'You will receive an email at %s to set your password when approved.', 'wporg' ) . '</p>' .
+			/* translators: %s: Support email address. */
 			'<p>' . esc_html__( 'Please contact %s for more details.', 'wporg' ) . '</p>' .
 			( $email_change_available ? '<a href="#" class="change-email">' . esc_html__( 'Incorrect email? Update email address.', 'wporg' ) . '</a>' : '' ),
 			'<code>' . esc_html( $pending_user['user_email'] ) . '</code>',

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/pending-profile.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/pending-profile.php
@@ -66,21 +66,21 @@ get_header();
 	<?php
 	if ( $pending_user['cleared'] ) {
 		printf(
-			'<h2>' . __( 'Confirm your email address', 'wporg' ) . '</h2>' .
+			'<h2>' . esc_html__( 'Confirm your email address', 'wporg' ) . '</h2>' .
 			/* translators: %s Email address */
-			'<p>' . __( 'Please check your email %s for a confirmation link to set your password.', 'wporg' ) . '</p>' .
-			'<p>' . '<a href="#" class="resend" data-account="%s">' . __( 'Resend confirmation email.', 'wporg' ) . '</a></p>' .
-			( $email_change_available ? '<a href="#" class="change-email">' . __( 'Incorrect email? Update email address.', 'wporg' ) . '</a>' : '' ),
+			'<p>' . esc_html__( 'Please check your email %s for a confirmation link to set your password.', 'wporg' ) . '</p>' .
+			'<p>' . '<a href="#" class="resend" data-account="%s">' . esc_html__( 'Resend confirmation email.', 'wporg' ) . '</a></p>' .
+			( $email_change_available ? '<a href="#" class="change-email">' . esc_html__( 'Incorrect email? Update email address.', 'wporg' ) . '</a>' : '' ),
 			'<code>' . esc_html( $pending_user['user_email'] ) . '</code>',
 			esc_attr( $pending_user['user_email'] )
 		);
 	} else {
 		printf(
-			'<h2>' . __( 'Your account is pending approval', 'wporg' ) . '</h2>' .
+			'<h2>' . esc_html__( 'Your account is pending approval', 'wporg' ) . '</h2>' .
 			/* translators: %s Email address */
-			'<p>' . __( 'You will receive an email at %s to set your password when approved.', 'wporg' ) . '</p>' .
-			'<p>' . __( 'Please contact %s for more details.', 'wporg' ) . '</p>' .
-			( $email_change_available ? '<a href="#" class="change-email">' . __( 'Incorrect email? Update email address.', 'wporg' ) . '</a>' : '' ),
+			'<p>' . esc_html__( 'You will receive an email at %s to set your password when approved.', 'wporg' ) . '</p>' .
+			'<p>' . esc_html__( 'Please contact %s for more details.', 'wporg' ) . '</p>' .
+			( $email_change_available ? '<a href="#" class="change-email">' . esc_html__( 'Incorrect email? Update email address.', 'wporg' ) . '</a>' : '' ),
 			'<code>' . esc_html( $pending_user['user_email'] ) . '</code>',
 			'<a href="mailto:' . $sso::SUPPORT_EMAIL . '">' . $sso::SUPPORT_EMAIL . '</a>'
 		);
@@ -95,7 +95,7 @@ get_header();
 	?>
 
 	<p class="login-email hidden">
-		<label for="user_email"><?php _e( 'Email', 'wporg' ); ?></label>
+		<label for="user_email"><?php esc_html_e( 'Email', 'wporg' ); ?></label>
 		<input type="text" name="user_email" value="<?php echo esc_attr( $pending_user['user_email'] ); ?>" size="20" maxlength="100" />
 	</p>
 
@@ -116,7 +116,7 @@ get_header();
 </form>
 
 <p id="nav">
-	<a href="<?php echo wporg_login_wordpress_url(); ?>"><?php _e( 'WordPress.org', 'wporg' ); ?></a>
+	<a href="<?php echo wporg_login_wordpress_url(); ?>"><?php esc_html_e( 'WordPress.org', 'wporg' ); ?></a>
 </p>
 
 <?php get_footer(); ?>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/pending-profile.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/pending-profile.php
@@ -69,7 +69,7 @@ get_header();
 			'<h2>' . esc_html__( 'Confirm your email address', 'wporg' ) . '</h2>' .
 			/* translators: %s Email address */
 			'<p>' . esc_html__( 'Please check your email %s for a confirmation link to set your password.', 'wporg' ) . '</p>' .
-			'<p>' . '<a href="#" class="resend" data-account="%s">' . esc_html__( 'Resend confirmation email.', 'wporg' ) . '</a></p>' .
+			'<p><a href="#" class="resend" data-account="%s">' . esc_html__( 'Resend confirmation email.', 'wporg' ) . '</a></p>' .
 			( $email_change_available ? '<a href="#" class="change-email">' . esc_html__( 'Incorrect email? Update email address.', 'wporg' ) . '</a>' : '' ),
 			'<code>' . esc_html( $pending_user['user_email'] ) . '</code>',
 			esc_attr( $pending_user['user_email'] )

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/register.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/register.php
@@ -82,17 +82,17 @@ get_header();
 ?>
 
 <?php if ( ! $user_registration_available ) : ?>
-		<p><?php printf( __( 'New user registration is currently unavailable. Please check back after the <a href="%s">holiday break</a>.', 'wporg' ), 'https://wordpress.org/news/2024/12/holiday-break/' ); ?></p>
+		<p><?php printf( wp_kses_post( __( 'New user registration is currently unavailable. Please check back after the <a href="%s">holiday break</a>.', 'wporg' ) ), 'https://wordpress.org/news/2024/12/holiday-break/' ); ?></p>
 <?php else: ?>
 
-<p class="intro"><?php _e( 'Create a WordPress.org account to start contributing to WordPress, get help in the support forums, or rate and review themes and plugins.', 'wporg' ); ?></p>
+<p class="intro"><?php esc_html_e( 'Create a WordPress.org account to start contributing to WordPress, get help in the support forums, or rate and review themes and plugins.', 'wporg' ); ?></p>
 
 <form name="registerform" id="registerform" action="/register" method="post">
 
 	<p class="login-username">
-		<label for="user_login"><?php _e( 'Username', 'wporg' ); ?></label>
+		<label for="user_login"><?php esc_html_e( 'Username', 'wporg' ); ?></label>
 		<input type="text" name="user_login" id="user_login" class="input <?php if ( $error_user_login ) echo 'error'; ?>" value="<?php echo esc_attr( $user_login ) ?>" size="20" maxlength="60" data-pattern-after-blur="[0-9a-z]{0,60}" required />
-		<span class="small"><?php _e( 'Only lower case letters (a-z) and numbers (0-9) are allowed.', 'wporg' ); ?></span>
+		<span class="small"><?php esc_html_e( 'Only lower case letters (a-z) and numbers (0-9) are allowed.', 'wporg' ); ?></span>
 	</p>
 	<?php
 	if ( $error_user_login ) {
@@ -106,9 +106,9 @@ get_header();
 	?>
 
 	<p class="login-email">
-		<label for="user_email"><?php _e( 'Email', 'wporg' ); ?></label>
+		<label for="user_email"><?php esc_html_e( 'Email', 'wporg' ); ?></label>
 		<input type="email" name="user_email" id="user_email" class="input <?php if ( $error_user_email ) echo 'error'; ?>" value="<?php echo esc_attr( $user_email ) ?>" size="20" maxlength="100" data-pattern-after-blur=".+@.+\..+" required />
-		<span class="small"><?php _e( 'A link to set your password will be sent here.', 'wporg' ); ?></span>
+		<span class="small"><?php esc_html_e( 'A link to set your password will be sent here.', 'wporg' ); ?></span>
 	</p>
 	<?php
 	if ( $error_user_email ) {
@@ -128,7 +128,7 @@ get_header();
 				$localised_domain = parse_url( wporg_login_wordpress_url(), PHP_URL_HOST );
 				printf(
 					/* translators: %s: List of linked policies, for example: <a>Privacy Policy</a> and <a>Terms of Service</a> */
-					_n( 'I have read and accept the %s', 'I have read and accept the %s', 1, 'wporg' ),
+					esc_html( _n( 'I have read and accept the %s', 'I have read and accept the %s', 1, 'wporg' ) ),
 					wp_sprintf_l( '%l', [
 						"<a href='https://{$localised_domain}/about/privacy/'>" . __( 'Privacy Policy', 'wporg' ) . '</a>',
 						// "<a href='https://{$localised_domain}/about/terms-of-service/'>" . __( 'Terms of Service', 'wporg' ) . '</a>',
@@ -142,12 +142,12 @@ get_header();
 	<p class="login-mailinglist checkbox">
 		<label for="user_mailinglist">
 			<input name="user_mailinglist" type="checkbox" id="user_mailinglist" value="true" <?php checked( $user_mailinglist, true ); ?>>
-			<?php _e( 'Subscribe to WordPress Announcements mailing list (a few messages a year)', 'wporg' ); ?>
+			<?php esc_html_e( 'Subscribe to WordPress Announcements mailing list (a few messages a year)', 'wporg' ); ?>
 		</label>
 	</p>
 	<?php
 		if ( $error_recapcha_status ) {
-			echo '<div class="message error"><p>' . __( 'Please try again.', 'wporg' ) . '</p></div>';
+			echo '<div class="message error"><p>' . esc_html__( 'Please try again.', 'wporg' ) . '</p></div>';
 		}
 	?>
 
@@ -160,8 +160,8 @@ get_header();
 <?php endif; // WPORG_ON_HOLIDAY else ?>
 
 <p id="nav">
-	<a href="/" title="<?php esc_attr_e( 'Already have an account?', 'wporg' ); ?>"><?php _e( 'Already have an account?', 'wporg' ); ?></a> &nbsp; • &nbsp;
-	<a href="<?php echo wporg_login_wordpress_url(); ?>"><?php _e( 'WordPress.org', 'wporg' ); ?></a>
+	<a href="/" title="<?php esc_attr_e( 'Already have an account?', 'wporg' ); ?>"><?php esc_html_e( 'Already have an account?', 'wporg' ); ?></a> &nbsp; • &nbsp;
+	<a href="<?php echo wporg_login_wordpress_url(); ?>"><?php esc_html_e( 'WordPress.org', 'wporg' ); ?></a>
 </p>
 
 <?php get_footer();

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/register.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/register.php
@@ -82,6 +82,7 @@ get_header();
 ?>
 
 <?php if ( ! $user_registration_available ) : ?>
+		<?php /* translators: %s: Holiday break announcement URL. */ ?>
 		<p><?php printf( wp_kses_post( __( 'New user registration is currently unavailable. Please check back after the <a href="%s">holiday break</a>.', 'wporg' ) ), 'https://wordpress.org/news/2024/12/holiday-break/' ); ?></p>
 <?php else: ?>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/updated-tos.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/updated-tos.php
@@ -58,7 +58,7 @@ get_header();
 <p>&nbsp;</p>
 
 <p>
-	<a href="https://<?php echo $localised_domain; ?>/about/privacy/"><?php _e( 'Privacy Policy', 'wporg' ); ?></a>
+	<a href="https://<?php echo $localised_domain; ?>/about/privacy/"><?php esc_html_e( 'Privacy Policy', 'wporg' ); ?></a>
 </p>
 <?php /* ?>
 <p>
@@ -84,8 +84,8 @@ get_header();
 </p>
 
 <p id="nav">
-	<a href="/"><?php _e( '&larr; Back to login', 'wporg' ); ?></a> &nbsp; • &nbsp;
-	<a href="<?php echo wporg_login_wordpress_url(); ?>"><?php _e( 'WordPress.org', 'wporg' ); ?></a>
+	<a href="/"><?php esc_html_e( '&larr; Back to login', 'wporg' ); ?></a> &nbsp; • &nbsp;
+	<a href="<?php echo wporg_login_wordpress_url(); ?>"><?php esc_html_e( 'WordPress.org', 'wporg' ); ?></a>
 </p>
 
 <?php get_footer(); ?>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-login/updated-tos.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-login/updated-tos.php
@@ -58,7 +58,7 @@ get_header();
 <p>&nbsp;</p>
 
 <p>
-	<a href="https://<?php echo $localised_domain; ?>/about/privacy/"><?php esc_html_e( 'Privacy Policy', 'wporg' ); ?></a>
+	<a href="<?php echo esc_url( 'https://' . $localised_domain . '/about/privacy/' ); ?>"><?php esc_html_e( 'Privacy Policy', 'wporg' ); ?></a>
 </p>
 <?php /* ?>
 <p>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-main/front-page.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-main/front-page.php
@@ -161,13 +161,15 @@ get_header( 'wporg' );
 					<?php
 					$plugin_count = defined( 'WP_PLUGIN_COUNT' ) ? WP_PLUGIN_COUNT : 54000;
 					printf(
-						/* translators: 1: Rounded number of plugins. 2: Link to Plugin Directory. */
-						wp_kses_post( _n(
-							'Extend WordPress with over %1$s plugin to help your website meet your needs. Add an online store, galleries, mailing lists, forums, analytics, and <a href="%2$s">much more</a>.',
-							'Extend WordPress with over %1$s plugins to help your website meet your needs. Add an online store, galleries, mailing lists, forums, analytics, and <a href="%2$s">much more</a>.',
-							$plugin_count,
-							'wporg'
-						) ),
+						wp_kses_post(
+							/* translators: 1: Rounded number of plugins. 2: Link to Plugin Directory. */
+							_n(
+								'Extend WordPress with over %1$s plugin to help your website meet your needs. Add an online store, galleries, mailing lists, forums, analytics, and <a href="%2$s">much more</a>.',
+								'Extend WordPress with over %1$s plugins to help your website meet your needs. Add an online store, galleries, mailing lists, forums, analytics, and <a href="%2$s">much more</a>.',
+								$plugin_count,
+								'wporg'
+							)
+						),
 						esc_html( number_format_i18n( $plugin_count ) ),
 						esc_url( home_url( '/plugins/' ) )
 					);
@@ -184,13 +186,15 @@ get_header( 'wporg' );
 						$meetups = 817;
 
 						printf(
-							/* translators: Number of meetups. */
-							esc_html( _n(
-								'Hundreds of thousands of developers, content creators, and site owners gather at monthly meetups in %s city worldwide.',
-								'Hundreds of thousands of developers, content creators, and site owners gather at monthly meetups in %s cities worldwide.',
-								$meetups,
-								'wporg'
-							) ),
+							esc_html(
+								/* translators: Number of meetups. */
+								_n(
+									'Hundreds of thousands of developers, content creators, and site owners gather at monthly meetups in %s city worldwide.',
+									'Hundreds of thousands of developers, content creators, and site owners gather at monthly meetups in %s cities worldwide.',
+									$meetups,
+									'wporg'
+								)
+							),
 							number_format_i18n( $meetups )
 						);
 						?>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-main/front-page.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-main/front-page.php
@@ -187,7 +187,7 @@ get_header( 'wporg' );
 
 						printf(
 							esc_html(
-								/* translators: Number of meetups. */
+								/* translators: %s: Number of meetups. */
 								_n(
 									'Hundreds of thousands of developers, content creators, and site owners gather at monthly meetups in %s city worldwide.',
 									'Hundreds of thousands of developers, content creators, and site owners gather at monthly meetups in %s cities worldwide.',

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-main/front-page.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-main/front-page.php
@@ -47,7 +47,7 @@ $banner_blocks = '<!-- wp:wporg/link-wrapper {"align":"full","style":{"elements"
 get_header( 'wporg' );
 ?>
 	<aside id="download-mobile">
-		<span class="download-ready"><?php _e( 'Ready to get started?', 'wporg' ); ?></span><a class="button download-button" href="/download/"><?php _e( 'Get WordPress', 'wporg' ); ?></a>
+		<span class="download-ready"><?php esc_html_e( 'Ready to get started?', 'wporg' ); ?></span><a class="button download-button" href="/download/"><?php esc_html_e( 'Get WordPress', 'wporg' ); ?></a>
 	</aside>
 
 	<style>
@@ -85,9 +85,9 @@ get_header( 'wporg' );
 
 	<header id="masthead" class="site-header" role="banner">
 		<div class="site-branding">
-			<p class="site-title"><?php _e( 'Meet WordPress', 'wporg' ); ?></p>
+			<p class="site-title"><?php esc_html_e( 'Meet WordPress', 'wporg' ); ?></p>
 
-			<p class="site-description"><?php _e( 'WordPress is open source software you can use to create a beautiful website, blog, or app.', 'wporg' ); ?></p>
+			<p class="site-description"><?php esc_html_e( 'WordPress is open source software you can use to create a beautiful website, blog, or app.', 'wporg' ); ?></p>
 		</div><!-- .site-branding -->
 	</header><!-- #masthead -->
 
@@ -96,7 +96,7 @@ get_header( 'wporg' );
 			<div id="lang-guess-wrap"></div>
 
 			<section class="intro">
-				<p class="subheading"><?php _e( 'Beautiful designs, powerful features, and the freedom to build anything you want. WordPress is both free and priceless at the same time.', 'wporg' ); ?></p>
+				<p class="subheading"><?php esc_html_e( 'Beautiful designs, powerful features, and the freedom to build anything you want. WordPress is both free and priceless at the same time.', 'wporg' ); ?></p>
 				<div class="screenshots">
 					<img src="https://s.w.org/images/home/screen-themes.png?4" class="dashboard" />
 					<img src="https://s.w.org/images/home/mobile-themes.png?4" class="dashboard-mobile" />
@@ -104,12 +104,12 @@ get_header( 'wporg' );
 			</section>
 
 			<section class="showcase">
-				<h2><?php _e( 'Trusted by the Best', 'wporg' ); ?></h2>
+				<h2><?php esc_html_e( 'Trusted by the Best', 'wporg' ); ?></h2>
 				<p class="subheading">
 					<?php
 					printf(
 						/* translators: WordPress market share: 30 - Note: The following percent sign is '%%' for escaping purposes; */
-						__( '%s%% of the web uses WordPress, from hobby blogs to the biggest news sites online.', 'wporg' ),
+						esc_html__( '%s%% of the web uses WordPress, from hobby blogs to the biggest news sites online.', 'wporg' ),
 						number_format_i18n( WP_MARKET_SHARE )
 					);
 					?>
@@ -117,44 +117,44 @@ get_header( 'wporg' );
 				<div class="collage">
 
 				</div>
-				<p class="cta-link"><a href="https://wordpress.org/showcase/"><?php _e( 'Discover more sites built with WordPress', 'wporg' ); ?></a></p>
+				<p class="cta-link"><a href="https://wordpress.org/showcase/"><?php esc_html_e( 'Discover more sites built with WordPress', 'wporg' ); ?></a></p>
 			</section>
 
 			<section class="features">
-				<h2><?php _e( 'Powerful Features', 'wporg' ); ?></h2>
-				<p class="subheading"><?php _e( 'Limitless possibilities. What will you create?', 'wporg' ); ?></p>
+				<h2><?php esc_html_e( 'Powerful Features', 'wporg' ); ?></h2>
+				<p class="subheading"><?php esc_html_e( 'Limitless possibilities. What will you create?', 'wporg' ); ?></p>
 				<ul>
 					<li>
 						<span class="dashicons dashicons-admin-customizer"></span>
-						<?php _e( 'Customizable<br />Designs', 'wporg' ); ?>
+						<?php echo wp_kses_post( __( 'Customizable<br />Designs', 'wporg' ) ); ?>
 					</li>
 					<li>
 						<span class="dashicons dashicons-welcome-widgets-menus"></span>
-						<?php _e( 'SEO<br />Friendly', 'wporg' ); ?>
+						<?php echo wp_kses_post( __( 'SEO<br />Friendly', 'wporg' ) ); ?>
 					</li>
 					<li>
 						<span class="dashicons dashicons-smartphone"></span>
-						<?php _e( 'Responsive<br />Mobile Sites', 'wporg' ); ?>
+						<?php echo wp_kses_post( __( 'Responsive<br />Mobile Sites', 'wporg' ) ); ?>
 					</li>
 					<li>
 						<span class="dashicons dashicons-chart-line"></span>
-						<?php _e( 'High<br />Performance', 'wporg' ); ?>
+						<?php echo wp_kses_post( __( 'High<br />Performance', 'wporg' ) ); ?>
 					</li>
 					<li>
 						<a href="https://wordpress.org/mobile/"><img src="https://s.w.org/images/home/icon-run-blue.svg" />
-							<?php _e( 'Manage<br />on the Go', 'wporg' ); ?></a>
+							<?php echo wp_kses_post( __( 'Manage<br />on the Go', 'wporg' ) ); ?></a>
 					</li>
 					<li>
 						<span class="dashicons dashicons-lock"></span>
-						<?php _e( 'High<br />Security', 'wporg' ); ?>
+						<?php echo wp_kses_post( __( 'High<br />Security', 'wporg' ) ); ?>
 					</li>
 					<li>
 						<span class="dashicons dashicons-images-alt2"></span>
-						<?php _e( 'Powerful<br />Media Management', 'wporg' ); ?>
+						<?php echo wp_kses_post( __( 'Powerful<br />Media Management', 'wporg' ) ); ?>
 					</li>
 					<li>
 						<span class="dashicons dashicons-universal-access"></span>
-						<?php _e( 'Easy and<br />Accessible', 'wporg' ); ?>
+						<?php echo wp_kses_post( __( 'Easy and<br />Accessible', 'wporg' ) ); ?>
 					</li>
 				</ul>
 				<p>
@@ -162,12 +162,12 @@ get_header( 'wporg' );
 					$plugin_count = defined( 'WP_PLUGIN_COUNT' ) ? WP_PLUGIN_COUNT : 54000;
 					printf(
 						/* translators: 1: Rounded number of plugins. 2: Link to Plugin Directory. */
-						_n(
+						wp_kses_post( _n(
 							'Extend WordPress with over %1$s plugin to help your website meet your needs. Add an online store, galleries, mailing lists, forums, analytics, and <a href="%2$s">much more</a>.',
 							'Extend WordPress with over %1$s plugins to help your website meet your needs. Add an online store, galleries, mailing lists, forums, analytics, and <a href="%2$s">much more</a>.',
 							$plugin_count,
 							'wporg'
-						),
+						) ),
 						esc_html( number_format_i18n( $plugin_count ) ),
 						esc_url( home_url( '/plugins/' ) )
 					);
@@ -178,32 +178,32 @@ get_header( 'wporg' );
 			<section class="community-2">
 				<div class="screen"></div>
 				<div class="container">
-					<h2><?php _e( 'Community', 'wporg' ); ?></h2>
+					<h2><?php esc_html_e( 'Community', 'wporg' ); ?></h2>
 					<p class="subheading">
 						<?php
 						$meetups = 817;
 
 						printf(
 							/* translators: Number of meetups. */
-							_n(
+							esc_html( _n(
 								'Hundreds of thousands of developers, content creators, and site owners gather at monthly meetups in %s city worldwide.',
 								'Hundreds of thousands of developers, content creators, and site owners gather at monthly meetups in %s cities worldwide.',
 								$meetups,
 								'wporg'
-							),
+							) ),
 							number_format_i18n( $meetups )
 						);
 						?>
 					</p>
-					<a class="button button-secondary button-large" href="https://make.wordpress.org/community/meetups-landing-page"><?php _e( 'Find a local WordPress community', 'wporg' ); ?></a>
+					<a class="button button-secondary button-large" href="https://make.wordpress.org/community/meetups-landing-page"><?php esc_html_e( 'Find a local WordPress community', 'wporg' ); ?></a>
 				</div>
 			</section>
 
 			<section class="get">
-				<h2><?php _e( 'Get Started with WordPress', 'wporg' ); ?></h2>
-				<p class="subheading"><?php _e( 'Over 60 million people have chosen WordPress to power the place on the web they call &ldquo;home&rdquo; &mdash; join the family.', 'wporg' ); ?></p>
+				<h2><?php esc_html_e( 'Get Started with WordPress', 'wporg' ); ?></h2>
+				<p class="subheading"><?php esc_html_e( 'Over 60 million people have chosen WordPress to power the place on the web they call &ldquo;home&rdquo; &mdash; join the family.', 'wporg' ); ?></p>
 				<div class="cta-wrapper">
-					<a href="<?php echo esc_url( get_downloads_url() ); ?>" class="button button-primary button-xl"><?php _e( 'Get WordPress', 'wporg' ); ?></a>
+					<a href="<?php echo esc_url( get_downloads_url() ); ?>" class="button button-primary button-xl"><?php esc_html_e( 'Get WordPress', 'wporg' ); ?></a>
 				</div>
 			</section>
 		</div>
@@ -231,7 +231,7 @@ get_header( 'wporg' );
 				printf(
 					'<h4><a href="%s">%s</a></h4>',
 					esc_url( $news_blog_url ),
-					__( 'News From Our Blog', 'wporg' )
+					esc_html__( 'News From Our Blog', 'wporg' )
 				);
 
 				// Forcibly hide all Jetpack sharing buttons.
@@ -255,7 +255,7 @@ get_header( 'wporg' );
 			</div>
 
 			<div class="col-4">
-				<h4><?php _e( 'It&rsquo;s Easy&nbsp;As&hellip;', 'wporg' ); ?></h4>
+				<h4><?php esc_html_e( 'It&rsquo;s Easy&nbsp;As&hellip;', 'wporg' ); ?></h4>
 
 				<ol class="steps">
 					<li class="one">
@@ -263,7 +263,7 @@ get_header( 'wporg' );
 						<?php
 						printf(
 							/* translators: URL to Hosting page. */
-							__( '<a href="%s">Find a trusted web host</a> and maybe support WordPress at the same&nbsp;time.', 'wporg' ),
+							wp_kses_post( __( '<a href="%s">Find a trusted web host</a> and maybe support WordPress at the same&nbsp;time.', 'wporg' ) ),
 							esc_url( 'https://wordpress.org/hosting/' )
 						);
 						?>
@@ -273,7 +273,7 @@ get_header( 'wporg' );
 						<?php
 						printf(
 							/* translators: URL to Downloads page. */
-							__( '<a href="%s">Download &amp; install WordPress</a> with our famous 5-minute&nbsp;installation. Publishing has never been&nbsp;easier.', 'wporg' ),
+							wp_kses_post( __( '<a href="%s">Download &amp; install WordPress</a> with our famous 5-minute&nbsp;installation. Publishing has never been&nbsp;easier.', 'wporg' ) ),
 							esc_url( get_downloads_url() )
 						);
 						?>
@@ -283,7 +283,7 @@ get_header( 'wporg' );
 						<?php
 						printf(
 							/* translators: URL to HelpHub. */
-							__( '<a href="%s">Spend some time reading our documentation</a>, get to know WordPress better every day and start helping others,&nbsp;too.', 'wporg' ),
+							wp_kses_post( __( '<a href="%s">Spend some time reading our documentation</a>, get to know WordPress better every day and start helping others,&nbsp;too.', 'wporg' ) ),
 							esc_url( __( 'https://wordpress.org/support/', 'wporg' ) )
 						);
 						?>
@@ -292,7 +292,7 @@ get_header( 'wporg' );
 			</div>
 
 			<div class="<?php echo esc_attr( $swag_class ); ?> first">
-				<h4><a href="https://mercantile.wordpress.org/"><?php _e( 'WordPress&nbsp;Swag', 'wporg' ); ?></a></h4>
+				<h4><a href="https://mercantile.wordpress.org/"><?php esc_html_e( 'WordPress&nbsp;Swag', 'wporg' ); ?></a></h4>
 				<a href="https://mercantile.wordpress.org/">
 					<?php if ( $showcase ) : ?>
 						<img width="288" height="288" src="https://s.w.org/images/home/swag_col-2.png" srcset="https://s.w.org/images/home/swag_col-2_x2.png 2x" alt="<?php esc_attr_e( 'WordPress Swag', 'wporg' ); ?>" />
@@ -303,7 +303,7 @@ get_header( 'wporg' );
 			</div>
 
 			<div class="<?php echo esc_attr( $user_class ); ?>">
-				<h4><a href="https://wordpress.org/showcase/"><?php _e( 'WordPress&nbsp;Users', 'wporg' ); ?></a></h4>
+				<h4><a href="https://wordpress.org/showcase/"><?php esc_html_e( 'WordPress&nbsp;Users', 'wporg' ); ?></a></h4>
 
 				<?php if ( $showcase ) : ?>
 					<div id="notable-users" class="notable-users col-12 row gutters">
@@ -346,7 +346,7 @@ get_header( 'wporg' );
 					</ul>
 				<?php endif; ?>
 
-				<a class="showcase-link" href="https://wordpress.org/showcase/"><?php _e( '&hellip; and hundreds more', 'wporg' ); ?></a>
+				<a class="showcase-link" href="https://wordpress.org/showcase/"><?php esc_html_e( '&hellip; and hundreds more', 'wporg' ); ?></a>
 			</div>
 		</div>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-main/page-download-beta-nightly.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-main/page-download-beta-nightly.php
@@ -63,7 +63,7 @@ the_post();
 						<?php
 						printf(
 							/* translators: %s Link to https://wordpress.org/download/releases/#betas */
-							__( 'You can find the latest beta releases on the <a href="%s">Beta Releases</a> page.', 'wporg' ),
+							wp_kses_post( __( 'You can find the latest beta releases on the <a href="%s">Beta Releases</a> page.', 'wporg' ) ),
 							'https://wordpress.org/download/releases/#betas'
 						);
 						?>
@@ -86,7 +86,7 @@ the_post();
 						<?php
 						printf(
 							/* translators: %s Link to the latest nightly release ZIP. */
-							__( 'You can download the latest nightly release here: <a href="%s">wordpress-latest.zip</a>.', 'wporg' ),
+							wp_kses_post( __( 'You can download the latest nightly release here: <a href="%s">wordpress-latest.zip</a>.', 'wporg' ) ),
 							'https://wordpress.org/nightly-builds/wordpress-latest.zip'
 						);
 						?>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-main/page-download.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-main/page-download.php
@@ -284,7 +284,7 @@ the_post();
 						<p>
 							<?php
 							printf(
-								__( 'For help getting started, check out our <a href="%s">Documentation and Support Forums</a>.', 'wporg' ),
+								wp_kses_post( __( 'For help getting started, check out our <a href="%s">Documentation and Support Forums</a>.', 'wporg' ) ),
 								esc_url( __( 'https://wordpress.org/support/', 'wporg' ) )
 							);
 							?>
@@ -293,7 +293,7 @@ the_post();
 							<?php
 							printf(
 								/* translators: 1: URL to WordPress Meetup group, 2: URL to WordCamp Central */
-								__( 'Meet other WordPress enthusiasts and share your knowledge at a <a href="%1$s">WordPress meetup group</a> or a <a href="%2$s">WordCamp</a>.', 'wporg' ),
+								wp_kses_post( __( 'Meet other WordPress enthusiasts and share your knowledge at a <a href="%1$s">WordPress meetup group</a> or a <a href="%2$s">WordCamp</a>.', 'wporg' ) ),
 								esc_url( __( 'https://www.meetup.com/pro/wordpress/', 'wporg' ) ),
 								esc_url( __( 'https://central.wordcamp.org/', 'wporg' ) )
 							);
@@ -302,7 +302,7 @@ the_post();
 						<p>
 							<?php
 							printf(
-								__( 'To support education about WordPress and open source software, please donate to the <a href="%s">WordPress Foundation</a>.', 'wporg' ),
+								wp_kses_post( __( 'To support education about WordPress and open source software, please donate to the <a href="%s">WordPress Foundation</a>.', 'wporg' ) ),
 								esc_url( __( 'https://wordpressfoundation.org/donate/', 'wporg' ) )
 							);
 							?>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-main/page-download.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-main/page-download.php
@@ -284,6 +284,7 @@ the_post();
 						<p>
 							<?php
 							printf(
+								/* translators: %s: Support URL. */
 								wp_kses_post( __( 'For help getting started, check out our <a href="%s">Documentation and Support Forums</a>.', 'wporg' ) ),
 								esc_url( __( 'https://wordpress.org/support/', 'wporg' ) )
 							);
@@ -302,6 +303,7 @@ the_post();
 						<p>
 							<?php
 							printf(
+								/* translators: %s: Donation URL. */
 								wp_kses_post( __( 'To support education about WordPress and open source software, please donate to the <a href="%s">WordPress Foundation</a>.', 'wporg' ) ),
 								esc_url( __( 'https://wordpressfoundation.org/donate/', 'wporg' ) )
 							);

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/inc/template-tags.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/inc/template-tags.php
@@ -748,7 +748,7 @@ function the_plugin_release_confirmation_form() {
 
 	if ( ! $confirmations_required && 'trunk' === $post->stable_tag ) {
 		echo '<div class="plugin-notice notice notice-warning notice-alt"><p>';
-			esc_html_e( "Release confirmations currently require tagged releases, as you're releasing from trunk they cannot be enabled.", 'wporg-plugins' );
+			esc_html_e( 'Release confirmations currently require tagged releases, as you&#8217;re releasing from trunk they cannot be enabled.', 'wporg-plugins' );
 		echo '</p></div>';
 
 	} else if ( ! $confirmations_required ) {

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/inc/template-tags.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/inc/template-tags.php
@@ -606,6 +606,7 @@ function the_plugin_self_close_button() {
 				</label>
 			</p>
 			<p>
+				<?php /* translators: %1$s: Plugins team email address. */ ?>
 				<?php printf( wp_kses_post( __( 'If you have any questions, please contact <a href="mailto:%1$s">%1$s</a> before proceeding with a link to your plugin and your questions.', 'wporg-plugins' ) ), 'plugins@wordpress.org' ); ?>
 			<p class="wp-block-button is-small">
 				<input class="wp-block-button__link" type="submit" value="<?php echo esc_attr( $close_button_text ); ?>" />

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/inc/template-tags.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/inc/template-tags.php
@@ -439,7 +439,7 @@ function the_plugin_community_zone() {
 	echo '</p>';
 	echo '<p class="wp-block-button is-small">';
 	echo '<button class="wp-block-button__link" type="submit">' . esc_html__( 'Save', 'wporg-plugins' ) . '</button>';
-	echo '<span class="success-msg">' . __( 'Saved!', 'wporg-plugins' ) . '</span>';
+	echo '<span class="success-msg">' . esc_html__( 'Saved!', 'wporg-plugins' ) . '</span>';
 	echo '</p>';
 	echo '</form>';
 }
@@ -485,7 +485,7 @@ function the_plugin_commercial_zone() {
 	echo '</p>';
 	echo '<p class="wp-block-button is-small">';
 	echo '<button class="wp-block-button__link" type="submit">' . esc_attr__( 'Save', 'wporg-plugins' ) . '</button>';
-	echo '<span class="success-msg">' . __( 'Saved!', 'wporg-plugins' ) . '</span>';
+	echo '<span class="success-msg">' . esc_html__( 'Saved!', 'wporg-plugins' ) . '</span>';
 	echo '</p>';
 	echo '</form>';
 }
@@ -550,10 +550,10 @@ function the_plugin_self_close_button() {
 	echo '<div class="plugin-notice notice notice-warning notice-alt"><p>';
 	if ( $active_installs >= 20000 ) {
 		// Translators: %s is the plugin team email address.
-		printf( __( '<strong>Notice:</strong> Due to the high volume of users for this plugin it cannot be closed without speaking directly to the plugins team. Please contact <a href="mailto:%1$s">%1$s</a> with a link to the plugin and explanation as to why it should be closed.', 'wporg-plugins' ), 'plugins@wordpress.org' );
+		printf( wp_kses_post( __( '<strong>Notice:</strong> Due to the high volume of users for this plugin it cannot be closed without speaking directly to the plugins team. Please contact <a href="mailto:%1$s">%1$s</a> with a link to the plugin and explanation as to why it should be closed.', 'wporg-plugins' ) ), 'plugins@wordpress.org' );
 	} else {
 		$close_link = Template::get_self_close_link( $post );
-		_e( '<strong>Warning:</strong> Closing a plugin is intended to be a <em>permanent</em> action. There is no way to reopen a plugin without contacting the plugins team.', 'wporg-plugins' );
+		echo wp_kses_post( __( '<strong>Warning:</strong> Closing a plugin is intended to be a <em>permanent</em> action. There is no way to reopen a plugin without contacting the plugins team.', 'wporg-plugins' ) );
 	}
 	echo '</p></div>';
 
@@ -567,9 +567,9 @@ function the_plugin_self_close_button() {
 	<div class="wp-block-button is-small"><button class="show-dialog wp-block-button__link" onclick="this.parentNode.nextElementSibling.showModal()"><?php echo $close_button_text; ?></button></div>
 	<dialog>
 		<a onclick="this.parentNode.close()" class="close dashicons dashicons-no-alt"></a>
-		<strong><?php _e( 'Close your plugin?', 'wporg-plugins' ); ?></strong>
+		<strong><?php esc_html_e( 'Close your plugin?', 'wporg-plugins' ); ?></strong>
 		<div class="notice notice-warning notice-alt"><p>
-			<?php _e( '<strong>Warning:</strong> Closing a plugin is intended to be a <em>permanent</em> action. There is no way to reopen a plugin without contacting the plugins team.', 'wporg-plugins' ); ?>
+			<?php echo wp_kses_post( __( '<strong>Warning:</strong> Closing a plugin is intended to be a <em>permanent</em> action. There is no way to reopen a plugin without contacting the plugins team.', 'wporg-plugins' ) ); ?>
 		</p></div>
 
 		<form method="POST" action="<?php echo esc_url( $close_link ); ?>">
@@ -578,7 +578,7 @@ function the_plugin_self_close_button() {
 					<input type="checkbox" name="confirm" required />
 					<?php printf(
 						/* translators: %s: The plugin name. */
-						__( 'Yes, I wish to close %s.', 'wporg-plugins' ),
+						esc_html__( 'Yes, I wish to close %s.', 'wporg-plugins' ),
 						'<code>' . get_the_title() . '</code>'
 					); ?>
 				</label>
@@ -586,27 +586,27 @@ function the_plugin_self_close_button() {
 			<p>
 				<label>
 					<input type="checkbox" name="confirm" required />
-					<?php _e( 'Yes, I understand that this is permanent.', 'wporg-plugins' ); ?>
+					<?php esc_html_e( 'Yes, I understand that this is permanent.', 'wporg-plugins' ); ?>
 				</label>
 			</p>
 			<p>
 				<label>
 					<input type="checkbox" name="confirm" required />
-					<?php _e( 'I am not working on a newer version to submit to the plugin directory.', 'wporg-plugins' ); ?>
+					<?php esc_html_e( 'I am not working on a newer version to submit to the plugin directory.', 'wporg-plugins' ); ?>
 				</label>
 			</p>
 			<p>
 				<label>
 					<?php printf(
 						/* translators: %s: The plugin slug. */
-						__( 'Please enter the plugin slug %s below.', 'wporg-plugins' ),
+						esc_html__( 'Please enter the plugin slug %s below.', 'wporg-plugins' ),
 						'<code>' . esc_html( $post->post_name ) . '</code>'
 					); ?><br>
 					<input type="text" name="confirm" pattern="<?php echo esc_attr( $post->post_name ); ?>" required class="has-large-font-size" />
 				</label>
 			</p>
 			<p>
-				<?php printf( __( 'If you have any questions, please contact <a href="mailto:%1$s">%1$s</a> before proceeding with a link to your plugin and your questions.', 'wporg-plugins' ), 'plugins@wordpress.org' ); ?>
+				<?php printf( wp_kses_post( __( 'If you have any questions, please contact <a href="mailto:%1$s">%1$s</a> before proceeding with a link to your plugin and your questions.', 'wporg-plugins' ) ), 'plugins@wordpress.org' ); ?>
 			<p class="wp-block-button is-small">
 				<input class="wp-block-button__link" type="submit" value="<?php echo esc_attr( $close_button_text ); ?>" />
 			</p>
@@ -638,15 +638,15 @@ function the_plugin_self_toggle_preview_button() {
 
 	if ( !isset( $blueprints[ 'blueprint.json' ] ) ) {
 		echo '<div class="plugin-notice notice notice-error notice-alt"><p>';
-		_e( '<strong>Note:</strong> Missing or invalid blueprint.json file.', 'wporg-plugins' );
+		echo wp_kses_post( __( '<strong>Note:</strong> Missing or invalid blueprint.json file.', 'wporg-plugins' ) );
 		echo '</p></div>';
 	} elseif ( $toggle_link ) {
 
 		echo '<div class="plugin-notice notice notice-warning notice-alt"><p>';
 		if ( 'enabled' === $preview_status ) {
-			_e( 'This will disable the Preview button for public users.', 'wporg-plugins' );
+			esc_html_e( 'This will disable the Preview button for public users.', 'wporg-plugins' );
 		} else {
-			_e( 'This will enable the Preview button for public users.', 'wporg-plugins' );
+			esc_html_e( 'This will enable the Preview button for public users.', 'wporg-plugins' );
 		}
 
 		echo '</p></div>';
@@ -683,7 +683,7 @@ function the_plugin_self_transfer_form() {
 
 	echo '<p>' . esc_html__( 'You are the current owner of this plugin. You may transfer those rights to another person at any time, provided they have commit access to this plugin.', 'wporg-plugins' ) . '</p>';
 
-	echo '<div class="plugin-notice notice notice-warning notice-alt"><p>' . __( '<strong>Warning:</strong> Transferring a plugin is intended to be <em>permanent</em>. There is no way to get plugin ownership back without contacting the plugin team.', 'wporg-plugins' ) . '</p></div>';
+	echo '<div class="plugin-notice notice notice-warning notice-alt"><p>' . wp_kses_post( __( '<strong>Warning:</strong> Transferring a plugin is intended to be <em>permanent</em>. There is no way to get plugin ownership back without contacting the plugin team.', 'wporg-plugins' ) ) . '</p></div>';
 
 	$disabled_users = [];
 	$users          = [];
@@ -699,13 +699,13 @@ function the_plugin_self_transfer_form() {
 		}
 	}
 	if ( ! $users ) {
-		echo '<div class="plugin-notice notice notice-error notice-alt"><p>' . __( 'To transfer a plugin, you must first add the new owner as a committer.', 'wporg-plugins' ) . '</p></div>';
+		echo '<div class="plugin-notice notice notice-error notice-alt"><p>' . esc_html__( 'To transfer a plugin, you must first add the new owner as a committer.', 'wporg-plugins' ) . '</p></div>';
 		return;
 	}
 
 	// Users must have 2FA enabled to be able to transfer a plugin.
 	if ( $disabled_users ) {
-		echo '<div class="plugin-notice notice notice-info notice-alt"><p>' . __( 'Only users with Two-Factor authentication enabled can be selected.', 'wporg-plugins' ) . '</p></div>';
+		echo '<div class="plugin-notice notice notice-info notice-alt"><p>' . esc_html__( 'Only users with Two-Factor authentication enabled can be selected.', 'wporg-plugins' ) . '</p></div>';
 	}
 
 	echo '<form method="POST" action="' . esc_url( Template::get_self_transfer_link() ) . '" onsubmit="return ( 0 != document.getElementById(\'transfer-new-owner\').value ) && confirm( jQuery(this).prev(\'.notice\').text() );">';
@@ -739,20 +739,20 @@ function the_plugin_release_confirmation_form() {
 
 	echo '<h4>' . esc_html__( 'Release Confirmation', 'wporg-plugins' ) . '</h4>';
 	if ( $confirmations_required ) {
-		echo '<p>' . __( 'Release confirmations for this plugin are <strong>enabled</strong>.', 'wporg-plugins' ) . '</p>';
+		echo '<p>' . wp_kses_post( __( 'Release confirmations for this plugin are <strong>enabled</strong>.', 'wporg-plugins' ) ) . '</p>';
 	} else {
-		echo '<p>' . __( 'Release confirmations for this plugin are <strong>disabled</strong>', 'wporg-plugins' ) . '</p>';
+		echo '<p>' . wp_kses_post( __( 'Release confirmations for this plugin are <strong>disabled</strong>', 'wporg-plugins' ) ) . '</p>';
 	}
 	echo '<p>' . esc_html__( 'All future releases will require email confirmation before being made available. This increases security and ensures that plugin releases are only made when intended.', 'wporg-plugins' ) . '</p>';
 
 	if ( ! $confirmations_required && 'trunk' === $post->stable_tag ) {
 		echo '<div class="plugin-notice notice notice-warning notice-alt"><p>';
-			_e( "Release confirmations currently require tagged releases, as you're releasing from trunk they cannot be enabled.", 'wporg-plugins' );
+			esc_html_e( "Release confirmations currently require tagged releases, as you're releasing from trunk they cannot be enabled.", 'wporg-plugins' );
 		echo '</p></div>';
 
 	} else if ( ! $confirmations_required ) {
 		echo '<div class="plugin-notice notice notice-warning notice-alt"><p>';
-			_e( '<strong>Warning:</strong> Enabling release confirmations is intended to be a <em>permanent</em> action. There is no way to disable this without contacting the plugins team.', 'wporg-plugins' );
+			echo wp_kses_post( __( '<strong>Warning:</strong> Enabling release confirmations is intended to be a <em>permanent</em> action. There is no way to disable this without contacting the plugins team.', 'wporg-plugins' ) );
 		echo '</p></div>';
 
 		echo '<form method="POST" action="' . esc_url( Template::get_enable_release_confirmation_link() ) . '" onsubmit="return confirm( jQuery(this).prev(\'.notice\').text() );">';
@@ -761,7 +761,7 @@ function the_plugin_release_confirmation_form() {
 
 	} else {
 		/* translators: 1: plugins@wordpress.org */
-		echo '<p>' . sprintf( __( 'To disable release confirmations, please contact the plugins team by emailing %s.', 'wporg-plugins' ), 'plugins@wordpress.org' ) . '</p>';
+		echo '<p>' . sprintf( esc_html__( 'To disable release confirmations, please contact the plugins team by emailing %s.', 'wporg-plugins' ), 'plugins@wordpress.org' ) . '</p>';
 	}
 }
 
@@ -781,7 +781,7 @@ function the_author_notice( $post = null ) {
 		printf(
 			'<div class="notice notice-alt notice-%s">%s</div>',
 			esc_attr( $notice['type'] ),
-			'<p><strong>' . __( 'A note from the Plugins Team, visible only to the plugin author &amp; committers.', 'wporg-plugins' ) . '</strong></p>' .
+			'<p><strong>' . esc_html__( 'A note from the Plugins Team, visible only to the plugin author &amp; committers.', 'wporg-plugins' ) . '</strong></p>' .
 			wp_kses_post( $notice['html'] ) // Should have wrapping <p> tags.
 		);
 	}
@@ -802,7 +802,7 @@ function the_author_notice( $post = null ) {
 		$import_warnings  = '<ul><li>' . implode( '</li><li>', $import_warnings ) . '</li></ul>';
 		printf(
 			'<div class="notice notice-error notice-alt">%s</div>',
-			'<p><strong>' . __( 'During the last import of your plugin the following warnings were encountered. This message is visible only to the plugin authors &amp; committers.', 'wporg-plugins' ) . '</strong></p>' .
+			'<p><strong>' . esc_html__( 'During the last import of your plugin the following warnings were encountered. This message is visible only to the plugin authors &amp; committers.', 'wporg-plugins' ) . '</strong></p>' .
 			wp_kses_post( $import_warnings )
 		);
 	}

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/patterns/page-add.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/patterns/page-add.php
@@ -58,7 +58,7 @@ do_blocks( '<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom"
 			<p>
 				<?php
 				printf(
-					__( 'Your plugin review cannot be prioritized over others, to help us approve your plugin sooner, please ensure that you have read the <a href="%s">Security chapter</a> of the Plugin Handbook.', 'wporg-plugins' ),
+					wp_kses_post( __( 'Your plugin review cannot be prioritized over others, to help us approve your plugin sooner, please ensure that you have read the <a href="%s">Security chapter</a> of the Plugin Handbook.', 'wporg-plugins' ) ),
 					'https://developer.wordpress.org/apis/security/'
 				);
 				?>
@@ -70,7 +70,7 @@ do_blocks( '<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom"
 				<li><?php printf( wp_kses_post( __( 'The plugin processes form data without a nonce: <a href="%s">Learn about Nonces</a>', 'wporg-plugins' ) ), esc_url( 'https://developer.wordpress.org/apis/security/nonces/' ) ); ?></li>
 				<li><?php printf( wp_kses_post( __( 'The plugin does not comply with the guidelines: <a href="%s">Check out the guidelines</a>', 'wporg-plugins' ) ), esc_url( 'https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/' ) ); ?></li>
 			</ul>
-			<p><?php _e( 'If the code in your plugin falls into one of the above categories, <strong>your plugin will not be approved</strong>. The Plugins Team will refer you back to these Handbook pages, adding further delay to the review process.', 'wporg-plugins' ); ?></p>
+			<p><?php echo wp_kses_post( __( 'If the code in your plugin falls into one of the above categories, <strong>your plugin will not be approved</strong>. The Plugins Team will refer you back to these Handbook pages, adding further delay to the review process.', 'wporg-plugins' ) ); ?></p>
 
 			<h3><?php esc_html_e( 'What will my plugin URL be?', 'wporg-plugins' ); ?></h3>
 			<p><?php echo wp_kses_post( __( 'Your plugin&#8217;s URL will be populated based on the value of <code>Plugin Name</code> in your main plugin file (the one with the plugin headers). If you set yours as <code>Plugin Name: Boaty McBoatface</code> then your URL will be <code>https://wordpress.org/plugins/boaty-mcboatface</code> and your slug will be <code>boaty-mcboatface</code> for example. If there is an existing plugin with your name, then you will be <code>boaty-mcboatface-2</code> and so on. It behaves exactly like WordPress post names.', 'wporg-plugins' ) ); ?></p>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/patterns/page-add.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins-2024/patterns/page-add.php
@@ -58,6 +58,7 @@ do_blocks( '<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom"
 			<p>
 				<?php
 				printf(
+					/* translators: %s: Security handbook URL. */
 					wp_kses_post( __( 'Your plugin review cannot be prioritized over others, to help us approve your plugin sooner, please ensure that you have read the <a href="%s">Security chapter</a> of the Plugin Handbook.', 'wporg-plugins' ) ),
 					'https://developer.wordpress.org/apis/security/'
 				);

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/404.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/404.php
@@ -13,8 +13,8 @@ $wp_query = new WP_Query( array( 'no_found_rows' => true, 'post_type' => 'post',
 
 					<div class="col-5">
 						<div class="storycontent">
-								<h2><?php _e( 'Page Not Found', 'wporg-showcase' ); ?></h2>
-								<p><?php _e( 'Sorry, we could not not find that site in the Showcase. We do have many others available though. Here&#8217;s one chosen at random!', 'wporg-showcase' ); ?></p>
+								<h2><?php esc_html_e( 'Page Not Found', 'wporg-showcase' ); ?></h2>
+								<p><?php esc_html_e( 'Sorry, we could not not find that site in the Showcase. We do have many others available though. Here&#8217;s one chosen at random!', 'wporg-showcase' ); ?></p>
 								<?php //breadcrumb(); ?>
 								<h2><?php the_title(); ?></h2>
 								<a href="<?php echo esc_url( 'http://' . get_site_domain( false, false ) ); ?>">

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/archive.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/archive.php
@@ -33,7 +33,7 @@ get_header();
 
 		<?php else : // have_posts ?>
 
-			<p><?php _e( 'Sorry, no sites in the Showcase matched your criteria.', 'wporg-showcase' ); ?></p>
+			<p><?php esc_html_e( 'Sorry, no sites in the Showcase matched your criteria.', 'wporg-showcase' ); ?></p>
 
 		<?php endif; ?>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/comments.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/comments.php
@@ -1,5 +1,5 @@
 <?php if ( !empty($post->post_password) && $_COOKIE['wp-postpass_' . COOKIEHASH] != $post->post_password) : ?>
-<p><?php _e( 'Enter your password to view comments.', 'wporg-showcase' ); ?></p>
+<p><?php esc_html_e( 'Enter your password to view comments.', 'wporg-showcase' ); ?></p>
 <?php return; endif; ?>
 
 <?php if ( is_single() ) : ?>
@@ -15,7 +15,7 @@
 	<?php comment_text() ?>
 	<p><cite><?php printf(
 		/* translators: 1: comment type, 2: comment author link, 3: comment date */
-		__( '%1$s from %2$s on %3$s', 'wporg-showcase' ),
+		esc_html__( '%1$s from %2$s on %3$s', 'wporg-showcase' ),
 		comment_type( __( 'Comment', 'wporg-showcase' ), __( 'Trackback', 'wporg-showcase' ), __( 'Pingback', 'wporg-showcase' ) ),
 		comment_author_link(),
 		comment_date()

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/functions.php
@@ -106,7 +106,7 @@ function site_screenshot_tag( $width = '', $classes='screenshot' ) {
 function wp_flavors() {
 	global $post;
 
-	echo '<h2 class="heading">' . __( 'Flavor', 'wporg-showcase' ). '</h2>';
+	echo '<h2 class="heading">' . esc_html__( 'Flavor', 'wporg-showcase' ) . '</h2>';
 	echo '<ul id="flavors">';
 
 	$flavors = array( 'WordPress.org', 'WordPress.com', 'WordPress.com VIP', 'WordPress MS' );
@@ -188,20 +188,20 @@ function breadcrumb() { ?>
 		<?php if ( is_search() ) : ?>
 			<?php
 				/* translators: %s: search query */
-				printf( __( '&raquo; Search for: %s', 'wporg-showcase' ), get_search_query() );
+				printf( esc_html__( '&raquo; Search for: %s', 'wporg-showcase' ), get_search_query() );
 			?>
 		<?php elseif ( strstr( $_SERVER['REQUEST_URI'], '/showcase/archives' ) ) : ?>
-			<?php _e( '&raquo; Archives', 'wporg-showcase' ); ?>
+			<?php esc_html_e( '&raquo; Archives', 'wporg-showcase' ); ?>
 		<?php else : ?>
 			<?php if ( is_category() ) : ?>
-				<?php _e( '&raquo; Flavor', 'wporg-showcase' ); ?>
+				<?php esc_html_e( '&raquo; Flavor', 'wporg-showcase' ); ?>
 			<?php elseif ( is_tag() ) : ?>
-				<?php _e( '&raquo; Tag', 'wporg-showcase' ); ?>
+				<?php esc_html_e( '&raquo; Tag', 'wporg-showcase' ); ?>
 			<?php endif; // is_category ?>
 
 			<?php
 				/* translators: %s: document title */
-				printf( __( '&raquo; %s', 'wporg-showcase' ), wp_get_document_title() );
+				printf( esc_html__( '&raquo; %s', 'wporg-showcase' ), wp_get_document_title() );
 			?>
 		<?php endif; // is_search ?>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/functions.php
@@ -201,7 +201,7 @@ function breadcrumb() { ?>
 
 			<?php
 				/* translators: %s: document title */
-				printf( esc_html__( '&raquo; %s', 'wporg-showcase' ), wp_get_document_title() );
+				printf( esc_html__( '&raquo; %s', 'wporg-showcase' ), esc_html( wp_get_document_title() ) );
 			?>
 		<?php endif; // is_search ?>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/index.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/index.php
@@ -26,7 +26,7 @@
 
 		<?php else : // have_posts ?>
 
-			<p><?php _e( 'Sorry, no sites in the Showcase matched your criteria.', 'wporg-showcase' ); ?></p>
+			<p><?php esc_html_e( 'Sorry, no sites in the Showcase matched your criteria.', 'wporg-showcase' ); ?></p>
 
 		<?php endif; ?>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/page-home.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/page-home.php
@@ -13,7 +13,7 @@ add_action( 'wp_head', function() {
 get_header();
 ?>
 <div id="pagebody" class="home">
-	<h2 class="screen-reader-text"><?php _e( 'Featured Sites', 'wporg-showcase' ); ?></h2>
+	<h2 class="screen-reader-text"><?php esc_html_e( 'Featured Sites', 'wporg-showcase' ); ?></h2>
 	<?php query_posts( array( 'cat' => 4, 'posts_per_page' => 9, 'post_status' => 'publish' ) ); ?>
 	<?php if ( have_posts() ) : ?>
 
@@ -37,7 +37,7 @@ get_header();
 							<?php if ( $wpsc_url ) : // Make sure the URL is valid; esc_url_raw() returns an empty string if not. ?>
 							<a href="<?php echo esc_url( $wpsc_url ); ?>" class="wpsc-linkout">
 								<?php echo esc_html( str_replace( parse_url( $wpsc_url, PHP_URL_SCHEME ) . '://', '', untrailingslashit( $wpsc_url ) ) ); ?>
-								<span class="linkout-symbol"><?php _ex( '&#10162;', 'linkout symbol', 'wporg-showcase' ); ?></span>
+								<span class="linkout-symbol"><?php echo esc_html_x( '&#10162;', 'linkout symbol', 'wporg-showcase' ); ?></span>
 							</a>
 							<?php endif; // $wpsc_url ?>
 
@@ -46,7 +46,7 @@ get_header();
 								the_excerpt();
 							?>
 							<a class="wpsc-hero-learnmore" href="<?php the_permalink(); ?>" title="<?php the_title_attribute(); ?>">
-								<?php _e( 'Learn More &rarr;', 'wporg-showcase' ); ?>
+								<?php esc_html_e( 'Learn More &rarr;', 'wporg-showcase' ); ?>
 							</a>
 								</div>
 							</div>
@@ -69,7 +69,7 @@ get_header();
 		<div class="maincontentwrapper">
 			<?php query_posts( array( 'cat' => 4, 'posts_per_page' => 3, 'tag' => 'business', 'orderby' => 'rand' ) ); ?>
 			<?php if ( have_posts() ) : ?>
-			<h2><?php _e( 'Featured Business Sites', 'wporg-showcase' ); ?></h2>
+			<h2><?php esc_html_e( 'Featured Business Sites', 'wporg-showcase' ); ?></h2>
 			<ul class="wpsc-recent">
 
 				<?php while ( have_posts() ) : the_post(); ?>
@@ -92,7 +92,7 @@ get_header();
 			<?php query_posts( array( 'posts_per_page' => 9 ) ); ?>
 			<?php if ( have_posts() ) : ?>
 
-			<h2><?php _e( 'Recently Added Sites', 'wporg-showcase' ); ?></h2>
+			<h2><?php esc_html_e( 'Recently Added Sites', 'wporg-showcase' ); ?></h2>
 			<ul class="wpsc-recent">
 
 				<?php while ( have_posts() ) : the_post(); ?>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/page-submit.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/page-submit.php
@@ -27,10 +27,10 @@ if ( !empty( $_POST ) ) {
 
 <?php if ( $_POST && ! $error ) : ?>
 	<div id="return">
-	<h3><?php _e( 'Submitted!', 'wporg-showcase' ); ?></h3>
+	<h3><?php esc_html_e( 'Submitted!', 'wporg-showcase' ); ?></h3>
 	<p><?php printf(
 		/* translators: %s: URL of the site submission form */
-		__( 'Thanks! You have successfully submitted a site for consideration to be added to the WordPress Showcase. If the site you submitted is added, you will be contacted via email within one week. We appreciate your interest in the WordPress Showcase! If you\'d like to submit another site, head back to the <a href="%s">submission form</a>.', 'wporg-showcase' ),
+		wp_kses_post( __( 'Thanks! You have successfully submitted a site for consideration to be added to the WordPress Showcase. If the site you submitted is added, you will be contacted via email within one week. We appreciate your interest in the WordPress Showcase! If you\'d like to submit another site, head back to the <a href="%s">submission form</a>.', 'wporg-showcase' ) ),
 		'https://wordpress.org/showcase/submit-a-wordpress-site/'
 	); ?></p>
 	</div>
@@ -54,20 +54,20 @@ if ( empty( $_POST ) || $error ) {
 ?>
 
 	<?php if ( $error ) : ?>
-		<h3 id="return"><?php _e( 'Whoops!', 'wporg-showcase' ); ?></h3>
+		<h3 id="return"><?php esc_html_e( 'Whoops!', 'wporg-showcase' ); ?></h3>
 
 		<?php if ( strstr( $url, 'blogspot.com' ) || strstr( $url, 'blogger.com' ) ) : ?>
-			<p><?php _e( 'Please submit a WordPress blog URL. Blogspot/Blogger blogs are not accepted.', 'wporg-showcase' ); ?></p>
+			<p><?php esc_html_e( 'Please submit a WordPress blog URL. Blogspot/Blogger blogs are not accepted.', 'wporg-showcase' ); ?></p>
 
 		<?php elseif ( $site_detected == "NO" ) : ?>
-			<p><?php _e( 'We didn\'t detect WordPress at the given URL. Please submit the URL of a site running WordPress.', 'wporg-showcase' ); ?></p>
+			<p><?php esc_html_e( 'We didn\'t detect WordPress at the given URL. Please submit the URL of a site running WordPress.', 'wporg-showcase' ); ?></p>
 
 		<?php elseif ( $site_detected == "YES" && version_compare($site_version, $latest_release, '<' ) ) : ?>
-			<p><?php _e( 'We were unable to detect the latest version of WordPress at the given URL. We\'d prefer submissions to the showcase to be running up-to-date versions of WordPress.', 'wporg-showcase' ); ?></p>
-			<p><?php _e( 'If you\'re sure the site is running the latest version of WordPress, then please check the URL to make sure it\'s accurate, and that the URL you submit points directly to the location where WordPress is running.', 'wporg-showcase' ); ?></p>
+			<p><?php esc_html_e( 'We were unable to detect the latest version of WordPress at the given URL. We\'d prefer submissions to the showcase to be running up-to-date versions of WordPress.', 'wporg-showcase' ); ?></p>
+			<p><?php esc_html_e( 'If you\'re sure the site is running the latest version of WordPress, then please check the URL to make sure it\'s accurate, and that the URL you submit points directly to the location where WordPress is running.', 'wporg-showcase' ); ?></p>
 
 		<?php else : ?>
-			<p><?php _e( 'There seems to have been a problem with the information you entered. Please make sure all fields have data and resubmit.', 'wporg-showcase' ); ?></p>
+			<p><?php esc_html_e( 'There seems to have been a problem with the information you entered. Please make sure all fields have data and resubmit.', 'wporg-showcase' ); ?></p>
 
 		<?php endif; ?>
 
@@ -76,28 +76,28 @@ if ( empty( $_POST ) || $error ) {
 <form action="/showcase/submit-a-wordpress-site/#return" method="post" id="submitform">
 	<input type="hidden" name="comment_post_ID" value="<?php echo $post->ID; ?>" />
 
-	<p><label for="submitname"><?php _e( 'Your Name', 'wporg-showcase' ); ?></label><br />
+	<p><label for="submitname"><?php esc_html_e( 'Your Name', 'wporg-showcase' ); ?></label><br />
 	<input type="text" name="submitname" id="submitname" class="text" value="<?php echo esc_attr( $submitname ); ?>" size="28" tabindex="2" required></p>
 
-	<p><label for="email"><?php _e( 'Your E-mail', 'wporg-showcase'); ?></label><br />
+	<p><label for="email"><?php esc_html_e( 'Your E-mail', 'wporg-showcase' ); ?></label><br />
 	<input type="email" name="email" id="email" value="<?php echo esc_attr( $email ); ?>" size="28" tabindex="3" class="text" required></p>
 
-	<p><label for="url"><?php _e( 'Site URL', 'wporg-showcase' ); ?></label><br />
+	<p><label for="url"><?php esc_html_e( 'Site URL', 'wporg-showcase' ); ?></label><br />
 	<input type="url" name="url" id="url" value="<?php echo esc_url( $url ); ?>" size="28" tabindex="4" class="text" required></p>
 
-	<p><label for="owner"><?php _e( "Do you own this site? (It's okay if you don't - we just want to know for contact purposes.)", 'wporg-showcase' ); ?></label><br />
+	<p><label for="owner"><?php esc_html_e( "Do you own this site? (It's okay if you don't - we just want to know for contact purposes.)", 'wporg-showcase' ); ?></label><br />
 	<select name="owner" id="owner" tabindex="5">
-		<option value="yes" <?php selected( $owner, 'yes' ); ?> ><?php _e( 'Yes', 'wporg-showcase' ); ?></option>
-		<option value="no" <?php selected( $owner, 'no' ); ?> ><?php _e( 'No', 'wporg-showcase' ); ?></option>
+		<option value="yes" <?php selected( $owner, 'yes' ); ?> ><?php esc_html_e( 'Yes', 'wporg-showcase' ); ?></option>
+		<option value="no" <?php selected( $owner, 'no' ); ?> ><?php esc_html_e( 'No', 'wporg-showcase' ); ?></option>
 	</select>
 
-	<p><label for="description"><?php _e( 'Please describe the site and, if applicable, the person or organization it represents.', 'wporg-showcase' ); ?></label><br />
+	<p><label for="description"><?php esc_html_e( 'Please describe the site and, if applicable, the person or organization it represents.', 'wporg-showcase' ); ?></label><br />
 	<textarea name="description" id="description" cols="60" rows="4" tabindex="6" class="text" required><?php echo esc_textarea( $description ); ?></textarea></p>
 
-	<p><label for="why"><?php _e( 'What justifies this site being added to the WordPress Showcase? What makes it unique or interesting?', 'wporg-showcase' ); ?></label><br />
+	<p><label for="why"><?php esc_html_e( 'What justifies this site being added to the WordPress Showcase? What makes it unique or interesting?', 'wporg-showcase' ); ?></label><br />
 	<textarea name="why" id="why" cols="60" rows="4" tabindex="7" class="text" required><?php echo esc_textarea( $why ); ?></textarea></p>
 
-	<p class="required"><?php _e( '* All fields are required.', 'wporg-showcase' ); ?></p>
+	<p class="required"><?php esc_html_e( '* All fields are required.', 'wporg-showcase' ); ?></p>
 
 	<?php
 	if ($use_recaptcha) {

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/page-submit.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/page-submit.php
@@ -30,7 +30,7 @@ if ( !empty( $_POST ) ) {
 	<h3><?php esc_html_e( 'Submitted!', 'wporg-showcase' ); ?></h3>
 	<p><?php printf(
 		/* translators: %s: URL of the site submission form */
-		wp_kses_post( __( 'Thanks! You have successfully submitted a site for consideration to be added to the WordPress Showcase. If the site you submitted is added, you will be contacted via email within one week. We appreciate your interest in the WordPress Showcase! If you\'d like to submit another site, head back to the <a href="%s">submission form</a>.', 'wporg-showcase' ) ),
+		wp_kses_post( __( 'Thanks! You have successfully submitted a site for consideration to be added to the WordPress Showcase. If the site you submitted is added, you will be contacted via email within one week. We appreciate your interest in the WordPress Showcase! If you&#8217;d like to submit another site, head back to the <a href="%s">submission form</a>.', 'wporg-showcase' ) ),
 		'https://wordpress.org/showcase/submit-a-wordpress-site/'
 	); ?></p>
 	</div>
@@ -60,11 +60,11 @@ if ( empty( $_POST ) || $error ) {
 			<p><?php esc_html_e( 'Please submit a WordPress blog URL. Blogspot/Blogger blogs are not accepted.', 'wporg-showcase' ); ?></p>
 
 		<?php elseif ( $site_detected == "NO" ) : ?>
-			<p><?php esc_html_e( 'We didn\'t detect WordPress at the given URL. Please submit the URL of a site running WordPress.', 'wporg-showcase' ); ?></p>
+			<p><?php esc_html_e( 'We didn&#8217;t detect WordPress at the given URL. Please submit the URL of a site running WordPress.', 'wporg-showcase' ); ?></p>
 
 		<?php elseif ( $site_detected == "YES" && version_compare($site_version, $latest_release, '<' ) ) : ?>
-			<p><?php esc_html_e( 'We were unable to detect the latest version of WordPress at the given URL. We\'d prefer submissions to the showcase to be running up-to-date versions of WordPress.', 'wporg-showcase' ); ?></p>
-			<p><?php esc_html_e( 'If you\'re sure the site is running the latest version of WordPress, then please check the URL to make sure it\'s accurate, and that the URL you submit points directly to the location where WordPress is running.', 'wporg-showcase' ); ?></p>
+			<p><?php esc_html_e( 'We were unable to detect the latest version of WordPress at the given URL. We&#8217;d prefer submissions to the showcase to be running up-to-date versions of WordPress.', 'wporg-showcase' ); ?></p>
+			<p><?php esc_html_e( 'If you&#8217;re sure the site is running the latest version of WordPress, then please check the URL to make sure it&#8217;s accurate, and that the URL you submit points directly to the location where WordPress is running.', 'wporg-showcase' ); ?></p>
 
 		<?php else : ?>
 			<p><?php esc_html_e( 'There seems to have been a problem with the information you entered. Please make sure all fields have data and resubmit.', 'wporg-showcase' ); ?></p>
@@ -85,7 +85,7 @@ if ( empty( $_POST ) || $error ) {
 	<p><label for="url"><?php esc_html_e( 'Site URL', 'wporg-showcase' ); ?></label><br />
 	<input type="url" name="url" id="url" value="<?php echo esc_url( $url ); ?>" size="28" tabindex="4" class="text" required></p>
 
-	<p><label for="owner"><?php esc_html_e( "Do you own this site? (It's okay if you don't - we just want to know for contact purposes.)", 'wporg-showcase' ); ?></label><br />
+	<p><label for="owner"><?php esc_html_e( 'Do you own this site? (It&#8217;s okay if you don&#8217;t - we just want to know for contact purposes.)', 'wporg-showcase' ); ?></label><br />
 	<select name="owner" id="owner" tabindex="5">
 		<option value="yes" <?php selected( $owner, 'yes' ); ?> ><?php esc_html_e( 'Yes', 'wporg-showcase' ); ?></option>
 		<option value="no" <?php selected( $owner, 'no' ); ?> ><?php esc_html_e( 'No', 'wporg-showcase' ); ?></option>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/sidebar-left.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/sidebar-left.php
@@ -9,7 +9,7 @@
 		<div class="col-2 secondary leftsidebar">
 			<a href="<?php echo esc_url( home_url( '/submit-a-wordpress-site/' ) ); ?>" class="wpsc-submit-site"><?php esc_html_e( 'Submit a Site &rarr;', 'wporg-showcase' ); ?></a>
 
-			<h2 class="heading search"><?php _e( 'Search', 'wporg-showcase' ); ?></h2>
+			<h2 class="heading search"><?php esc_html_e( 'Search', 'wporg-showcase' ); ?></h2>
 			<?php // @todo: use get_search_form(); ?>
 			<form method="get" id="searchform" action="<?php echo esc_url( home_url( '/' ) ); ?>">
 				<input type="text" value="<?php the_search_query(); ?>" name="s" id="s" class="text" />
@@ -19,7 +19,7 @@
 			<?php popular_tags(); ?>
 			<a href='<?php echo esc_url( home_url( '/tag-cloud/' ) ); ?>' class="wpsc-all-tags"><?php esc_html_e( 'View All Tags &rarr;', 'wporg-showcase' ); ?></a>
 
-			<h2 class="heading"><?php _e( 'Browse by Flavor', 'wporg-showcase' ); ?></h2>
+			<h2 class="heading"><?php esc_html_e( 'Browse by Flavor', 'wporg-showcase' ); ?></h2>
 			<ul class="submenu">
 				<?php wp_list_categories( 'exclude=4&title_li=' ); ?>
 			</ul>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/404.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/404.php
@@ -17,7 +17,7 @@ get_header(); ?>
 
 		<section class="error-404 not-found">
 			<header class="page-header">
-				<h1 class="page-title"><?php _e( 'Oops! That page can&rsquo;t be found.', 'wporg-forums' ); ?></h1>
+				<h1 class="page-title"><?php esc_html_e( 'Oops! That page can&rsquo;t be found.', 'wporg-forums' ); ?></h1>
 			</header><!-- .page-header -->
 
 			<div class="page-content">

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/archive-forum.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/archive-forum.php
@@ -16,7 +16,7 @@ get_header(); ?>
 			<section>
 				<p><?php printf(
 					/* Translators: forums welcome page URL */
-					__( 'Our community-based support forums are a great place to learn, share, and help each other. <a href="%s">Find out how to get started</a>.', 'wporg-forums' ),
+					wp_kses_post( __( 'Our community-based support forums are a great place to learn, share, and help each other. <a href="%s">Find out how to get started</a>.', 'wporg-forums' ) ),
 					esc_url( wporg_support_get_welcome_url() )
 				) ?></p>
 			</section>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/content-single-forum.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/content-single-forum.php
@@ -10,7 +10,7 @@
 ?>
 
 <header class="page-header">
-	<h1 class="page-title"><?php printf( __( '%s Forum', 'wporg-forums' ), bbp_get_topic_title() ); ?></h1>
+	<h1 class="page-title"><?php printf( esc_html__( '%s Forum', 'wporg-forums' ), bbp_get_topic_title() ); ?></h1>
 	<p><?php bbp_forum_content(); ?></p>
 </header>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/content-single-forum.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/content-single-forum.php
@@ -10,6 +10,7 @@
 ?>
 
 <header class="page-header">
+	<?php /* translators: %s: Forum name. */ ?>
 	<h1 class="page-title"><?php printf( esc_html__( '%s Forum', 'wporg-forums' ), bbp_get_topic_title() ); ?></h1>
 	<p><?php bbp_forum_content(); ?></p>
 </header>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/content-single-forum.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/content-single-forum.php
@@ -11,7 +11,7 @@
 
 <header class="page-header">
 	<?php /* translators: %s: Forum name. */ ?>
-	<h1 class="page-title"><?php printf( esc_html__( '%s Forum', 'wporg-forums' ), esc_html( bbp_get_topic_title() ) ); ?></h1>
+	<h1 class="page-title"><?php printf( esc_html__( '%s Forum', 'wporg-forums' ), wp_kses_post( bbp_get_topic_title() ) ); ?></h1>
 	<p><?php bbp_forum_content(); ?></p>
 </header>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/content-single-forum.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/content-single-forum.php
@@ -11,7 +11,7 @@
 
 <header class="page-header">
 	<?php /* translators: %s: Forum name. */ ?>
-	<h1 class="page-title"><?php printf( esc_html__( '%s Forum', 'wporg-forums' ), bbp_get_topic_title() ); ?></h1>
+	<h1 class="page-title"><?php printf( esc_html__( '%s Forum', 'wporg-forums' ), esc_html( bbp_get_topic_title() ) ); ?></h1>
 	<p><?php bbp_forum_content(); ?></p>
 </header>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/feedback-no-search.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/feedback-no-search.php
@@ -1,3 +1,11 @@
+<?php
+/**
+ * Notice shown when a forum search has no results.
+ *
+ * @package WPBBP
+ */
+
+?>
 <div class="bbp-template-notice">
 	<p><?php esc_html_e( 'No results found. Try a different search or start a new post.', 'wporg-forums' ); ?></p>
 </div>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/feedback-no-search.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/feedback-no-search.php
@@ -2,7 +2,7 @@
 /**
  * Notice shown when a forum search has no results.
  *
- * @package WPBBP
+ * @package bbPress
  */
 
 ?>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/feedback-no-search.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/feedback-no-search.php
@@ -1,3 +1,3 @@
 <div class="bbp-template-notice">
-	<p><?php _e( 'No results found. Try a different search or start a new post.', 'wporg-forums' ); ?></p>
+	<p><?php esc_html_e( 'No results found. Try a different search or start a new post.', 'wporg-forums' ); ?></p>
 </div>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/feedback-no-topics.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/feedback-no-topics.php
@@ -2,7 +2,7 @@
 /**
  * Notice shown when a forum view has no topics.
  *
- * @package WPBBP
+ * @package bbPress
  */
 
 ?>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/feedback-no-topics.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/feedback-no-topics.php
@@ -1,3 +1,11 @@
+<?php
+/**
+ * Notice shown when a forum view has no topics.
+ *
+ * @package WPBBP
+ */
+
+?>
 <div class="bbp-template-notice">
 	<p><?php esc_html_e( 'No topics found. Select another view or start a new post.', 'wporg-forums' ); ?></p>
 </div>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/feedback-no-topics.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/feedback-no-topics.php
@@ -1,3 +1,3 @@
 <div class="bbp-template-notice">
-	<p><?php _e( 'No topics found. Select another view or start a new post.', 'wporg-forums' ); ?></p>
+	<p><?php esc_html_e( 'No topics found. Select another view or start a new post.', 'wporg-forums' ); ?></p>
 </div>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/feedback-search.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/feedback-search.php
@@ -2,7 +2,7 @@
 /**
  * Notice shown when a forum search has no terms.
  *
- * @package WPBBP
+ * @package bbPress
  */
 
 ?>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/feedback-search.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/feedback-search.php
@@ -1,3 +1,3 @@
 <div class="bbp-template-notice">
-	<p><?php _e( 'Please enter some search terms above', 'wporg-forums' ); ?></p>
+	<p><?php esc_html_e( 'Please enter some search terms above', 'wporg-forums' ); ?></p>
 </div>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/feedback-search.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/feedback-search.php
@@ -1,3 +1,11 @@
+<?php
+/**
+ * Notice shown when a forum search has no terms.
+ *
+ * @package WPBBP
+ */
+
+?>
 <div class="bbp-template-notice">
 	<p><?php esc_html_e( 'Please enter some search terms above', 'wporg-forums' ); ?></p>
 </div>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/form-reply.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/form-reply.php
@@ -84,7 +84,7 @@ if ( bbp_is_reply_edit() ) : ?>
 
 						<?php if ( bbp_allow_topic_tags() ) : ?>
 						<p>
-							<label for="bbp_topic_tags"><?php _e( 'Topic Tags:', 'wporg-forums' ); ?></label><br />
+							<label for="bbp_topic_tags"><?php esc_html_e( 'Topic Tags:', 'wporg-forums' ); ?></label><br />
 							<input type="text" value="<?php bbp_form_topic_tags(); ?>" size="40" name="bbp_topic_tags" id="bbp_topic_tags" aria-describedby="bbp_topic_tags_description" <?php disabled( bbp_is_topic_spam() ); ?> /><br />
 							<em id="bbp_topic_tags_description"><?php esc_html_e( 'Separate tags with commas', 'wporg-forums' ); ?></em>
 						</p>
@@ -231,11 +231,11 @@ if ( bbp_is_reply_edit() ) : ?>
 			<?php if ( current_user_can( bbp_get_spectator_role() ) && ! bbp_is_topic_closed() && ! bbp_is_forum_closed( bbp_get_topic_forum_id() ) ) : ?>
 				<p><?php
 					printf(
-						__( 'This may be caused by your account being marked as a brand or shared company account.', 'wporg-forums' ) . '<br>' .
+						esc_html__( 'This may be caused by your account being marked as a brand or shared company account.', 'wporg-forums' ) . '<br>' .
 						/* translators: %s: Link to https://make.wordpress.org/support/2025/03/about-the-spectator-role-in-the-wordpress-support-forums/ */
-						__( '<a href="%s">Please read this announcement</a> for more information.', 'wporg-forums' ) . '<br>' .
+						wp_kses_post( __( '<a href="%s">Please read this announcement</a> for more information.', 'wporg-forums' ) ) . '<br>' .
 						/* translators: %s: Email address. */
-						__( 'If you believe this to be in error, please contact the forum moderation team via <code>%s</code>.', 'wporg-forums' ),
+						wp_kses_post( __( 'If you believe this to be in error, please contact the forum moderation team via <code>%s</code>.', 'wporg-forums' ) ),
 						'https://make.wordpress.org/support/2025/03/about-the-spectator-role-in-the-wordpress-support-forums/',
 						WordPressdotorg\Forums\MODERATION_EMAIL
 					);

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/form-topic-merge.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/form-topic-merge.php
@@ -15,12 +15,14 @@
 
 		<div id="merge-topic-<?php bbp_topic_id(); ?>" class="bbp-topic-merge">
 
+			<?php /* translators: %s: Topic title. */ ?>
 			<h1><?php printf( esc_html__( 'Merge topic "%s"', 'wporg-forums' ), bbp_get_topic_title() ); ?></h1>
 
 			<form id="merge_topic" name="merge_topic" method="post" action="<?php the_permalink(); ?>">
 
 				<fieldset class="bbp-form">
 
+					<?php /* translators: %s: Topic title. */ ?>
 					<legend><?php printf( esc_html__( 'Merge topic "%s"', 'wporg-forums' ), bbp_get_topic_title() ); ?></legend>
 
 					<div>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/form-topic-merge.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/form-topic-merge.php
@@ -15,31 +15,31 @@
 
 		<div id="merge-topic-<?php bbp_topic_id(); ?>" class="bbp-topic-merge">
 
-			<h1><?php printf( __( 'Merge topic "%s"', 'wporg-forums' ), bbp_get_topic_title() ); ?></h1>
+			<h1><?php printf( esc_html__( 'Merge topic "%s"', 'wporg-forums' ), bbp_get_topic_title() ); ?></h1>
 
 			<form id="merge_topic" name="merge_topic" method="post" action="<?php the_permalink(); ?>">
 
 				<fieldset class="bbp-form">
 
-					<legend><?php printf( __( 'Merge topic "%s"', 'wporg-forums' ), bbp_get_topic_title() ); ?></legend>
+					<legend><?php printf( esc_html__( 'Merge topic "%s"', 'wporg-forums' ), bbp_get_topic_title() ); ?></legend>
 
 					<div>
 
 						<div class="bbp-template-notice info">
-							<p><?php _e( 'Select the topic to merge this one into. The destination topic will remain the lead topic, and this one will change into a reply.', 'wporg-forums' ); ?></p>
-							<p><?php _e( 'To keep this topic as the lead, go to the other topic and use the merge tool from there instead.', 'wporg-forums' ); ?></p>
+							<p><?php esc_html_e( 'Select the topic to merge this one into. The destination topic will remain the lead topic, and this one will change into a reply.', 'wporg-forums' ); ?></p>
+							<p><?php esc_html_e( 'To keep this topic as the lead, go to the other topic and use the merge tool from there instead.', 'wporg-forums' ); ?></p>
 						</div>
 
 						<div class="bbp-template-notice">
-							<p><?php _e( 'All replies within both the topics will be merged chronologically. The order of the merged replies is based on the time they were posted. If the destination topic was created after this one, its post date will be updated to a second earlier than this one.', 'wporg-forums' ); ?></p>
+							<p><?php esc_html_e( 'All replies within both the topics will be merged chronologically. The order of the merged replies is based on the time they were posted. If the destination topic was created after this one, its post date will be updated to a second earlier than this one.', 'wporg-forums' ); ?></p>
 						</div>
 
 						<fieldset class="bbp-form">
-							<legend><?php _e( 'Destination', 'wporg-forums' ); ?></legend>
+							<legend><?php esc_html_e( 'Destination', 'wporg-forums' ); ?></legend>
 							<div>
 								<?php if ( bbp_has_topics( array( 'show_stickies' => false, 'post_parent' => bbp_get_topic_forum_id( bbp_get_topic_id() ), 'post__not_in' => array( bbp_get_topic_id() ) ) ) ) : ?>
 
-									<label for="bbp_destination_topic"><?php _e( 'Merge with this topic:', 'wporg-forums' ); ?></label>
+									<label for="bbp_destination_topic"><?php esc_html_e( 'Merge with this topic:', 'wporg-forums' ); ?></label>
 
 									<?php
 										bbp_dropdown( array(
@@ -57,7 +57,7 @@
 
 								<?php else : ?>
 
-									<label><?php _e( 'There are no other topics in this forum to merge with.', 'wporg-forums' ); ?></label>
+									<label><?php esc_html_e( 'There are no other topics in this forum to merge with.', 'wporg-forums' ); ?></label>
 
 								<?php endif; ?>
 
@@ -65,24 +65,24 @@
 						</fieldset>
 
 						<fieldset class="bbp-form">
-							<legend><?php _e( 'Topic Extras', 'wporg-forums' ); ?></legend>
+							<legend><?php esc_html_e( 'Topic Extras', 'wporg-forums' ); ?></legend>
 
 							<div>
 
 								<?php if ( bbp_is_subscriptions_active() ) : ?>
 
 									<input name="bbp_topic_subscribers" id="bbp_topic_subscribers" type="checkbox" value="1" checked="checked" />
-									<label for="bbp_topic_subscribers"><?php _e( 'Merge topic subscribers', 'wporg-forums' ); ?></label><br />
+									<label for="bbp_topic_subscribers"><?php esc_html_e( 'Merge topic subscribers', 'wporg-forums' ); ?></label><br />
 
 								<?php endif; ?>
 
 								<input name="bbp_topic_favoriters" id="bbp_topic_favoriters" type="checkbox" value="1" checked="checked" />
-								<label for="bbp_topic_favoriters"><?php _e( 'Merge topic favoriters', 'wporg-forums' ); ?></label><br />
+								<label for="bbp_topic_favoriters"><?php esc_html_e( 'Merge topic favoriters', 'wporg-forums' ); ?></label><br />
 
 								<?php if ( bbp_allow_topic_tags() ) : ?>
 
 									<input name="bbp_topic_tags" id="bbp_topic_tags" type="checkbox" value="1" checked="checked" />
-									<label for="bbp_topic_tags"><?php _e( 'Merge topic tags', 'wporg-forums' ); ?></label><br />
+									<label for="bbp_topic_tags"><?php esc_html_e( 'Merge topic tags', 'wporg-forums' ); ?></label><br />
 
 								<?php endif; ?>
 
@@ -90,11 +90,11 @@
 						</fieldset>
 
 						<div class="bbp-template-notice error">
-							<p><?php _e( '<strong>WARNING:</strong> This process cannot be undone.', 'wporg-forums' ); ?></p>
+							<p><?php echo wp_kses_post( __( '<strong>WARNING:</strong> This process cannot be undone.', 'wporg-forums' ) ); ?></p>
 						</div>
 
 						<div class="bbp-submit-wrapper">
-							<button type="submit" id="bbp_merge_topic_submit" name="bbp_merge_topic_submit" class="button button-primary submit"><?php _e( 'Submit', 'wporg-forums' ); ?></button>
+							<button type="submit" id="bbp_merge_topic_submit" name="bbp_merge_topic_submit" class="button button-primary submit"><?php esc_html_e( 'Submit', 'wporg-forums' ); ?></button>
 						</div>
 					</div>
 
@@ -107,7 +107,7 @@
 	<?php else : ?>
 
 		<div id="no-topic-<?php bbp_topic_id(); ?>" class="bbp-no-topic">
-			<div class="entry-content"><?php is_user_logged_in() ? _e( 'You do not have the permissions to edit this topic!', 'wporg-forums' ) : _e( 'You cannot edit this topic.', 'wporg-forums' ); ?></div>
+			<div class="entry-content"><?php is_user_logged_in() ? esc_html_e( 'You do not have the permissions to edit this topic!', 'wporg-forums' ) : esc_html_e( 'You cannot edit this topic.', 'wporg-forums' ); ?></div>
 		</div>
 
 	<?php endif; ?>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/form-topic-merge.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/form-topic-merge.php
@@ -16,14 +16,14 @@
 		<div id="merge-topic-<?php bbp_topic_id(); ?>" class="bbp-topic-merge">
 
 			<?php /* translators: %s: Topic title. */ ?>
-			<h1><?php printf( esc_html__( 'Merge topic "%s"', 'wporg-forums' ), wp_kses_post( bbp_get_topic_title() ) ); ?></h1>
+			<h1><?php printf( esc_html__( 'Merge topic &#8220;%s&#8221;', 'wporg-forums' ), wp_kses_post( bbp_get_topic_title() ) ); ?></h1>
 
 			<form id="merge_topic" name="merge_topic" method="post" action="<?php the_permalink(); ?>">
 
 				<fieldset class="bbp-form">
 
 					<?php /* translators: %s: Topic title. */ ?>
-					<legend><?php printf( esc_html__( 'Merge topic "%s"', 'wporg-forums' ), wp_kses_post( bbp_get_topic_title() ) ); ?></legend>
+					<legend><?php printf( esc_html__( 'Merge topic &#8220;%s&#8221;', 'wporg-forums' ), wp_kses_post( bbp_get_topic_title() ) ); ?></legend>
 
 					<div>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/form-topic-merge.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/form-topic-merge.php
@@ -16,14 +16,14 @@
 		<div id="merge-topic-<?php bbp_topic_id(); ?>" class="bbp-topic-merge">
 
 			<?php /* translators: %s: Topic title. */ ?>
-			<h1><?php printf( esc_html__( 'Merge topic "%s"', 'wporg-forums' ), bbp_get_topic_title() ); ?></h1>
+			<h1><?php printf( esc_html__( 'Merge topic "%s"', 'wporg-forums' ), esc_html( bbp_get_topic_title() ) ); ?></h1>
 
 			<form id="merge_topic" name="merge_topic" method="post" action="<?php the_permalink(); ?>">
 
 				<fieldset class="bbp-form">
 
 					<?php /* translators: %s: Topic title. */ ?>
-					<legend><?php printf( esc_html__( 'Merge topic "%s"', 'wporg-forums' ), bbp_get_topic_title() ); ?></legend>
+					<legend><?php printf( esc_html__( 'Merge topic "%s"', 'wporg-forums' ), esc_html( bbp_get_topic_title() ) ); ?></legend>
 
 					<div>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/form-topic-merge.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/form-topic-merge.php
@@ -16,14 +16,14 @@
 		<div id="merge-topic-<?php bbp_topic_id(); ?>" class="bbp-topic-merge">
 
 			<?php /* translators: %s: Topic title. */ ?>
-			<h1><?php printf( esc_html__( 'Merge topic "%s"', 'wporg-forums' ), esc_html( bbp_get_topic_title() ) ); ?></h1>
+			<h1><?php printf( esc_html__( 'Merge topic "%s"', 'wporg-forums' ), wp_kses_post( bbp_get_topic_title() ) ); ?></h1>
 
 			<form id="merge_topic" name="merge_topic" method="post" action="<?php the_permalink(); ?>">
 
 				<fieldset class="bbp-form">
 
 					<?php /* translators: %s: Topic title. */ ?>
-					<legend><?php printf( esc_html__( 'Merge topic "%s"', 'wporg-forums' ), esc_html( bbp_get_topic_title() ) ); ?></legend>
+					<legend><?php printf( esc_html__( 'Merge topic "%s"', 'wporg-forums' ), wp_kses_post( bbp_get_topic_title() ) ); ?></legend>
 
 					<div>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/form-topic-split.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/form-topic-split.php
@@ -15,30 +15,30 @@
 
 		<div id="split-topic-<?php bbp_topic_id(); ?>" class="bbp-topic-split">
 
-			<h1><?php printf( __( 'Split topic "%s"', 'wporg-forums' ), bbp_get_topic_title() ); ?></h1>
+			<h1><?php printf( esc_html__( 'Split topic "%s"', 'wporg-forums' ), bbp_get_topic_title() ); ?></h1>
 
 			<form id="split_topic" name="split_topic" method="post" action="<?php the_permalink(); ?>">
 
 				<fieldset class="bbp-form">
 
-					<legend><?php printf( __( 'Split topic "%s"', 'wporg-forums' ), bbp_get_topic_title() ); ?></legend>
+					<legend><?php printf( esc_html__( 'Split topic "%s"', 'wporg-forums' ), bbp_get_topic_title() ); ?></legend>
 
 					<div>
 
 						<div class="bbp-template-notice info">
-							<p><?php _e( 'When you split a topic, you are slicing it in half starting with the reply you just selected. Choose to use that reply as a new topic with a new title, or merge those replies into an existing topic.', 'wporg-forums' ); ?></p>
+							<p><?php esc_html_e( 'When you split a topic, you are slicing it in half starting with the reply you just selected. Choose to use that reply as a new topic with a new title, or merge those replies into an existing topic.', 'wporg-forums' ); ?></p>
 						</div>
 
 						<div class="bbp-template-notice">
-							<p><?php _e( 'If you use the existing topic option, replies within both topics will be merged chronologically. The order of the merged replies is based on the time and date they were posted.', 'wporg-forums' ); ?></p>
+							<p><?php esc_html_e( 'If you use the existing topic option, replies within both topics will be merged chronologically. The order of the merged replies is based on the time and date they were posted.', 'wporg-forums' ); ?></p>
 						</div>
 
 						<fieldset class="bbp-form">
-							<legend><?php _e( 'Split Method', 'wporg-forums' ); ?></legend>
+							<legend><?php esc_html_e( 'Split Method', 'wporg-forums' ); ?></legend>
 
 							<div>
 								<input name="bbp_topic_split_option" id="bbp_topic_split_option_reply" type="radio" checked="checked" value="reply" />
-								<label for="bbp_topic_split_option_reply"><?php printf( __( 'New topic in <strong>%s</strong> titled:', 'wporg-forums' ), bbp_get_forum_title( bbp_get_topic_forum_id( bbp_get_topic_id() ) ) ); ?></label>
+								<label for="bbp_topic_split_option_reply"><?php printf( wp_kses_post( __( 'New topic in <strong>%s</strong> titled:', 'wporg-forums' ) ), bbp_get_forum_title( bbp_get_topic_forum_id( bbp_get_topic_id() ) ) ); ?></label>
 								<input type="text" id="bbp_topic_split_destination_title" value="<?php echo esc_attr( sprintf( __( 'Split: %s', 'wporg-forums' ), bbp_get_topic_title() ) ); ?>" size="35" name="bbp_topic_split_destination_title" />
 							</div>
 
@@ -46,7 +46,7 @@
 
 								<div>
 									<input name="bbp_topic_split_option" id="bbp_topic_split_option_existing" type="radio" value="existing" />
-									<label for="bbp_topic_split_option_existing"><?php _e( 'Use an existing topic in this forum:', 'wporg-forums' ); ?></label>
+									<label for="bbp_topic_split_option_existing"><?php esc_html_e( 'Use an existing topic in this forum:', 'wporg-forums' ); ?></label>
 
 									<?php
 										bbp_dropdown( array(
@@ -68,24 +68,24 @@
 						</fieldset>
 
 						<fieldset class="bbp-form">
-							<legend><?php _e( 'Topic Extras', 'wporg-forums' ); ?></legend>
+							<legend><?php esc_html_e( 'Topic Extras', 'wporg-forums' ); ?></legend>
 
 							<div>
 
 								<?php if ( bbp_is_subscriptions_active() ) : ?>
 
 									<input name="bbp_topic_subscribers" id="bbp_topic_subscribers" type="checkbox" value="1" checked="checked" />
-									<label for="bbp_topic_subscribers"><?php _e( 'Copy subscribers to the new topic', 'wporg-forums' ); ?></label><br />
+									<label for="bbp_topic_subscribers"><?php esc_html_e( 'Copy subscribers to the new topic', 'wporg-forums' ); ?></label><br />
 
 								<?php endif; ?>
 
 								<input name="bbp_topic_favoriters" id="bbp_topic_favoriters" type="checkbox" value="1" checked="checked" />
-								<label for="bbp_topic_favoriters"><?php _e( 'Copy favoriters to the new topic', 'wporg-forums' ); ?></label><br />
+								<label for="bbp_topic_favoriters"><?php esc_html_e( 'Copy favoriters to the new topic', 'wporg-forums' ); ?></label><br />
 
 								<?php if ( bbp_allow_topic_tags() ) : ?>
 
 									<input name="bbp_topic_tags" id="bbp_topic_tags" type="checkbox" value="1" checked="checked" />
-									<label for="bbp_topic_tags"><?php _e( 'Copy topic tags to the new topic', 'wporg-forums' ); ?></label><br />
+									<label for="bbp_topic_tags"><?php esc_html_e( 'Copy topic tags to the new topic', 'wporg-forums' ); ?></label><br />
 
 								<?php endif; ?>
 
@@ -93,11 +93,11 @@
 						</fieldset>
 
 						<div class="bbp-template-notice error">
-							<p><?php _e( '<strong>WARNING:</strong> This process cannot be undone.', 'wporg-forums' ); ?></p>
+							<p><?php echo wp_kses_post( __( '<strong>WARNING:</strong> This process cannot be undone.', 'wporg-forums' ) ); ?></p>
 						</div>
 
 						<div class="bbp-submit-wrapper">
-							<button type="submit" id="bbp_merge_topic_submit" name="bbp_merge_topic_submit" class="button button-primary submit"><?php _e( 'Submit', 'wporg-forums' ); ?></button>
+							<button type="submit" id="bbp_merge_topic_submit" name="bbp_merge_topic_submit" class="button button-primary submit"><?php esc_html_e( 'Submit', 'wporg-forums' ); ?></button>
 						</div>
 					</div>
 
@@ -110,7 +110,7 @@
 	<?php else : ?>
 
 		<div id="no-topic-<?php bbp_topic_id(); ?>" class="bbp-no-topic">
-			<div class="entry-content"><?php is_user_logged_in() ? _e( 'You do not have the permissions to edit this topic!', 'wporg-forums' ) : _e( 'You cannot edit this topic.', 'wporg-forums' ); ?></div>
+			<div class="entry-content"><?php is_user_logged_in() ? esc_html_e( 'You do not have the permissions to edit this topic!', 'wporg-forums' ) : esc_html_e( 'You cannot edit this topic.', 'wporg-forums' ); ?></div>
 		</div>
 
 	<?php endif; ?>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/form-topic-split.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/form-topic-split.php
@@ -16,14 +16,14 @@
 		<div id="split-topic-<?php bbp_topic_id(); ?>" class="bbp-topic-split">
 
 			<?php /* translators: %s: Topic title. */ ?>
-			<h1><?php printf( esc_html__( 'Split topic "%s"', 'wporg-forums' ), bbp_get_topic_title() ); ?></h1>
+			<h1><?php printf( esc_html__( 'Split topic "%s"', 'wporg-forums' ), esc_html( bbp_get_topic_title() ) ); ?></h1>
 
 			<form id="split_topic" name="split_topic" method="post" action="<?php the_permalink(); ?>">
 
 				<fieldset class="bbp-form">
 
 					<?php /* translators: %s: Topic title. */ ?>
-					<legend><?php printf( esc_html__( 'Split topic "%s"', 'wporg-forums' ), bbp_get_topic_title() ); ?></legend>
+					<legend><?php printf( esc_html__( 'Split topic "%s"', 'wporg-forums' ), esc_html( bbp_get_topic_title() ) ); ?></legend>
 
 					<div>
 
@@ -41,7 +41,7 @@
 							<div>
 								<input name="bbp_topic_split_option" id="bbp_topic_split_option_reply" type="radio" checked="checked" value="reply" />
 								<?php /* translators: %s: Forum title. */ ?>
-								<label for="bbp_topic_split_option_reply"><?php printf( wp_kses_post( __( 'New topic in <strong>%s</strong> titled:', 'wporg-forums' ) ), bbp_get_forum_title( bbp_get_topic_forum_id( bbp_get_topic_id() ) ) ); ?></label>
+								<label for="bbp_topic_split_option_reply"><?php printf( wp_kses_post( __( 'New topic in <strong>%s</strong> titled:', 'wporg-forums' ) ), esc_html( bbp_get_forum_title( bbp_get_topic_forum_id( bbp_get_topic_id() ) ) ) ); ?></label>
 								<input type="text" id="bbp_topic_split_destination_title" value="<?php echo esc_attr( sprintf( __( 'Split: %s', 'wporg-forums' ), bbp_get_topic_title() ) ); ?>" size="35" name="bbp_topic_split_destination_title" />
 							</div>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/form-topic-split.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/form-topic-split.php
@@ -16,14 +16,14 @@
 		<div id="split-topic-<?php bbp_topic_id(); ?>" class="bbp-topic-split">
 
 			<?php /* translators: %s: Topic title. */ ?>
-			<h1><?php printf( esc_html__( 'Split topic "%s"', 'wporg-forums' ), wp_kses_post( bbp_get_topic_title() ) ); ?></h1>
+			<h1><?php printf( esc_html__( 'Split topic &#8220;%s&#8221;', 'wporg-forums' ), wp_kses_post( bbp_get_topic_title() ) ); ?></h1>
 
 			<form id="split_topic" name="split_topic" method="post" action="<?php the_permalink(); ?>">
 
 				<fieldset class="bbp-form">
 
 					<?php /* translators: %s: Topic title. */ ?>
-					<legend><?php printf( esc_html__( 'Split topic "%s"', 'wporg-forums' ), wp_kses_post( bbp_get_topic_title() ) ); ?></legend>
+					<legend><?php printf( esc_html__( 'Split topic &#8220;%s&#8221;', 'wporg-forums' ), wp_kses_post( bbp_get_topic_title() ) ); ?></legend>
 
 					<div>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/form-topic-split.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/form-topic-split.php
@@ -15,12 +15,14 @@
 
 		<div id="split-topic-<?php bbp_topic_id(); ?>" class="bbp-topic-split">
 
+			<?php /* translators: %s: Topic title. */ ?>
 			<h1><?php printf( esc_html__( 'Split topic "%s"', 'wporg-forums' ), bbp_get_topic_title() ); ?></h1>
 
 			<form id="split_topic" name="split_topic" method="post" action="<?php the_permalink(); ?>">
 
 				<fieldset class="bbp-form">
 
+					<?php /* translators: %s: Topic title. */ ?>
 					<legend><?php printf( esc_html__( 'Split topic "%s"', 'wporg-forums' ), bbp_get_topic_title() ); ?></legend>
 
 					<div>
@@ -38,6 +40,7 @@
 
 							<div>
 								<input name="bbp_topic_split_option" id="bbp_topic_split_option_reply" type="radio" checked="checked" value="reply" />
+								<?php /* translators: %s: Forum title. */ ?>
 								<label for="bbp_topic_split_option_reply"><?php printf( wp_kses_post( __( 'New topic in <strong>%s</strong> titled:', 'wporg-forums' ) ), bbp_get_forum_title( bbp_get_topic_forum_id( bbp_get_topic_id() ) ) ); ?></label>
 								<input type="text" id="bbp_topic_split_destination_title" value="<?php echo esc_attr( sprintf( __( 'Split: %s', 'wporg-forums' ), bbp_get_topic_title() ) ); ?>" size="35" name="bbp_topic_split_destination_title" />
 							</div>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/form-topic-split.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/form-topic-split.php
@@ -16,14 +16,14 @@
 		<div id="split-topic-<?php bbp_topic_id(); ?>" class="bbp-topic-split">
 
 			<?php /* translators: %s: Topic title. */ ?>
-			<h1><?php printf( esc_html__( 'Split topic "%s"', 'wporg-forums' ), esc_html( bbp_get_topic_title() ) ); ?></h1>
+			<h1><?php printf( esc_html__( 'Split topic "%s"', 'wporg-forums' ), wp_kses_post( bbp_get_topic_title() ) ); ?></h1>
 
 			<form id="split_topic" name="split_topic" method="post" action="<?php the_permalink(); ?>">
 
 				<fieldset class="bbp-form">
 
 					<?php /* translators: %s: Topic title. */ ?>
-					<legend><?php printf( esc_html__( 'Split topic "%s"', 'wporg-forums' ), esc_html( bbp_get_topic_title() ) ); ?></legend>
+					<legend><?php printf( esc_html__( 'Split topic "%s"', 'wporg-forums' ), wp_kses_post( bbp_get_topic_title() ) ); ?></legend>
 
 					<div>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/form-topic.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/form-topic.php
@@ -99,7 +99,7 @@
 									/* translators: 1: Theme Directory URL, 2: Appearance icon, 3: Plugin Directory URL, 4: Plugins icon */
 									printf(
 										/* translators: 1: Theme directory URL, 2: Plugin directory URL. */
-										wp_kses_post( __( '<strong>Don\'t use this forum to ask for help with <a href="%1$s">themes</a> or <a href="%2$s">plugins</a></strong>.  Instead, head to the theme or plugin\'s page and find the "View support forum" link for its specific forum.', 'wporg-forums' ) ),
+										wp_kses_post( __( '<strong>Don&#8217;t use this forum to ask for help with <a href="%1$s">themes</a> or <a href="%2$s">plugins</a></strong>.  Instead, head to the theme or plugin&#8217;s page and find the "View support forum" link for its specific forum.', 'wporg-forums' ) ),
 										esc_url( __( 'https://wordpress.org/themes/', 'wporg-forums' ) ),
 										esc_url( __( 'https://wordpress.org/plugins/', 'wporg-forums' ) )
 									);

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/form-topic.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/form-topic.php
@@ -15,6 +15,7 @@
 			<?php if ( bbp_is_topic_edit() ) { ?>
 
 				<h1>
+					<?php /* translators: %s: Topic title. */ ?>
 					<?php printf( esc_html__( 'Now Editing &ldquo;%s&rdquo;', 'wporg-forums' ), bbp_get_topic_title() ); ?>
 				</h1>
 
@@ -77,6 +78,7 @@
 								<li><?php
 									/* translators: %s: Handbook URL for forum welcome */
 									printf(
+										/* translators: %s: Welcome guide URL. */
 										wp_kses_post( __( '<strong><a href="%s">Read the Welcome Guide</a></strong> to maximize your odds of getting help.', 'wporg-forums' ) ),
 										esc_url( __( 'https://wordpress.org/support/welcome/', 'wporg-forums' ) )
 									);
@@ -84,6 +86,7 @@
 								<li><?php
 									/* translators: %s: URL to search */
 									printf(
+										/* translators: %s: Forum search URL. */
 										wp_kses_post( __( '<strong><a href="%s">Search the forums</a></strong> for similar inquiries.', 'wporg-forums' ) ),
 										esc_url( bbp_get_search_url() )
 									);
@@ -95,6 +98,7 @@
 								<li><?php
 									/* translators: 1: Theme Directory URL, 2: Appearance icon, 3: Plugin Directory URL, 4: Plugins icon */
 									printf(
+										/* translators: 1: Theme directory URL, 2: Plugin directory URL. */
 										wp_kses_post( __( '<strong>Don\'t use this forum to ask for help with <a href="%1$s">themes</a> or <a href="%2$s">plugins</a></strong>.  Instead, head to the theme or plugin\'s page and find the "View support forum" link for its specific forum.', 'wporg-forums' ) ),
 										esc_url( __( 'https://wordpress.org/themes/', 'wporg-forums' ) ),
 										esc_url( __( 'https://wordpress.org/plugins/', 'wporg-forums' ) )
@@ -104,6 +108,7 @@
 								<li><?php
 									/* translators: %s: Handbook URL for reporting security issues */
 									printf(
+										/* translators: %s: Vulnerability reporting guidelines URL. */
 										wp_kses_post( __( '<strong>Reporting a security issue?</strong> Please follow the guidelines on <a href="%s">reporting vulnerabilities responsibly</a>.', 'wporg-forums' ) ),
 										esc_url( __( 'https://make.wordpress.org/core/handbook/testing/reporting-security-vulnerabilities/', 'wporg-forums' ) )
 									);
@@ -143,8 +148,10 @@
 					<p>
 						<label for="bbp_topic_title"><?php
 							if ( bbp_is_single_view() && 'reviews' === bbp_get_view_id() ) {
+								/* translators: %d: Maximum title length. */
 								printf( esc_html__( 'Review Title (Maximum Length: %d):', 'wporg-forums' ), bbp_get_title_max_length() );
 							} else {
+								/* translators: %d: Maximum title length. */
 								printf( esc_html__( 'Topic Title (Maximum Length: %d):', 'wporg-forums' ), bbp_get_title_max_length() );
 							}
 						?></label><br />
@@ -256,6 +263,7 @@
 
 	<div id="no-topic-<?php bbp_topic_id(); ?>" class="bbp-no-topic">
 		<div class="bbp-template-notice">
+			<?php /* translators: %s: Forum title. */ ?>
 			<p><?php printf( esc_html__( 'The forum &#8216;%s&#8217; is closed to new topics and replies.', 'wporg-forums' ), bbp_get_forum_title() ); ?></p>
 		</div>
 	</div>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/form-topic.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/form-topic.php
@@ -15,18 +15,18 @@
 			<?php if ( bbp_is_topic_edit() ) { ?>
 
 				<h1>
-					<?php printf( __( 'Now Editing &ldquo;%s&rdquo;', 'wporg-forums' ), bbp_get_topic_title() ); ?>
+					<?php printf( esc_html__( 'Now Editing &ldquo;%s&rdquo;', 'wporg-forums' ), bbp_get_topic_title() ); ?>
 				</h1>
 
 			<?php } else { ?>
 
 				<h2>
 					<?php if ( bbp_is_single_forum() ) {
-						_e( 'Create a new topic in this forum', 'wporg-forums' );
+						esc_html_e( 'Create a new topic in this forum', 'wporg-forums' );
 					} elseif ( bbp_is_single_view() && 'reviews' === bbp_get_view_id() ) {
-						_e( 'Create a new review', 'wporg-forums' );
+						esc_html_e( 'Create a new review', 'wporg-forums' );
 					} else {
-						_e( 'Create a new topic', 'wporg-forums' );
+						esc_html_e( 'Create a new topic', 'wporg-forums' );
 					} ?>
 				</h2>
 
@@ -72,27 +72,30 @@
 
 						<?php else : ?>
 
-							<p><?php _e( 'Before posting a new topic, follow these steps:', 'wporg-forums' ); ?></p>
+							<p><?php esc_html_e( 'Before posting a new topic, follow these steps:', 'wporg-forums' ); ?></p>
 							<ul>
 								<li><?php
 									/* translators: %s: Handbook URL for forum welcome */
-									printf( __( '<strong><a href="%s">Read the Welcome Guide</a></strong> to maximize your odds of getting help.', 'wporg-forums' ),
+									printf(
+										wp_kses_post( __( '<strong><a href="%s">Read the Welcome Guide</a></strong> to maximize your odds of getting help.', 'wporg-forums' ) ),
 										esc_url( __( 'https://wordpress.org/support/welcome/', 'wporg-forums' ) )
 									);
 								?></li>
 								<li><?php
 									/* translators: %s: URL to search */
-									printf( __( '<strong><a href="%s">Search the forums</a></strong> for similar inquiries.', 'wporg-forums' ),
+									printf(
+										wp_kses_post( __( '<strong><a href="%s">Search the forums</a></strong> for similar inquiries.', 'wporg-forums' ) ),
 										esc_url( bbp_get_search_url() )
 									);
 								?></li>
-								<li><?php _e( '<strong>Update your plugins, themes, and WordPress site</strong> to the latest versions.', 'wporg-forums' ); ?></li>
-								<li><?php _e( '<strong>Describe the steps</strong> needed to reproduce an issue.', 'wporg-forums' ); ?></li>
-								<li><?php _e( '<strong>Provide relevant information</strong>, such as your browser, operating system, or server environment.', 'wporg-forums' ); ?></li>
+								<li><?php echo wp_kses_post( __( '<strong>Update your plugins, themes, and WordPress site</strong> to the latest versions.', 'wporg-forums' ) ); ?></li>
+								<li><?php echo wp_kses_post( __( '<strong>Describe the steps</strong> needed to reproduce an issue.', 'wporg-forums' ) ); ?></li>
+								<li><?php echo wp_kses_post( __( '<strong>Provide relevant information</strong>, such as your browser, operating system, or server environment.', 'wporg-forums' ) ); ?></li>
 								<?php if ( ! bbp_is_single_view() || ! in_array( bbp_get_view_id(), array( 'theme', 'plugin' ) ) ) : ?>
 								<li><?php
 									/* translators: 1: Theme Directory URL, 2: Appearance icon, 3: Plugin Directory URL, 4: Plugins icon */
-									printf( __( '<strong>Don\'t use this forum to ask for help with <a href="%1$s">themes</a> or <a href="%2$s">plugins</a></strong>.  Instead, head to the theme or plugin\'s page and find the "View support forum" link for its specific forum.', 'wporg-forums' ),
+									printf(
+										wp_kses_post( __( '<strong>Don\'t use this forum to ask for help with <a href="%1$s">themes</a> or <a href="%2$s">plugins</a></strong>.  Instead, head to the theme or plugin\'s page and find the "View support forum" link for its specific forum.', 'wporg-forums' ) ),
 										esc_url( __( 'https://wordpress.org/themes/', 'wporg-forums' ) ),
 										esc_url( __( 'https://wordpress.org/plugins/', 'wporg-forums' ) )
 									);
@@ -100,7 +103,8 @@
 								<?php endif; ?>
 								<li><?php
 									/* translators: %s: Handbook URL for reporting security issues */
-									printf( __( '<strong>Reporting a security issue?</strong> Please follow the guidelines on <a href="%s">reporting vulnerabilities responsibly</a>.', 'wporg-forums' ),
+									printf(
+										wp_kses_post( __( '<strong>Reporting a security issue?</strong> Please follow the guidelines on <a href="%s">reporting vulnerabilities responsibly</a>.', 'wporg-forums' ) ),
 										esc_url( __( 'https://make.wordpress.org/core/handbook/testing/reporting-security-vulnerabilities/', 'wporg-forums' ) )
 									);
 								?></li>
@@ -115,7 +119,7 @@
 				<?php if ( !bbp_is_topic_edit() && bbp_is_forum_closed() ) : ?>
 
 					<div class="bbp-template-notice">
-						<p><?php _e( 'This forum is marked as closed to new topics, however your posting capabilities still allow you to create a topic.', 'wporg-forums' ); ?></p>
+						<p><?php esc_html_e( 'This forum is marked as closed to new topics, however your posting capabilities still allow you to create a topic.', 'wporg-forums' ); ?></p>
 					</div>
 
 				<?php endif; ?>
@@ -123,7 +127,7 @@
 				<?php if ( current_user_can( 'unfiltered_html' ) ) : ?>
 
 					<div class="bbp-template-notice">
-						<p><?php _e( 'Your account has the ability to post unrestricted HTML content.', 'wporg-forums' ); ?></p>
+						<p><?php esc_html_e( 'Your account has the ability to post unrestricted HTML content.', 'wporg-forums' ); ?></p>
 					</div>
 
 				<?php endif; ?>
@@ -139,9 +143,9 @@
 					<p>
 						<label for="bbp_topic_title"><?php
 							if ( bbp_is_single_view() && 'reviews' === bbp_get_view_id() ) {
-								printf( __( 'Review Title (Maximum Length: %d):', 'wporg-forums' ), bbp_get_title_max_length() );
+								printf( esc_html__( 'Review Title (Maximum Length: %d):', 'wporg-forums' ), bbp_get_title_max_length() );
 							} else {
-								printf( __( 'Topic Title (Maximum Length: %d):', 'wporg-forums' ), bbp_get_title_max_length() );
+								printf( esc_html__( 'Topic Title (Maximum Length: %d):', 'wporg-forums' ), bbp_get_title_max_length() );
 							}
 						?></label><br />
 						<input type="text" id="bbp_topic_title" value="<?php bbp_form_topic_title(); ?>" size="40" name="bbp_topic_title" maxlength="<?php bbp_title_max_length(); ?>" />
@@ -160,7 +164,7 @@
 
 					<?php if ( bbp_allow_topic_tags() ) : ?>
 					<p>
-						<label for="bbp_topic_tags"><?php _e( 'Topic Tags:', 'wporg-forums' ); ?></label><br />
+						<label for="bbp_topic_tags"><?php esc_html_e( 'Topic Tags:', 'wporg-forums' ); ?></label><br />
 						<input type="text" value="<?php bbp_form_topic_tags(); ?>" size="40" name="bbp_topic_tags" id="bbp_topic_tags" aria-describedby="bbp_topic_tags_description" <?php disabled( bbp_is_topic_spam() ); ?> /><br />
 						<em id="bbp_topic_tags_description"><?php esc_html_e( 'Separate tags with commas', 'wporg-forums' ); ?></em>
 					</p>
@@ -173,7 +177,7 @@
 						<?php do_action( 'bbp_theme_before_topic_form_forum' ); ?>
 
 						<p>
-							<label for="bbp_forum_id"><?php _e( 'Forum:', 'wporg-forums' ); ?></label><br />
+							<label for="bbp_forum_id"><?php esc_html_e( 'Forum:', 'wporg-forums' ); ?></label><br />
 							<?php bbp_dropdown( array( 'selected' => bbp_get_form_topic_forum() ) ); ?>
 						</p>
 
@@ -190,11 +194,11 @@
 
 							<?php if ( bbp_is_topic_edit() && ( get_the_author_meta( 'ID' ) != bbp_get_current_user_id() ) ) : ?>
 
-								<label for="bbp_topic_subscription"><?php _e( 'Notify the author of follow-up replies via email', 'wporg-forums' ); ?></label>
+								<label for="bbp_topic_subscription"><?php esc_html_e( 'Notify the author of follow-up replies via email', 'wporg-forums' ); ?></label>
 
 							<?php else : ?>
 
-								<label for="bbp_topic_subscription"><?php _e( 'Notify me of follow-up replies via email', 'wporg-forums' ); ?></label>
+								<label for="bbp_topic_subscription"><?php esc_html_e( 'Notify me of follow-up replies via email', 'wporg-forums' ); ?></label>
 
 							<?php endif; ?>
 						</p>
@@ -210,11 +214,11 @@
 						<fieldset class="bbp-form log-edit">
 							<legend>
 								<input name="bbp_log_topic_edit" id="bbp_log_topic_edit" type="checkbox" value="1" <?php bbp_form_topic_log_edit(); ?> />
-								<label for="bbp_log_topic_edit"><?php _e( 'Keep a log of this edit:', 'wporg-forums' ); ?></label><br />
+								<label for="bbp_log_topic_edit"><?php esc_html_e( 'Keep a log of this edit:', 'wporg-forums' ); ?></label><br />
 							</legend>
 
 							<div>
-								<label for="bbp_topic_edit_reason"><em><?php _e( 'Optional reason for editing:', 'wporg-forums' ); ?></em></label><br />
+								<label for="bbp_topic_edit_reason"><em><?php esc_html_e( 'Optional reason for editing:', 'wporg-forums' ); ?></em></label><br />
 								<input type="text" value="<?php bbp_form_topic_edit_reason(); ?>" size="40" name="bbp_topic_edit_reason" id="bbp_topic_edit_reason" />
 							</div>
 						</fieldset>
@@ -229,7 +233,7 @@
 
 						<?php do_action( 'bbp_theme_before_topic_form_submit_button' ); ?>
 
-						<button type="submit" id="bbp_topic_submit" name="bbp_topic_submit" class="button button-primary submit"><?php _e( 'Submit', 'wporg-forums' ); ?></button>
+						<button type="submit" id="bbp_topic_submit" name="bbp_topic_submit" class="button button-primary submit"><?php esc_html_e( 'Submit', 'wporg-forums' ); ?></button>
 
 						<?php do_action( 'bbp_theme_after_topic_form_submit_button' ); ?>
 
@@ -252,7 +256,7 @@
 
 	<div id="no-topic-<?php bbp_topic_id(); ?>" class="bbp-no-topic">
 		<div class="bbp-template-notice">
-			<p><?php printf( __( 'The forum &#8216;%s&#8217; is closed to new topics and replies.', 'wporg-forums' ), bbp_get_forum_title() ); ?></p>
+			<p><?php printf( esc_html__( 'The forum &#8216;%s&#8217; is closed to new topics and replies.', 'wporg-forums' ), bbp_get_forum_title() ); ?></p>
 		</div>
 	</div>
 
@@ -260,15 +264,15 @@
 
 	<div id="no-topic-<?php bbp_topic_id(); ?>" class="bbp-no-topic">
 		<div class="bbp-template-notice">
-			<p><?php _e( 'You cannot create new topics at this time.', 'wporg-forums' ); ?></p>
+			<p><?php esc_html_e( 'You cannot create new topics at this time.', 'wporg-forums' ); ?></p>
 			<?php if ( current_user_can( bbp_get_spectator_role() ) ) : ?>
 				<p><?php
 					printf(
-						__( 'This may be caused by your account being marked as a brand or shared company account.', 'wporg-forums' ) . '<br>' .
+						esc_html__( 'This may be caused by your account being marked as a brand or shared company account.', 'wporg-forums' ) . '<br>' .
 						/* translators: %s: Link to https://make.wordpress.org/support/2025/03/about-the-spectator-role-in-the-wordpress-support-forums/ */
-						__( '<a href="%s">Please read this announcement</a> for more information.', 'wporg-forums' ) . '<br>' .
+						wp_kses_post( __( '<a href="%s">Please read this announcement</a> for more information.', 'wporg-forums' ) ) . '<br>' .
 						/* translators: %s: Email address. */
-						__( 'If you believe this to be in error, please contact the forum moderation team via <code>%s</code>.', 'wporg-forums' ),
+						wp_kses_post( __( 'If you believe this to be in error, please contact the forum moderation team via <code>%s</code>.', 'wporg-forums' ) ),
 						'https://make.wordpress.org/support/2025/03/about-the-spectator-role-in-the-wordpress-support-forums/',
 						WordPressdotorg\Forums\MODERATION_EMAIL
 					);

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/form-topic.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/form-topic.php
@@ -16,7 +16,7 @@
 
 				<h1>
 					<?php /* translators: %s: Topic title. */ ?>
-					<?php printf( esc_html__( 'Now Editing &ldquo;%s&rdquo;', 'wporg-forums' ), esc_html( bbp_get_topic_title() ) ); ?>
+					<?php printf( esc_html__( 'Now Editing &ldquo;%s&rdquo;', 'wporg-forums' ), wp_kses_post( bbp_get_topic_title() ) ); ?>
 				</h1>
 
 			<?php } else { ?>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/form-topic.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/form-topic.php
@@ -16,7 +16,7 @@
 
 				<h1>
 					<?php /* translators: %s: Topic title. */ ?>
-					<?php printf( esc_html__( 'Now Editing &ldquo;%s&rdquo;', 'wporg-forums' ), bbp_get_topic_title() ); ?>
+					<?php printf( esc_html__( 'Now Editing &ldquo;%s&rdquo;', 'wporg-forums' ), esc_html( bbp_get_topic_title() ) ); ?>
 				</h1>
 
 			<?php } else { ?>
@@ -149,10 +149,10 @@
 						<label for="bbp_topic_title"><?php
 							if ( bbp_is_single_view() && 'reviews' === bbp_get_view_id() ) {
 								/* translators: %d: Maximum title length. */
-								printf( esc_html__( 'Review Title (Maximum Length: %d):', 'wporg-forums' ), bbp_get_title_max_length() );
+								printf( esc_html__( 'Review Title (Maximum Length: %d):', 'wporg-forums' ), (int) bbp_get_title_max_length() );
 							} else {
 								/* translators: %d: Maximum title length. */
-								printf( esc_html__( 'Topic Title (Maximum Length: %d):', 'wporg-forums' ), bbp_get_title_max_length() );
+								printf( esc_html__( 'Topic Title (Maximum Length: %d):', 'wporg-forums' ), (int) bbp_get_title_max_length() );
 							}
 						?></label><br />
 						<input type="text" id="bbp_topic_title" value="<?php bbp_form_topic_title(); ?>" size="40" name="bbp_topic_title" maxlength="<?php bbp_title_max_length(); ?>" />
@@ -264,7 +264,7 @@
 	<div id="no-topic-<?php bbp_topic_id(); ?>" class="bbp-no-topic">
 		<div class="bbp-template-notice">
 			<?php /* translators: %s: Forum title. */ ?>
-			<p><?php printf( esc_html__( 'The forum &#8216;%s&#8217; is closed to new topics and replies.', 'wporg-forums' ), bbp_get_forum_title() ); ?></p>
+			<p><?php printf( esc_html__( 'The forum &#8216;%s&#8217; is closed to new topics and replies.', 'wporg-forums' ), esc_html( bbp_get_forum_title() ) ); ?></p>
 		</div>
 	</div>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/form-topic.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/form-topic.php
@@ -96,7 +96,6 @@
 								<li><?php echo wp_kses_post( __( '<strong>Provide relevant information</strong>, such as your browser, operating system, or server environment.', 'wporg-forums' ) ); ?></li>
 								<?php if ( ! bbp_is_single_view() || ! in_array( bbp_get_view_id(), array( 'theme', 'plugin' ) ) ) : ?>
 								<li><?php
-									/* translators: 1: Theme Directory URL, 2: Appearance icon, 3: Plugin Directory URL, 4: Plugins icon */
 									printf(
 										/* translators: 1: Theme directory URL, 2: Plugin directory URL. */
 										wp_kses_post( __( '<strong>Don&#8217;t use this forum to ask for help with <a href="%1$s">themes</a> or <a href="%2$s">plugins</a></strong>.  Instead, head to the theme or plugin&#8217;s page and find the "View support forum" link for its specific forum.', 'wporg-forums' ) ),

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/form-user-edit.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/form-user-edit.php
@@ -119,7 +119,7 @@ defined( 'ABSPATH' ) || exit;
 
 			<p id="security">
 				<?php printf(
-					__( 'Your password and two-factor authentication settings can be changed in <a href="%s">the Account section</a>.', 'wporg' ),
+					wp_kses_post( __( 'Your password and two-factor authentication settings can be changed in <a href="%s">the Account section</a>.', 'wporg' ) ),
 					esc_url( get_edit_account_url( bbp_get_displayed_user_id() ) )
 				); ?>
 			</p>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/form-user-edit.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/form-user-edit.php
@@ -119,6 +119,7 @@ defined( 'ABSPATH' ) || exit;
 
 			<p id="security">
 				<?php printf(
+					/* translators: %s: Account settings URL. */
 					wp_kses_post( __( 'Your password and two-factor authentication settings can be changed in <a href="%s">the Account section</a>.', 'wporg' ) ),
 					esc_url( get_edit_account_url( bbp_get_displayed_user_id() ) )
 				); ?>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/loop-forums-homepage.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/loop-forums-homepage.php
@@ -2,7 +2,7 @@
 
 
 <section class="forums-homepage-list">
-	<h2 class="has-heading-5-font-size"><?php _e( 'Forums', 'wporg-forums' ); ?></h2>
+	<h2 class="has-heading-5-font-size"><?php esc_html_e( 'Forums', 'wporg-forums' ); ?></h2>
 
 	<?php echo do_blocks(
 		sprintf(
@@ -17,7 +17,7 @@
 </section>
 
 <section class="forums-homepage-topics">
-	<h2 class="has-heading-5-font-size"><?php _e( 'Topics', 'wporg-forums' ); ?></h2>
+	<h2 class="has-heading-5-font-size"><?php esc_html_e( 'Topics', 'wporg-forums' ); ?></h2>
 
 	<?php echo do_blocks(
 		sprintf(

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/loop-forums.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/loop-forums.php
@@ -5,9 +5,9 @@
 	<li class="bbp-header">
 
 		<ul class="forum-titles">
-			<li class="bbp-forum-info"><?php _e( 'Forum', 'wporg-forums' ); ?></li>
-			<li class="bbp-forum-topic-count"><?php _e( 'Topics', 'wporg-forums' ); ?></li>
-			<li class="bbp-forum-reply-count"><?php _e( 'Posts', 'wporg-forums' ); ?></li>
+			<li class="bbp-forum-info"><?php esc_html_e( 'Forum', 'wporg-forums' ); ?></li>
+			<li class="bbp-forum-topic-count"><?php esc_html_e( 'Topics', 'wporg-forums' ); ?></li>
+			<li class="bbp-forum-reply-count"><?php esc_html_e( 'Posts', 'wporg-forums' ); ?></li>
 		</ul>
 
 	</li><!-- .bbp-header -->

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/loop-single-reply-topic.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/loop-single-reply-topic.php
@@ -21,13 +21,16 @@
 			<span class="bbp-topic-started-by">
 			<?php
 			printf(
+				/* translators: %1$s: Topic author link. */
 				esc_html__( 'Started by: %1$s', 'wporg-forums' ),
-				bbp_get_topic_author_link(
-					array(
-					'post_id' => $topic_id,
-					'size' => '14'
-					) 
-				) 
+				wp_kses_post(
+					bbp_get_topic_author_link(
+						array(
+							'post_id' => $topic_id,
+							'size'    => '14',
+						)
+					)
+				)
 			);
 			?>
 			</span>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/loop-single-reply-topic.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/loop-single-reply-topic.php
@@ -23,12 +23,11 @@
 			printf(
 				/* translators: %1$s: Topic author link. */
 				esc_html__( 'Started by: %1$s', 'wporg-forums' ),
-				wp_kses_post(
-					bbp_get_topic_author_link(
-						array(
-							'post_id' => $topic_id,
-							'size'    => '14',
-						)
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- bbPress builds this markup; wp_kses_post() would strip the avatar's srcset and decoding attributes.
+				bbp_get_topic_author_link(
+					array(
+						'post_id' => $topic_id,
+						'size'    => '14',
 					)
 				)
 			);

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/loop-single-reply-topic.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/loop-single-reply-topic.php
@@ -18,7 +18,19 @@
 
 			<?php do_action( 'bbp_theme_before_topic_started_by' ); ?>
 
-			<span class="bbp-topic-started-by"><?php printf( __( 'Started by: %1$s', 'wporg-forums' ), bbp_get_topic_author_link( array( 'post_id' => $topic_id, 'size' => '14' ) ) ); ?></span>
+			<span class="bbp-topic-started-by">
+			<?php
+			printf(
+				esc_html__( 'Started by: %1$s', 'wporg-forums' ),
+				bbp_get_topic_author_link(
+					array(
+					'post_id' => $topic_id,
+					'size' => '14'
+					) 
+				) 
+			);
+			?>
+			</span>
 
 			<?php do_action( 'bbp_theme_after_topic_started_by' ); ?>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/loop-single-topic.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/loop-single-topic.php
@@ -46,6 +46,7 @@
 
 			<?php do_action( 'bbp_theme_before_topic_started_by' ); ?>
 
+			<?php /* translators: %1$s: Topic author link. */ ?>
 			<span class="bbp-topic-started-by"><?php printf( esc_html__( 'Started by: %1$s', 'wporg-forums' ), bbp_get_topic_author_link( array( 'size' => '14' ) ) ); ?></span>
 
 			<?php do_action( 'bbp_theme_after_topic_started_by' ); ?>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/loop-single-topic.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/loop-single-topic.php
@@ -47,7 +47,7 @@
 			<?php do_action( 'bbp_theme_before_topic_started_by' ); ?>
 
 			<?php /* translators: %1$s: Topic author link. */ ?>
-			<span class="bbp-topic-started-by"><?php printf( esc_html__( 'Started by: %1$s', 'wporg-forums' ), bbp_get_topic_author_link( array( 'size' => '14' ) ) ); ?></span>
+			<span class="bbp-topic-started-by"><?php printf( esc_html__( 'Started by: %1$s', 'wporg-forums' ), wp_kses_post( bbp_get_topic_author_link( array( 'size' => '14' ) ) ) ); ?></span>
 
 			<?php do_action( 'bbp_theme_after_topic_started_by' ); ?>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/loop-single-topic.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/loop-single-topic.php
@@ -47,7 +47,7 @@
 			<?php do_action( 'bbp_theme_before_topic_started_by' ); ?>
 
 			<?php /* translators: %1$s: Topic author link. */ ?>
-			<span class="bbp-topic-started-by"><?php printf( esc_html__( 'Started by: %1$s', 'wporg-forums' ), wp_kses_post( bbp_get_topic_author_link( array( 'size' => '14' ) ) ) ); ?></span>
+			<span class="bbp-topic-started-by"><?php printf( esc_html__( 'Started by: %1$s', 'wporg-forums' ), bbp_get_topic_author_link( array( 'size' => '14' ) ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- bbPress builds this markup; wp_kses_post() would strip the avatar's srcset and decoding attributes. ?></span>
 
 			<?php do_action( 'bbp_theme_after_topic_started_by' ); ?>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/loop-single-topic.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/loop-single-topic.php
@@ -46,7 +46,7 @@
 
 			<?php do_action( 'bbp_theme_before_topic_started_by' ); ?>
 
-			<span class="bbp-topic-started-by"><?php printf( __( 'Started by: %1$s', 'wporg-forums' ), bbp_get_topic_author_link( array( 'size' => '14' ) ) ); ?></span>
+			<span class="bbp-topic-started-by"><?php printf( esc_html__( 'Started by: %1$s', 'wporg-forums' ), bbp_get_topic_author_link( array( 'size' => '14' ) ) ); ?></span>
 
 			<?php do_action( 'bbp_theme_after_topic_started_by' ); ?>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/user-profile.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/user-profile.php
@@ -71,15 +71,17 @@ do_action( 'bbp_template_before_user_profile' ); ?>
 			$slack_username = wporg_support_get_slack_username();
 
 			if ( $slack_username && $slack_username != $user_nicename ) {
-				/* translators: 1: user's WordPress.org profile link, 2: user's Slack username, 3: make.wordpress.org/chat URL */
-				printf( wp_kses_post( __( '%1$s on WordPress.org, %2$s on <a href="%3$s">Slack</a>', 'wporg-forums' ) ),
+				printf(
+					/* translators: 1: user's WordPress.org profile link, 2: user's Slack username, 3: make.wordpress.org/chat URL */
+					wp_kses_post( __( '%1$s on WordPress.org, %2$s on <a href="%3$s">Slack</a>', 'wporg-forums' ) ),
 					wporg_support_get_wporg_profile_link(),
 					'@' . esc_html( $slack_username ),
 					'https://make.wordpress.org/chat/'
 				);
 			} elseif( $slack_username ) {
-				/* translators: 1: WordPress.org and Slack username, 2: URL for information about Slack */
-				printf( wp_kses_post( __( '%1$s on WordPress.org and <a href="%2$s">Slack</a>', 'wporg-forums' ) ),
+				printf(
+					/* translators: 1: WordPress.org and Slack username, 2: URL for information about Slack */
+					wp_kses_post( __( '%1$s on WordPress.org and <a href="%2$s">Slack</a>', 'wporg-forums' ) ),
 					wporg_support_get_wporg_profile_link(),
 					'https://make.wordpress.org/chat/'
 				);

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/user-profile.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/user-profile.php
@@ -72,7 +72,7 @@ do_action( 'bbp_template_before_user_profile' ); ?>
 
 			if ( $slack_username && $slack_username != $user_nicename ) {
 				printf(
-					/* translators: 1: user's WordPress.org profile link, 2: user's Slack username, 3: make.wordpress.org/chat URL */
+					/* translators: 1: User's WordPress.org profile link, 2: User's Slack username, 3: make.wordpress.org/chat URL. */
 					wp_kses_post( __( '%1$s on WordPress.org, %2$s on <a href="%3$s">Slack</a>', 'wporg-forums' ) ),
 					wporg_support_get_wporg_profile_link(),
 					'@' . esc_html( $slack_username ),
@@ -80,7 +80,7 @@ do_action( 'bbp_template_before_user_profile' ); ?>
 				);
 			} elseif( $slack_username ) {
 				printf(
-					/* translators: 1: WordPress.org and Slack username, 2: URL for information about Slack */
+					/* translators: 1: WordPress.org and Slack username, 2: URL for information about Slack. */
 					wp_kses_post( __( '%1$s on WordPress.org and <a href="%2$s">Slack</a>', 'wporg-forums' ) ),
 					wporg_support_get_wporg_profile_link(),
 					'https://make.wordpress.org/chat/'

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/user-profile.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/user-profile.php
@@ -72,14 +72,14 @@ do_action( 'bbp_template_before_user_profile' ); ?>
 
 			if ( $slack_username && $slack_username != $user_nicename ) {
 				/* translators: 1: user's WordPress.org profile link, 2: user's Slack username, 3: make.wordpress.org/chat URL */
-				printf( __( '%1$s on WordPress.org, %2$s on <a href="%3$s">Slack</a>', 'wporg-forums' ),
+				printf( wp_kses_post( __( '%1$s on WordPress.org, %2$s on <a href="%3$s">Slack</a>', 'wporg-forums' ) ),
 					wporg_support_get_wporg_profile_link(),
 					'@' . esc_html( $slack_username ),
 					'https://make.wordpress.org/chat/'
 				);
 			} elseif( $slack_username ) {
 				/* translators: 1: WordPress.org and Slack username, 2: URL for information about Slack */
-				printf( __( '%1$s on WordPress.org and <a href="%2$s">Slack</a>', 'wporg-forums' ),
+				printf( wp_kses_post( __( '%1$s on WordPress.org and <a href="%2$s">Slack</a>', 'wporg-forums' ) ),
 					wporg_support_get_wporg_profile_link(),
 					'https://make.wordpress.org/chat/'
 				);

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/user-subscriptions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/bbpress/user-subscriptions.php
@@ -33,9 +33,9 @@ do_action( 'bbp_template_before_user_subscriptions' ); ?>
 
 				<?php else :
 					if ( bbp_get_user_id() == get_current_user_id() ) {
-						echo '<p>' . __( 'You are not currently subscribed to any topics.', 'wporg-forums' ) . '</p>';
+						echo '<p>' . esc_html__( 'You are not currently subscribed to any topics.', 'wporg-forums' ) . '</p>';
 					} else {
-						echo '<p>' . __( 'This user is not currently subscribed to any topics.', 'wporg-forums' ) . '</p>';
+						echo '<p>' . esc_html__( 'This user is not currently subscribed to any topics.', 'wporg-forums' ) . '</p>';
 					}
 				endif ?>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/functions.php
@@ -1355,8 +1355,8 @@ function bb_base_search_form() {
 
 	<form role="search" method="get" id="searchform" action="https://wordpress.org/search/do-search.php">
 		<div>
-			<h3><?php _e( 'Forum Search', 'wporg-forums' ); ?></h3>
-			<label class="screen-reader-text hidden" for="search"><?php _e( 'Search for:', 'wporg-forums' ); ?></label>
+			<h3><?php esc_html_e( 'Forum Search', 'wporg-forums' ); ?></h3>
+			<label class="screen-reader-text hidden" for="search"><?php esc_html_e( 'Search for:', 'wporg-forums' ); ?></label>
 			<input name="search" class="text" id="forumsearchbox" value type="text" />
 			<input name="go" class="button" type="submit" id="searchsubmit" value="<?php esc_attr_e( 'Search', 'wporg-forums' ); ?>" />
 			<input value="1" name="forums" type="hidden">
@@ -1371,8 +1371,8 @@ function bb_base_topic_search_form() {
 
 	<form role="search" method="get" id="searchform" action="">
 		<div>
-			<h3><?php _e( 'Forum Search', 'wporg-forums' ); ?></h3>
-			<label class="screen-reader-text hidden" for="ts"><?php _e( 'Search for:', 'wporg-forums' ); ?></label>
+			<h3><?php esc_html_e( 'Forum Search', 'wporg-forums' ); ?></h3>
+			<label class="screen-reader-text hidden" for="ts"><?php esc_html_e( 'Search for:', 'wporg-forums' ); ?></label>
 			<input type="text" value="<?php echo bb_base_topic_search_query(); ?>" name="ts" id="ts" />
 			<input class="button" type="submit" id="searchsubmit" value="<?php esc_attr_e( 'Search', 'wporg-forums' ); ?>" />
 		</div>
@@ -1386,8 +1386,8 @@ function bb_base_reply_search_form() {
 
 	<form role="search" method="get" id="searchform" action="">
 		<div>
-			<h3><?php _e( 'Reply Search', 'wporg-forums' ); ?></h3>
-			<label class="screen-reader-text hidden" for="rs"><?php _e( 'Search for:', 'wporg-forums' ); ?></label>
+			<h3><?php esc_html_e( 'Reply Search', 'wporg-forums' ); ?></h3>
+			<label class="screen-reader-text hidden" for="rs"><?php esc_html_e( 'Search for:', 'wporg-forums' ); ?></label>
 			<input type="text" value="<?php echo bb_base_reply_search_query(); ?>" name="rs" id="rs" />
 			<input class="button" type="submit" id="searchsubmit" value="<?php esc_attr_e( 'Search', 'wporg-forums' ); ?>" />
 		</div>
@@ -1401,8 +1401,8 @@ function bb_base_plugin_search_form() {
 
 	<form role="search" method="get" id="searchform" action="">
 		<div>
-			<h3><?php _e( 'Plugin Search', 'wporg-forums' ); ?></h3>
-			<label class="screen-reader-text hidden" for="ps"><?php _e( 'Search for:', 'wporg-forums' ); ?></label>
+			<h3><?php esc_html_e( 'Plugin Search', 'wporg-forums' ); ?></h3>
+			<label class="screen-reader-text hidden" for="ps"><?php esc_html_e( 'Search for:', 'wporg-forums' ); ?></label>
 			<input type="text" value="<?php echo bb_base_plugin_search_query(); ?>" name="ps" id="ts" />
 			<input class="button" type="submit" id="searchsubmit" value="<?php esc_attr_e( 'Search', 'wporg-forums' ); ?>" />
 		</div>
@@ -1485,7 +1485,7 @@ function bb_base_single_topic_description() {
 		echo '<li class="topic-forum">';
 		printf(
 			/* translators: %s: forum title */
-			__( 'In: %s', 'wporg-forums' ),
+			esc_html__( 'In: %s', 'wporg-forums' ),
 			sprintf( '<a href="%s">%s</a>',
 				esc_url( bbp_get_forum_permalink( bbp_get_topic_forum_id() ) ),
 				bbp_get_topic_forum_title()
@@ -1504,7 +1504,7 @@ function bb_base_single_topic_description() {
 	<?php if ( !empty( $last_reply  ) ) : ?>
 		<li class="topic-freshness-author"><?php
 			/* translators: %s: reply author link */
-			printf( __( 'Last reply from: %s', 'wporg-forums' ),
+			printf( esc_html__( 'Last reply from: %s', 'wporg-forums' ),
 				bbp_get_author_link( array( 'type' => 'name', 'post_id' => $last_reply, 'size' => '15' ) )
 			);
 		?></li>
@@ -1512,7 +1512,7 @@ function bb_base_single_topic_description() {
 	<?php if ( !empty( $time_since  ) ) : ?>
 		<li class="topic-freshness-time"><?php
 			/* translators: %s: date/time link to the latest post */
-			printf( __( 'Last activity: %s', 'wporg-forums' ), $time_since );
+			printf( esc_html__( 'Last activity: %s', 'wporg-forums' ), $time_since );
 		?></li>
 	<?php endif; ?>
 	<?php if ( ! empty( $wp_version ) ) : ?>
@@ -1526,9 +1526,9 @@ function bb_base_single_topic_description() {
 	<?php if ( bbp_current_user_can_access_create_reply_form() /*bbp_is_topic_open( $_topic_id )*/ ) : ?>
 		<li class="create-reply"><a href="#new-post"><?php
 			if ( wporg_support_is_single_review() ) {
-				_e( 'Reply to Review', 'wporg-forums' );
+				esc_html_e( 'Reply to Review', 'wporg-forums' );
 			} else {
-				_e( 'Reply to Topic', 'wporg-forums' );
+				esc_html_e( 'Reply to Topic', 'wporg-forums' );
 			}
 		?></a></li>
 	<?php endif; ?>
@@ -1550,7 +1550,7 @@ function bb_base_single_forum_description() {
 	if ( bbp_get_forum_parent_id() ) : ?>
 		<li class="topic-parent"><?php
 			/* translators: %s: forum title */
-			printf( __( 'In: %s', 'wporg-forums' ),
+			printf( esc_html__( 'In: %s', 'wporg-forums' ),
 				sprintf( '<a href="%s">%s</a>',
 					esc_url( bbp_get_forum_permalink( bbp_get_forum_parent_id() ) ),
 					bbp_get_forum_title( bbp_get_forum_parent_id() )

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/functions.php
@@ -1488,7 +1488,7 @@ function bb_base_single_topic_description() {
 			esc_html__( 'In: %s', 'wporg-forums' ),
 			sprintf( '<a href="%s">%s</a>',
 				esc_url( bbp_get_forum_permalink( bbp_get_topic_forum_id() ) ),
-				bbp_get_topic_forum_title()
+				esc_html( bbp_get_topic_forum_title() )
 			)
 		);
 		echo '</li>';
@@ -1504,7 +1504,7 @@ function bb_base_single_topic_description() {
 	<?php if ( !empty( $last_reply  ) ) : ?>
 		<li class="topic-freshness-author"><?php
 			printf(
-				/* translators: %s: reply author link */
+				/* translators: %s: Reply author link. */
 				esc_html__( 'Last reply from: %s', 'wporg-forums' ),
 				wp_kses_post(
 					bbp_get_author_link(
@@ -1559,7 +1559,7 @@ function bb_base_single_forum_description() {
 	if ( bbp_get_forum_parent_id() ) : ?>
 		<li class="topic-parent"><?php
 			printf(
-				/* translators: %s: forum title */
+				/* translators: %s: Forum title. */
 				esc_html__( 'In: %s', 'wporg-forums' ),
 				sprintf(
 					'<a href="%s">%s</a>',

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/functions.php
@@ -1503,16 +1503,25 @@ function bb_base_single_topic_description() {
 	<?php endif; ?>
 	<?php if ( !empty( $last_reply  ) ) : ?>
 		<li class="topic-freshness-author"><?php
-			/* translators: %s: reply author link */
-			printf( esc_html__( 'Last reply from: %s', 'wporg-forums' ),
-				bbp_get_author_link( array( 'type' => 'name', 'post_id' => $last_reply, 'size' => '15' ) )
+			printf(
+				/* translators: %s: reply author link */
+				esc_html__( 'Last reply from: %s', 'wporg-forums' ),
+				wp_kses_post(
+					bbp_get_author_link(
+						array(
+							'type'    => 'name',
+							'post_id' => $last_reply,
+							'size'    => '15',
+						)
+					)
+				)
 			);
 		?></li>
 	<?php endif; ?>
 	<?php if ( !empty( $time_since  ) ) : ?>
 		<li class="topic-freshness-time"><?php
 			/* translators: %s: date/time link to the latest post */
-			printf( esc_html__( 'Last activity: %s', 'wporg-forums' ), $time_since );
+			printf( esc_html__( 'Last activity: %s', 'wporg-forums' ), esc_html( $time_since ) );
 		?></li>
 	<?php endif; ?>
 	<?php if ( ! empty( $wp_version ) ) : ?>
@@ -1549,11 +1558,13 @@ function bb_base_single_forum_description() {
 
 	if ( bbp_get_forum_parent_id() ) : ?>
 		<li class="topic-parent"><?php
-			/* translators: %s: forum title */
-			printf( esc_html__( 'In: %s', 'wporg-forums' ),
-				sprintf( '<a href="%s">%s</a>',
+			printf(
+				/* translators: %s: forum title */
+				esc_html__( 'In: %s', 'wporg-forums' ),
+				sprintf(
+					'<a href="%s">%s</a>',
 					esc_url( bbp_get_forum_permalink( bbp_get_forum_parent_id() ) ),
-					bbp_get_forum_title( bbp_get_forum_parent_id() )
+					esc_html( bbp_get_forum_title( bbp_get_forum_parent_id() ) )
 				)
 			);
 		?></li>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/functions.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/functions.php
@@ -1521,7 +1521,7 @@ function bb_base_single_topic_description() {
 	<?php if ( !empty( $time_since  ) ) : ?>
 		<li class="topic-freshness-time"><?php
 			/* translators: %s: date/time link to the latest post */
-			printf( esc_html__( 'Last activity: %s', 'wporg-forums' ), esc_html( $time_since ) );
+			printf( esc_html__( 'Last activity: %s', 'wporg-forums' ), wp_kses_post( $time_since ) );
 		?></li>
 	<?php endif; ?>
 	<?php if ( ! empty( $wp_version ) ) : ?>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/page-homepage.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/page-homepage.php
@@ -32,19 +32,19 @@ get_header(); ?>
 		</section>
 
 		<section class="forums-homepage-topics">
-			<h2 class="has-heading-5-font-size"><?php _e( 'Topics', 'wporg-forums' ); ?></h2>
+			<h2 class="has-heading-5-font-size"><?php esc_html_e( 'Topics', 'wporg-forums' ); ?></h2>
 
 			<?php echo do_blocks( '<!-- wp:pattern {"slug":"wporg-support/forums-views"} /-->' ); ?>
 		</section>
 
 		<section class="clear helpful-links">
 			<div>
-				<h2 class="has-heading-5-font-size"><?php _e( 'Helpful Links', 'wporg-forums' ); ?></h2>
+				<h2 class="has-heading-5-font-size"><?php esc_html_e( 'Helpful Links', 'wporg-forums' ); ?></h2>
 				<ul class="meta-list">
-					<li><?php _e( '<a href="https://wordpress.org/support/article/new_to_wordpress_-_where_to_start/">New to WordPress &mdash; Where to Start</a>', 'wporg-forums' ); ?></li>
-					<li><?php _e( '<a href="https://wordpress.org/support/article/faq-installation/">Frequently Asked Questions about Installing WordPress</a>', 'wporg-forums' ); ?></li>
-					<li><?php _e( '<a href="https://wordpress.org/support/article/first-steps-with-wordpress-classic/">First Steps with WordPress</a>', 'wporg-forums' ); ?></li>
-					<li><?php _e( '<a href="https://wordpress.org/support/article/writing-posts/">Writing Posts</a>', 'wporg-forums' ); ?></li>
+					<li><?php echo wp_kses_post( __( '<a href="https://wordpress.org/support/article/new_to_wordpress_-_where_to_start/">New to WordPress &mdash; Where to Start</a>', 'wporg-forums' ) ); ?></li>
+					<li><?php echo wp_kses_post( __( '<a href="https://wordpress.org/support/article/faq-installation/">Frequently Asked Questions about Installing WordPress</a>', 'wporg-forums' ) ); ?></li>
+					<li><?php echo wp_kses_post( __( '<a href="https://wordpress.org/support/article/first-steps-with-wordpress-classic/">First Steps with WordPress</a>', 'wporg-forums' ) ); ?></li>
+					<li><?php echo wp_kses_post( __( '<a href="https://wordpress.org/support/article/writing-posts/">Writing Posts</a>', 'wporg-forums' ) ); ?></li>
 				</ul>
 			</div>
 		</section>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/searchform.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/searchform.php
@@ -5,21 +5,21 @@ namespace WordPressdotorg\Forums;
 <?php if ( bb_is_intl_forum() ) : ?>
 
 <form role="search" method="get" class="search-form" action="<?php bbp_search_url(); ?>">
-	<label for="s" class="screen-reader-text"><?php _ex( 'Search for:', 'label', 'wporg-forums' ); ?></label>
+	<label for="s" class="screen-reader-text"><?php echo esc_html_x( 'Search for:', 'label', 'wporg-forums' ); ?></label>
 	<input type="hidden" name="action" value="bbp-search-request" />
 	<input type="search" id="s" class="search-field" placeholder="<?php echo esc_attr_x( 'Search forums', 'placeholder', 'wporg-forums' ); ?>" value="<?php echo esc_attr( bbp_get_search_terms() ); ?>" name="bbp_search" required />
 	<button class="button button-search">
 		<svg class="search-icon" viewBox="0 0 24 24" width="24" height="24">
 			<path d="M13 5c-3.3 0-6 2.7-6 6 0 1.4.5 2.7 1.3 3.7l-3.8 3.8 1.1 1.1 3.8-3.8c1 .8 2.3 1.3 3.7 1.3 3.3 0 6-2.7 6-6S16.3 5 13 5zm0 10.5c-2.5 0-4.5-2-4.5-4.5s2-4.5 4.5-4.5 4.5 2 4.5 4.5-2 4.5-4.5 4.5z"></path>
 		</svg>
-		<span class="screen-reader-text"><?php _e( 'Search forums', 'wporg-forums' ); ?></span>
+		<span class="screen-reader-text"><?php esc_html_e( 'Search forums', 'wporg-forums' ); ?></span>
 	</button>
 </form>
 
 <?php else : ?>
 
 <form role="search" method="get" class="search-form" action="<?php echo esc_url( home_url( '/' ) ); ?>">
-	<label for="s" class="screen-reader-text"><?php _ex( 'Search for:', 'label', 'wporg-forums' ); ?></label>
+	<label for="s" class="screen-reader-text"><?php echo esc_html_x( 'Search for:', 'label', 'wporg-forums' ); ?></label>
 	<?php
 		$tab = null;
 		if ( in_array( current_action(), [ 'bbp_template_before_pagination_loop', 'wporg_compat_before_single_view' ] ) ) {
@@ -45,7 +45,7 @@ namespace WordPressdotorg\Forums;
 		<svg class="search-icon" viewBox="0 0 24 24" width="24" height="24">
 			<path d="M13 5c-3.3 0-6 2.7-6 6 0 1.4.5 2.7 1.3 3.7l-3.8 3.8 1.1 1.1 3.8-3.8c1 .8 2.3 1.3 3.7 1.3 3.3 0 6-2.7 6-6S16.3 5 13 5zm0 10.5c-2.5 0-4.5-2-4.5-4.5s2-4.5 4.5-4.5 4.5 2 4.5 4.5-2 4.5-4.5 4.5z"></path>
 		</svg>
-		<span class="screen-reader-text"><?php _e( 'Search forums', 'wporg-forums' ); ?></span>
+		<span class="screen-reader-text"><?php esc_html_e( 'Search forums', 'wporg-forums' ); ?></span>
 	</button>
 </form>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/sidebar.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/sidebar.php
@@ -10,7 +10,7 @@
 					printf(
 						/* translators: %s: Current user's profile link. */
 						esc_html__( 'Howdy, %s', 'wporg-forums' ),
-						'<a href="' . esc_url( bbp_get_user_profile_url( bbp_get_current_user_id() ) ) . '">' . bbp_get_current_user_name() . '</a>'
+						'<a href="' . esc_url( bbp_get_user_profile_url( bbp_get_current_user_id() ) ) . '">' . esc_html( bbp_get_current_user_name() ) . '</a>'
 					);
 				?></li>
 				<li><a href="<?php echo esc_url( wp_logout_url() ); ?>"><?php esc_html_e( 'Log Out', 'wporg-forums' ); ?></a></li>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/sidebar.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/sidebar.php
@@ -8,6 +8,7 @@
 				<li><?php
 					/* translators: %s: user's display name */
 					printf(
+						/* translators: %s: Current user's profile link. */
 						esc_html__( 'Howdy, %s', 'wporg-forums' ),
 						'<a href="' . esc_url( bbp_get_user_profile_url( bbp_get_current_user_id() ) ) . '">' . bbp_get_current_user_name() . '</a>'
 					);

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/sidebar.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/sidebar.php
@@ -6,7 +6,6 @@
 		<div class="my-account">
 			<ul>
 				<li><?php
-					/* translators: %s: user's display name */
 					printf(
 						/* translators: %s: Current user's profile link. */
 						esc_html__( 'Howdy, %s', 'wporg-forums' ),

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/sidebar.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-support-2024/sidebar.php
@@ -7,11 +7,12 @@
 			<ul>
 				<li><?php
 					/* translators: %s: user's display name */
-					printf( __( 'Howdy, %s', 'wporg-forums' ),
+					printf(
+						esc_html__( 'Howdy, %s', 'wporg-forums' ),
 						'<a href="' . esc_url( bbp_get_user_profile_url( bbp_get_current_user_id() ) ) . '">' . bbp_get_current_user_name() . '</a>'
 					);
 				?></li>
-				<li><a href="<?php echo esc_url( wp_logout_url() ); ?>"><?php _e( 'Log Out', 'wporg-forums' ); ?></a></li>
+				<li><a href="<?php echo esc_url( wp_logout_url() ); ?>"><?php esc_html_e( 'Log Out', 'wporg-forums' ); ?></a></li>
 			</ul>
 		</div>
 
@@ -24,8 +25,8 @@
 			<div>
 				<ul class="forum-info">
 					<?php bb_base_single_forum_description(); ?>
-					<li><a class="feed" href="<?php bbp_forum_permalink(); ?>feed/"><?php _e( 'RSS Recent Posts', 'wporg-forums' ); ?></a></li>
-					<li><a class="feed" href="<?php bbp_forum_permalink(); ?>feed/?type=topic"><?php _e( 'RSS Recent Topics', 'wporg-forums' ); ?></a></li>
+					<li><a class="feed" href="<?php bbp_forum_permalink(); ?>feed/"><?php esc_html_e( 'RSS Recent Posts', 'wporg-forums' ); ?></a></li>
+					<li><a class="feed" href="<?php bbp_forum_permalink(); ?>feed/?type=topic"><?php esc_html_e( 'RSS Recent Topics', 'wporg-forums' ); ?></a></li>
 					<?php if ( is_user_logged_in() && $forum_subscription_link = bbp_get_forum_subscription_link() ) : ?>
 						<li class="forum-subscribe"><?php echo wp_kses_post( $forum_subscription_link ); ?></li>
 					<?php endif; ?>
@@ -85,7 +86,7 @@
 		<?php if ( ! bbp_is_single_user() && ! ( wporg_support_is_compat_forum() ) ) : ?>
 
 			<div>
-				<h2><?php _e( 'Topics', 'wporg-forums' ); ?></h2>
+				<h2><?php esc_html_e( 'Topics', 'wporg-forums' ); ?></h2>
 
 				<?php echo do_blocks(
 					sprintf(
@@ -102,10 +103,10 @@
 		<?php if ( bbp_is_single_view() && ! wporg_support_is_compat_view() || is_tax( 'topic-tag' ) ) : ?>
 
 			<div>
-				<h2><?php _e( 'Feeds', 'wporg-forums' ); ?></h2>
+				<h2><?php esc_html_e( 'Feeds', 'wporg-forums' ); ?></h2>
 				<ul class="forum-feeds">
-					<li><a class="feed" href="<?php bbp_forums_url(); ?>feed/"><?php _e( 'RSS Recent Posts', 'wporg-forums' ); ?></a></li>
-					<li><a class="feed" href="<?php bbp_topics_url(); ?>feed/"><?php _e( 'RSS Recent Topics', 'wporg-forums' ); ?></a></li>
+					<li><a class="feed" href="<?php bbp_forums_url(); ?>feed/"><?php esc_html_e( 'RSS Recent Posts', 'wporg-forums' ); ?></a></li>
+					<li><a class="feed" href="<?php bbp_topics_url(); ?>feed/"><?php esc_html_e( 'RSS Recent Topics', 'wporg-forums' ); ?></a></li>
 				</ul>
 			</div>
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg/404.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg/404.php
@@ -23,7 +23,7 @@ get_header(); ?>
 					<?php
 					printf(
 						/* translators: Home URL. */
-						__( 'Try searching from the field above, or go to the <a href="%s">home page</a>.', 'wporg' ), // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+						wp_kses_post( __( 'Try searching from the field above, or go to the <a href="%s">home page</a>.', 'wporg' ) ), // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 						esc_url( get_home_url() )
 					);
 					?>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg/404.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg/404.php
@@ -23,7 +23,7 @@ get_header(); ?>
 					<?php
 					printf(
 						/* translators: Home URL. */
-						wp_kses_post( __( 'Try searching from the field above, or go to the <a href="%s">home page</a>.', 'wporg' ) ), // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+						wp_kses_post( __( 'Try searching from the field above, or go to the <a href="%s">home page</a>.', 'wporg' ) ),
 						esc_url( get_home_url() )
 					);
 					?>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg/inc/template-tags.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg/inc/template-tags.php
@@ -30,7 +30,7 @@ if ( ! function_exists( __NAMESPACE__ . '\entry_meta' ) ) :
 			// phpcs:disable WordPress.XSS.EscapeOutput.OutputNotEscaped
 			printf(
 				/* translators: 1: post date 2: post author */
-				'<span class="posted-on">' . __( 'Posted on %1$s by %2$s.', 'wporg' ) . '</span>',
+				'<span class="posted-on">' . esc_html__( 'Posted on %1$s by %2$s.', 'wporg' ) . '</span>',
 				$time_string,
 				$author_string
 			);

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg/template-parts/content-none.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg/template-parts/content-none.php
@@ -19,7 +19,7 @@
 				<?php
 				printf(
 					/* translators: Link to post editor. */
-					__( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', 'wporg' ), // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+					wp_kses_post( __( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', 'wporg' ) ), // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 					esc_url( admin_url( 'post-new.php' ) )
 				);
 				?>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg/template-parts/content-none.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg/template-parts/content-none.php
@@ -19,7 +19,7 @@
 				<?php
 				printf(
 					/* translators: Link to post editor. */
-					wp_kses_post( __( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', 'wporg' ) ), // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+					wp_kses_post( __( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', 'wporg' ) ),
 					esc_url( admin_url( 'post-new.php' ) )
 				);
 				?>

--- a/wordpress.tv/public_html/wp-content/themes/wptv2/404.php
+++ b/wordpress.tv/public_html/wp-content/themes/wptv2/404.php
@@ -19,6 +19,7 @@ global $wp_query, $post, $wptv;
 		<div class="primary-content">
 			<div class="baron-von-pick">
 				<img src="<?php echo esc_url( get_theme_file_uri( 'i/michael-pick-stashes-a-guinness.gif' ) ); ?>" alt="" /><br />
+				<?php /* translators: %s: Photo credit link. */ ?>
 				<?php printf( esc_html__( 'Photo animation credit: %s.', 'wptv' ), '<a href="https://markjaquith.com/">Mark Jaquith</a>' ); ?>
 			</div>
 			<div class="message-404">
@@ -26,6 +27,7 @@ global $wp_query, $post, $wptv;
 				<p><?php esc_html_e( 'These sorts of things happen&hellip;', 'wptv' ); ?></p>
 				<p><?php esc_html_e( 'Try searching for what you were looking for.', 'wptv' ); ?></p>
 				<p><?php echo get_search_form(); ?></p>
+				<?php /* translators: %s: Homepage URL. */ ?>
 				<p><?php printf( wp_kses_post( __( 'Or, <a href="%s">visit the homepage</a> to start a fresh journey.', 'wptv' ) ), '/' ); ?></p>
 			</div>
 		</div>

--- a/wordpress.tv/public_html/wp-content/themes/wptv2/404.php
+++ b/wordpress.tv/public_html/wp-content/themes/wptv2/404.php
@@ -19,14 +19,14 @@ global $wp_query, $post, $wptv;
 		<div class="primary-content">
 			<div class="baron-von-pick">
 				<img src="<?php echo esc_url( get_theme_file_uri( 'i/michael-pick-stashes-a-guinness.gif' ) ); ?>" alt="" /><br />
-				<?php printf( __( 'Photo animation credit: %s.', 'wptv' ), '<a href="https://markjaquith.com/">Mark Jaquith</a>' ); ?>
+				<?php printf( esc_html__( 'Photo animation credit: %s.', 'wptv' ), '<a href="https://markjaquith.com/">Mark Jaquith</a>' ); ?>
 			</div>
 			<div class="message-404">
 				<h2><?php esc_html_e( 'Uh oh, someone made a mistake!', 'wptv' ); ?></h2>
 				<p><?php esc_html_e( 'These sorts of things happen&hellip;', 'wptv' ); ?></p>
 				<p><?php esc_html_e( 'Try searching for what you were looking for.', 'wptv' ); ?></p>
 				<p><?php echo get_search_form(); ?></p>
-				<p><?php printf( __( 'Or, <a href="%s">visit the homepage</a> to start a fresh journey.', 'wptv' ), '/' ); ?></p>
+				<p><?php printf( wp_kses_post( __( 'Or, <a href="%s">visit the homepage</a> to start a fresh journey.', 'wptv' ) ), '/' ); ?></p>
 			</div>
 		</div>
 	</div><!-- container -->

--- a/wordpress.tv/public_html/wp-content/themes/wptv2/archive.php
+++ b/wordpress.tv/public_html/wp-content/themes/wptv2/archive.php
@@ -24,15 +24,15 @@ global $wp_query, $post, $wptv;
 
 		elseif ( is_day() ) :
 			/* translators: %s: Date. */
-			printf( esc_html_x( 'Archive for %s', 'Daily archive page', 'wptv' ), get_the_time( __( 'F jS, Y', 'wptv' ) ) );
+			printf( esc_html_x( 'Archive for %s', 'Daily archive page', 'wptv' ), esc_html( get_the_time( __( 'F jS, Y', 'wptv' ) ) ) );
 
 		elseif ( is_month() ) :
 			/* translators: %s: Month. */
-			printf( esc_html_x( 'Archive for %s', 'Monthly archive page', 'wptv' ), get_the_time( __( 'F, Y', 'wptv' ) ) );
+			printf( esc_html_x( 'Archive for %s', 'Monthly archive page', 'wptv' ), esc_html( get_the_time( __( 'F, Y', 'wptv' ) ) ) );
 
 		elseif ( is_year() ) :
 			/* translators: %s: Year. */
-			printf( esc_html_x( 'Archive for %s', 'Yearly archive page', 'wptv' ), get_the_time( __( 'Y', 'wptv' ) ) );
+			printf( esc_html_x( 'Archive for %s', 'Yearly archive page', 'wptv' ), esc_html( get_the_time( __( 'Y', 'wptv' ) ) ) );
 
 		elseif ( is_author() ) :
 			esc_html_e( 'Author Archive', 'wptv' );

--- a/wordpress.tv/public_html/wp-content/themes/wptv2/archive.php
+++ b/wordpress.tv/public_html/wp-content/themes/wptv2/archive.php
@@ -16,23 +16,26 @@ global $wp_query, $post, $wptv;
 	<h2 class="page-title"><?php
 		if ( is_category() ) :
 			/* translators: %s: Category name. */
-			printf( esc_html__( '&#8216;%s&#8217; Videos', 'wptv' ), single_cat_title( '', false ) );
+			printf( esc_html__( '&#8216;%s&#8217; Videos', 'wptv' ), esc_html( single_cat_title( '', false ) ) );
 
 		elseif ( is_tag() ) :
 			/* translators: %s: Tag name. */
-			printf( esc_html__( '&#8216;%s&#8217; Videos', 'wptv' ), single_tag_title( '', false ) );
+			printf( esc_html__( '&#8216;%s&#8217; Videos', 'wptv' ), esc_html( single_tag_title( '', false ) ) );
 
 		elseif ( is_day() ) :
+			$archive_date = get_the_time( __( 'F jS, Y', 'wptv' ) );
 			/* translators: %s: Date. */
-			printf( esc_html_x( 'Archive for %s', 'Daily archive page', 'wptv' ), esc_html( get_the_time( __( 'F jS, Y', 'wptv' ) ) ) );
+			printf( esc_html_x( 'Archive for %s', 'Daily archive page', 'wptv' ), esc_html( $archive_date ) );
 
 		elseif ( is_month() ) :
+			$archive_date = get_the_time( __( 'F, Y', 'wptv' ) );
 			/* translators: %s: Month. */
-			printf( esc_html_x( 'Archive for %s', 'Monthly archive page', 'wptv' ), esc_html( get_the_time( __( 'F, Y', 'wptv' ) ) ) );
+			printf( esc_html_x( 'Archive for %s', 'Monthly archive page', 'wptv' ), esc_html( $archive_date ) );
 
 		elseif ( is_year() ) :
+			$archive_date = get_the_time( __( 'Y', 'wptv' ) );
 			/* translators: %s: Year. */
-			printf( esc_html_x( 'Archive for %s', 'Yearly archive page', 'wptv' ), esc_html( get_the_time( __( 'Y', 'wptv' ) ) ) );
+			printf( esc_html_x( 'Archive for %s', 'Yearly archive page', 'wptv' ), esc_html( $archive_date ) );
 
 		elseif ( is_author() ) :
 			esc_html_e( 'Author Archive', 'wptv' );

--- a/wordpress.tv/public_html/wp-content/themes/wptv2/archive.php
+++ b/wordpress.tv/public_html/wp-content/themes/wptv2/archive.php
@@ -15,18 +15,23 @@ global $wp_query, $post, $wptv;
 <div class="wptv-hero">
 	<h2 class="page-title"><?php
 		if ( is_category() ) :
+			/* translators: %s: Category name. */
 			printf( esc_html__( '&#8216;%s&#8217; Videos', 'wptv' ), single_cat_title( '', false ) );
 
 		elseif ( is_tag() ) :
+			/* translators: %s: Tag name. */
 			printf( esc_html__( '&#8216;%s&#8217; Videos', 'wptv' ), single_tag_title( '', false ) );
 
 		elseif ( is_day() ) :
+			/* translators: %s: Date. */
 			printf( esc_html_x( 'Archive for %s', 'Daily archive page', 'wptv' ), get_the_time( __( 'F jS, Y', 'wptv' ) ) );
 
 		elseif ( is_month() ) :
+			/* translators: %s: Month. */
 			printf( esc_html_x( 'Archive for %s', 'Monthly archive page', 'wptv' ), get_the_time( __( 'F, Y', 'wptv' ) ) );
 
 		elseif ( is_year() ) :
+			/* translators: %s: Year. */
 			printf( esc_html_x( 'Archive for %s', 'Yearly archive page', 'wptv' ), get_the_time( __( 'Y', 'wptv' ) ) );
 
 		elseif ( is_author() ) :
@@ -38,6 +43,7 @@ global $wp_query, $post, $wptv;
 			print( "$tax->label: $terms->name" );
 
 		elseif ( is_search() ) :
+			/* translators: %s: Search query. */
 			printf( esc_html__( 'Search Results for &#8216;%s&#8217;', 'wptv' ), '<span>' . get_search_query() . '</span>' );
 
 		else :

--- a/wordpress.tv/public_html/wp-content/themes/wptv2/archive.php
+++ b/wordpress.tv/public_html/wp-content/themes/wptv2/archive.php
@@ -15,19 +15,19 @@ global $wp_query, $post, $wptv;
 <div class="wptv-hero">
 	<h2 class="page-title"><?php
 		if ( is_category() ) :
-			printf( __( '&#8216;%s&#8217; Videos', 'wptv' ), single_cat_title( '', false ) );
+			printf( esc_html__( '&#8216;%s&#8217; Videos', 'wptv' ), single_cat_title( '', false ) );
 
 		elseif ( is_tag() ) :
-			printf( __( '&#8216;%s&#8217; Videos', 'wptv' ), single_tag_title( '', false ) );
+			printf( esc_html__( '&#8216;%s&#8217; Videos', 'wptv' ), single_tag_title( '', false ) );
 
 		elseif ( is_day() ) :
-			printf( _x( 'Archive for %s', 'Daily archive page', 'wptv' ), get_the_time( __( 'F jS, Y', 'wptv' ) ) );
+			printf( esc_html_x( 'Archive for %s', 'Daily archive page', 'wptv' ), get_the_time( __( 'F jS, Y', 'wptv' ) ) );
 
 		elseif ( is_month() ) :
-			printf( _x( 'Archive for %s', 'Monthly archive page', 'wptv' ), get_the_time( __( 'F, Y', 'wptv' ) ) );
+			printf( esc_html_x( 'Archive for %s', 'Monthly archive page', 'wptv' ), get_the_time( __( 'F, Y', 'wptv' ) ) );
 
 		elseif ( is_year() ) :
-			printf( _x( 'Archive for %s', 'Yearly archive page', 'wptv' ), get_the_time( __( 'Y', 'wptv' ) ) );
+			printf( esc_html_x( 'Archive for %s', 'Yearly archive page', 'wptv' ), get_the_time( __( 'Y', 'wptv' ) ) );
 
 		elseif ( is_author() ) :
 			esc_html_e( 'Author Archive', 'wptv' );
@@ -38,7 +38,7 @@ global $wp_query, $post, $wptv;
 			print( "$tax->label: $terms->name" );
 
 		elseif ( is_search() ) :
-			printf( __( 'Search Results for &#8216;%s&#8217;', 'wptv' ), '<span>' . get_search_query() . '</span>' );
+			printf( esc_html__( 'Search Results for &#8216;%s&#8217;', 'wptv' ), '<span>' . get_search_query() . '</span>' );
 
 		else :
 			esc_html_e( 'Archives', 'wptv' );

--- a/wordpress.tv/public_html/wp-content/themes/wptv2/breadcrumbs.php
+++ b/wordpress.tv/public_html/wp-content/themes/wptv2/breadcrumbs.php
@@ -8,7 +8,7 @@
 global $wptv;
 ?>
 <div class="breadcrumb">
-	<a href="<?php echo esc_url( home_url() ); ?>"><?php _e( 'Home', 'wptv' ); ?></a>
+	<a href="<?php echo esc_url( home_url() ); ?>"><?php esc_html_e( 'Home', 'wptv' ); ?></a>
 	<?php
 		$wptv->the_category( '<span class="arrow">&raquo;</span>' );
 		$wptv->the_event( '<span class="arrow">&raquo;</span>' );

--- a/wordpress.tv/public_html/wp-content/themes/wptv2/comments.php
+++ b/wordpress.tv/public_html/wp-content/themes/wptv2/comments.php
@@ -27,7 +27,7 @@ if ( have_comments() ) :
 			} else {
 				printf(
 					esc_html(
-						/* translators: 1: number of comments, 2: post title */
+						/* translators: 1: Number of comments, 2: Post title. */
 						_nx(
 							'%1$s response on &ldquo;%2$s&rdquo;',
 							'%1$s responses on &ldquo;%2$s&rdquo;',

--- a/wordpress.tv/public_html/wp-content/themes/wptv2/comments.php
+++ b/wordpress.tv/public_html/wp-content/themes/wptv2/comments.php
@@ -23,19 +23,21 @@ if ( have_comments() ) :
 			$comments_number = get_comments_number();
 			if ( 1 == $comments_number ) {
 				/* translators: %s: post title */
-				printf( esc_html_x( 'One response on &ldquo;%s&rdquo;', 'comments title', 'wptv' ), '<span>' . get_the_title() . '</span>' );
+				printf( esc_html_x( 'One response on &ldquo;%s&rdquo;', 'comments title', 'wptv' ), '<span>' . esc_html( get_the_title() ) . '</span>' );
 			} else {
 				printf(
-					/* translators: 1: number of comments, 2: post title */
-					esc_html( _nx(
-						'%1$s response on &ldquo;%2$s&rdquo;',
-						'%1$s responses on &ldquo;%2$s&rdquo;',
-						$comments_number,
-						'comments title',
-						'wptv'
-					) ),
+					esc_html(
+						/* translators: 1: number of comments, 2: post title */
+						_nx(
+							'%1$s response on &ldquo;%2$s&rdquo;',
+							'%1$s responses on &ldquo;%2$s&rdquo;',
+							$comments_number,
+							'comments title',
+							'wptv'
+						)
+					),
 					number_format_i18n( $comments_number ),
-					'<span>' . get_the_title() . '</span>'
+					'<span>' . esc_html( get_the_title() ) . '</span>'
 				);
 			}
 		?>

--- a/wordpress.tv/public_html/wp-content/themes/wptv2/comments.php
+++ b/wordpress.tv/public_html/wp-content/themes/wptv2/comments.php
@@ -23,17 +23,17 @@ if ( have_comments() ) :
 			$comments_number = get_comments_number();
 			if ( 1 == $comments_number ) {
 				/* translators: %s: post title */
-				printf( _x( 'One response on &ldquo;%s&rdquo;', 'comments title', 'wptv' ), '<span>' . get_the_title() . '</span>' );
+				printf( esc_html_x( 'One response on &ldquo;%s&rdquo;', 'comments title', 'wptv' ), '<span>' . get_the_title() . '</span>' );
 			} else {
 				printf(
 					/* translators: 1: number of comments, 2: post title */
-					_nx(
+					esc_html( _nx(
 						'%1$s response on &ldquo;%2$s&rdquo;',
 						'%1$s responses on &ldquo;%2$s&rdquo;',
 						$comments_number,
 						'comments title',
 						'wptv'
-					),
+					) ),
 					number_format_i18n( $comments_number ),
 					'<span>' . get_the_title() . '</span>'
 				);

--- a/wordpress.tv/public_html/wp-content/themes/wptv2/functions.php
+++ b/wordpress.tv/public_html/wp-content/themes/wptv2/functions.php
@@ -477,6 +477,7 @@ class WordPressTV_Theme {
 			<?php if ( $comment->comment_type != 'pingback' ) : ?>
 
 				<small class="commentmetadata">
+					<?php /* translators: 1: Comment date, 2: Comment time. */ ?>
 					<a href="#comment-<?php comment_ID(); ?>" title=""><?php printf( esc_html__( '%1$s at %2$s', 'wptv' ), get_comment_date(), get_comment_time() ); ?></a>
 					<?php
 						edit_comment_link( __( 'edit', 'wptv' ), '&nbsp;&nbsp;', '' );

--- a/wordpress.tv/public_html/wp-content/themes/wptv2/functions.php
+++ b/wordpress.tv/public_html/wp-content/themes/wptv2/functions.php
@@ -477,7 +477,7 @@ class WordPressTV_Theme {
 			<?php if ( $comment->comment_type != 'pingback' ) : ?>
 
 				<small class="commentmetadata">
-					<a href="#comment-<?php comment_ID() ?>" title=""><?php printf( __( '%1$s at %2$s', 'wptv' ), get_comment_date(), get_comment_time() ); ?></a>
+					<a href="#comment-<?php comment_ID(); ?>" title=""><?php printf( esc_html__( '%1$s at %2$s', 'wptv' ), get_comment_date(), get_comment_time() ); ?></a>
 					<?php
 						edit_comment_link( __( 'edit', 'wptv' ), '&nbsp;&nbsp;', '' );
 						echo comment_reply_link( array(
@@ -492,7 +492,7 @@ class WordPressTV_Theme {
 
 			<div class="commenttext">
 				<?php if ( $comment->comment_approved == '0' ) : ?>
-					<em><?php _e( 'Your comment is awaiting moderation.', 'wptv' ); ?></em>
+					<em><?php esc_html_e( 'Your comment is awaiting moderation.', 'wptv' ); ?></em>
 				<?php endif; // comment_approved == 0 ?>
 
 				<?php comment_text(); ?>

--- a/wordpress.tv/public_html/wp-content/themes/wptv2/functions.php
+++ b/wordpress.tv/public_html/wp-content/themes/wptv2/functions.php
@@ -478,7 +478,7 @@ class WordPressTV_Theme {
 
 				<small class="commentmetadata">
 					<?php /* translators: 1: Comment date, 2: Comment time. */ ?>
-					<a href="#comment-<?php comment_ID(); ?>" title=""><?php printf( esc_html__( '%1$s at %2$s', 'wptv' ), get_comment_date(), get_comment_time() ); ?></a>
+					<a href="#comment-<?php comment_ID(); ?>" title=""><?php printf( esc_html__( '%1$s at %2$s', 'wptv' ), esc_html( get_comment_date() ), esc_html( get_comment_time() ) ); ?></a>
 					<?php
 						edit_comment_link( __( 'edit', 'wptv' ), '&nbsp;&nbsp;', '' );
 						echo comment_reply_link( array(

--- a/wordpress.tv/public_html/wp-content/themes/wptv2/index.php
+++ b/wordpress.tv/public_html/wp-content/themes/wptv2/index.php
@@ -74,6 +74,7 @@ if ( have_posts() ) :
 				<p><?php esc_html_e( 'These sorts of things happen&hellip;' ); ?></p>
 				<p class="center"><?php esc_html_e( 'Try searching for what you were looking for.' ); ?></p>
 				<p><?php echo get_search_form(); ?></p>
+				<?php /* translators: %s: Homepage URL. */ ?>
 				<p><?php printf( wp_kses_post( __( 'Or, <a href="%s">visit the homepage</a> to start a fresh journey.', 'wptv' ) ), '/' ); ?></p>
 				<p>
 					<img src="<?php echo esc_url( get_theme_file_uri( 'i/michael-pick-stashes-a-guinness.gif' ) ); ?>" alt="" /><br />

--- a/wordpress.tv/public_html/wp-content/themes/wptv2/index.php
+++ b/wordpress.tv/public_html/wp-content/themes/wptv2/index.php
@@ -74,7 +74,7 @@ if ( have_posts() ) :
 				<p><?php esc_html_e( 'These sorts of things happen&hellip;' ); ?></p>
 				<p class="center"><?php esc_html_e( 'Try searching for what you were looking for.' ); ?></p>
 				<p><?php echo get_search_form(); ?></p>
-				<p><?php printf ( __( 'Or, <a href="%s">visit the homepage</a> to start a fresh journey.', 'wptv' ), '/' ); ?></p>
+				<p><?php printf( wp_kses_post( __( 'Or, <a href="%s">visit the homepage</a> to start a fresh journey.', 'wptv' ) ), '/' ); ?></p>
 				<p>
 					<img src="<?php echo esc_url( get_theme_file_uri( 'i/michael-pick-stashes-a-guinness.gif' ) ); ?>" alt="" /><br />
 					Photo animation credit: <a href="https://markjaquith.com/">Mark Jaquith</a>.

--- a/wordpress.tv/public_html/wp-content/themes/wptv2/upload-subtitles-template.php
+++ b/wordpress.tv/public_html/wp-content/themes/wptv2/upload-subtitles-template.php
@@ -166,6 +166,7 @@ if ( post_password_required() ) :
 
 	<div class="container">
 		<div class="video-upload">
+			<?php /* translators: %s: Contact form URL. */ ?>
 			<p><?php printf( wp_kses_post( __( 'Hey there! If you&#8217;re interested in subtitling or captioning videos for WordPress.tv, please fill out the <a href="%s">contact form</a>, and we&#8217;ll be in touch.', 'wptv' ) ), 'https://wordpress.tv/contact/' ); ?></p>
 			<div class="pass-form">
 				<?php echo get_the_password_form(); ?>

--- a/wordpress.tv/public_html/wp-content/themes/wptv2/upload-subtitles-template.php
+++ b/wordpress.tv/public_html/wp-content/themes/wptv2/upload-subtitles-template.php
@@ -166,7 +166,7 @@ if ( post_password_required() ) :
 
 	<div class="container">
 		<div class="video-upload">
-			<p><?php printf( __( 'Hey there! If you&#8217;re interested in subtitling or captioning videos for WordPress.tv, please fill out the <a href="%s">contact form</a>, and we&#8217;ll be in touch.', 'wptv' ), 'https://wordpress.tv/contact/' ); ?></p>
+			<p><?php printf( wp_kses_post( __( 'Hey there! If you&#8217;re interested in subtitling or captioning videos for WordPress.tv, please fill out the <a href="%s">contact form</a>, and we&#8217;ll be in touch.', 'wptv' ) ), 'https://wordpress.tv/contact/' ); ?></p>
 			<div class="pass-form">
 				<?php echo get_the_password_form(); ?>
 			</div>
@@ -254,7 +254,7 @@ if ( ! empty( $_REQUEST['error'] ) ) {
 
 			<table>
 				<tr>
-					<th><label for="wptv_wporg_username"><?php _e( 'WordPress.org Username' ); ?><span class="required"> * </span></label></th>
+					<th><label for="wptv_wporg_username"><?php esc_html_e( 'WordPress.org Username' ); ?><span class="required"> * </span></label></th>
 					<td>
 						<input type="text" id="wptv_wporg_username" name="wptv_wporg_username" /><br />
 						To contribute subtitles, you must be a registered user at the <a href="https://wordpress.org">WordPress.org</a> website. Note that this is the username you use to log in at WordPress.org, not the username you use to log in on your own WordPress-powered site.<br />
@@ -271,7 +271,7 @@ if ( ! empty( $_REQUEST['error'] ) ) {
 				</tr>
 
 				<tr>
-					<th><label for="wptv_language"><?php _e( 'Language' ); ?><span class="required"> * </span></label></th>
+					<th><label for="wptv_language"><?php esc_html_e( 'Language' ); ?><span class="required"> * </span></label></th>
 					<td>
 						<select name="wptv_language">
 							<?php $tracks = VideoPress_Subtitles::get_tracks( $video->guid ); ?>
@@ -283,7 +283,7 @@ if ( ! empty( $_REQUEST['error'] ) ) {
 				</tr>
 
 				<tr>
-					<th><label for="wptv_subtitles_file"><?php _e( 'Subtitles File' ); ?><span class="required"> * </span></label></th>
+					<th><label for="wptv_subtitles_file"><?php esc_html_e( 'Subtitles File' ); ?><span class="required"> * </span></label></th>
 					<td><input type="file" name="wptv_subtitles_file" id="wptv_subtitles_file" /></td>
 				</tr>
 

--- a/wp15.wordpress.net/public_html/content/mu-plugins/locales.php
+++ b/wp15.wordpress.net/public_html/content/mu-plugins/locales.php
@@ -241,7 +241,7 @@ function locale_notice() {
 				?>
 			</p>
 			<button type="button" class="wp15-locale-notice-dismiss">
-				<span class="screen-reader-text"><?php _e( 'Dismiss this notice.' ); ?></span>
+				<span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice.' ); ?></span>
 			</button>
 		</div>
 	<?php endif;


### PR DESCRIPTION
Escapes translated strings on their way into markup, clearing every `WordPress.Security.EscapeOutput.UnsafePrintingFunction` violation and the `__()`-family `OutputNotEscaped` ones (EscapeOutput total 2,437 → 1,080; UnsafePrintingFunction 826 → 0). Second batch after #814.

Where a rewrite put a line into the diff, the other violations the changed-lines linter reports for that line are fixed alongside it, which is what the fourth commit is.

Commit by commit:

1. Rewrites the flagged `_e()`, `_ex()`, `__()`, `_x()`, `_n()` and `_nx()` calls. Plain strings become `esc_html_e()` / `esc_html__()`, or the `esc_attr` variants where the call sits inside an attribute. Plural calls are wrapped in `esc_html()`. The 139 strings that carry markup are wrapped in `wp_kses_post()` rather than restructured, so those strings keep their existing translations. One string printed into a JavaScript literal goes through `esc_js()`. Call spacing and missing semicolons on the touched lines are normalised. Also fixes a `<span5%s</span>` typo in the bb-base activity nav that broke the BuddyPress translation lookup for that label.
2. The handbook watch link only needs its label translated, so the anchor becomes the format string and the label goes through `esc_html__()`.
3. Adds translators comments to the placeholder strings on touched lines that lacked one.
4. The rest of what the changed-lines linter reports: escapes the neighbouring output on the same lines (bbPress titles and author links, counts, dates, widget title markup, activity nav URLs); numbers the placeholders in five strings that use `%s` more than once; turns the concatenated `_n()` in the Trac components page into a proper plural string with the milestone as a placeholder; reflows multi-line `printf()` calls into the ruleset's call-signature format; adds file docblocks to templates whose first line changed; registers `jobswp_field_value()` as auto-escaping in the ruleset since it returns `selected()` markup, a kses-filtered description, or an `esc_attr()`'d value; and marks with scoped `phpcs:ignore` comments the jobswp templates' reads of `$_POST['errors']` and `$_POST['job_token']`, which the plugin's own form handler sets, and the two list-table search subtitles that are escaped for display. Two rosetta templates and two forum notices go from CRLF to LF.
5. Straight apostrophes in the translated strings on touched lines become `&#8217;`, the form the surrounding strings already use, and strings that only needed double quotes for an apostrophe move to single quotes. Also fixes "are't" in the Photo Directory stats notice.
6. Review fixes: `wp_kses_post()` where the wrapped value is markup (bbPress freshness links, the author card status labels, the Photo Directory rejecting-user link) and the `$format` template the photo submitbox still used.
7. Review fixes: the support forums prepend an `<abbr>` to NSFW topic titles, so the support-2024 headings use `wp_kses_post()`; the plugin title and committer name that reach HTML slots as `printf()` arguments are escaped; and the "No site" string the first commit had turned into "None" is restored.

Decisions worth a look:

- Strings with markup keep their text and get `wp_kses_post()`. Moving the tags out would change the translation keys for dozens of locales. The handbook watch link is the one place that was done, on request. The strings that do change are the two watch labels, the five with numbered placeholders, the Trac milestone plural, the `<span5` typo, and the 21 apostrophes.
- `bbp_get_topic_author_link()` and `get_the_author_posts_link()` return markup and get `wp_kses_post()`; widget `$before_title` / `$after_title` too.
- Counts get an `(int)` cast rather than `esc_html()`.

Left for follow-ups, in this order: the known-safe function outputs (`number_format_i18n()`, `human_time_diff()`, `get_the_*()`, bbPress getters), the 29 exception messages, then the plain variables one component at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
