### PR TITLE
Redirects: Stop fataling on unknown hosts that already sent headers

### DIFF
--- a/wordpress.org/public_html/wp-content/mu-plugins/pub/wporg-redirects.php
+++ b/wordpress.org/public_html/wp-content/mu-plugins/pub/wporg-redirects.php
@@ -270,9 +270,13 @@ function wporg_redirect_site_not_found() {
 	if ( ! headers_sent() ) {
 		header( 'Location: ' . $location, true, $status_code );
 	} else {
-		// Headers should not have been sent at this point in time.
-		// On some pages, such as wp-cron.php the request has been terminated prior to WordPress loading, and so headers were "sent".
-		printf( '<a href="%1$s">%2$s</a>', esc_url( $location ), esc_html( $location ) );
+		/*
+		 * Headers should not have been sent at this point in time.
+		 * On some pages, such as wp-cron.php the request has been terminated prior to WordPress loading, and so headers were "sent".
+		 *
+		 * sunrise.php runs before kses.php loads, so the esc_*() helpers are unavailable here.
+		 */
+		printf( '<a href="%1$s">%1$s</a>', htmlspecialchars( $location, ENT_QUOTES, 'UTF-8' ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped above.
 	}
 	exit;
 }


### PR DESCRIPTION
Regression from #902 / [15190].

`wporg_redirect_site_not_found()` is called from `sunrise.php`, which runs at `wp-settings.php:159` (`ms-settings.php`). `kses.php` is not loaded until line 239. `esc_url()` calls `wp_kses_normalize_entities()` unconditionally, so the fallback branch fatals:

```
E_ERROR: Uncaught Error: Call to undefined function wp_kses_normalize_entities()
  in wp-includes/formatting.php:4590
#0 wp-content/mu-plugins/pub/wporg-redirects.php(275): esc_url('https://wordpre...')
#1 wp-content/sunrise.php(16): wporg_redirect_site_not_found()
...
#10 wp-cron.php(46): require_once('/home/wporg/pub...')
```

Any request to an unknown host that had already produced output — `wp-cron.php` is the common one — gets a 500 instead of the fallback link.

`esc_html()` and `esc_attr()` are not a way out either: `_wp_specialchars()` calls the same kses function as soon as the string contains any of `& < > " '`, which covers every URL with a query string. This uses `htmlspecialchars()`, which has no load-order dependency. `ENT_QUOTES` covers both the attribute and the text context, and `$location` always carries a hard-coded `https://` scheme, so there is no untrusted scheme left for `esc_url()` to reject.

## Testing

Reproduced end to end against a harness that recreates the sunrise load state exactly (`compat`, `plugin`, `utf8`, `formatting`, `functions` loaded; `kses.php` not) and forces `headers_sent()` to be true the way `wp-cron.php` does, then calls the real function.

Using the host and URI from the error report:

| | before | after |
|---|---|---|
| `www.weekendtheater.wordpress.org` + `/wp-cron.php?doing_wp_cron=…` | fatal, matching the production trace line for line | `<a href="https://wordpress.org/">https://wordpress.org/</a>` |

Other branches of the `switch`, after the fix:

- `xn--tg8hcb.wordpress.org` → `<a href="https://emoji.wordpress.org/">…</a>`
- `2026.wordpress.org` → `<a href="https://2026.wordpress.net/">…</a>`
- `profile.wordpress.org` + `/obenland/"><script>alert(1)</script>&x=1` → `…/obenland/&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;&amp;x=1`, neutralised in both the `href` and the link text. That last one is the only branch carrying attacker-controlled content, and it is also a request that kills the current code outright.

`phpcs` reports no `WordPress.Security.EscapeOutput` violations on the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fallback redirect handling during early WordPress startup.
  * Ensured redirect output is safely escaped even before standard WordPress helpers are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->