### PR TITLE
SSO: Normalize the remote-login bounce URL to https

### DIFF
--- a/common/includes/wporg-sso/wp-plugin.php
+++ b/common/includes/wporg-sso/wp-plugin.php
@@ -686,6 +686,7 @@ if ( class_exists( 'WPOrg_SSO' ) && ! class_exists( 'WP_WPOrg_SSO' ) ) {
 			$redirect_host = parse_url( $redirect, PHP_URL_HOST );
 
 			if ( $user && $this->_is_valid_targeted_domain( $redirect_host ) && ! preg_match( '!wordpress.org$!i', $redirect_host ) ) {
+				$redirect  = set_url_scheme( $redirect, 'https' );
 				$sso_token = $this->_generate_remote_token( $user, $redirect_host );
 				$redirect  = add_query_arg( 'sso_token', urlencode( $sso_token ), $redirect );
 			}


### PR DESCRIPTION
All remote-login destinations (bbpress.org, buddypress.org, wordcamp.org) are served over https. When the SSO bounces a logged-in user to one of them, build the bounce URL on that scheme regardless of how the `redirect_to` was written, so the hand-off goes straight to the canonical scheme instead of relying on the destination to redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote login redirects by ensuring they use HTTPS before adding the single sign-on token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->