### PR TITLE
Support Forums: Keep the oEmbed proxy in step with rendering

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-blocks.php
+++ b/wordpress.org/public_html/wp-content/plugins/support-forums/inc/class-blocks.php
@@ -228,6 +228,15 @@ class Blocks {
 			return bbp_current_user_can_publish_topics() || bbp_current_user_can_publish_replies();
 		};
 
+		$callback = $oembed_proxy_route_args[0]['callback'];
+
+		// Discovery fetches the client-supplied URL; rendering has it off (embed_oembed_discover), so the preview shouldn't either.
+		$oembed_proxy_route_args[0]['callback'] = function ( $request ) use ( $callback ) {
+			$request['discover'] = false;
+
+			return call_user_func( $callback, $request );
+		};
+
 		register_rest_route(
 			'oembed/1.0',
 			'/proxy',


### PR DESCRIPTION
See #6608.

The support forums render topic and reply content with oEmbed discovery turned off (`embed_oembed_discover` is filtered to `false` in `class-hooks.php`). The block editor's embed preview goes through the `oembed/1.0/proxy` route, which still had discovery on by default. So a URL that isn't in the registered provider list could preview fine in the editor and then never render in the published post.

This pins the proxy's `discover` argument to `false` in the same place the plugin already adjusts that route, so editor previews come from the registered provider list only, matching what the front end will actually show. The permission callback is unchanged.

This applies to every user of the forum editor, moderators included, since the front-end behaviour is the same for everyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved oEmbed preview rendering by disabling automatic URL discovery.
  - Previews now consistently use the provided embed information without fetching additional data from the client-supplied URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->