### PR TITLE
Improve single result rendering

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/phpunit-test-reporter/parts/single-result.php
+++ b/wordpress.org/public_html/wp-content/plugins/phpunit-test-reporter/parts/single-result.php
@@ -36,7 +36,7 @@ if ( $user ) {
 $parent = get_post( $report->post_parent );
 if ( $parent ) :
 	?>
-<p><a href="<?php echo esc_url( get_permalink( $parent ) ); ?>">&larr; <?php echo esc_html( $parent->post_name ) . ': ' . apply_filters( 'the_title', get_the_title( $parent ) ); ?></a></p>
+<p><a href="<?php echo esc_url( get_permalink( $parent ) ); ?>">&larr; <?php echo esc_html( $parent->post_name ) . ': ' . esc_html( $parent->post_title ); ?></a></p>
 <?php endif; ?>
 
 <p><a href="<?php echo esc_url( get_permalink( $report->ID ) ); ?>" title="<?php echo esc_attr( $status_title ); ?>" class="<?php echo esc_attr( 'ptr-status-badge ptr-status-badge-' . strtolower( $status ) ); ?>"><?php echo esc_html( $status ); ?></a></p>

--- a/wordpress.org/public_html/wp-content/plugins/phpunit-test-reporter/phpunit-test-reporter.php
+++ b/wordpress.org/public_html/wp-content/plugins/phpunit-test-reporter/phpunit-test-reporter.php
@@ -27,7 +27,13 @@ add_action( 'init', array( 'PTR\Display', 'action_init_register_shortcode' ) );
 add_action( 'get_post_metadata', array( 'PTR\Display', 'filter_get_post_metadata' ), 10, 4 );
 add_action( 'body_class', array( 'PTR\Display', 'filter_body_class' ) );
 add_action( 'post_class', array( 'PTR\Display', 'filter_post_class' ) );
-add_action( 'the_content', array( 'PTR\Display', 'filter_the_content' ) );
+// This callback discards its $content input and returns a freshly rendered report,
+// so it must run after every shortcode-parsing pass or that generated markup — which
+// contains esc_html'd, submitter-controlled data — gets fed back to the parser.
+// Core's do_shortcode is at priority 11; a late priority (99) also runs after any
+// third-party shortcode filter registered above that. add_filter (not add_action) as
+// the returned value is used.
+add_filter( 'the_content', array( 'PTR\Display', 'filter_the_content' ), 99 );
 add_action( 'rest_api_init', array( 'PTR\RestAPI', 'register_routes' ) );
 add_action( 'load-edit.php', 'ptr_load_edit_php' );
 


### PR DESCRIPTION
## Summary
- Render the single result view after WordPress runs the content shortcode pass, so the generated report markup isn't processed a second time. `add_action` on `the_content` is also switched to `add_filter` (the callback's return value is used).
- Escape the parent changeset title in `single-result.php`, matching the escaping posture of the sibling templates (`result-set-single.php`, `result-set-all.php`). This intentionally drops the `the_title` filter for that title (it's plain-text commit message data), so its quote styling differs slightly from the siblings; escaping it via the raw value also avoids double-encoding.

## Testing
Confirmed the single result and result set views still render correctly after the change, in a local environment set up to mimic production as closely as possible.

See screenshots in https://github.com/WordPress/phpunit-test-reporter/pull/124


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Parent-post breadcrumb titles are now displayed consistently and safely.
  - Test report content is rendered more reliably, preventing generated markup from being processed incorrectly and improving the display of submitted results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->