### PR TITLE
Plugin Directory: Helpscout: Scope slug unwrapping to the plugin that owns the slug

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-upload-handler.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-upload-handler.php
@@ -760,6 +760,11 @@ class Upload_Handler {
 			'acf-gallery',
 		);
 
+		// Slugs in the namespace used internally for rejected plugins.
+		if ( preg_match( Helpscout::REJECTED_SLUG_REGEX, $this->plugin_slug ) ) {
+			return true;
+		}
+
 		return in_array( $this->plugin_slug, $reserved_slugs );
 	}
 

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Helpscout_Slug_Scope_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Helpscout_Slug_Scope_Test.php
@@ -57,10 +57,12 @@ class Helpscout_Slug_Scope_Test extends TestCase {
 	protected function create_plugin( string $slug ): WP_Post {
 		$plugin_id = wp_insert_post(
 			array(
-				'post_type'   => 'plugin',
-				'post_title'  => $slug,
-				'post_name'   => $slug,
-				'post_status' => 'new',
+				'post_type'         => 'plugin',
+				'post_title'        => $slug,
+				'post_name'         => $slug,
+				'post_status'       => 'new',
+				'post_modified'     => current_time( 'mysql' ),
+				'post_modified_gmt' => current_time( 'mysql', 1 ),
 			),
 			true
 		);

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Helpscout_Slug_Scope_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Helpscout_Slug_Scope_Test.php
@@ -153,11 +153,10 @@ class Helpscout_Slug_Scope_Test extends TestCase {
 	 */
 	public static function data_namespaced_slugs(): array {
 		return array(
-			'wrapped'          => array( 'rejected-fixture-sample-rejected' ),
-			'prefix only'      => array( 'rejected-fixture-sample' ),
-			'suffix only'      => array( 'fixture-sample-rejected' ),
-			'suffixed with -1' => array( 'fixture-sample-rejected-1' ),
-			'mixed case'       => array( 'Rejected-Fixture-Sample' ),
+			'wrapped'           => array( 'rejected-fixture-sample-rejected' ),
+			'wrapped, suffixed' => array( 'rejected-fixture-sample-rejected-2' ),
+			'suffixed past -9'  => array( 'rejected-fixture-sample-rejected-12' ),
+			'mixed case'        => array( 'Rejected-Fixture-Sample-Rejected' ),
 		);
 	}
 
@@ -178,14 +177,34 @@ class Helpscout_Slug_Scope_Test extends TestCase {
 	}
 
 	/**
-	 * An ordinary slug is still allowed.
+	 * Slugs that only look like the wrapper, which the unwrapping leaves alone.
 	 *
+	 * @return array
+	 */
+	public static function data_one_sided_slugs(): array {
+		return array(
+			'ordinary'    => array( 'fixture-sample' ),
+			'prefix only' => array( 'rejected-fixture-sample' ),
+			'suffix only' => array( 'fixture-sample-rejected' ),
+		);
+	}
+
+	/**
+	 * A slug outside the wrapper format stays available, and stays as it is.
+	 *
+	 * @dataProvider data_one_sided_slugs
+	 *
+	 * @param string $slug The slug to check.
 	 * @return void
 	 */
-	public function test_an_ordinary_slug_is_not_reserved(): void {
+	#[DataProvider( 'data_one_sided_slugs' )]
+	public function test_a_slug_outside_the_wrapper_format_is_left_alone( string $slug ): void {
 		$upload_handler              = new Upload_Handler();
-		$upload_handler->plugin_slug = 'fixture-sample';
+		$upload_handler->plugin_slug = $slug;
 
 		$this->assertFalse( $upload_handler->has_reserved_slug() );
+
+		$plugin = $this->create_plugin( $slug );
+		$this->assertSame( $slug, $this->unwrap( $slug, $plugin->ID ) );
 	}
 }

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Helpscout_Slug_Scope_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Helpscout_Slug_Scope_Test.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * Tests that the rejected-slug namespace stays tied to the plugin that owns it.
+ *
+ * A rejected plugin's slug is wrapped as `rejected-{slug}-rejected` to free up the
+ * original slug for another submission. `Helpscout` unwraps it again to find the
+ * emails recorded before the rename, which is only the right slug for as long as the
+ * original is still unclaimed.
+ *
+ * @package plugin-directory
+ */
+
+declare( strict_types = 1 );
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use WordPressdotorg\Plugin_Directory\Shortcodes\Upload_Handler;
+use WordPressdotorg\Plugin_Directory\Tools\Helpscout;
+
+/**
+ * Tests for `Helpscout::get_unwrapped_slug()` and `Upload_Handler::has_reserved_slug()`.
+ *
+ * @group plugin-directory
+ */
+#[Group( 'plugin-directory' )]
+class Helpscout_Slug_Scope_Test extends TestCase {
+
+	/**
+	 * IDs of posts created during a test, deleted again on teardown.
+	 *
+	 * @var int[]
+	 */
+	protected $post_ids = array();
+
+	/**
+	 * Removes the posts the test created.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		foreach ( $this->post_ids as $post_id ) {
+			wp_cache_delete( get_post_field( 'post_name', $post_id ), 'plugin-slugs' );
+			wp_delete_post( $post_id, true );
+		}
+		$this->post_ids = array();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Creates a plugin holding a given slug.
+	 *
+	 * @param string $slug The slug to give it.
+	 * @return WP_Post
+	 */
+	protected function create_plugin( string $slug ): WP_Post {
+		$plugin_id = wp_insert_post(
+			array(
+				'post_type'   => 'plugin',
+				'post_title'  => $slug,
+				'post_name'   => $slug,
+				'post_status' => 'new',
+			),
+			true
+		);
+
+		$this->assertIsInt( $plugin_id );
+		$this->post_ids[] = $plugin_id;
+
+		return get_post( $plugin_id );
+	}
+
+	/**
+	 * Asks `Helpscout` which slug a post's emails may also be recorded against.
+	 *
+	 * @param string $post_name The post slug.
+	 * @param int    $post_id   The post ID.
+	 * @return string
+	 */
+	protected function unwrap( string $post_name, int $post_id ): string {
+		$method = new ReflectionMethod( Helpscout::class, 'get_unwrapped_slug' );
+
+		return $method->invoke( null, $post_name, $post_id );
+	}
+
+	/**
+	 * A unique slug, so one test's `plugin-slugs` cache entries can't reach another.
+	 *
+	 * @return string
+	 */
+	protected function unique_slug(): string {
+		return 'fixture-' . strtolower( wp_generate_password( 8, false ) );
+	}
+
+	/**
+	 * A slug outside the namespace is left alone.
+	 *
+	 * @return void
+	 */
+	public function test_a_slug_outside_the_namespace_is_unchanged(): void {
+		$plugin = $this->create_plugin( $this->unique_slug() );
+
+		$this->assertSame( $plugin->post_name, $this->unwrap( $plugin->post_name, $plugin->ID ) );
+	}
+
+	/**
+	 * A wrapped slug unwraps while nothing holds the slug inside it.
+	 *
+	 * @return void
+	 */
+	public function test_a_wrapped_slug_unwraps_when_the_slug_is_unclaimed(): void {
+		$slug   = $this->unique_slug();
+		$plugin = $this->create_plugin( "rejected-{$slug}-rejected" );
+
+		$this->assertSame( $slug, $this->unwrap( $plugin->post_name, $plugin->ID ) );
+	}
+
+	/**
+	 * A wrapped slug unwraps when the post asking is the one holding the slug inside it,
+	 * which is the state a restored plugin is in by the time the rename is recorded.
+	 *
+	 * @return void
+	 */
+	public function test_a_wrapped_slug_unwraps_for_the_post_that_holds_the_slug(): void {
+		$slug   = $this->unique_slug();
+		$plugin = $this->create_plugin( $slug );
+
+		$this->assertSame( $slug, $this->unwrap( "rejected-{$slug}-rejected", $plugin->ID ) );
+	}
+
+	/**
+	 * A wrapped slug stops unwrapping once a different plugin holds the slug inside it.
+	 *
+	 * @return void
+	 */
+	public function test_a_wrapped_slug_does_not_unwrap_onto_another_plugin(): void {
+		$slug  = $this->unique_slug();
+		$owner = $this->create_plugin( $slug );
+
+		$wrapped = $this->create_plugin( "rejected-{$slug}-rejected" );
+
+		$this->assertNotSame( $owner->ID, $wrapped->ID );
+		$this->assertSame( $wrapped->post_name, $this->unwrap( $wrapped->post_name, $wrapped->ID ) );
+	}
+
+	/**
+	 * Slugs the unwrapping would rewrite, which are therefore not free to be given out.
+	 *
+	 * @return array
+	 */
+	public static function data_namespaced_slugs(): array {
+		return array(
+			'wrapped'          => array( 'rejected-fixture-sample-rejected' ),
+			'prefix only'      => array( 'rejected-fixture-sample' ),
+			'suffix only'      => array( 'fixture-sample-rejected' ),
+			'suffixed with -1' => array( 'fixture-sample-rejected-1' ),
+			'mixed case'       => array( 'Rejected-Fixture-Sample' ),
+		);
+	}
+
+	/**
+	 * A slug in the namespace is reserved, so no upload or rename can take one.
+	 *
+	 * @dataProvider data_namespaced_slugs
+	 *
+	 * @param string $slug The slug to check.
+	 * @return void
+	 */
+	#[DataProvider( 'data_namespaced_slugs' )]
+	public function test_a_namespaced_slug_is_reserved( string $slug ): void {
+		$upload_handler              = new Upload_Handler();
+		$upload_handler->plugin_slug = $slug;
+
+		$this->assertTrue( $upload_handler->has_reserved_slug() );
+	}
+
+	/**
+	 * An ordinary slug is still allowed.
+	 *
+	 * @return void
+	 */
+	public function test_an_ordinary_slug_is_not_reserved(): void {
+		$upload_handler              = new Upload_Handler();
+		$upload_handler->plugin_slug = 'fixture-sample';
+
+		$this->assertFalse( $upload_handler->has_reserved_slug() );
+	}
+}

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tools/class-helpscout.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tools/class-helpscout.php
@@ -1,7 +1,40 @@
 <?php
 namespace WordPressdotorg\Plugin_Directory\Tools;
 
+use WordPressdotorg\Plugin_Directory\Plugin_Directory;
+
 class Helpscout {
+
+	/**
+	 * The namespace a rejected plugin's slug is wrapped in.
+	 */
+	const REJECTED_SLUG_REGEX = '/(^rejected-|-rejected(-\d)?$)/i';
+
+	/**
+	 * Fetch the slug a post's emails may also be recorded against.
+	 *
+	 * A rejected plugin's slug is wrapped to free up the original slug, so emails for
+	 * it may still be recorded against the unwrapped one. That's only true for as long
+	 * as no other plugin holds the unwrapped slug.
+	 *
+	 * @param string $post_name The post slug.
+	 * @param int    $post_id   The post ID.
+	 * @return string The unwrapped slug, or $post_name if it isn't this post's to claim.
+	 */
+	protected static function get_unwrapped_slug( $post_name, $post_id ) {
+		$unwrapped = preg_replace( self::REJECTED_SLUG_REGEX, '', $post_name );
+		if ( ! $unwrapped || $unwrapped === $post_name ) {
+			return $post_name;
+		}
+
+		$owner = Plugin_Directory::get_plugin_post( $unwrapped );
+		if ( $owner && (int) $owner->ID !== (int) $post_id ) {
+			return $post_name;
+		}
+
+		return $unwrapped;
+	}
+
 	/**
 	 * Fetch the list of known Helpscout emails for a given post.
 	 *
@@ -18,7 +51,7 @@ class Helpscout {
 		}
 
 		// Trim off the rejected prefix/suffix.
-		$slug   = preg_replace( '/(^rejected-|-rejected(-\d)?$)/i', '', $post->post_name );
+		$slug   = self::get_unwrapped_slug( $post->post_name, $post->ID );
 		$wheres = '';
 
 		foreach ( $filters as $key => $value ) { 
@@ -69,7 +102,7 @@ class Helpscout {
 		}
 
 		$new_slug = $post_after->post_name;
-		$old_slug = preg_replace( '/(^rejected-|-rejected(-\d)?$)/i', '', $post_before->post_name );
+		$old_slug = self::get_unwrapped_slug( $post_before->post_name, $post_id );
 
 		$wpdb->query( $wpdb->prepare(
 			"UPDATE %i meta

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tools/class-helpscout.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tools/class-helpscout.php
@@ -7,8 +7,11 @@ class Helpscout {
 
 	/**
 	 * The namespace a rejected plugin's slug is wrapped in.
+	 *
+	 * The trailing digits are the suffix `wp_update_post()` adds when the wrapped slug
+	 * is itself taken.
 	 */
-	const REJECTED_SLUG_REGEX = '/(^rejected-|-rejected(-\d)?$)/i';
+	const REJECTED_SLUG_REGEX = '/^rejected-(.+)-rejected(-\d+)?$/i';
 
 	/**
 	 * Fetch the slug a post's emails may also be recorded against.
@@ -22,7 +25,7 @@ class Helpscout {
 	 * @return string The unwrapped slug, or $post_name if it isn't this post's to claim.
 	 */
 	protected static function get_unwrapped_slug( $post_name, $post_id ) {
-		$unwrapped = preg_replace( self::REJECTED_SLUG_REGEX, '', $post_name );
+		$unwrapped = preg_replace( self::REJECTED_SLUG_REGEX, '$1', $post_name );
 		if ( ! $unwrapped || $unwrapped === $post_name ) {
 			return $post_name;
 		}


### PR DESCRIPTION
`Helpscout::get_emails()` and `Helpscout::post_updated()` trim the `rejected-{slug}-rejected` wrapper off a plugin's `post_name` before matching `helpscout_meta` rows.

This makes that unwrapping conditional on the current plugin actually owning the unwrapped slug, and keeps the wrapper namespace out of publicly-settable slugs via `Upload_Handler::has_reserved_slug()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YCbYDrCx4YsS6f6uTZGfmu


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of rejected plugin slugs to prevent conflicts with reserved naming patterns.
  - Preserved the correct slug when an unwrapped slug is already assigned to another plugin.
  - Improved consistency for support email lookups and plugin metadata updates involving rejected plugins.
- **Tests**
  - Added coverage for rejected-slug handling, reserved naming patterns, wrapped and suffixed variants, and conflicts with existing plugin slugs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->