### PR TITLE
Fix escaped committer links in release confirmation

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-release-confirmation.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-release-confirmation.php
@@ -197,7 +197,7 @@ class Release_Confirmation {
 						esc_attr( gmdate( 'Y-m-d H:i:s', $data['date'] ) ),
 						esc_html( sprintf( __( '%s ago', 'wporg-plugins' ), human_time_diff( $data['date'] ) ) ),
 					),
-					esc_html( implode( ', ', $data['committer'] ) ),
+					implode( ', ', $data['committer'] ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Each committer link escapes its URL and label above.
 				),
 				self::get_actions( $plugin, $data ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Button attributes and labels are escaped in get_actions().
 				self::get_approval_text( $plugin, $data, $current_release ) . // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped when built.

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-release-confirmation.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-release-confirmation.php
@@ -161,7 +161,7 @@ class Release_Confirmation {
 			foreach ( $data['committer'] as $i => $login ) {
 				$data['committer'][ $i ] = sprintf(
 					'<a href="%s">%s</a>',
-					'https://profiles.wordpress.org/' . ( get_user_by( 'login', $login )->user_nicename ?? '' ) . '/',
+					esc_url( 'https://profiles.wordpress.org/' . ( get_user_by( 'login', $login )->user_nicename ?? '' ) . '/' ),
 					esc_html( $login )
 				);
 			}

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-release-confirmation.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/shortcodes/class-release-confirmation.php
@@ -197,7 +197,7 @@ class Release_Confirmation {
 						esc_attr( gmdate( 'Y-m-d H:i:s', $data['date'] ) ),
 						esc_html( sprintf( __( '%s ago', 'wporg-plugins' ), human_time_diff( $data['date'] ) ) ),
 					),
-					implode( ', ', $data['committer'] ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Each committer link escapes its URL and label above.
+					wp_kses_post( implode( ', ', $data['committer'] ) ),
 				),
 				self::get_actions( $plugin, $data ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Button attributes and labels are escaped in get_actions().
 				self::get_approval_text( $plugin, $data, $current_release ) . // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped when built.

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Current_Release_Resolution_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Current_Release_Resolution_Test.php
@@ -607,6 +607,27 @@ class Current_Release_Resolution_Test extends TestCase {
 	}
 
 	/**
+	 * Committer profile links remain links in the release listing.
+	 */
+	public function test_release_listing_renders_committer_profile_link(): void {
+		$login   = 'release-committer-' . ( ++self::$plugin_count );
+		$user_id = wp_create_user( $login, wp_generate_password(), $login . '@example.org' );
+
+		$this->assertIsInt( $user_id );
+		$this->add_release( self::HELD_TAG, self::RENAMED_VERSION, array( 'committer' => array( $login ) ) );
+
+		ob_start();
+		Release_Confirmation::single_plugin( get_post( $this->plugin->ID ) );
+		$listing = ob_get_clean();
+
+		$this->assertStringContainsString(
+			'<a href="https://profiles.wordpress.org/' . $login . '/">' . $login . '</a>',
+			$listing
+		);
+		$this->assertStringNotContainsString( '&lt;a href=', $listing );
+	}
+
+	/**
 	 * The listing's cooldown line follows the same resolution as the rest of the
 	 * UI: with the stable tag flipped to trunk at an unchanged version, the
 	 * fallback-resolved release is the current one and keeps its line.

--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Current_Release_Resolution_Test.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/tests/Current_Release_Resolution_Test.php
@@ -618,7 +618,7 @@ class Current_Release_Resolution_Test extends TestCase {
 
 		ob_start();
 		Release_Confirmation::single_plugin( get_post( $this->plugin->ID ) );
-		$listing = ob_get_clean();
+		$listing = (string) ob_get_clean();
 
 		$this->assertStringContainsString(
 			'<a href="https://profiles.wordpress.org/' . $login . '/">' . $login . '</a>',


### PR DESCRIPTION
The release-confirmation listing builds an escaped profile link for every committer, then escapes the complete HTML link while interpolating it into the release sentence.

As a result, plugin committers see literal <a> markup instead of a clickable profile link.\n\nRender the already-escaped committer links directly and document that escaping boundary for PHPCS. Add a regression test that renders the release listing and verifies that the profile link remains HTML rather than becoming &lt;a&gt; text.\n\nValidation: PHP syntax checks passed for both changed files, and PHPCS passed for the added test.

<img width="1184" height="235" alt="image" src="https://github.com/user-attachments/assets/aa6ae16d-203d-434c-a483-e754ad0337c0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Release listings now render committer profile links correctly, while filtering potentially unsafe markup from the displayed content.

## Tests

- Added coverage confirming that committer profile links appear as clickable links rather than escaped HTML in release listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->