### PR TITLE
Templates: Stop escaping markup that is meant to render

### DIFF
--- a/buddypress.org/public_html/wp-content/themes/bporg-developer/reference/template-source.php
+++ b/buddypress.org/public_html/wp-content/themes/bporg-developer/reference/template-source.php
@@ -24,7 +24,7 @@ if ( ! empty( $source_file ) ) :
 
 		<?php if ( post_type_has_source_code() ) : ?>
 			<div class="source-code-container">
-				<pre class="brush: php; toolbar: false; first-line: <?php echo esc_attr( get_post_meta( get_the_ID(), '_wp-parser_line_num', true ) ); ?>"><?php echo esc_html( get_source_code() ); ?></pre>
+				<pre class="brush: php; toolbar: false; first-line: <?php echo esc_attr( get_post_meta( get_the_ID(), '_wp-parser_line_num', true ) ); ?>"><?php echo htmlentities( get_source_code() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- htmlentities() encodes the listing; esc_html() would swallow entity text in the source. ?></pre>
 			</div>
 			<p class="source-code-links">
 				<span>

--- a/buddypress.org/public_html/wp-content/themes/bporg-developer/reference/template-source.php
+++ b/buddypress.org/public_html/wp-content/themes/bporg-developer/reference/template-source.php
@@ -24,7 +24,7 @@ if ( ! empty( $source_file ) ) :
 
 		<?php if ( post_type_has_source_code() ) : ?>
 			<div class="source-code-container">
-				<pre class="brush: php; toolbar: false; first-line: <?php echo esc_attr( get_post_meta( get_the_ID(), '_wp-parser_line_num', true ) ); ?>"><?php echo esc_html( htmlentities( get_source_code() ) ); ?></pre>
+				<pre class="brush: php; toolbar: false; first-line: <?php echo esc_attr( get_post_meta( get_the_ID(), '_wp-parser_line_num', true ) ); ?>"><?php echo esc_html( get_source_code() ); ?></pre>
 			</div>
 			<p class="source-code-links">
 				<span>

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/index-locales.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/index-locales.php
@@ -35,13 +35,7 @@ gp_tmpl_header();
 					<li class="code"><?php echo wp_kses_post( gp_link_get( gp_url_join( '/locale', $locale->slug ), esc_html( $wp_locale ) ) ); ?></li>
 				</ul>
 				<div class="contributors">
-					<?php
-					$contributors = sprintf(
-						'<span class="dashicons dashicons-admin-users"></span><br />%s',
-						isset( $contributors_count[ $locale->slug ] ) ? $contributors_count[ $locale->slug ] : 0
-					);
-					?>
-					<a href="<?php echo esc_url( 'https://make.wordpress.org/polyglots/teams/?locale=' . $locale->wp_locale ); ?>"><?php echo esc_html( $contributors ); ?></a>
+					<a href="<?php echo esc_url( 'https://make.wordpress.org/polyglots/teams/?locale=' . $locale->wp_locale ); ?>"><span class="dashicons dashicons-admin-users"></span><br /><?php echo esc_html( isset( $contributors_count[ $locale->slug ] ) ? $contributors_count[ $locale->slug ] : 0 ); ?></a>
 				</div>
 				<div class="percent">
 					<div class="percent-complete" style="width:<?php echo esc_attr( $percent_complete ); ?>%;"></div>

--- a/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/locale-projects.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/templates/locale-projects.php
@@ -51,13 +51,7 @@ gp_tmpl_header();
 			<?php endif; ?>
 		</ul>
 		<div class="contributors">
-			<?php
-			$contributors = sprintf(
-				'<span class="dashicons dashicons-admin-users"></span><br />%s',
-				isset( $contributors_count[ $locale->slug ] ) ? $contributors_count[ $locale->slug ] : 0
-			);
-			?>
-			<a href="<?php echo esc_url( 'https://make.wordpress.org/polyglots/teams/?locale=' . $locale->wp_locale ); ?>"><?php echo esc_html( $contributors ); ?></a>
+			<a href="<?php echo esc_url( 'https://make.wordpress.org/polyglots/teams/?locale=' . $locale->wp_locale ); ?>"><span class="dashicons dashicons-admin-users"></span><br /><?php echo esc_html( isset( $contributors_count[ $locale->slug ] ) ? $contributors_count[ $locale->slug ] : 0 ); ?></a>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
The template output cleanup in r15188 (#901) wrapped two strings that carry intentional markup in `esc_html()`.

- The locale contributor counts on translate.wordpress.org printed their dashicon span as literal text, on both the locale project pages and the locales index.
- The BuddyPress developer reference double-encoded source listings, because `esc_html()` was stacked on top of `htmlentities()`.

The contributor markup now lives in the template and only the count is escaped, so there is no composed markup string left for a future escaping pass to wrap. r15081 had already corrected this same block once, and the project icons it also fixed survived r15188 because they kept a `phpcs:ignore` annotation.

Source listings go back to the `htmlentities()` call they used before r15188, annotated for PHPCS. Swapping in `esc_html()` is not equivalent here: it does not double-encode, so a listing containing entity text such as `&amp;` would render as `&` rather than the characters actually present in the source.

Validation: PHP syntax checks on the three changed files, PHPCS against the repository ruleset with no findings on the changed lines, and rendering checks of the contributor markup and of both encoders against source containing entity text.

Props timse201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Source code listings now display special characters correctly without redundant encoding.
  * Contributor links now render user icons properly instead of showing icon markup as text.
  * Contributor counts display correctly in locale listings and project headers.
  * Contributor links retain their visible icon and count information with improved rendering consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->